### PR TITLE
Avoid NPE when tearing down test

### DIFF
--- a/dropwizard-testing/src/main/java/com/yammer/dropwizard/testing/ResourceTest.java
+++ b/dropwizard-testing/src/main/java/com/yammer/dropwizard/testing/ResourceTest.java
@@ -77,6 +77,8 @@ public abstract class ResourceTest {
 
     @After
     public void tearDownJersey() throws Exception {
-        test.tearDown();
+        if (test != null) {
+            test.tearDown();
+        }
     }
 }


### PR DESCRIPTION
If setUpResources() throws an exception, the JerseyTest field is never initialized. This causes an NPE later in tearDownJersey() and masks the underlying error.
