### PR TITLE
Added missing argument to error message in AssetsBundle

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/bundles/AssetsBundle.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/bundles/AssetsBundle.java
@@ -80,7 +80,7 @@ public class AssetsBundle implements Bundle {
      */
     public AssetsBundle(String resourcePath, CacheBuilderSpec cacheBuilderSpec, String uriPath) {
         checkArgument(resourcePath.startsWith("/"), "%s is not an absolute path", resourcePath);
-        checkArgument(!"/".equals(resourcePath), "%s is the classpath root");
+        checkArgument(!"/".equals(resourcePath), "%s is the classpath root", resourcePath);
         this.resourcePath = resourcePath.endsWith("/") ? resourcePath : (resourcePath + '/');
         this.uriPath = uriPath.endsWith("/") ? uriPath : (uriPath + '/');
         this.cacheBuilderSpec = cacheBuilderSpec;


### PR DESCRIPTION
Just a real minor fix, a checkArgument call had a %s in the error message but was missing the varargs parameter.
