### PR TITLE
More support for servlet listeners

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/config/ServerFactory.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/config/ServerFactory.java
@@ -26,7 +26,6 @@ import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.util.thread.ThreadPool;
 
-import javax.servlet.ServletContextListener;
 import java.util.EnumSet;
 import java.util.EventListener;
 
@@ -160,7 +159,7 @@ public class ServerFactory {
     private Handler createHandler(Environment env) {
         final HandlerCollection collection = new HandlerCollection();
 
-        collection.addHandler(createExternalServlet(env.getServlets(), env.getFilters(), env.getServletContextListeners()));
+        collection.addHandler(createExternalServlet(env.getServlets(), env.getFilters(), env.getServletListeners()));
         collection.addHandler(createInternalServlet(env));
 
         if (requestLogHandlerFactory.isEnabled()) {
@@ -180,7 +179,7 @@ public class ServerFactory {
 
     private Handler createExternalServlet(ImmutableMap<String, ServletHolder> servlets,
                                           ImmutableMap<String, FilterHolder> filters,
-                                          ImmutableSet<ServletContextListener> listeners) {
+                                          ImmutableSet<EventListener> listeners) {
         final ServletContextHandler handler = new ServletContextHandler();
         handler.setBaseResource(Resource.newClassPathResource("."));
 
@@ -193,8 +192,7 @@ public class ServerFactory {
         }
 
         final EventListener[] eventListeners = new EventListener[listeners.size()];
-        listeners.toArray(eventListeners);
-        handler.setEventListeners(eventListeners);
+        handler.setEventListeners(listeners.toArray(eventListeners));
 
         handler.setConnectorNames(new String[]{"main"});
 


### PR DESCRIPTION
Both servlet context and servlet request listeners can now be added to a Dropwizard environment during service initialization.

The closest supertype is `EventListener` and it seemed too much to add four different `addXXX` methods to environment, so there's instead one `addServletListener(EventListener... listeners)` method that can take an arbitrary number and type of servlet event listeners.
