### PR TITLE
Add jersey-test-framework-core to POM

### DIFF
--- a/dropwizard-testing/pom.xml
+++ b/dropwizard-testing/pom.xml
@@ -19,6 +19,11 @@
         </dependency>
         <dependency>
             <groupId>com.sun.jersey.jersey-test-framework</groupId>
+            <artifactId>jersey-test-framework-core</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.jersey.jersey-test-framework</groupId>
             <artifactId>jersey-test-framework-inmemory</artifactId>
             <version>${jersey.version}</version>
         </dependency>


### PR DESCRIPTION
While jersey-test-framework-inmemory seems to depend on jersey-test-framework-core Gradle (and probably some other build tools) doesn't add it to the list of dependencies. The dependency list on http://mvnrepository.com/artifact/com.sun.jersey.jersey-test-framework/jersey-test-framework-inmemory/1.12 also doesn't list jersey-test-framework-core.

This problem can easily be fixed by adding the dependency on jersey-test-framework-core to dropwizard-testing's POM file.
