### PR TITLE
JacksonMessageBodyProvider should not try to serialize, byte[], String, ...

### DIFF
--- a/dropwizard-core/src/test/java/com/yammer/dropwizard/jersey/JacksonMessageBodyProviderTest.java
+++ b/dropwizard-core/src/test/java/com/yammer/dropwizard/jersey/JacksonMessageBodyProviderTest.java
@@ -49,24 +49,65 @@ public class JacksonMessageBodyProviderTest {
 
     @Test
     public void readsDeserializableTypes() throws Exception {
-        assertThat(provider.isReadable(String.class, null, null, null),
+        assertThat(provider.isReadable(Example.class, null, null, null),
                    is(true));
 
-        verify(json).canDeserialize(String.class);
+        verify(json).canDeserialize(Example.class);
     }
 
     @Test
     public void writesSerializableTypes() throws Exception {
-        assertThat(provider.isWriteable(String.class, null, null, null),
+        assertThat(provider.isWriteable(Example.class, null, null, null),
                    is(true));
 
-        verify(json).canSerialize(String.class);
+        verify(json).canSerialize(Example.class);
     }
 
     @Test
     public void doesNotWriteIgnoredTypes() throws Exception {
         assertThat(provider.isWriteable(Ignorable.class, null, null, null),
                    is(false));
+    }
+
+    @Test
+    public void doesNotWriteDefaultIgnoredTypes() throws Exception {
+        assertThat(provider.isWriteable(byte[].class, null, null, null),
+                   is(false));
+        assertThat(provider.isWriteable(String.class, null, null, null),
+            is(false));
+
+        for (final Class<?> cls : JacksonMessageBodyProvider.DEFAULT_IGNORE) {
+            assertThat(provider.isWriteable(cls, null, null, null),
+                is(false));
+        }
+    }
+
+    @Test
+    public void doesNotWriteNonJsonMediaTypes() throws Exception {
+        assertThat(provider.isWriteable(Example.class, null, null, MediaType.APPLICATION_ATOM_XML_TYPE),
+                   is(false));
+        assertThat(provider.isWriteable(Example.class, null, null, MediaType.APPLICATION_OCTET_STREAM_TYPE),
+            is(false));
+        assertThat(provider.isWriteable(Example.class, null, null, MediaType.TEXT_XML_TYPE),
+            is(false));
+    }
+
+    @Test
+    public void writeJsonMediaTypes() throws Exception {
+        assertThat(provider.isWriteable(Example.class, null, null, MediaType.APPLICATION_JSON_TYPE),
+                   is(true));
+        assertThat(provider.isWriteable(Example.class, null, null, MediaType.valueOf("application/foo+json")),
+            is(true));
+    }
+
+    @Test
+    public void writePossibleJsonMediaTypes() throws Exception {
+        assertThat(provider.isWriteable(Example.class, null, null, null),
+                   is(true));
+        assertThat(provider.isWriteable(Example.class, null, null, MediaType.WILDCARD_TYPE),
+            is(true));
+        assertThat(provider.isWriteable(Example.class, null, null, MediaType.valueOf("application/*")),
+            is(true));
     }
 
     @Test


### PR DESCRIPTION
...InputStream...
- canSerialize will return true for things that could be valid json
  properties. For example, a byte[] is base64 encoded and
  written. That's not really a json object by itself, though. The
  client probably wanted the built-in byte array provider to kick in.
- Added a DEFAULT_IGNORE set of classes to ignore. Similar idea to Tatu's own provider:
  https://github.com/FasterXML/jackson-jaxrs-json-provider/blob/master/src/main/java/com/fasterxml/jackson/jaxrs/json/JacksonJsonProvider.java
- Also check the media type. If it's not set, or looks like any json
  type, we continue with the other checks. If it's a word doc media
  type, well, don't continue.
