### PR TITLE
Update jdbi version to use the most recent bugfix release (2.37.2).

### DIFF
--- a/dropwizard-db/pom.xml
+++ b/dropwizard-db/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi</artifactId>
-            <version>2.37.1</version>
+            <version>2.37.2</version>
         </dependency>
         <dependency>
             <groupId>com.yammer.metrics</groupId>


### PR DESCRIPTION
This fixes a bug where onDemand sql objects were not properly reentrant relative to the handle in use (not concurrency). See https://github.com/brianm/jdbi/pull/31 .
