### PR TITLE
Support for alternate database connection pools

### DIFF
--- a/dropwizard-db/src/main/java/com/yammer/dropwizard/db/Database.java
+++ b/dropwizard-db/src/main/java/com/yammer/dropwizard/db/Database.java
@@ -7,22 +7,22 @@ import com.yammer.dropwizard.db.logging.LogbackLog;
 import com.yammer.dropwizard.lifecycle.Managed;
 import com.yammer.metrics.Metrics;
 import com.yammer.metrics.jdbi.InstrumentedTimingCollector;
-import org.apache.tomcat.dbcp.pool.ObjectPool;
 import org.skife.jdbi.v2.ColonPrefixNamedParamStatementRewriter;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
 import javax.sql.DataSource;
 import java.sql.SQLException;
 
 public class Database extends DBI implements Managed {
     private static final Logger LOGGER = (Logger) LoggerFactory.getLogger(Database.class);
 
-    private final ObjectPool pool;
+    private final Closeable pool;
     private final String validationQuery;
 
-    public Database(DataSource dataSource, ObjectPool pool, String validationQuery) {
+    public Database(DataSource dataSource, Closeable pool, String validationQuery) {
         super(dataSource);
         this.pool = pool;
         this.validationQuery = validationQuery;


### PR DESCRIPTION
This minor change removes the Tomcat DBCP dependency from the Database class without losing any functionality. This will allow users to substitute another database pooling provider if they chose to do so.
#### Background

DBCP is causing problems in our staging environments at Gilt since it doesn't seem to be gracefully handling the instability (database, network, etc) in our test systems. We use C3P0 for all of our services here, and it seems to be working far better with dropwizard-db and our systems compared to DBCP.

I also have a C3P0DatabaseFactory class which is able to fully configure an instance of a C3P0 pool – using the existing DatabaseConfiguration class – suitable for passing to new Database(). I can provide that factory as a helpful alternative and companion to this change if you'd like.
