### PR TITLE
Added property support for Jersey Config of ResourceTest

### DIFF
--- a/dropwizard-testing/src/main/java/com/yammer/dropwizard/testing/ResourceTest.java
+++ b/dropwizard-testing/src/main/java/com/yammer/dropwizard/testing/ResourceTest.java
@@ -27,6 +27,7 @@ public abstract class ResourceTest {
     private final Set<Class<?>> providers = Sets.newHashSet();
     private final List<Module> modules = Lists.newArrayList();
     private final Map<String, Boolean> features = Maps.newHashMap();
+    private final Map<String, Object> properties = Maps.newHashMap();
 
     private JerseyTest test;
 
@@ -46,6 +47,10 @@ public abstract class ResourceTest {
 
     protected void addFeature(String feature, Boolean value) {
         features.put(feature, value);
+    }
+
+    protected void addProperty(String property, Object value) {
+        properties.put(property, value);
     }
 
     protected Json getJson() {
@@ -76,6 +81,9 @@ public abstract class ResourceTest {
                 final Json json = getJson();
                 for (Map.Entry<String, Boolean> feature : features.entrySet()) {
                     config.getFeatures().put(feature.getKey(), feature.getValue());
+                }
+                for (Map.Entry<String, Object> property : properties.entrySet()) {
+                    config.getProperties().put(property.getKey(), property.getValue());
                 }
                 config.getSingletons().add(new JacksonMessageBodyProvider(json));
                 config.getSingletons().addAll(singletons);


### PR DESCRIPTION
ResourceTest do not have a point for registering jersey configurations e.g. ResourceFilterFactory. This change lets the ResourceTest subclasses to add properties to Jersey Configuration.
