### PR TITLE
Add ability to configure read-only database connections

### DIFF
--- a/dropwizard-db/src/main/java/com/yammer/dropwizard/db/DatabaseConfiguration.java
+++ b/dropwizard-db/src/main/java/com/yammer/dropwizard/db/DatabaseConfiguration.java
@@ -61,6 +61,9 @@ public class DatabaseConfiguration {
     @JsonProperty
     private Duration closeConnectionIfIdleFor = Duration.minutes(1);
 
+    @JsonProperty
+    private boolean defaultReadOnly = false;
+
     public String getDriverClass() {
         return driverClass;
     }
@@ -157,6 +160,14 @@ public class DatabaseConfiguration {
         this.closeConnectionIfIdleFor = closeConnectionIfIdleFor;
     }
 
+    public boolean isDefaultReadOnly() {
+        return defaultReadOnly;
+    }
+
+    public void setDefaultReadOnly(boolean defaultReadOnly) {
+        this.defaultReadOnly = defaultReadOnly;
+    }
+
     @ValidationMethod(message = ".minSize must be less than or equal to maxSize")
     public boolean isPoolSizedCorrectly() {
         return minSize <= maxSize;
@@ -172,6 +183,7 @@ public class DatabaseConfiguration {
                 (minSize == that.minSize) &&
                 !((checkConnectionHealthWhenIdleFor != null) ? !checkConnectionHealthWhenIdleFor.equals(that.checkConnectionHealthWhenIdleFor) : (that.checkConnectionHealthWhenIdleFor != null)) &&
                 !((closeConnectionIfIdleFor != null) ? !closeConnectionIfIdleFor.equals(that.closeConnectionIfIdleFor) : (that.closeConnectionIfIdleFor != null)) &&
+                (defaultReadOnly == that.defaultReadOnly) &&
                 !((driverClass != null) ? !driverClass.equals(that.driverClass) : (that.driverClass != null)) &&
                 !((maxWaitForConnection != null) ? !maxWaitForConnection.equals(that.maxWaitForConnection) : (that.maxWaitForConnection != null)) &&
                 !((password != null) ? !password.equals(that.password) : (that.password != null)) &&
@@ -195,6 +207,7 @@ public class DatabaseConfiguration {
         result = (31 * result) + (checkConnectionWhileIdle ? 1 : 0);
         result = (31 * result) + ((checkConnectionHealthWhenIdleFor != null) ? checkConnectionHealthWhenIdleFor.hashCode() : 0);
         result = (31 * result) + ((closeConnectionIfIdleFor != null) ? closeConnectionIfIdleFor.hashCode() : 0);
+        result = (31 * result) + (defaultReadOnly ? 1 : 0);
         return result;
     }
 
@@ -213,6 +226,7 @@ public class DatabaseConfiguration {
                       .add("checkConnectionWhileIdle", checkConnectionWhileIdle)
                       .add("checkConnectionHealthWhenIdleFor", checkConnectionHealthWhenIdleFor)
                       .add("closeConnectionIfIdleFor", closeConnectionIfIdleFor)
+                      .add("defaultReadOnly", defaultReadOnly)
                       .toString();
     }
 }

--- a/dropwizard-db/src/main/java/com/yammer/dropwizard/db/DatabaseFactory.java
+++ b/dropwizard-db/src/main/java/com/yammer/dropwizard/db/DatabaseFactory.java
@@ -43,7 +43,7 @@ public class DatabaseFactory {
                                                                                           pool,
                                                                                           null,
                                                                                           connectionConfig.getValidationQuery(),
-                                                                                          false,
+                                                                                          connectionConfig.isDefaultReadOnly(),
                                                                                           true);
         connectionFactory.setPool(pool);
 


### PR DESCRIPTION
Attempting to access a read-only database fails with the following error:

`! Caused by: org.apache.tomcat.dbcp.dbcp.SQLNestedException: Cannot get a
connection, pool error Could not create a validated object, cause: A read-only
user or a user in a read-only database is not permitted to disable read-only
mode on a connection.
!   at org.apache.tomcat.dbcp.dbcp.PoolingDataSource.getConnection(PoolingDataSource.java:114)
!   at org.skife.jdbi.v2.DataSourceConnectionFactory.openConnection(DataSourceConnectionFactory.java:36)
!   at org.skife.jdbi.v2.DBI.open(DBI.java:192)
!   ... 52 more`

This commit allows configuration of read-only connections while defaulting to the current behavior of forcing writable connections.
