### PR TITLE
Freemarker + Encoding Mappings

### DIFF
--- a/dropwizard-views/src/main/java/com/yammer/dropwizard/views/freemarker/FreemarkerViewRenderer.java
+++ b/dropwizard-views/src/main/java/com/yammer/dropwizard/views/freemarker/FreemarkerViewRenderer.java
@@ -24,6 +24,7 @@ public class FreemarkerViewRenderer implements ViewRenderer {
         public Configuration load(Class<?> key) throws Exception {
             final Configuration configuration = new Configuration();
             configuration.setObjectWrapper(new DefaultObjectWrapper());
+            configuration.loadBuiltInEncodingMap();
             configuration.setDefaultEncoding(Charsets.UTF_8.name());
             configuration.setClassForTemplateLoading(key, "/");
             return configuration;


### PR DESCRIPTION
I've attached a quick 1-liner pull request that loads the default encoding mappings when building the Freemarker configuration.

Previously it was setting a default encoding of UTF-8, but not having any mechanism to use anything locale-specific.
