### PR TITLE
Update pom.xml plugins and add versions plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.2</version>
+                        <version>1.4</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -127,10 +127,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>2.5</version>
                 <configuration>
                     <source>1.6</source>
                     <target>1.6</target>
+                    <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
             <plugin>
@@ -162,7 +163,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>2.3.1</version>
                 <configuration>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <mavenExecutorId>forked-path</mavenExecutorId>
@@ -188,10 +189,16 @@
                     </execution>
                 </executions>
             </plugin>
+            <!--  use mvn versions:display-dependency-updates versions:display-plugin-updates -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>1.3.1</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.0</version>
+                <version>3.1</version>
                 <configuration>
                     <reportPlugins>
                         <plugin>
@@ -216,7 +223,7 @@
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-checkstyle-plugin</artifactId>
-                            <version>2.8</version>
+                            <version>2.9.1</version>
                             <configuration>
                                 <configLocation>http://codahale.com/checkstyle.xml</configLocation>
                                 <encoding>UTF-8</encoding>


### PR DESCRIPTION
Use:

mvn versions:display-dependency-updates versions:display-plugin-updates

To report dependecy & plugin updates. Note that I only updated plugin
dependencies (have been using these versiosn for a few weeks on other
DW projects as well.)

There are also dependency updates, but did NOT changes those (Jersey
is now on 1.13, httpclient on 4.2.1, etc.)
