### PR TITLE
Add Min/Max Constraints for Duration and Size

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/validation/MaxDuration.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/validation/MaxDuration.java
@@ -1,0 +1,39 @@
+package com.yammer.dropwizard.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The annotated element must be a {@link com.yammer.dropwizard.util.Duration}
+ * whose value must be higher or equal to the specified minimum.
+ * <p/>
+ * <code>null</code> elements are considered valid
+ */
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = MaxDurationValidator.class)
+public @interface MaxDuration {
+    String message() default "must be less than or equal to {value} {unit}";
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default {};
+
+    /**
+     * @return value the element must be higher or equal to
+     */
+    long value();
+
+    /**
+     * @return unit of the value the element must be higher or equal to
+     */
+    TimeUnit unit() default TimeUnit.SECONDS;
+}

--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/validation/MaxDurationValidator.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/validation/MaxDurationValidator.java
@@ -1,0 +1,28 @@
+package com.yammer.dropwizard.validation;
+
+import com.yammer.dropwizard.util.Duration;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Check that a {@link Duration} being validated is less than or equal to the
+ * minimum value specified.
+ */
+public class MaxDurationValidator implements ConstraintValidator<MaxDuration, Duration> {
+
+    private long maxQty;
+    private TimeUnit maxUnit;
+
+    @Override
+    public void initialize(MaxDuration minValue) {
+        this.maxQty = minValue.value();
+        this.maxUnit = minValue.unit();
+    }
+
+    @Override
+    public boolean isValid(Duration value, ConstraintValidatorContext constraintValidatorContext) {
+        return value == null || value.toNanoseconds() <= maxUnit.toNanos(maxQty);
+    }
+}

--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/validation/MaxSize.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/validation/MaxSize.java
@@ -1,0 +1,40 @@
+package com.yammer.dropwizard.validation;
+
+import com.yammer.dropwizard.util.SizeUnit;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The annotated element must be a {@link com.yammer.dropwizard.util.Size}
+ * whose value must be higher or equal to the specified minimum.
+ * <p/>
+ * <code>null</code> elements are considered valid
+ */
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = MaxSizeValidator.class)
+public @interface MaxSize {
+    String message() default "must be less than or equal to {value} {unit}";
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default {};
+
+    /**
+     * @return value the element must be higher or equal to
+     */
+    long value();
+
+    /**
+     * @return unit of the value the element must be higher or equal to
+     */
+    SizeUnit unit() default SizeUnit.BYTES;
+}

--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/validation/MaxSizeValidator.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/validation/MaxSizeValidator.java
@@ -1,0 +1,28 @@
+package com.yammer.dropwizard.validation;
+
+import com.yammer.dropwizard.util.Size;
+import com.yammer.dropwizard.util.SizeUnit;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * Check that a {@link Size} being validated is less than or equal to the
+ * minimum value specified.
+ */
+public class MaxSizeValidator implements ConstraintValidator<MaxSize, Size> {
+
+    private long maxQty;
+    private SizeUnit maxUnit;
+
+    @Override
+    public void initialize(MaxSize minValue) {
+        this.maxQty = minValue.value();
+        this.maxUnit = minValue.unit();
+    }
+
+    @Override
+    public boolean isValid(Size value, ConstraintValidatorContext constraintValidatorContext) {
+        return value == null || value.toBytes() <= maxUnit.toBytes(maxQty);
+    }
+}

--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/validation/MinDuration.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/validation/MinDuration.java
@@ -1,0 +1,39 @@
+package com.yammer.dropwizard.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The annotated element must be a {@link com.yammer.dropwizard.util.Duration}
+ * whose value must be higher or equal to the specified minimum.
+ * <p/>
+ * <code>null</code> elements are considered valid
+ */
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = MinDurationValidator.class)
+public @interface MinDuration {
+    String message() default "must be greater than or equal to {value} {unit}";
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default {};
+
+    /**
+     * @return value the element must be higher or equal to
+     */
+    long value();
+
+    /**
+     * @return unit of the value the element must be higher or equal to
+     */
+    TimeUnit unit() default TimeUnit.SECONDS;
+}

--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/validation/MinDurationValidator.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/validation/MinDurationValidator.java
@@ -1,0 +1,28 @@
+package com.yammer.dropwizard.validation;
+
+import com.yammer.dropwizard.util.Duration;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Check that a {@link Duration} being validated is greater than or equal to the
+ * minimum value specified.
+ */
+public class MinDurationValidator implements ConstraintValidator<MinDuration, Duration> {
+
+    private long minQty;
+    private TimeUnit minUnit;
+
+    @Override
+    public void initialize(MinDuration minValue) {
+        this.minQty = minValue.value();
+        this.minUnit = minValue.unit();
+    }
+
+    @Override
+    public boolean isValid(Duration value, ConstraintValidatorContext constraintValidatorContext) {
+        return value == null || value.toNanoseconds() >= minUnit.toNanos(minQty);
+    }
+}

--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/validation/MinSize.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/validation/MinSize.java
@@ -1,0 +1,40 @@
+package com.yammer.dropwizard.validation;
+
+import com.yammer.dropwizard.util.SizeUnit;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The annotated element must be a {@link com.yammer.dropwizard.util.Size}
+ * whose value must be higher or equal to the specified minimum.
+ * <p/>
+ * <code>null</code> elements are considered valid
+ */
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = MinSizeValidator.class)
+public @interface MinSize {
+    String message() default "must be greater than or equal to {value} {unit}";
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default {};
+
+    /**
+     * @return value the element must be higher or equal to
+     */
+    long value();
+
+    /**
+     * @return unit of the value the element must be higher or equal to
+     */
+    SizeUnit unit() default SizeUnit.BYTES;
+}

--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/validation/MinSizeValidator.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/validation/MinSizeValidator.java
@@ -1,0 +1,28 @@
+package com.yammer.dropwizard.validation;
+
+import com.yammer.dropwizard.util.Size;
+import com.yammer.dropwizard.util.SizeUnit;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * Check that a {@link Size} being validated is greater than or equal to the
+ * minimum value specified.
+ */
+public class MinSizeValidator implements ConstraintValidator<MinSize, Size> {
+
+    private long minQty;
+    private SizeUnit minUnit;
+
+    @Override
+    public void initialize(MinSize minValue) {
+        this.minQty = minValue.value();
+        this.minUnit = minValue.unit();
+    }
+
+    @Override
+    public boolean isValid(Size value, ConstraintValidatorContext constraintValidatorContext) {
+        return value == null || value.toBytes() >= minUnit.toBytes(minQty);
+    }
+}

--- a/dropwizard-core/src/test/java/com/yammer/dropwizard/validation/tests/DurationValidatorTest.java
+++ b/dropwizard-core/src/test/java/com/yammer/dropwizard/validation/tests/DurationValidatorTest.java
@@ -1,0 +1,54 @@
+package com.yammer.dropwizard.validation.tests;
+
+import com.google.common.collect.ImmutableList;
+import com.yammer.dropwizard.util.Duration;
+import com.yammer.dropwizard.validation.MaxDuration;
+import com.yammer.dropwizard.validation.MinDuration;
+import com.yammer.dropwizard.validation.Validator;
+import org.junit.Test;
+
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class DurationValidatorTest {
+    @SuppressWarnings("unused")
+    public static class Example {
+        @MaxDuration(value = 30, unit = TimeUnit.SECONDS)
+        private Duration tooBig = Duration.minutes(10);
+
+        @MinDuration(value = 30, unit = TimeUnit.SECONDS)
+        private Duration tooSmall = Duration.milliseconds(100);
+
+        public void setTooBig(Duration tooBig) {
+            this.tooBig = tooBig;
+        }
+        public void setTooSmall(Duration tooSmall) {
+            this.tooSmall = tooSmall;
+        }
+    }
+
+    private final Validator validator = new Validator();
+
+    @Test
+    public void returnsASetOfErrorsForAnObject() throws Exception {
+        if ("en".equals(Locale.getDefault().getLanguage())) {
+            assertThat(validator.validate(new Example()),
+                    is(ImmutableList.of(
+                            "tooBig must be less than or equal to 30 SECONDS (was 10 minutes)",
+                            "tooSmall must be greater than or equal to 30 SECONDS (was 100 milliseconds)")));
+        }
+    }
+
+    @Test
+    public void returnsAnEmptySetForAValidObject() throws Exception {
+        final Example example = new Example();
+        example.setTooBig(Duration.seconds(10));
+        example.setTooSmall(Duration.seconds(100));
+
+        assertThat(validator.validate(example),
+                is(ImmutableList.<String>of()));
+    }
+}

--- a/dropwizard-core/src/test/java/com/yammer/dropwizard/validation/tests/SizeValidatorTest.java
+++ b/dropwizard-core/src/test/java/com/yammer/dropwizard/validation/tests/SizeValidatorTest.java
@@ -1,0 +1,54 @@
+package com.yammer.dropwizard.validation.tests;
+
+import com.google.common.collect.ImmutableList;
+import com.yammer.dropwizard.util.Duration;
+import com.yammer.dropwizard.util.Size;
+import com.yammer.dropwizard.util.SizeUnit;
+import com.yammer.dropwizard.validation.*;
+import org.junit.Test;
+
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class SizeValidatorTest {
+    @SuppressWarnings("unused")
+    public static class Example {
+        @MaxSize(value = 30, unit = SizeUnit.KILOBYTES)
+        private Size tooBig = Size.gigabytes(2);
+
+        @MinSize(value = 30, unit = SizeUnit.KILOBYTES)
+        private Size tooSmall = Size.bytes(100);
+
+        public void setTooBig(Size tooBig) {
+            this.tooBig = tooBig;
+        }
+        public void setTooSmall(Size tooSmall) {
+            this.tooSmall = tooSmall;
+        }
+    }
+
+    private final Validator validator = new Validator();
+
+    @Test
+    public void returnsASetOfErrorsForAnObject() throws Exception {
+        if ("en".equals(Locale.getDefault().getLanguage())) {
+            assertThat(validator.validate(new Example()),
+                    is(ImmutableList.of(
+                            "tooBig must be less than or equal to 30 KILOBYTES (was 2 gigabytes)",
+                            "tooSmall must be greater than or equal to 30 KILOBYTES (was 100 bytes)")));
+        }
+    }
+
+    @Test
+    public void returnsAnEmptySetForAValidObject() throws Exception {
+        final Example example = new Example();
+        example.setTooBig(Size.bytes(10));
+        example.setTooSmall(Size.megabytes(10));
+
+        assertThat(validator.validate(example),
+                is(ImmutableList.<String>of()));
+    }
+}


### PR DESCRIPTION
`Duration` and `Size` are highly useful for `Configuration` classes, keeping them human-readable. However, they're limited to validating manually using `ValidationMethod` only.

Specifying an upper and/or lower bounds on such parameters is a very common case, so lets start with implementations for `@Min` and `@Max`.

Unfortunately, because both `Duration` and `Size` convey more information than just a scalar value (the _unit_ of the value), we cannot simply use `@Min` and `@Max`.
## Duration

`@MinDuration` and `@MaxDuration` constrain the upper and lower bounds of a `Duration` respectively:

``` java
@MinDuration(value = 30, unit = TimeUnit.MINUTES)
@MaxDuration(value = 1, unit = TimeUnit.HOURS)
private Duration timeout = Duration.seconds(1);
```

The _unit_ defaults to `TimeUnit.SECONDS`, so you only need to name parameters if you're providing the unit explcitly:

``` java
@MinDuration(30) // 30 seconds minimum
@MaxDuration(3600) // 3600 seconds (1 hour) minimum
private Duration timeout = Duration.seconds(30);
```

Even if you define all `@MinDuration` and `@MaxDuration` constraints in seconds, this allows Configuration files to define value in any time unit that `Duration` understands.
## Size

`@MinSize` and `@MaxSize` work in much the same way as their sister constraints for `Duration` do, except they constrain a `Size`:

``` java
@MinSize(value = 1, unit = SizeUnit.KILOBYTES)
@MaxSize(value = 1, unit = SizeUnit.MEGABYTES)
private Size receiveBuffer = Size.bytes(1024);
```

The default value for _unit_ here is `SizeUnit.BYTES`, allowing you to easily define everything as bytes:

``` java
@MinSize(1024) // 1KB min
@MaxSize(10240) // 10KB max
private Size receiveBuffer = Size.bytes(1024);
```

Again, this allows `Confiuration` files to describe their properties using any unit that `Size` understands, whilst still being constrained correctly.

Tests included for happy merging. I was considering a `DurationRange` and `SizeRange` too, but I wanted to be sure this would be accepted before heading in too deep.
