### PR TITLE
SSL improvements to allow Windows key stores.

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/config/SslConfiguration.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/config/SslConfiguration.java
@@ -18,6 +18,9 @@ public class SslConfiguration {
     @JsonProperty
     private String keyStoreType = "JKS";
 
+    @JsonProperty
+    private String certAlias = null;
+
     @NotEmpty
     @JsonProperty
     protected ImmutableList<String> supportedProtocols = ImmutableList.of("SSLv3",
@@ -39,6 +42,10 @@ public class SslConfiguration {
 
     public Optional<String> getKeyStoreType() {
         return Optional.fromNullable(keyStoreType);
+    }
+
+    public Optional<String> getCertAlias() {
+        return Optional.fromNullable(certAlias);
     }
 
     public String[] getSupportedProtocols() {


### PR DESCRIPTION
This patch allows dropwizard to be configured to use Windows certificate stores accessed by the `SunMSCAPI` provider introduced in Java 6. The `KeyStore` has to be loaded manually, as Jetty's `SslContextFactory` doesn't properly load the `KeyStore` just based on type.

Also, in a development environment the Windows certificate store will often contain many private keys, and it's necessary to let Jetty know which one to use. This patch adds configuration for the `certAlias` parameter of Jetty's `SslContextFactory`.
