### PR TITLE
Update to current JDBI Version

### DIFF
--- a/dropwizard-db/pom.xml
+++ b/dropwizard-db/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi</artifactId>
-            <version>2.38.1</version>
+            <version>2.39</version>
         </dependency>
         <dependency>
             <groupId>com.yammer.metrics</groupId>


### PR DESCRIPTION
JDBI 2.39 provides better StringTemplate statement location mechanisms. Out of the box it should make no difference to dropwizard, but it's good to be on the current version.
