### PR TITLE
Propagate log level changes to JUL

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/config/LoggingFactory.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/config/LoggingFactory.java
@@ -2,6 +2,9 @@ package com.yammer.dropwizard.config;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.jul.LevelChangePropagator;
+import ch.qos.logback.classic.spi.LoggerContextListener;
 import com.google.common.base.Optional;
 import com.yammer.dropwizard.logging.LogbackFactory;
 import com.yammer.dropwizard.logging.LoggingBean;
@@ -97,6 +100,12 @@ public class LoggingFactory {
     private Logger configureLevels() {
         final Logger root = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
         root.getLoggerContext().reset();
+
+        final LevelChangePropagator levelChangePropagator = new LevelChangePropagator();
+        levelChangePropagator.setResetJUL(true);
+
+        root.getLoggerContext().addListener(levelChangePropagator);
+
         root.setLevel(config.getLevel());
 
         for (Map.Entry<String, Level> entry : config.getLoggers().entrySet()) {


### PR DESCRIPTION
`SLF4JBridgeHandler` only sees logs that are actually emitted by `java.util.logging`, and the default logging level for JUL is `INFO`. Because of this, no matter how verbose the Dropwizard logging level is set, it won't get those messages unless the JUL logger is also set to the same level or lower.

Two approaches to this are possible.
1. Set the Level for the root JUL Logger to `ALL`. This is the simplest approach, but has an overhead cost for processing log messages that are not emitted by Logback. This cost is further discussed in the [slf4j docs](http://www.slf4j.org/legacy.html#jul-to-slf4j).
2. Add an instance of `ch.qos.logback.classic.jul.LevelChangePropagator` to the `LoggerContext`. This class listens for logger level changes and makes an equivalent change happen on the JUL Logger with the same name.

This patch takes the second approach. Unfortunately, since the listener needs to be added _after_ the LoggerContext is reset, but _before_ the logging levels are configured, the patch changes `configureLevels` instead of `hijackJDKLogging`. Let me know if you rather I refactor the logging configuration to make this cleaner.
