### PR TITLE
remove unused formal template parameter

### DIFF
--- a/dropwizard-example/src/main/resources/com/example/helloworld/db/PeopleDAO.sql.stg
+++ b/dropwizard-example/src/main/resources/com/example/helloworld/db/PeopleDAO.sql.stg
@@ -4,7 +4,7 @@ createPeopleTable() ::= <<
   create table people (id Serial primary key, fullName varchar(255), jobTitle varchar(100))
 >>
 
-findById(id) ::= <<
+findById() ::= <<
   select id, fullName, jobTitle from people where id = :id
 >>
 


### PR DESCRIPTION
Remove unused, and therefore slightly confusing, formal template parameter from findById()
