### PR TITLE
JSON error messages on entity validation and as the server error handler

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/config/ServerFactory.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/config/ServerFactory.java
@@ -7,7 +7,7 @@ import com.google.common.collect.ImmutableSet;
 import com.yammer.dropwizard.jetty.BiDiGzipHandler;
 import com.yammer.dropwizard.jetty.InstrumentedSslSelectChannelConnector;
 import com.yammer.dropwizard.jetty.InstrumentedSslSocketConnector;
-import com.yammer.dropwizard.jetty.QuietErrorHandler;
+import com.yammer.dropwizard.jetty.JsonErrorHandler;
 import com.yammer.dropwizard.logging.Log;
 import com.yammer.dropwizard.servlets.ThreadNameFilter;
 import com.yammer.dropwizard.tasks.TaskServlet;
@@ -97,7 +97,7 @@ public class ServerFactory {
             server.addConnector(createInternalConnector());
         }
 
-        server.addBean(new QuietErrorHandler());
+        server.addBean(new JsonErrorHandler());
 
         server.setSendDateHeader(config.isDateHeaderEnabled());
         server.setSendServerVersion(config.isServerHeaderEnabled());
@@ -140,7 +140,7 @@ public class ServerFactory {
         connector.setResponseHeaderSize((int) config.getResponseHeaderBufferSize().toBytes());
 
         connector.setReuseAddress(config.isReuseAddressEnabled());
-        
+
         final Optional<Duration> lingerTime = config.getSoLingerTime();
 
         if (lingerTime.isPresent()) {
@@ -284,7 +284,7 @@ public class ServerFactory {
         for (Map.Entry<String, String> entry : config.getContextParameters().entrySet()) {
             handler.setInitParameter( entry.getKey(), entry.getValue() );
         }
-        
+
         handler.setConnectorNames(new String[]{"main"});
 
         return wrapHandler(handler);

--- a/dropwizard-core/src/test/java/com/yammer/dropwizard/jersey/JacksonMessageBodyProviderTest.java
+++ b/dropwizard-core/src/test/java/com/yammer/dropwizard/jersey/JacksonMessageBodyProviderTest.java
@@ -117,9 +117,10 @@ public class JacksonMessageBodyProviderTest {
             assertThat(e.getResponse().getStatus(),
                        is(422));
 
-            assertThat((String) e.getResponse().getEntity(),
-                       is("The request entity had the following errors:\n" +
-                                  "  * id must be greater than or equal to 0 (was -1)\n"));
+            final String body = (String) e.getResponse().getEntity();
+
+            assertThat(body,
+                       is("{\"request_entity_errors\":[\"id must be greater than or equal to 0 (was -1)\"]}"));
         }
     }
 


### PR DESCRIPTION
Replaces QuietErrorHandler with JsonErrorHandler, a slightly modified version of the original that returns error messages as a JSON document.

A similar pattern is used for returning entity validation errors as JSON.

The main motivation for this change to is prevent reflected XSS attacks by not returning client-controlled values in a format that could result in script execution in some browser scenarios. With client-controlled values safely formatted in JSON documents, achieving script execution should be far more difficult for an attacker.

Note that I haven't modified the 500 plain text response returned by `com.yammer.dropwizard.jersey.LoggingExceptionMapper`. It may make sense to have that return JSON for consistency, but it does not reflect any client-controlled values and as such poses no known security risk.
