### PR TITLE
Switched dropwizard-db to use Logback for query logs.

### DIFF
--- a/dropwizard-db/src/main/java/com/yammer/dropwizard/db/Database.java
+++ b/dropwizard-db/src/main/java/com/yammer/dropwizard/db/Database.java
@@ -1,21 +1,22 @@
 package com.yammer.dropwizard.db;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 import com.yammer.dropwizard.db.args.OptionalArgumentFactory;
+import com.yammer.dropwizard.db.logging.LogbackLog;
 import com.yammer.dropwizard.lifecycle.Managed;
 import com.yammer.metrics.Metrics;
 import com.yammer.metrics.jdbi.InstrumentedTimingCollector;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.apache.tomcat.dbcp.pool.ObjectPool;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
-import org.skife.jdbi.v2.logging.Log4JLog;
+import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
 import java.sql.SQLException;
 
 public class Database extends DBI implements Managed {
-    private static final Logger LOGGER = Logger.getLogger(Database.class);
+    private static final Logger LOGGER = (Logger) LoggerFactory.getLogger(Database.class);
 
     private final ObjectPool pool;
     private final String validationQuery;
@@ -24,7 +25,7 @@ public class Database extends DBI implements Managed {
         super(dataSource);
         this.pool = pool;
         this.validationQuery = validationQuery;
-        setSQLLog(new Log4JLog(LOGGER, Level.TRACE));
+        setSQLLog(new LogbackLog(LOGGER, Level.TRACE));
         setTimingCollector(new InstrumentedTimingCollector(Metrics.defaultRegistry()));
         setStatementRewriter(new NamePrependingStatementRewriter());
         registerArgumentFactory(new OptionalArgumentFactory());

--- a/dropwizard-db/src/main/java/com/yammer/dropwizard/db/logging/LogbackLog.java
+++ b/dropwizard-db/src/main/java/com/yammer/dropwizard/db/logging/LogbackLog.java
@@ -1,0 +1,55 @@
+package com.yammer.dropwizard.db.logging;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.logging.FormattedLog;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Logs SQL via Logback
+ */
+public class LogbackLog extends FormattedLog {
+    private final Logger log;
+    private Level level;
+    private String fqcn;
+
+    /**
+     * Logs to org.skife.jdbi.v2 logger at the debug level
+     */
+    public LogbackLog()
+    {
+        this((Logger) LoggerFactory.getLogger(DBI.class.getPackage().getName()));
+    }
+
+    /**
+     * Use an arbitrary logger to log to at the debug level
+     */
+    public LogbackLog(Logger log)
+    {
+        this(log, Level.DEBUG);
+    }
+
+    /**
+     * Specify both the logger and the level to log at
+     * @param log The logger to log to
+     * @param level the priority to log at
+     */
+    public LogbackLog(Logger log, Level level) {
+        this.log = log;
+        this.level = level;
+        this.fqcn = LogbackLog.class.getName();
+    }
+
+    @Override
+    protected final boolean isEnabled()
+    {
+        return log.isEnabledFor(level);
+    }
+
+    @Override
+    protected final void log(String msg)
+    {
+        log.log(null, fqcn, level.toLocationAwareLoggerInteger(level), msg, null, null);
+    }
+}


### PR DESCRIPTION
Dropwizard-db currently uses Log4j for query logging. Lets switch it to Logback to keep things in sync with the rest of Dropwizard.

NOTE: `LogbackLog` is an implementation of JDBI's `SQLLog` interface. It should probably live upstream (or a more generic SLF4J based implementation) but I felt it better to include it directly for now until it's handled upstream.
