### PR TITLE
Support for configurable AsyncAppender properties in logging configuration

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -442,6 +442,34 @@ other loggers in your YAML configuration file:
         # Overrides the level of com.example.dw.Thing and sets it to DEBUG.
         "com.example.dw.Thing": DEBUG
 
+.. _man-core-logging-appender:
+
+Logging Appender
+----------------
+
+Dropwizard uses logback async appender. You can configure appender properties by
+editing the ``logging`` section of your YAML configuration file:
+
+.. code-block:: yaml
+
+    logging:
+
+      # ...
+      # Async appender properties.
+      appender:
+
+        # The maximum capacity of the blocking queue where appender buffers events. Default queueSize is set to 256.
+        queueSize: 512
+
+        # When the blocking queue has 20% capacity remaining, it will drop events of level TRACE, DEBUG and INFO,
+        # keeping only events of level WARN and ERROR. To keep all events, set discardingThreshold to 0.
+        discardingThreshold: 0
+
+        # Extracting caller data can be rather expensive. To improve performance, by default, caller data associated
+        # with an event is not extracted when the event added to the event queue. By default, only "cheap" data like the
+        # thread name and the MDC are copied. You can include caller data by setting this property to true.
+        includeCallerData: false
+
 .. _man-core-logging-console:
 
 Console Logging

--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/config/LoggingConfiguration.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/config/LoggingConfiguration.java
@@ -17,6 +17,29 @@ import java.util.TimeZone;
 public class LoggingConfiguration {
     static final TimeZone UTC = TimeZone.getTimeZone("UTC");
 
+    public static class AppenderConfiguration {
+        @JsonProperty
+        protected int queueSize;
+
+        @JsonProperty
+        protected int discardingThreshold;
+
+        @JsonProperty
+        protected boolean includeCallerData;
+
+        public int getQueueSize() {
+            return queueSize;
+        }
+
+        public int getDiscardingThreshold() {
+            return discardingThreshold;
+        }
+
+        public boolean isIncludeCallerData() {
+            return includeCallerData;
+        }
+
+    }
     public static class ConsoleConfiguration {
         @JsonProperty
         protected boolean enabled = true;
@@ -183,6 +206,9 @@ public class LoggingConfiguration {
     @JsonProperty
     protected ImmutableMap<String, Level> loggers = ImmutableMap.of();
 
+    @JsonProperty
+    protected AppenderConfiguration appender = new AppenderConfiguration();
+
     @Valid
     @NotNull
     @JsonProperty
@@ -216,5 +242,9 @@ public class LoggingConfiguration {
 
     public SyslogConfiguration getSyslogConfiguration() {
         return syslog;
+    }
+
+    public AppenderConfiguration getAppenderConfiguration() {
+        return appender;
     }
 }

--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/config/LoggingFactory.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/config/LoggingFactory.java
@@ -1,5 +1,6 @@
 package com.yammer.dropwizard.config;
 
+import ch.qos.logback.classic.AsyncAppender;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.jul.LevelChangePropagator;
@@ -48,26 +49,39 @@ public class LoggingFactory {
 
         final Logger root = configureLevels();
 
+        final AppenderConfiguration appenderConfig = config.getAppenderConfiguration();
         final ConsoleConfiguration console = config.getConsoleConfiguration();
         if (console.isEnabled()) {
-            root.addAppender(LogbackFactory.wrapAsync(LogbackFactory.buildConsoleAppender(console,
-                                                                                          root.getLoggerContext(),
-                                                                                          console.getLogFormat())));
+            AsyncAppender appender = (AsyncAppender) LogbackFactory.wrapAsync(LogbackFactory.buildConsoleAppender(console,
+                                                                        root.getLoggerContext(),
+                                                                        console.getLogFormat()));
+            appender.setIncludeCallerData(appenderConfig.isIncludeCallerData());
+            appender.setQueueSize(appenderConfig.getQueueSize());
+            appender.setDiscardingThreshold(appenderConfig.getDiscardingThreshold());
+            root.addAppender(appender);
         }
 
         final FileConfiguration file = config.getFileConfiguration();
         if (file.isEnabled()) {
-            root.addAppender(LogbackFactory.wrapAsync(LogbackFactory.buildFileAppender(file,
-                                                                                       root.getLoggerContext(),
-                                                                                       file.getLogFormat())));
+            AsyncAppender appender = (AsyncAppender) LogbackFactory.wrapAsync(LogbackFactory.buildFileAppender(file,
+                                                                                    root.getLoggerContext(),
+                                                                                    file.getLogFormat()));
+            appender.setIncludeCallerData(appenderConfig.isIncludeCallerData());
+            appender.setQueueSize(appenderConfig.getQueueSize());
+            appender.setDiscardingThreshold(appenderConfig.getDiscardingThreshold());
+            root.addAppender(appender);
         }
 
         final SyslogConfiguration syslog = config.getSyslogConfiguration();
         if (syslog.isEnabled()) {
-            root.addAppender(LogbackFactory.wrapAsync(LogbackFactory.buildSyslogAppender(syslog,
-                                                                                         root.getLoggerContext(),
-                                                                                         name,
-                                                                                         syslog.getLogFormat())));
+            AsyncAppender appender = (AsyncAppender) LogbackFactory.wrapAsync(LogbackFactory.buildSyslogAppender(syslog,
+                                                                                                root.getLoggerContext(),
+                                                                                                name,
+                                                                                                syslog.getLogFormat()));
+            appender.setIncludeCallerData(appenderConfig.isIncludeCallerData());
+            appender.setQueueSize(appenderConfig.getQueueSize());
+            appender.setDiscardingThreshold(appenderConfig.getDiscardingThreshold());
+            root.addAppender(appender);
         }
 
         final MBeanServer server = ManagementFactory.getPlatformMBeanServer();

--- a/dropwizard-core/src/test/java/com/yammer/dropwizard/config/tests/LoggingConfigurationTest.java
+++ b/dropwizard-core/src/test/java/com/yammer/dropwizard/config/tests/LoggingConfigurationTest.java
@@ -13,6 +13,8 @@ import java.io.File;
 
 import static com.yammer.dropwizard.config.LoggingConfiguration.ConsoleConfiguration;
 import static com.yammer.dropwizard.config.LoggingConfiguration.FileConfiguration;
+import static com.yammer.dropwizard.config.LoggingConfiguration.SyslogConfiguration;
+import static com.yammer.dropwizard.config.LoggingConfiguration.AppenderConfiguration;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -37,6 +39,17 @@ public class LoggingConfigurationTest {
     public void hasASetOfOverriddenLevels() throws Exception {
         assertThat(config.getLoggers(),
                    is(ImmutableMap.of("com.example.app", Level.DEBUG)));
+    }
+
+    @Test
+    public void hasAppenderConfiguration() throws Exception {
+        final AppenderConfiguration appenderConfig = config.getAppenderConfiguration();
+        assertThat(appenderConfig.getQueueSize(),
+                   is(512));
+        assertThat(appenderConfig.getDiscardingThreshold(),
+                   is(0));
+        assertThat(appenderConfig.isIncludeCallerData(),
+                is(true));
     }
 
     @Test
@@ -68,5 +81,20 @@ public class LoggingConfigurationTest {
 
         assertThat(file.getArchivedFileCount(),
                    is(5));
+    }
+
+    @Test
+    public void hasSyslogConfiguration() throws Exception {
+        final SyslogConfiguration syslog = config.getSyslogConfiguration();
+
+        assertThat(syslog.isEnabled(),
+                   is(false));
+
+        assertThat(syslog.getHost(),
+                   is("localhost"));
+
+        assertThat(syslog.getFacility(),
+                   is("local0"));
+
     }
 }

--- a/dropwizard-core/src/test/resources/logging.yml
+++ b/dropwizard-core/src/test/resources/logging.yml
@@ -1,6 +1,10 @@
 level: INFO
 loggers:
   com.example.app: DEBUG
+appender:
+  queueSize: 512
+  discardingThreshold: 0
+  includeCallerData: true
 console:
   enabled: true
   threshold: ALL


### PR DESCRIPTION
This can be quite useful for DW apps, especially when systems can handle more than the logback defaults and this provides users an opportunity to configure appenders based on their requirements. 

Would this be useful for DW logging core?
