### PR TITLE
Move registration of jackson modules into ResourceTest.getJson()

### DIFF
--- a/dropwizard-testing/src/main/java/com/yammer/dropwizard/testing/ResourceTest.java
+++ b/dropwizard-testing/src/main/java/com/yammer/dropwizard/testing/ResourceTest.java
@@ -50,7 +50,11 @@ public abstract class ResourceTest {
     }
 
     protected Json getJson() {
-        return new Json();
+        final Json json = new Json();
+        for (Module module : modules) {
+            json.registerModule(module);
+        }
+        return json;
     }
     
     protected Client client() {
@@ -71,9 +75,6 @@ public abstract class ResourceTest {
                     config.getClasses().add(provider);
                 }
                 Json json = getJson();
-                for (Module module : modules) {
-                    json.registerModule(module);
-                }
                 for (Map.Entry<String, Boolean> feature : features.entrySet()) {
                     config.getFeatures().put(feature.getKey(), feature.getValue());
                 }


### PR DESCRIPTION
This makes ResourceTest behave more like AbstractService and makes it
easier to test with custom providers that need a fully-initialized Json
instance.
