### PR TITLE
Updated README and documentation to reflect switch to Logback

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ historically not sucked:
 * [Jetty](http://www.eclipse.org/jetty/) for HTTP servin'.
 * [Jersey](http://jersey.java.net/) for REST modelin'.
 * [Jackson](http://jackson.codehaus.org) for JSON parsin' and generatin'.
-* [Log4j](http://logging.apache.org/log4j/1.2/) for loggin'.
+* [Logback](http://logback.qos.ch/) for loggin'.
 * [Hibernate Validator](http://www.hibernate.org/subprojects/validator.html) for validatin'.
 * [Metrics](https://github.com/codahale/metrics) for figurin' out what your service is doing in
   production.

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -82,7 +82,7 @@ we've come to rely on:
 
 * Guava_, which, in addition to highly optimized immutable data structures, provides a growing
   number of classes to speed up development in Java.
-* Log4j_ and slf4j_ for performant logging.
+* Logback_ and slf4j_ for performant logging.
 * `Hibernate Validator`_, the `JSR-303`_ reference implementation, provides an easy, declarative
   framework for validating user input and generating helpful, internationalizable error messages.
 * The `Apache HttpClient`_ and Jersey_ client libraries allow for both low- and high-level
@@ -91,7 +91,7 @@ we've come to rely on:
 * Freemarker_ is a simple template system for more user-facing services.
 
 .. _Guava: http://code.google.com/p/guava-libraries/
-.. _Log4j: http://logging.apache.org/log4j/1.2/
+.. _Logback: http://logback.qos.ch/
 .. _slf4j: http://www.slf4j.org/
 .. _Hibernate Validator: http://www.hibernate.org/subprojects/validator.html
 .. _JSR-303: http://jcp.org/en/jsr/detail?id=303

--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -16,7 +16,7 @@ It includes:
 * Jackson, the best JSON library for the JVM.
 * Metrics, `Yammer's`__ own library for application metrics.
 * Guava, Google's excellent utility library.
-* Log4j, Java's most widely-used logging framework.
+* Logback, the successor to Log4j, Java's most widely-used logging framework.
 * Hibernate Validator, the reference implementation of the Java Bean Validation standard.
 
 .. __: https://www.yammer.com
@@ -324,10 +324,10 @@ port. For example::
 Logging
 =======
 
-Dropwizard uses Log4j_ for its logging backend. It provides an slf4j_ implementation, and even
-routes all ``java.util.logging`` usage through log4j.
+Dropwizard uses Logback_ for its logging backend. It provides an slf4j_ implementation, and even
+routes all ``java.util.logging`` usage through Logback.
 
-.. _Log4j: http://logging.apache.org/log4j/1.2/
+.. _Logback: http://logback.qos.ch/
 .. _slf4j: http://www.slf4j.org/
 
 .. _man-core-logging-class:


### PR DESCRIPTION
Updates some docs that were missed in the first pass.

I noticed that the change to Logback hasn't been reflected in:
- dropwizard-db - Constructs a log4j Logger for SQL trace logging, as the DBI API requires it. Will this cause SQL logging to be logged independently of configuration?
- dropwizard-scala - Examples all use Logula, wouldn't they be better of just using com.yammer.dropwizard.logging.Log instead?
