### PR TITLE
Add GenericType methods to JerseyClient

### DIFF
--- a/dropwizard-client/src/main/java/com/yammer/dropwizard/client/JerseyClient.java
+++ b/dropwizard-client/src/main/java/com/yammer/dropwizard/client/JerseyClient.java
@@ -1,5 +1,6 @@
 package com.yammer.dropwizard.client;
 
+import com.sun.jersey.api.client.GenericType;
 import com.sun.jersey.api.client.config.ClientConfig;
 import com.sun.jersey.client.apache4.ApacheHttpClient4;
 import com.sun.jersey.client.apache4.ApacheHttpClient4Handler;
@@ -16,7 +17,15 @@ public class JerseyClient extends ApacheHttpClient4 {
         return resource(uri).accept(acceptedMediaType).get(klass);
     }
 
+    public <T> T get(URI uri, MediaType acceptedMediaType, GenericType<T> klass) {
+        return resource(uri).accept(acceptedMediaType).get(klass);
+    }
+
     public <T> T put(URI uri, MediaType contentType, Object entity, Class<T> returnType) {
+        return resource(uri).type(contentType).put(returnType, entity);
+    }
+
+    public <T> T put(URI uri, MediaType contentType, Object entity, GenericType<T> returnType) {
         return resource(uri).type(contentType).put(returnType, entity);
     }
 
@@ -24,7 +33,15 @@ public class JerseyClient extends ApacheHttpClient4 {
         return resource(uri).type(contentType).post(returnType, entity);
     }
 
+    public <T> T post(URI uri, MediaType contentType, Object entity, GenericType<T> returnType) {
+        return resource(uri).type(contentType).post(returnType, entity);
+    }
+
     public <T> T delete(URI uri, Class<T> klass) {
+        return resource(uri).delete(klass);
+    }
+
+    public <T> T delete(URI uri, GenericType<T> klass) {
         return resource(uri).delete(klass);
     }
 }


### PR DESCRIPTION
In order to allow for things like:

jerseyClient.get(..., ..., new GenericType<Collection<Foo>>() {});

You need to have the GenericType methods exposed on JerseyClient.  Easy fix :-)
