### PR TITLE
(dropwizard-db) Database Health Checks Use Hardcoded SQL

### DIFF
--- a/dropwizard-db/src/main/java/com/yammer/dropwizard/db/DatabaseFactory.java
+++ b/dropwizard-db/src/main/java/com/yammer/dropwizard/db/DatabaseFactory.java
@@ -28,7 +28,10 @@ public class DatabaseFactory {
         final DataSource dataSource = buildDataSource(connectionConfig, pool);
         final Database database = new Database(dataSource, pool);
         environment.manage(database);
-        environment.addHealthCheck(new DatabaseHealthCheck(database, name));
+        final String validationQuery = connectionConfig.getValidationQuery();
+        if(validationQuery != null){
+            environment.addHealthCheck(new DatabaseHealthCheck(database, name, validationQuery));
+        }
         return database;
     }
 

--- a/dropwizard-db/src/main/java/com/yammer/dropwizard/db/DatabaseHealthCheck.java
+++ b/dropwizard-db/src/main/java/com/yammer/dropwizard/db/DatabaseHealthCheck.java
@@ -1,18 +1,25 @@
 package com.yammer.dropwizard.db;
 
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.util.StringMapper;
+
 import com.yammer.metrics.core.HealthCheck;
 
 public class DatabaseHealthCheck extends HealthCheck {
     private final Database database;
+    private final String checkSql;
 
-    public DatabaseHealthCheck(Database database, String name) {
+    public DatabaseHealthCheck(Database database, String name, String checkSql) {
         super(name + "-db");
         this.database = database;
+        this.checkSql = checkSql;
     }
 
     @Override
     protected Result check() throws Exception {
-        database.ping();
-        return Result.healthy();
+        Handle h = database.open();
+        String val = h.createQuery(this.checkSql).map(StringMapper.FIRST).first();
+        h.close();
+        return Result.healthy("Check query returned: " + val);
     }
 }


### PR DESCRIPTION
This is a small fix to make db health checks configurable.

Currently db health checks use the Database.ping() method which uses hard-coded sql to perform the check:

"SELECT 1"

Which won't work on all dbs, such as Oracle.

With this patch, a db health check will be added if the connection config has a "validationQuery" param, and use that sql for the health check.

I didn't muck with the Database.ping() method, but IMO it should be removed or refactored... The above approach seemed easiest since "ping()" sql was tied up in an annotation.

-Taylor
