### PR TITLE
Correctly log managed object names

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/config/Environment.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/config/Environment.java
@@ -368,19 +368,7 @@ public class Environment extends AbstractLifeCycle {
     private void logManagedObjects() {
         final ImmutableSet.Builder<String> builder = ImmutableSet.builder();
         for (Object bean : lifeCycle.getBeans()) {
-            if (bean instanceof JettyManaged) {
-                bean = ((JettyManaged)bean).getWrappedInstance();
-                String canonicalName = bean.getClass().getCanonicalName();
-                if (bean instanceof ExecutorServiceManager) {
-                    String poolName = ((ExecutorServiceManager)bean).getPoolName();
-                    canonicalName += "(" + poolName + ")";
-                }
-                builder.add(canonicalName);
-            }
-            else {
-                builder.add(bean.getClass().getCanonicalName());
-            }
-
+            builder.add(bean.toString());
         }
         LOG.debug("managed objects = {}", builder.build());
     }

--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/jetty/JettyManaged.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/jetty/JettyManaged.java
@@ -29,10 +29,9 @@ public class JettyManaged extends AbstractLifeCycle implements Managed {
         managed.stop();
     }
 
-    /**
-     * @return the instance wrapped by this JettyManaged object
-     */
-    public Managed getWrappedInstance() {
-        return managed;
+    @Override
+    public String toString() {
+        //Delegate to the wrapped instance
+        return managed.toString();
     }
 }

--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/lifecycle/ExecutorServiceManager.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/lifecycle/ExecutorServiceManager.java
@@ -27,7 +27,9 @@ public class ExecutorServiceManager implements Managed {
         executor.awaitTermination(shutdownPeriod, unit);
     }
 
-    public String getPoolName() {
-        return poolName;
+    @Override
+    public String toString() {
+        return super.toString() + "(" + poolName + ")";
     }
+
 }


### PR DESCRIPTION
This fix ensures that managed objects are correctly logged at startup. Because of the use of a Set, and wrapping with JettyManaged object, before this fix you will generally see a single entry in the logged set:

DEBUG com.yammer.dropwizard.config.Environment: managed objects = [com.yammer.dropwizard.jetty.JettyManaged]

After this fix, you will see the actual classes:

DEBUG com.yammer.dropwizard.config.Environment: managed objects = [x.y.z.MemcacheAccessor, x.y.z.RandomInsultGenerator]

Managed executors are a special case, there is likely to be more than on of same instance, the fix appends the pool's name format for threads to the class name, e.g. you will see:

DEBUG com.yammer.dropwizard.config.Environment: managed objects = [com.yammer.dropwizard.lifecycle.ExecutorServiceManager(foo-{}), com.yammer.dropwizard.lifecycle.ExecutorServiceManager(bar-{})]

While we could do something even neater - giving a pool name instead of using the name format, I think this approach is probably sufficient without making bigger changes and adding new method signatures for Environment.managedExecutorService(...).

Thanks!
