### PR TITLE
Add method path to startup log message

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/config/Environment.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/config/Environment.java
@@ -439,7 +439,7 @@ public class Environment extends AbstractLifeCycle {
                 String methodPath = "";
                 if (method.isAnnotationPresent(Path.class)) {
                     methodPath = method.getAnnotation(Path.class).value();
-                    if (!methodPath.startsWith("/")) {
+                    if (!methodPath.startsWith("/") && !path.endsWith("/")) {
                         methodPath = "/" + methodPath;
                     }
                 }


### PR DESCRIPTION
If a method of class annotated with Path contains a Path annotation itself, add that path to what is logged on start up. Thus if there are multiple GET methods on a class with distinct Path extensions, you can see the difference
