### PR TITLE
Don't throw NPE for anonymous HealthChecks

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/config/Environment.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/config/Environment.java
@@ -68,11 +68,13 @@ public class Environment extends AbstractLifeCycle {
             @Override
             public void validate() {
                 super.validate();
-                logResources();
-                logProviders();
-                logHealthChecks();
-                logManagedObjects();
-                logEndpoints();
+                if (LOG.isDebugEnabled()) {
+                    logResources();
+                    logProviders();
+                    logHealthChecks();
+                    logManagedObjects();
+                    logEndpoints();
+                }
             }
         };
         this.healthChecks = ImmutableSet.builder();
@@ -375,8 +377,13 @@ public class Environment extends AbstractLifeCycle {
 
     private void logHealthChecks() {
         final ImmutableSet.Builder<String> builder = ImmutableSet.builder();
-        for (HealthCheck healthCheck : healthChecks.build()) {
-            builder.add(healthCheck.getClass().getCanonicalName());
+        for (final HealthCheck healthCheck : healthChecks.build()) {
+            final String canonicalName = healthCheck.getClass().getCanonicalName();
+            if (canonicalName == null) {
+                builder.add(String.format("%s(\"%s\")", HealthCheck.class.getCanonicalName(), healthCheck.getName()));
+            } else {
+                builder.add(canonicalName);
+            }
         }
         LOG.debug("health checks = {}", builder.build());
     }


### PR DESCRIPTION
This would fail:

``` java

/** Anyonymous Healthchecks don't work because dropwizard
tries to add it's null canonical class name to Immutable list for
debug logging */

environment.addHealthCheck(new HealthCheck("Foo") {
    @Override protected Result check() throws Exception {
        final int status = jerseyClient.resource(resource).path(myPath).post(ClientResponse.class).getStatus();
        if (status != 200) {
            return Result.unhealthy("Foo should have returned 200");
        }
        return Result.healthy();
    }
});
```

These are put into an ImmutableList for debug logging.
1. Only do the list building stuff for logResources, logProviders, etc
   if LOG.isDebugEnabled()
2. Handle null canonical names by logging this instead:

com.yammer.metrics.core.HealthCheck("Foo")

With the name of the healtcheck in parens.
