### PR TITLE
Queueing log events for asynchronous processing loses thread context (i.e., MDC)

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/logging/AsyncAppender.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/logging/AsyncAppender.java
@@ -43,6 +43,7 @@ public class AsyncAppender extends AppenderBase<ILoggingEvent> implements Runnab
 
     @Override
     protected void append(ILoggingEvent eventObject) {
+        eventObject.prepareForDeferredProcessing();
         queue.add(eventObject);
     }
 


### PR DESCRIPTION
Log events need to be prepared for asynchronous processing in order to gather thread-local data (and lazy-loaded properties).
