### PR TITLE
Fix async log clean shutdown, and test

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/jetty/AsyncRequestLog.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/jetty/AsyncRequestLog.java
@@ -60,7 +60,7 @@ public class AsyncRequestLog extends AbstractLifeCycle implements RequestLog {
         }
 
         public void stop() {
-            this.running = true;
+            this.running = false;
         }
     }
 
@@ -105,6 +105,11 @@ public class AsyncRequestLog extends AbstractLifeCycle implements RequestLog {
         dispatcher.stop();
     }
 
+    // for testing
+    public boolean isThreadAlive() {
+        return dispatchThread.isAlive();
+    }
+    
     @Override
     public void log(Request request, Response response) {
         // copied almost entirely from NCSARequestLog

--- a/dropwizard-core/src/test/java/com/yammer/dropwizard/jetty/tests/AsyncRequestLogTest.java
+++ b/dropwizard-core/src/test/java/com/yammer/dropwizard/jetty/tests/AsyncRequestLogTest.java
@@ -1,0 +1,28 @@
+package com.yammer.dropwizard.jetty.tests;
+
+import static org.mockito.Mockito.mock;
+
+import java.util.TimeZone;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import ch.qos.logback.core.spi.AppenderAttachableImpl;
+
+import com.yammer.dropwizard.jetty.AsyncRequestLog;
+
+public class AsyncRequestLogTest {
+    private final AppenderAttachableImpl appender = mock(AppenderAttachableImpl.class);
+    private final AsyncRequestLog asyncRequestLog = new AsyncRequestLog(appender, TimeZone.getDefault());
+
+    @Test
+    public void startsAndStops() throws Exception {
+        asyncRequestLog.start();
+        asyncRequestLog.stop();
+        for (int i=0; i<100; i++) {
+            if (!asyncRequestLog.isThreadAlive()) break;
+            Thread.sleep(100);
+        }
+        Assert.assertFalse(asyncRequestLog.isThreadAlive());
+    }
+}


### PR DESCRIPTION
Have been having problems where my tests don't stop cleanly.  The root problem (in AsyncAppender.stop) seems already to have been fixed in 0.6.0-SNAPSHOT.  But I noticed this probably also deserved fixing.

The test fails without the change to AsyncRequestLog.Dispatcher.stop(), passes with that change.
