### PR TITLE
custom log format pattern

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/logging/LogFormatter.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/logging/LogFormatter.java
@@ -7,11 +7,12 @@ import org.apache.log4j.EnhancedPatternLayout;
 import org.apache.log4j.spi.LoggingEvent;
 
 public class LogFormatter extends EnhancedPatternLayout {
+    private static final String DROPWIZARD_LOG_PATTERN = "%-5p [%d{ISO8601}{UTC}] %c: %m\n";
     private static final String STACK_TRACE_PREFIX = "! ";
     private static final char NEWLINE = '\n';
 
     public LogFormatter() {
-        super("%-5p [%d{ISO8601}{UTC}] %c: %m\n");
+        super(System.getProperty("logging.layout.pattern", DROPWIZARD_LOG_PATTERN));
     }
 
     @Override


### PR DESCRIPTION
The patch provide an easier way to substitute ISO8601 date format in log output :

-Dlogging.layout.pattern="%-5p [%d{yyyy-MM-dd HH:mm:ss,SSS z}"] %c: %m\n"

(previously the format pattern is hard-coded in the constructor).
