### PR TITLE
Expose count and unit in Size and Duration

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/util/Duration.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/util/Duration.java
@@ -110,6 +110,14 @@ public class Duration {
         this.unit = checkNotNull(unit);
     }
 
+    public long getQuantity() {
+        return count;
+    }
+
+    public TimeUnit getUnit() {
+        return unit;
+    }
+
     public long toNanoseconds() {
         return TimeUnit.NANOSECONDS.convert(count, unit);
     }

--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/util/Size.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/util/Size.java
@@ -93,6 +93,14 @@ public class Size {
         this.unit = checkNotNull(unit);
     }
 
+    public long getQuantity() {
+        return count;
+    }
+
+    public SizeUnit getUnit() {
+        return unit;
+    }
+
     public long toBytes() {
         return SizeUnit.BYTES.convert(count, unit);
     }


### PR DESCRIPTION
It's often useful to use a `Duration` defined in a `Configuration` to provide timing information to parts of `java.util.concurrent`:

``` java
Duration delay = Duration.seconds(1);
executor.schedule(task, delay.toSeconds(), TimeUnit.SECONDS);
```

However, when this `Duration` is defined elsewhere (e.g. in a `Configuration`) it's not possible to know the unit type. Therefore, to ensure no loss in granularity you must use the most fine-grained `TimeUnit`:

``` java
public void schedule(Runnable task, delay: Duration) {
    executor.schedule(task, delay.toNanoseconds(), TimeUnit.NANOSECONDS);
}
```

While under the hood this is always translated to nanoseconds anyway, it creates potentially misleading code, as the reader may erroneously interpret such timings to be miniscule.

As a convenience, it'd be nice if we could ask `Duration` for its quantity and unit explicitly:

``` java
public void schedule(Runnable task, delay: Duration) {
    executor.schedule(task, delay.getQuantity(), delay.getUnit());
}
```

The same is done for `Size` for consistency.
