### PR TITLE
Allow setting filter and servlet names

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/config/FilterConfiguration.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/config/FilterConfiguration.java
@@ -5,7 +5,9 @@ import org.eclipse.jetty.servlet.FilterHolder;
 
 import java.util.Map;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Strings.isNullOrEmpty;
 
 /**
  * The configuration for a servlet {@link javax.servlet.Filter}.
@@ -26,6 +28,23 @@ public class FilterConfiguration {
         this.mappings = mappings;
     }
 
+    /**
+     * Sets the filter's name.
+     * 
+     * @param name    the name of the filter
+     * @return {@code this}
+     */
+    public FilterConfiguration setName(String name) {
+        checkArgument( !isNullOrEmpty( name ), "name must be non-empty" );
+        /*
+         * We are warned against ordering setting the held class (which 
+         * has already happened by the time this configuration is instantiated) 
+         * before the name, but it seems harmless to do so.
+         */
+        holder.setName( name );
+        return this;
+    }
+    
     /**
      * Sets the given filter initialization parameter.
      *

--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/config/ServletConfiguration.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/config/ServletConfiguration.java
@@ -5,7 +5,9 @@ import org.eclipse.jetty.servlet.ServletHolder;
 
 import java.util.Map;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Strings.isNullOrEmpty;
 
 /**
  * The configuration for a {@link javax.servlet.Servlet}.
@@ -26,6 +28,23 @@ public class ServletConfiguration {
         this.mappings = mappings;
     }
 
+    /**
+     * Sets the servlet's name.
+     * 
+     * @param name    the name of the servlet
+     * @return {@code this}
+     */
+    public ServletConfiguration setName(String name) {
+        checkArgument( !isNullOrEmpty( name ), "name must be non-empty" );
+        /*
+         * We are warned against ordering setting the held class (which 
+         * has already happened by the time this configuration is instantiated) 
+         * before the name, but it seems harmless to do so.
+         */
+        holder.setName( name );
+        return this;
+    }
+    
     /**
      * Sets the servlet's initialization order.
      *


### PR DESCRIPTION
This allows setting names for filters and servlets as they would be given in the deployment descriptor. Some filters and servlets use their given name as a lookup key in another registry (I'm looking at you, Spring) and this change enables using those filters and servlets in Dropwizard.

I'm not really happy with piling on to the existing amount of code duplication between `FilterConfiguration` and `ServletConfiguration`, but I wanted to keep this patch small.
