### PR TITLE
Allow admin to be disabled

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/config/HttpConfiguration.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/config/HttpConfiguration.java
@@ -47,6 +47,9 @@ public class HttpConfiguration {
     @JsonProperty
     private int adminPort = 8081;
 
+    @JsonProperty
+    private boolean adminEnabled = true;
+
     @Min(2)
     @Max(1000000)
     @JsonProperty
@@ -172,6 +175,10 @@ public class HttpConfiguration {
 
     public int getAdminPort() {
         return adminPort;
+    }
+
+    public boolean isAdminEnabled() {
+        return adminEnabled;
     }
 
     public int getMaxThreads() {

--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/config/ServerFactory.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/config/ServerFactory.java
@@ -80,7 +80,9 @@ public class ServerFactory {
         final Server server = new Server();
 
         server.addConnector(createExternalConnector());
-        server.addConnector(createInternalConnector());
+        if(config.isAdminEnabled()) {
+            server.addConnector(createInternalConnector());
+        }
 
         server.addBean(new QuietErrorHandler());
 
@@ -167,7 +169,9 @@ public class ServerFactory {
         final HandlerCollection collection = new HandlerCollection();
 
         collection.addHandler(createExternalServlet(env.getServlets(), env.getFilters(), env.getServletListeners()));
-        collection.addHandler(createInternalServlet(env));
+        if(config.isAdminEnabled()) {
+            collection.addHandler(createInternalServlet(env));
+        }
 
         if (requestLogHandlerFactory.isEnabled()) {
             collection.addHandler(requestLogHandlerFactory.build());

--- a/dropwizard-core/src/test/java/com/yammer/dropwizard/config/tests/HttpConfigurationTest.java
+++ b/dropwizard-core/src/test/java/com/yammer/dropwizard/config/tests/HttpConfigurationTest.java
@@ -56,6 +56,12 @@ public class HttpConfigurationTest {
     }
 
     @Test
+    public void canEnableAdmin() throws Exception {
+        assertThat(http.isAdminEnabled(),
+                   is(false));
+    }
+
+    @Test
     public void hasAMaximumNumberOfThreads() throws Exception {
         assertThat(http.getMaxThreads(),
                    is(101));

--- a/dropwizard-core/src/test/resources/yaml/http.yml
+++ b/dropwizard-core/src/test/resources/yaml/http.yml
@@ -4,6 +4,7 @@ gzip:
   enabled: false
 port: 9080
 adminPort: 9081
+adminEnabled: false
 maxThreads: 101
 minThreads: 89
 rootPath: "/services/*"


### PR DESCRIPTION
(This _should_ be the final nail in the getting-dropwizard-to-work-on-heroku-out-of-box coffin.)

[Heroku kills processes that bind to more than one port](http://devcenter.heroku.com/articles/error-codes#r11__bad_bind), which doesn't exactly jive with having the admin servlet bind on a separate port. Ideally the admin servlet could live on "/admin" with some http basic auth guarding it, but it seems like that would require rejiggering ServerFactory quite a bit. This is a quick and dirty solution that should get people up and running on Heroku.
