### PR TITLE
JerseyClientFactory now accepts a HttpClientFactory

### DIFF
--- a/dropwizard-client/src/main/java/com/yammer/dropwizard/client/JerseyClientFactory.java
+++ b/dropwizard-client/src/main/java/com/yammer/dropwizard/client/JerseyClientFactory.java
@@ -22,8 +22,13 @@ public class JerseyClientFactory {
     private final ApacheHttpClient4Config config;
 
     public JerseyClientFactory(JerseyClientConfiguration configuration) {
+        this(configuration, new HttpClientFactory(configuration));
+    }
+
+    public JerseyClientFactory(JerseyClientConfiguration configuration,
+                               HttpClientFactory httpClientFactory) {
         this.configuration = configuration;
-        this.factory = new HttpClientFactory(configuration);
+        this.factory = httpClientFactory;
         this.config = new DefaultApacheHttpClient4Config();
     }
 


### PR DESCRIPTION
In order to start support client-certificate based authentication, there needs to be a way to configure the HttpClient.
