### PR TITLE
Add provider to ResourceTest to enable things such as Exception mappers

### DIFF
--- a/dropwizard-testing/src/main/java/com/yammer/dropwizard/testing/ResourceTest.java
+++ b/dropwizard-testing/src/main/java/com/yammer/dropwizard/testing/ResourceTest.java
@@ -23,6 +23,7 @@ import com.yammer.dropwizard.json.Json;
  */
 public abstract class ResourceTest {
     private final Set<Object> singletons = Sets.newHashSet();
+    private final Set<Class<?>> providers = Sets.newHashSet();
     private final List<Module> modules = Lists.newArrayList();
 
     private JerseyTest test;
@@ -31,6 +32,10 @@ public abstract class ResourceTest {
 
     protected void addResource(Object resource) {
         singletons.add(resource);
+    }
+
+    public void addProvider(Class<?> klass) {
+        providers.add(klass);
     }
 
     protected void addJacksonModule(Module module) {
@@ -50,6 +55,9 @@ public abstract class ResourceTest {
                 final DropwizardResourceConfig config = new DropwizardResourceConfig();
                 for (Object provider : JavaBundle.DEFAULT_PROVIDERS) { // sorry, Scala folks
                     config.getSingletons().add(provider);
+                }
+                for (Class<?> provider : providers) {
+                    config.getClasses().add(provider);
                 }
                 Json json = new Json();
                 for (Module module : modules) {


### PR DESCRIPTION
Our "store" throws an Exception when the resource cannot be found, and we have an Exception mapper that turns it into a 404 Response.
