### PR TITLE
Fix logging FileConfiguration validation function.

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/config/LoggingConfiguration.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/config/LoggingConfiguration.java
@@ -93,7 +93,7 @@ public class LoggingConfiguration {
 
         @ValidationMethod(message = "must have logging.file.archivedLogFilenamePattern if logging.file.archive is true")
         public boolean isValidArchiveConfiguration() {
-            return !archive || archivedLogFilenamePattern != null;
+            return !enabled || !archive || archivedLogFilenamePattern != null;
         }
 
         @ValidationMethod(message = "must have logging.file.currentLogFilename if logging.file.enabled is true")

--- a/dropwizard-core/src/test/java/com/yammer/dropwizard/config/tests/LoggingConfigurationTest.java
+++ b/dropwizard-core/src/test/java/com/yammer/dropwizard/config/tests/LoggingConfigurationTest.java
@@ -72,4 +72,12 @@ public class LoggingConfigurationTest {
         assertThat(file.getArchivedFileCount(),
                    is(5));
     }
+    
+    @Test
+    public void defaultFileConfigurationIsValid() throws Exception {
+        final FileConfiguration file = new FileConfiguration();
+        
+        assertThat(file.isValidArchiveConfiguration(),
+                   is(true));
+    }
 }


### PR DESCRIPTION
Check that file logging is actually enabled before checking if the
archive logging configuration is valid. Also add a unit test to check
that the defaults are valid.

This is the same as the fix mentioned on the [user group](https://groups.google.com/d/topic/dropwizard-user/2aE1un1dpN0/discussion).
