### PR TITLE
Enhancements to the Log class

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/logging/Log.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/logging/Log.java
@@ -11,8 +11,12 @@ import java.util.Locale;
  * A logger class which provides SLF4J-style formatting without SLF4J's less-than-pleasant API.
  *
  * <code>
+ *
+ * // Explicit class specification
  * private static final Log LOG = Log.forClass(Thingy.class);
  *
+ * // Or, automatic class specification
+ * private static final Log LOG = Log.forThisClass();
  * ...
  *
  * LOG.debug("Simple usage: {} / {}", a, b);
@@ -22,7 +26,22 @@ import java.util.Locale;
  */
 @SuppressWarnings("UnusedDeclaration")
 public class Log {
-    /**
+
+	/**
+	 * Returns a {@link Log} instance for the current class.
+	 * The current class is determined in the static context by inspecting the stack.
+	 * Further details about this approach may be found
+	 * <a href="http://www.javaspecialists.eu/archive/Issue137.html">here</a>.
+	 * 
+	 * @return a {@link Log} instance with the current class name
+	 */
+	public static Log forThisClass() {
+		Throwable t = new Throwable();
+		StackTraceElement directCaller = t.getStackTrace()[1];
+		return named(directCaller.getClassName());
+	}
+
+	/**
      * Returns a {@link Log} instance for the given class.
      *
      * @param klass    a given class


### PR DESCRIPTION
Allow loggers to be created without repetition of class names in a static context. This is achieved by inspecting stack frame, more details here. I've used this code in production systems for a few years now, and think it avoids a large class of copy-paste logger errors some programmers make.

More details about the "inventor" here:
http://www.javaspecialists.eu/archive/Issue137.html
