### PR TITLE
Enable downstream projects to customize how Jackson is used

### DIFF
--- a/dropwizard-client/src/main/java/com/yammer/dropwizard/client/JerseyClientFactory.java
+++ b/dropwizard-client/src/main/java/com/yammer/dropwizard/client/JerseyClientFactory.java
@@ -26,7 +26,8 @@ public class JerseyClientFactory {
         final ApacheHttpClient4Handler handler = new ApacheHttpClient4Handler(client, null, true);
 
         final ApacheHttpClient4Config config = new DefaultApacheHttpClient4Config();
-        config.getSingletons().add(new JacksonMessageBodyProvider(environment.getService().getJacksonModules()));
+        config.getSingletons().add(new JacksonMessageBodyProvider(environment.getJsonEnvironmentClass(), 
+            environment.getService().getJacksonModules()));
 
         final JerseyClient jerseyClient = new JerseyClient(handler, config);
         jerseyClient.setExecutorService(environment.managedExecutorService("jersey-client-%d",

--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/bundles/JavaBundle.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/bundles/JavaBundle.java
@@ -25,7 +25,7 @@ public class JavaBundle implements Bundle {
 
     @Override
     public void initialize(Environment environment) {
-        environment.addProvider(new JacksonMessageBodyProvider(service.getJacksonModules()));
+        environment.addProvider(new JacksonMessageBodyProvider(environment.getJsonEnvironmentClass(), service.getJacksonModules()));
         for (Object provider : DEFAULT_PROVIDERS) {
             environment.addProvider(provider);
         }

--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/config/Configuration.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/config/Configuration.java
@@ -52,6 +52,11 @@ public class Configuration {
     @JsonProperty
     private LoggingConfiguration logging = new LoggingConfiguration();
 
+    @Valid
+    @NotNull
+    @JsonProperty
+    private JsonConfiguration json = new JsonConfiguration();
+
     /**
      * Returns the HTTP-specific section of the configuration file.
      *
@@ -68,5 +73,14 @@ public class Configuration {
      */
     public LoggingConfiguration getLoggingConfiguration() {
         return logging;
+    }
+
+    /**
+     * Returns the json-specific section of the configuration file.
+     *
+     * @return json-specific configuration parameters
+     */
+    public JsonConfiguration getJsonConfiguration() {
+        return json;
     }
 }

--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/config/JsonConfiguration.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/config/JsonConfiguration.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2012 Brightcove Inc. All Rights Reserved. No use, copying or distribution of this
+ * work may be made except in accordance with a valid license agreement from Brightcove Inc. This
+ * notice must be included on all copies, modifications and derivatives of this work.
+ * 
+ * Brightcove Inc MAKES NO REPRESENTATIONS OR WARRANTIES ABOUT THE SUITABILITY OF THE SOFTWARE,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT. BRIGHTCOVE SHALL NOT BE
+ * LIABLE FOR ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT OF USING, MODIFYING OR DISTRIBUTING THIS
+ * SOFTWARE OR ITS DERIVATIVES.
+ * 
+ * "Brightcove" is a registered trademark of Brightcove Inc.
+ */
+package com.yammer.dropwizard.config;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+
+public class JsonConfiguration {
+
+    @JsonProperty
+    private String jsonEnvironmentClass = "com.yammer.dropwizard.json.Json";
+    
+    /**
+     * @return The class name to instantiate that creates the json environment
+     */
+    public String getJsonEnvironmentClass() {
+        return jsonEnvironmentClass;
+    }
+}

--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/jersey/JacksonMessageBodyProvider.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/jersey/JacksonMessageBodyProvider.java
@@ -52,8 +52,12 @@ public class JacksonMessageBodyProvider implements MessageBodyReader<Object>,
 
     private final Json json;
 
-    public JacksonMessageBodyProvider(Iterable<Module> modules) {
-        this.json = new Json();
+    public JacksonMessageBodyProvider(Class<? extends Json> jsonEnvironmentClass, Iterable<Module> modules) {
+        try {
+            this.json = jsonEnvironmentClass.newInstance();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Could not create json environment class", e);
+        }
         for (Module module : modules) {
             json.registerModule(module);
         }

--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/json/Json.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/json/Json.java
@@ -26,9 +26,9 @@ import java.lang.reflect.Type;
  * </ul>
  */
 public class Json {
-    private final JsonFactory factory;
-    private final ObjectMapper mapper;
-    private final TypeFactory typeFactory;
+    protected JsonFactory factory;
+    protected ObjectMapper mapper;
+    protected TypeFactory typeFactory;
 
     /**
      * Creates a new {@link Json} instance.

--- a/dropwizard-core/src/test/java/com/yammer/dropwizard/bundles/tests/JavaBundleTest.java
+++ b/dropwizard-core/src/test/java/com/yammer/dropwizard/bundles/tests/JavaBundleTest.java
@@ -7,6 +7,8 @@ import com.yammer.dropwizard.config.Environment;
 import com.yammer.dropwizard.jersey.JacksonMessageBodyProvider;
 import com.yammer.dropwizard.jersey.OauthTokenProvider;
 import com.yammer.dropwizard.jersey.OptionalQueryParamInjectableProvider;
+import com.yammer.dropwizard.json.Json;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -23,6 +25,8 @@ public class JavaBundleTest {
     @Before
     public void setUp() throws Exception {
         when(service.getJacksonModules()).thenReturn(ImmutableList.of());
+        Class jsonClass= Json.class;
+        when(environment.getJsonEnvironmentClass()).thenReturn(jsonClass);
     }
 
     @Test

--- a/dropwizard-scala_2.9.1/src/main/java/com/yammer/dropwizard/bundles/ScalaBundle.java
+++ b/dropwizard-scala_2.9.1/src/main/java/com/yammer/dropwizard/bundles/ScalaBundle.java
@@ -16,7 +16,7 @@ public class ScalaBundle implements Bundle {
 
     @Override
     public void initialize(Environment environment) {
-        environment.addProvider(new JacksonMessageBodyProvider(service.getJacksonModules()));
+        environment.addProvider(new JacksonMessageBodyProvider(environment.getJsonEnvironmentClass(), service.getJacksonModules()));
         environment.addProvider(new OauthTokenProvider());
         environment.addProvider(new ScalaCollectionsQueryParamInjectableProvider());
     }

--- a/dropwizard-testing/src/main/java/com/yammer/dropwizard/testing/ResourceTest.java
+++ b/dropwizard-testing/src/main/java/com/yammer/dropwizard/testing/ResourceTest.java
@@ -1,5 +1,12 @@
 package com.yammer.dropwizard.testing;
 
+import java.util.List;
+import java.util.Set;
+
+import org.codehaus.jackson.map.Module;
+import org.junit.After;
+import org.junit.Before;
+
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.sun.jersey.api.client.Client;
@@ -9,12 +16,7 @@ import com.sun.jersey.test.framework.LowLevelAppDescriptor;
 import com.yammer.dropwizard.bundles.JavaBundle;
 import com.yammer.dropwizard.config.DropwizardResourceConfig;
 import com.yammer.dropwizard.jersey.JacksonMessageBodyProvider;
-import org.codehaus.jackson.map.Module;
-import org.junit.After;
-import org.junit.Before;
-
-import java.util.List;
-import java.util.Set;
+import com.yammer.dropwizard.json.Json;
 
 /**
  * A base test class for testing Dropwizard resources.
@@ -49,7 +51,7 @@ public abstract class ResourceTest {
                 for (Object provider : JavaBundle.DEFAULT_PROVIDERS) { // sorry, Scala folks
                     config.getSingletons().add(provider);
                 }
-                config.getSingletons().add(new JacksonMessageBodyProvider(modules));
+                config.getSingletons().add(new JacksonMessageBodyProvider(Json.class, modules));
                 config.getSingletons().addAll(singletons);
                 return new LowLevelAppDescriptor.Builder(config).build();
             }


### PR DESCRIPTION
This change allows a dropwizard project to use a subclass of
com.yammer.dropwizard.json.Json as an alternative. This would
enable customizing how jackson is configured or how it is used.

This takes a pretty blunt approach, but should hopefully enable any customizations necessary. The JsonConfiguration object might be a place for finer tuned json configuration in the future.

Our project needs this so we can work around a specific jackson issue we have been running into (http://jira.codehaus.org/browse/JACKSON-799)

thanks
sam
