### PR TITLE
Fix support for Optional resource method parameters in test

### DIFF
--- a/dropwizard-testing/src/main/java/com/yammer/dropwizard/testing/ResourceTest.java
+++ b/dropwizard-testing/src/main/java/com/yammer/dropwizard/testing/ResourceTest.java
@@ -72,8 +72,8 @@ public abstract class ResourceTest {
             @Override
             protected AppDescriptor configure() {
                 final DropwizardResourceConfig config = new DropwizardResourceConfig(true);
-                for (Object provider : JavaBundle.DEFAULT_PROVIDERS) { // sorry, Scala folks
-                    config.getSingletons().add(provider);
+                for (Class<?> provider : JavaBundle.DEFAULT_PROVIDERS) { // sorry, Scala folks
+                    config.getClasses().add(provider);
                 }
                 for (Class<?> provider : providers) {
                     config.getClasses().add(provider);


### PR DESCRIPTION
The fix for issue #111 broke the use of Optional params in tests.
