### PR TITLE
relax access controls so subclasses can access the mapper, etc

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/json/Json.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/json/Json.java
@@ -26,9 +26,9 @@ import java.lang.reflect.Type;
  * </ul>
  */
 public class Json {
-    private final JsonFactory factory;
-    private final ObjectMapper mapper;
-    private final TypeFactory typeFactory;
+    protected JsonFactory factory;
+    protected ObjectMapper mapper;
+    protected TypeFactory typeFactory;
 
     /**
      * Creates a new {@link Json} instance.


### PR DESCRIPTION
I forgot to change these to protected in my last pull request. Makes the subclass much cleaner :)

thanks
sam
