### PR TITLE
Support servlet context parameters

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/config/HttpConfiguration.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/config/HttpConfiguration.java
@@ -1,6 +1,7 @@
 package com.yammer.dropwizard.config;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 import com.yammer.dropwizard.util.Duration;
 import com.yammer.dropwizard.util.Size;
 import com.yammer.dropwizard.validation.ValidationMethod;
@@ -26,6 +27,10 @@ public class HttpConfiguration {
     @JsonProperty
     private GzipConfiguration gzip = new GzipConfiguration();
 
+    @NotNull
+    @JsonProperty
+    private ImmutableMap<String, String> contextParameters = ImmutableMap.of();
+    
     public enum ConnectorType {
         SOCKET,
         BLOCKING_CHANNEL,
@@ -145,6 +150,10 @@ public class HttpConfiguration {
         return gzip;
     }
 
+    public ImmutableMap<String, String> getContextParameters() {
+        return contextParameters;
+    }
+    
     public ConnectorType getConnectorType() {
         if ("blocking".equalsIgnoreCase(connectorType)) {
             return ConnectorType.BLOCKING_CHANNEL;

--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/config/ServerFactory.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/config/ServerFactory.java
@@ -28,6 +28,7 @@ import org.eclipse.jetty.util.thread.ThreadPool;
 
 import java.util.EnumSet;
 import java.util.EventListener;
+import java.util.Map;
 
 // TODO: 11/7/11 <coda> -- document ServerFactory
 // TODO: 11/7/11 <coda> -- document ServerFactory
@@ -195,6 +196,10 @@ public class ServerFactory {
             handler.addEventListener(listener);
         }
 
+        for (Map.Entry<String, String> entry : config.getContextParameters().entrySet()) {
+            handler.setInitParameter( entry.getKey(), entry.getValue() );
+        }
+        
         handler.setConnectorNames(new String[]{"main"});
 
         return wrapHandler(handler);

--- a/dropwizard-core/src/test/java/com/yammer/dropwizard/config/tests/HttpConfigurationTest.java
+++ b/dropwizard-core/src/test/java/com/yammer/dropwizard/config/tests/HttpConfigurationTest.java
@@ -1,6 +1,7 @@
 package com.yammer.dropwizard.config.tests;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import com.yammer.dropwizard.config.ConfigurationFactory;
 import com.yammer.dropwizard.config.HttpConfiguration;
@@ -36,6 +37,12 @@ public class HttpConfigurationTest {
                    is(true));
     }
 
+    @Test
+    public void loadsContextParams() throws Exception {
+        assertThat(http.getContextParameters(), 
+                   is(ImmutableMap.of("param", "value")));
+    }
+    
     @Test
     public void hasAServicePort() throws Exception {
         assertThat(http.getPort(),

--- a/dropwizard-core/src/test/resources/basic-configuration.yml
+++ b/dropwizard-core/src/test/resources/basic-configuration.yml
@@ -88,7 +88,11 @@ http:
 
     # The maximum number of old log files to retain.
     retainedFileCount: 5
-
+  
+  # Servlet context parameters
+  contextParameters:
+    param: value
+    
 # Logging settings.
 logging:
 

--- a/dropwizard-core/src/test/resources/yaml/http.yml
+++ b/dropwizard-core/src/test/resources/yaml/http.yml
@@ -27,3 +27,5 @@ useDateHeader: false
 useForwardedHeaders: false
 useDirectBuffers: false
 bindHost: "localhost"
+contextParameters:
+  param: value


### PR DESCRIPTION
`HttpConfiguration` now has a `contextParameters` node that contains name/value pairs for all context parameters. `ServerFactory` sets context init parameters using the service configuration.
