### PR TITLE
Update HttpClientConfiguration, Refactor HttpClientFactory

### DIFF
--- a/dropwizard-client/src/main/java/com/yammer/dropwizard/client/HttpClientConfiguration.java
+++ b/dropwizard-client/src/main/java/com/yammer/dropwizard/client/HttpClientConfiguration.java
@@ -11,6 +11,9 @@ public class HttpClientConfiguration {
     private Duration timeout = Duration.milliseconds(500);
 
     @NotNull
+    private Duration connectionTimeout = Duration.milliseconds(500);
+
+    @NotNull
     private Duration timeToLive = Duration.hours(1);
 
     private boolean cookiesEnabled = false;
@@ -19,8 +22,34 @@ public class HttpClientConfiguration {
     @Min(1)
     private int maxConnections = 1024;
 
+    @NotNull
+    private Duration keepAlive = Duration.milliseconds(0l);
+
+    @Max(Integer.MAX_VALUE)
+    @Min(1)
+    private int maxConnectionsPerRoute = 1024;
+
+    public Duration getKeepAlive() {
+        return keepAlive;
+    }
+
+    public void setKeepAlive(Duration keepAlive) {
+        this.keepAlive = keepAlive;
+    }
+
+    public int getMaxConnectionsPerRoute() {
+        return maxConnectionsPerRoute;
+    }
+
+    public void setMaxConnectionsPerRoute(int maxConnectionsPerRoute) {
+        this.maxConnectionsPerRoute = maxConnectionsPerRoute;
+    }
     public Duration getTimeout() {
         return timeout;
+    }
+
+    public Duration getConnectionTimeout() {
+        return connectionTimeout;
     }
 
     public Duration getTimeToLive() {
@@ -33,6 +62,10 @@ public class HttpClientConfiguration {
 
     public void setTimeout(Duration duration) {
         this.timeout = duration;
+    }
+
+    public void setConnectionTimeout(Duration duration) {
+        this.connectionTimeout = duration;
     }
 
     public void setTimeToLive(Duration timeToLive) {

--- a/dropwizard-client/src/main/java/com/yammer/dropwizard/client/HttpClientFactory.java
+++ b/dropwizard-client/src/main/java/com/yammer/dropwizard/client/HttpClientFactory.java
@@ -2,11 +2,17 @@ package com.yammer.dropwizard.client;
 
 import com.yammer.metrics.httpclient.InstrumentedClientConnManager;
 import com.yammer.metrics.httpclient.InstrumentedHttpClient;
+import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.params.AllClientPNames;
 import org.apache.http.client.params.CookiePolicy;
+import org.apache.http.conn.scheme.SchemeRegistry;
+import org.apache.http.impl.DefaultConnectionReuseStrategy;
+import org.apache.http.impl.NoConnectionReuseStrategy;
+import org.apache.http.impl.client.DefaultConnectionKeepAliveStrategy;
 import org.apache.http.impl.conn.SchemeRegistryFactory;
 import org.apache.http.params.BasicHttpParams;
+import org.apache.http.protocol.HttpContext;
 
 import java.util.concurrent.TimeUnit;
 
@@ -18,7 +24,49 @@ public class HttpClientFactory {
     }
 
     public HttpClient build() {
-        final BasicHttpParams params = new BasicHttpParams();
+        final BasicHttpParams params = createHttpParams();
+        final InstrumentedClientConnManager manager = createConnectionManager(SchemeRegistryFactory.createDefault());
+        InstrumentedHttpClient client = new InstrumentedHttpClient(manager, params);
+        setStrategiesForClient(client);
+
+        return client;
+    }
+
+    /**
+     * Add strategies to client such as ConnectionReuseStrategy and KeepAliveStrategy
+     * Note that this method mutates the client object by setting the strategies
+     * @param client The InstrumentedHttpClient that should be configured with strategies
+     */
+    private void setStrategiesForClient(InstrumentedHttpClient client) {
+        final long keepAlive = configuration.getKeepAlive().toMilliseconds();
+
+        //don't keep alive the HTTP connection and thus don't reuse the TCP socket
+        if(keepAlive == 0) {
+            client.setReuseStrategy(new NoConnectionReuseStrategy());
+        } else {
+            client.setReuseStrategy(new DefaultConnectionReuseStrategy());
+            //either keep alive based on response header Keep-Alive,
+            //or if the server can keep a persistent connection (-1), then override based on client's configuration
+            client.setKeepAliveStrategy(new DefaultConnectionKeepAliveStrategy() {
+                @Override
+                public long getKeepAliveDuration(HttpResponse response, HttpContext context) {
+                    long duration = super.getKeepAliveDuration(response, context);
+                    if(duration == -1) {
+                        return keepAlive;
+                    } else {
+                        return duration;
+                    }
+                }
+            });
+        }
+    }
+
+    /**
+     * Map the parameters in HttpClientConfiguration to a BasicHttpParams object
+     * @return a BasicHttpParams object from the HttpClientConfiguration
+     */
+    protected BasicHttpParams createHttpParams() {
+        BasicHttpParams params = new BasicHttpParams();
 
         // TODO: 11/16/11 <coda> -- figure out the full set of options to support
 
@@ -30,19 +78,27 @@ public class HttpClientFactory {
 
         final Integer timeout = (int) configuration.getTimeout().toMilliseconds();
         params.setParameter(AllClientPNames.SO_TIMEOUT, timeout);
-        params.setParameter(AllClientPNames.CONNECTION_TIMEOUT, timeout);
+
+        final Integer connectionTimeout = (int) configuration.getConnectionTimeout().toMilliseconds();
+        params.setParameter(AllClientPNames.CONNECTION_TIMEOUT, connectionTimeout);
 
         params.setParameter(AllClientPNames.TCP_NODELAY, Boolean.TRUE);
         params.setParameter(AllClientPNames.STALE_CONNECTION_CHECK, Boolean.FALSE);
 
-        final InstrumentedClientConnManager manager = new InstrumentedClientConnManager(
-                SchemeRegistryFactory.createDefault(),
-                configuration.getTimeToLive().toMilliseconds(),
-                TimeUnit.MILLISECONDS
-        );
-        manager.setDefaultMaxPerRoute(configuration.getMaxConnections());
-        manager.setMaxTotal(configuration.getMaxConnections());
+        return params;
+    }
 
-        return new InstrumentedHttpClient(manager, params);
+    /**
+     * Create a InstrumentedClientConnManager based on the HttpClientConfiguration. It sets the maximum connections per
+     * route and the maximum total connections that the connection manager can create
+     * @param registry the SchemeRegistry
+     * @return a InstrumentedClientConnManger instance
+     */
+    protected InstrumentedClientConnManager createConnectionManager(SchemeRegistry registry) {
+        long ttl = configuration.getTimeToLive().toMilliseconds();
+        InstrumentedClientConnManager manager = new InstrumentedClientConnManager(registry, ttl, TimeUnit.MILLISECONDS);
+        manager.setDefaultMaxPerRoute(configuration.getMaxConnectionsPerRoute());
+        manager.setMaxTotal(configuration.getMaxConnections());
+        return manager;
     }
 }


### PR DESCRIPTION
HttpClientFactory:
- refactor to allow sub-classes to override creating HTTP params and
  connection manager
- add connection reuse strategy adn keep alive strategy based on
  keepAlive configuration
- remove the use of 'timeout' for 'connectionTimeout' (use the new
  config value instead)

HttpClientFactory:
- add connectionTimeout, maxConnectionsPerRoute, keepAlive

Note: keepAlive default value is 0 - NoConnectionReuseStrategy
