### PR TITLE
bootstrapping changed slightly

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/Service.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/Service.java
@@ -57,7 +57,7 @@ public abstract class Service<T extends Configuration> {
      *
      * @param bootstrap the service bootstrap
      */
-    public abstract void initialize(Bootstrap<T> bootstrap);
+    public abstract void initialize(Bootstrap<T> bootstrap, Environment environment);
 
     /**
      * When the service runs, this is called after the {@link Bundle}s are run. Override it to add
@@ -81,7 +81,6 @@ public abstract class Service<T extends Configuration> {
         final Bootstrap<T> bootstrap = new Bootstrap<T>(this);
         bootstrap.addCommand(new ServerCommand<T>(this));
         bootstrap.addBundle(new BasicBundle());
-        initialize(bootstrap);
         final Cli cli = new Cli(this.getClass(), bootstrap);
         cli.run(arguments);
     }

--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/cli/EnvironmentCommand.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/cli/EnvironmentCommand.java
@@ -32,6 +32,7 @@ public abstract class EnvironmentCommand<T extends Configuration> extends Config
         final Environment environment = new Environment(bootstrap.getName(),
                                                         configuration,
                                                         bootstrap.getObjectMapperFactory().copy());
+        service.initialize(bootstrap, environment);
         bootstrap.runWithBundles(configuration, environment);
         service.run(configuration, environment);
         run(environment, namespace, configuration);

--- a/dropwizard-core/src/test/java/com/yammer/dropwizard/tests/ServiceTest.java
+++ b/dropwizard-core/src/test/java/com/yammer/dropwizard/tests/ServiceTest.java
@@ -18,7 +18,7 @@ public class ServiceTest {
 
     private class FakeService extends Service<FakeConfiguration> {
         @Override
-        public void initialize(Bootstrap<FakeConfiguration> bootstrap) {
+        public void initialize(Bootstrap<FakeConfiguration> bootstrap, Environment environment) {
             bootstrap.addBundle(bundle);
         }
 

--- a/dropwizard-example/src/main/java/com/example/helloworld/HelloWorldService.java
+++ b/dropwizard-example/src/main/java/com/example/helloworld/HelloWorldService.java
@@ -26,7 +26,8 @@ public class HelloWorldService extends Service<HelloWorldConfiguration> {
     }
 
     @Override
-    public void initialize(Bootstrap<HelloWorldConfiguration> bootstrap) {
+    public void initialize(Bootstrap<HelloWorldConfiguration> bootstrap,
+                           Environment environment) {
         bootstrap.setName("hello-world");
         bootstrap.addCommand(new RenderCommand());
         bootstrap.addBundle(new AssetsBundle());

--- a/dropwizard-scala_2.9.1/src/main/scala/com/yammer/dropwizard/ScalaService.scala
+++ b/dropwizard-scala_2.9.1/src/main/scala/com/yammer/dropwizard/ScalaService.scala
@@ -1,11 +1,11 @@
 package com.yammer.dropwizard
 
-import config.{Bootstrap, Configuration}
+import config.{Environment, Bootstrap, Configuration}
 import bundles.ScalaBundle
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 
 abstract class ScalaService[T <: Configuration] extends Service[T] {
-  override def initialize(bootstrap: Bootstrap[T]) {
+  override def initialize(bootstrap: Bootstrap[T], environment: Environment ) {
     bootstrap.addBundle(new ScalaBundle())
     // TODO: 10/3/12 <coda> -- move this to the bundle when bundles can hook into the bootstrap
     bootstrap.getObjectMapperFactory.registerModule(new DefaultScalaModule)

--- a/dropwizard-scala_2.9.1/src/test/scala/com/yammer/dropwizard/examples/ExampleService.scala
+++ b/dropwizard-scala_2.9.1/src/test/scala/com/yammer/dropwizard/examples/ExampleService.scala
@@ -4,8 +4,8 @@ import com.yammer.dropwizard.config.{Bootstrap, Environment}
 import com.yammer.dropwizard.{Logging, ScalaService}
 
 object ExampleService extends ScalaService[ExampleConfiguration] with Logging {
-  override def initialize(bootstrap: Bootstrap[ExampleConfiguration]) {
-    super.initialize(bootstrap)
+  override def initialize(bootstrap: Bootstrap[ExampleConfiguration], environment: Environment) {
+    super.initialize(bootstrap,environment)
     bootstrap.addCommand(new SayCommand)
     bootstrap.addCommand(new SplodyCommand)
   }

--- a/dropwizard-views/src/test/java/com/yammer/dropwizard/views/example/TemplateService.java
+++ b/dropwizard-views/src/test/java/com/yammer/dropwizard/views/example/TemplateService.java
@@ -12,7 +12,7 @@ public class TemplateService extends Service<Configuration> {
     }
 
     @Override
-    public void initialize(Bootstrap<Configuration> bootstrap) {
+    public void initialize(Bootstrap<Configuration> bootstrap, Environment environment) {
         bootstrap.setName("template");
         bootstrap.addBundle(new ViewBundle());
     }


### PR DESCRIPTION
Bundles which depends on Environment suffering initializing order. Our bundles depends on Database and DBIFactory depends on Environment which is restricting bundle scopes greatly.

In this pull request Environment parameter was added to init method of the service.

Maybe this is not exactly in your mind to solve this problem but It would be great to elaborate on this issue. 
