### PR TITLE
Add @Range constraint for Size and Duration

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/validation/DurationRange.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/validation/DurationRange.java
@@ -1,0 +1,54 @@
+package com.yammer.dropwizard.validation;
+
+import javax.validation.Constraint;
+import javax.validation.OverridesAttribute;
+import javax.validation.Payload;
+import javax.validation.ReportAsSingleViolation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The annotated element has to be in the appropriate range. Apply on {@link Duration}
+ */
+@Documented
+@Constraint(validatedBy = { })
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
+@Retention(RUNTIME)
+@MinDuration(0)
+@MaxDuration(value = Long.MAX_VALUE, unit = TimeUnit.DAYS)
+@ReportAsSingleViolation
+public @interface DurationRange {
+    @OverridesAttribute(constraint = MinDuration.class, name = "value")
+    long min() default 0;
+
+    @OverridesAttribute(constraint = MaxDuration.class, name = "value")
+    long max() default Long.MAX_VALUE;
+
+    @OverridesAttribute.List({
+        @OverridesAttribute(constraint = MinDuration.class, name = "unit"),
+        @OverridesAttribute(constraint = MaxDuration.class, name = "unit")
+    })
+    TimeUnit unit() default TimeUnit.SECONDS;
+
+    String message() default "must be between {min} {unit} and {max} {unit}";
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default { };
+
+    /**
+     * Defines several {@code @DurationRange} annotations on the same element.
+     */
+    @Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
+    @Retention(RUNTIME)
+    @Documented
+    public @interface List {
+        DurationRange[] value();
+    }
+}

--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/validation/SizeRange.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/validation/SizeRange.java
@@ -1,0 +1,55 @@
+package com.yammer.dropwizard.validation;
+
+import javax.validation.Constraint;
+import javax.validation.OverridesAttribute;
+import javax.validation.Payload;
+import javax.validation.ReportAsSingleViolation;
+
+import com.yammer.dropwizard.util.SizeUnit;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The annotated element has to be in the appropriate range. Apply on {@link Size}
+ */
+@Documented
+@Constraint(validatedBy = { })
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
+@Retention(RUNTIME)
+@MinSize(0)
+@MaxSize(value = Long.MAX_VALUE, unit = SizeUnit.TERABYTES)
+@ReportAsSingleViolation
+public @interface SizeRange {
+    @OverridesAttribute(constraint = MinSize.class, name = "value")
+    long min() default 0;
+
+    @OverridesAttribute(constraint = MaxSize.class, name = "value")
+    long max() default Long.MAX_VALUE;
+
+    @OverridesAttribute.List({
+        @OverridesAttribute(constraint = MinSize.class, name = "unit"),
+        @OverridesAttribute(constraint = MaxSize.class, name = "unit")
+    })
+    SizeUnit unit() default SizeUnit.BYTES;
+
+    String message() default "must be between {min} {unit} and {max} {unit}";
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default { };
+
+    /**
+     * Defines several {@code @SizeRange} annotations on the same element.
+     */
+    @Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
+    @Retention(RUNTIME)
+    @Documented
+    public @interface List {
+        SizeRange[] value();
+    }
+}

--- a/dropwizard-core/src/test/java/com/yammer/dropwizard/validation/tests/DurationValidatorTest.java
+++ b/dropwizard-core/src/test/java/com/yammer/dropwizard/validation/tests/DurationValidatorTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.yammer.dropwizard.util.Duration;
 import com.yammer.dropwizard.validation.MaxDuration;
 import com.yammer.dropwizard.validation.MinDuration;
+import com.yammer.dropwizard.validation.DurationRange;
 import com.yammer.dropwizard.validation.Validator;
 import org.junit.Test;
 
@@ -21,12 +22,18 @@ public class DurationValidatorTest {
 
         @MinDuration(value = 30, unit = TimeUnit.SECONDS)
         private Duration tooSmall = Duration.milliseconds(100);
+        
+        @DurationRange(min = 10, max = 30, unit = TimeUnit.MINUTES)
+        private Duration outOfRange = Duration.minutes(60);
 
         public void setTooBig(Duration tooBig) {
             this.tooBig = tooBig;
         }
         public void setTooSmall(Duration tooSmall) {
             this.tooSmall = tooSmall;
+        }
+        public void setOutOfRange(Duration outOfRange) {
+            this.outOfRange = outOfRange;
         }
     }
 
@@ -37,6 +44,7 @@ public class DurationValidatorTest {
         if ("en".equals(Locale.getDefault().getLanguage())) {
             assertThat(validator.validate(new Example()),
                     is(ImmutableList.of(
+                            "outOfRange must be between 10 MINUTES and 30 MINUTES (was 60 minutes)",
                             "tooBig must be less than or equal to 30 SECONDS (was 10 minutes)",
                             "tooSmall must be greater than or equal to 30 SECONDS (was 100 milliseconds)")));
         }
@@ -47,6 +55,7 @@ public class DurationValidatorTest {
         final Example example = new Example();
         example.setTooBig(Duration.seconds(10));
         example.setTooSmall(Duration.seconds(100));
+        example.setOutOfRange(Duration.minutes(15));
 
         assertThat(validator.validate(example),
                 is(ImmutableList.<String>of()));

--- a/dropwizard-core/src/test/java/com/yammer/dropwizard/validation/tests/SizeValidatorTest.java
+++ b/dropwizard-core/src/test/java/com/yammer/dropwizard/validation/tests/SizeValidatorTest.java
@@ -1,14 +1,15 @@
 package com.yammer.dropwizard.validation.tests;
 
 import com.google.common.collect.ImmutableList;
-import com.yammer.dropwizard.util.Duration;
 import com.yammer.dropwizard.util.Size;
 import com.yammer.dropwizard.util.SizeUnit;
-import com.yammer.dropwizard.validation.*;
+import com.yammer.dropwizard.validation.MaxSize;
+import com.yammer.dropwizard.validation.MinSize;
+import com.yammer.dropwizard.validation.SizeRange;
+import com.yammer.dropwizard.validation.Validator;
 import org.junit.Test;
 
 import java.util.Locale;
-import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -21,12 +22,18 @@ public class SizeValidatorTest {
 
         @MinSize(value = 30, unit = SizeUnit.KILOBYTES)
         private Size tooSmall = Size.bytes(100);
+        
+        @SizeRange(min = 10, max = 100, unit = SizeUnit.KILOBYTES)
+        private Size outOfRange = Size.megabytes(2);
 
         public void setTooBig(Size tooBig) {
             this.tooBig = tooBig;
         }
         public void setTooSmall(Size tooSmall) {
             this.tooSmall = tooSmall;
+        }
+        public void setOutOfRange(Size outOfRange) {
+            this.outOfRange = outOfRange;
         }
     }
 
@@ -37,6 +44,7 @@ public class SizeValidatorTest {
         if ("en".equals(Locale.getDefault().getLanguage())) {
             assertThat(validator.validate(new Example()),
                     is(ImmutableList.of(
+                            "outOfRange must be between 10 KILOBYTES and 100 KILOBYTES (was 2 megabytes)",
                             "tooBig must be less than or equal to 30 KILOBYTES (was 2 gigabytes)",
                             "tooSmall must be greater than or equal to 30 KILOBYTES (was 100 bytes)")));
         }
@@ -47,6 +55,7 @@ public class SizeValidatorTest {
         final Example example = new Example();
         example.setTooBig(Size.bytes(10));
         example.setTooSmall(Size.megabytes(10));
+        example.setOutOfRange(Size.kilobytes(64));
 
         assertThat(validator.validate(example),
                 is(ImmutableList.<String>of()));


### PR DESCRIPTION
Provides a convenience for defining a range constraint on `Duration` and `Size`, using `@MinDuration`, `@MaxDuration`, `@MinSize` and `@MaxSize` that was introduced in #115:

``` java
@DurationRange(min = 10, max = 60, unit = TimeUnit.SECONDS)
private Duration timeout = Duration.seconds(10);

@SizeRange(min = 1024, max = 10240, unit = SizeUnit.KILOBYTES)
private Size chunkSize = Size.megabytes(1);
```

The _unit_ parameter defines the unit for both the _min_ and _max_ parameters; it is not possible to mix quantities of different units in a range constraint.
