### PR TITLE
Cleanup Scala Service initialization

### DIFF
--- a/dropwizard-scala_2.9.1/src/main/java/com/yammer/dropwizard/bundles/ScalaBundle.java
+++ b/dropwizard-scala_2.9.1/src/main/java/com/yammer/dropwizard/bundles/ScalaBundle.java
@@ -1,10 +1,19 @@
 package com.yammer.dropwizard.bundles;
 
+import com.fasterxml.jackson.module.scala.DefaultScalaModule;
 import com.yammer.dropwizard.Bundle;
+import com.yammer.dropwizard.config.Bootstrap;
 import com.yammer.dropwizard.config.Environment;
 import com.yammer.dropwizard.scala.inject.ScalaCollectionsQueryParamInjectableProvider;
 
 public class ScalaBundle extends Bundle {
+
+    @Override
+    public void initialize(final Bootstrap<?> bootstrap) {
+        bootstrap.addBundle(new ScalaBundle());
+        bootstrap.getObjectMapperFactory().registerModule(new DefaultScalaModule());
+    }
+
     @Override
     public void run(Environment environment) {
         environment.addProvider(new ScalaCollectionsQueryParamInjectableProvider());

--- a/dropwizard-scala_2.9.1/src/main/scala/com/yammer/dropwizard/ScalaService.scala
+++ b/dropwizard-scala_2.9.1/src/main/scala/com/yammer/dropwizard/ScalaService.scala
@@ -1,16 +1,8 @@
 package com.yammer.dropwizard
 
-import config.{Bootstrap, Configuration}
-import bundles.ScalaBundle
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import config.Configuration
 
 abstract class ScalaService[T <: Configuration] extends Service[T] {
-  override def initialize(bootstrap: Bootstrap[T]) {
-    bootstrap.addBundle(new ScalaBundle())
-    // TODO: 10/3/12 <coda> -- move this to the bundle when bundles can hook into the bootstrap
-    bootstrap.getObjectMapperFactory.registerModule(new DefaultScalaModule)
-  }
-
   final def main(args: Array[String]) {
     run(args)
   }

--- a/dropwizard-scala_2.9.1/src/test/scala/com/yammer/dropwizard/examples/ExampleService.scala
+++ b/dropwizard-scala_2.9.1/src/test/scala/com/yammer/dropwizard/examples/ExampleService.scala
@@ -4,8 +4,7 @@ import com.yammer.dropwizard.config.{Bootstrap, Environment}
 import com.yammer.dropwizard.{Logging, ScalaService}
 
 object ExampleService extends ScalaService[ExampleConfiguration] with Logging {
-  override def initialize(bootstrap: Bootstrap[ExampleConfiguration]) {
-    super.initialize(bootstrap)
+  def initialize(bootstrap: Bootstrap[ExampleConfiguration]) {
     bootstrap.addCommand(new SayCommand)
     bootstrap.addCommand(new SplodyCommand)
   }


### PR DESCRIPTION
Now that Bundles can hook in to the Bootstrap process, we can move all the Scala customizations from `ScalaService` to `ScalaBundle`.

`ScalaService` remains solely to provide the default `main` method for Scala Services.
