### PR TITLE
Add JsonHelpers.jsonRoundTrip(T) and jsonRoundTripWithEquality(T)

### DIFF
--- a/dropwizard-testing/src/main/java/com/yammer/dropwizard/testing/JsonHelpers.java
+++ b/dropwizard-testing/src/main/java/com/yammer/dropwizard/testing/JsonHelpers.java
@@ -1,12 +1,17 @@
 package com.yammer.dropwizard.testing;
 
-import com.yammer.dropwizard.json.Json;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.type.TypeReference;
+import static com.yammer.dropwizard.testing.FixtureHelpers.fixture;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 
-import static com.yammer.dropwizard.testing.FixtureHelpers.fixture;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.type.TypeReference;
+
+import com.yammer.dropwizard.json.Json;
 
 /**
  * A set of helper methods for testing the serialization and deserialization of classes to and from
@@ -74,4 +79,53 @@ public class JsonHelpers {
     public static String jsonFixture(String filename) throws IOException {
         return JSON.writeValueAsString(JSON.readValue(fixture(filename), JsonNode.class));
     }
+    
+    /**
+     * This method will "round trip" test the supplied {@code type} by first serializing it to 
+     * JSON and compare it against the fixture file named as:
+     * "{@code instance.getClass().getSimpleName().toLowerCase()}.json" and then
+     * deserializing the same fixture file to an instance of {@code T}
+     * 
+     * @param type       the instance to serialize and deserialize
+     * @param <T>        the type that {@code json} should be converted to
+     * @return the fixture as an instance of {@code T}
+     * @throws Exception if the fixture file can't be deserialized into an instance of {@code T}
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T jsonRoundTrip(T type) throws Exception {
+        final String klass = type.getClass().getName();
+        final String fixtureName = type.getClass().getSimpleName().toLowerCase();
+        final String fixture = jsonFixture("fixtures/" + fixtureName + ".json");
+        assertThat(klass + " bad json,",
+                asJson(type),
+                is(fixture));
+        try {
+            return fromJson(fixture, (Class<T>)type.getClass());
+        }
+        catch(final Exception e) {
+            throw new Exception("Can't deserialize:\n" + asJson(type), e);
+        }
+    }
+
+    /**
+     * This method will first call {@link JsonHelpers#jsonRoundTrip(Object)} and in addition
+     * also verify that the supplied {@code type} is equal to the deserialized instance and
+     * that they both return the same hashcode.
+     * 
+     * @param type the instance to serialize and deserialize
+     * @return the fixture as an instance of {@code T}
+     * @throws Exception if the fixture file can't be deserialized into an instance of {@code T}
+     */
+    public static <T> T jsonRoundTripWithEquality(T type) throws Exception {
+        final String klass = type.getClass().getName();
+        final T deserialized = jsonRoundTrip(type);
+        assertEquals(klass + " bad equals,",
+                deserialized,
+                type);
+        assertEquals(klass + " bad hashcode,",
+                deserialized.hashCode(),
+                type.hashCode());
+        return deserialized;
+    }
+
 }

--- a/dropwizard-testing/src/test/java/com/yammer/dropwizard/testing/tests/JsonHelpersTest.java
+++ b/dropwizard-testing/src/test/java/com/yammer/dropwizard/testing/tests/JsonHelpersTest.java
@@ -1,5 +1,8 @@
 package com.yammer.dropwizard.testing.tests;
 
+import java.util.Random;
+
+import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.type.TypeReference;
 import org.junit.Test;
 
@@ -29,5 +32,31 @@ public class JsonHelpersTest {
 
         assertThat(fromJson(jsonFixture("fixtures/person.json"), new TypeReference<Person>() {}),
                    is(new Person("Coda", "coda@example.com")));
+    }
+    
+    @Test
+    public void succesfulRoundTrip() throws Exception {
+        jsonRoundTrip(new Person("Coda", "coda@example.com"));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void failingRoundTrip() throws Exception {
+        jsonRoundTrip(new Person("Mårten", "marten@example.com"));
+    }
+
+    @Test
+    public void succesfulRoundTripWithEquality() throws Exception {
+        jsonRoundTripWithEquality(new Person("Coda", "coda@example.com"));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void roundTripWithBadEquals() throws Exception {
+        jsonRoundTripWithEquality(new BadEquality());
+    }
+    
+    public static class BadEquality {
+        @JsonProperty private String value = "value";
+        
+        BadEquality() { /* Jackson deserialization */ }
     }
 }

--- a/dropwizard-testing/src/test/resources/fixtures/badequality.json
+++ b/dropwizard-testing/src/test/resources/fixtures/badequality.json
@@ -1,0 +1,3 @@
+{
+    "value": "value"
+}


### PR DESCRIPTION
Convenience methods for testing serialization and deserialization (with optional equals/hashcode test) of representation classes
