### PR TITLE
Fixed an incorrect class-name in the OAuth example.

### DIFF
--- a/docs/source/manual/auth.rst
+++ b/docs/source/manual/auth.rst
@@ -98,7 +98,7 @@ which takes an instance of ``String``.
     @Override
     protected void initialize(ExampleConfiguration configuration,
                               Environment environment) {
-        environment.addProvider(new BasicAuthProvider<User>(new ExampleAuthenticator(),
+        environment.addProvider(new OAuthProvider<User>(new ExampleAuthenticator(),
                                                             "SUPER SECRET STUFF"));
     }
 


### PR DESCRIPTION
The example code found in the documentation for dropwizard-auth has a copy&paste mistake. 

In the section about OAuth2 authentication, the example uses the BasicAuthProvider.
