### PR TITLE
Allow disabling request entity compression.

### DIFF
--- a/dropwizard-client/src/main/java/com/yammer/dropwizard/client/JerseyClientConfiguration.java
+++ b/dropwizard-client/src/main/java/com/yammer/dropwizard/client/JerseyClientConfiguration.java
@@ -16,6 +16,8 @@ public class JerseyClientConfiguration extends HttpClientConfiguration {
 
     private boolean gzipEnabled = true;
 
+    private boolean compressRequestEntity = true;
+
     public int getMinThreads() {
         return minThreads;
     }
@@ -40,8 +42,22 @@ public class JerseyClientConfiguration extends HttpClientConfiguration {
         this.gzipEnabled = enable;
     }
 
+    public boolean isCompressRequestEntity() {
+        return compressRequestEntity;
+    }
+
+    public void setCompressRequestEntity(boolean compressRequestEntity) {
+        this.compressRequestEntity = compressRequestEntity;
+    }
+
     @ValidationMethod(message = ".minThreads must be less than or equal to maxThreads")
     public boolean isThreadPoolSizedCorrectly() {
         return minThreads <= maxThreads;
     }
+    
+    @ValidationMethod(message = ".compressRequestEntity requires gzipEnabled set to true")
+    public boolean isCompressionConfigurationValid() {
+        return compressRequestEntity ? gzipEnabled : true; 
+    }
+    
 }

--- a/dropwizard-client/src/main/java/com/yammer/dropwizard/client/JerseyClientFactory.java
+++ b/dropwizard-client/src/main/java/com/yammer/dropwizard/client/JerseyClientFactory.java
@@ -57,7 +57,7 @@ public class JerseyClientFactory {
                                                                            TimeUnit.SECONDS));
 
         if (configuration.isGzipEnabled()) {
-            jerseyClient.addFilter(new GZIPContentEncodingFilter());
+            jerseyClient.addFilter(new GZIPContentEncodingFilter(configuration.isCompressRequestEntity()));
         }
 
         return jerseyClient;


### PR DESCRIPTION
Some servers cannot handle compressed request entities. This patch adds the ability to disable compressing the request entity. It does not affect decompressing the response.
