### PR TITLE
Make service name optional (defualt to Class.getSimpleName() of subclass)

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/AbstractService.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/AbstractService.java
@@ -43,12 +43,13 @@ public abstract class AbstractService<T extends Configuration> {
     private final SortedMap<String, Command> commands;
 
     /**
-     * Creates a new service with the given name.
+     * Creates a new service with the given name. If name is {@code null} the service is named as
+     * the subclass by using {@link Class#getSimpleName()}.
      *
      * @param name    the service's name
      */
     protected AbstractService(String name) {
-        this.name = name;
+        this.name = (name == null) ? getClass().getSimpleName() : name;
         this.bundles = Lists.newArrayList();
         this.configuredBundles = Lists.newArrayList();
         this.modules = Lists.newArrayList();

--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/Service.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/Service.java
@@ -10,10 +10,15 @@ import com.yammer.dropwizard.config.Configuration;
  * @see Configuration
  */
 public abstract class Service<T extends Configuration> extends AbstractService<T> {
+
     protected Service(String name) {
         super(name);
         addBundle(new JavaBundle(this));
         checkForScalaExtensions();
+    }
+
+    protected Service() {
+        this(null);
     }
 
     @Override

--- a/dropwizard-core/src/test/java/com/yammer/dropwizard/tests/ServiceTest.java
+++ b/dropwizard-core/src/test/java/com/yammer/dropwizard/tests/ServiceTest.java
@@ -18,7 +18,6 @@ public class ServiceTest {
 
     private class FakeService extends Service<FakeConfiguration> {
         FakeService() {
-            super("test");
             addBundle(bundle);
         }
 
@@ -43,5 +42,13 @@ public class ServiceTest {
     public void canDetermineConfiguration() throws Exception {
         assertThat(new PoserService().getConfigurationClass(),
                 is(sameInstance(FakeConfiguration.class)));
+    }
+
+    @Test
+    public void defualtNameIsSimpleNameOfServiceClass() throws Exception {
+        assertThat(new FakeService().getName(),
+                is(FakeService.class.getSimpleName()));
+        assertThat(new PoserService().getName(),
+                is(PoserService.class.getSimpleName()));
     }
 }


### PR DESCRIPTION
Since all my services look like this...

``` java
public class ApiService extends Service<ApiConfiguration> {

    protected ApiService() {
        super(ApiService.class.getSimpleName());
    }
}
```

...I'd find it nice to not having to explicitly invoke the parent constructor but rather just have the service being named as the class. Admittedly, the change became somewhat more intrusive than I would have liked it to be.
