### PR TITLE
switch link from ruby yaml to snakeyaml in the docs

### DIFF
--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -832,7 +832,7 @@ INFO  [2011-12-03 00:38:33,238] org.eclipse.jetty.server.AbstractConnector: Star
 
         <p><a class="btn" href="http://wiki.fasterxml.com/JacksonDocumentation">Learn more about Jackson &raquo;</a></p>
 
-        <p><a class="btn" href="http://www.yaml.org/YAML_for_ruby.html">Learn more about YAML &raquo;</a></p>
+        <p><a class="btn" href="http://code.google.com/p/snakeyaml/">Learn more about YAML &raquo;</a></p>
 
         <footer>
             <p>&copy; Yammer 2011</p>


### PR DESCRIPTION
the ruby yaml has a decent overview of yaml, but the snakeyaml stuff has stuff specific to dw. plus there are links to the 'official' yaml home page at snakeyaml's site, in case people want to learn more about yaml in general,
