### PR TITLE
Allow the ability to set min number of connections on Jetty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ streamie.conf
 atlassian-ide-plugin.xml
 project/plugins/project/build.properties
 logs
+*.iml

--- a/src/main/scala/com/yammer/dropwizard/modules/ServerModule.scala
+++ b/src/main/scala/com/yammer/dropwizard/modules/ServerModule.scala
@@ -47,9 +47,12 @@ class ServerModule extends ProviderModule {
 
   private def makeServer(config: Configuration, connectors: Connector*) = {
     val server = new Server
+    val threadPool = new QueuedThreadPool
     connectors.foreach(server.addConnector)
     server.setSendServerVersion(false)
-    server.setThreadPool(new QueuedThreadPool(config("http.max_connections").or(50)))
+    threadPool.setMaxThreads(config("http.max_connections").or(50))
+    threadPool.setMinThreads(config("http.min_connections").or(8))
+    server.setThreadPool(threadPool)
     server.setStopAtShutdown(true)
     server.setGracefulShutdown(config("http.shutdown_milliseconds").or(2000))
     server


### PR DESCRIPTION
I'd like to have this ability, as it's slightly traumatic for observatory to get hit with a boatload of http all at once and spin up ~300 threads.
