### PR TITLE
Include rootPath when logging end points.

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/config/Environment.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/config/Environment.java
@@ -473,7 +473,13 @@ public class Environment extends AbstractLifeCycle {
             final String path = klass.getAnnotation(Path.class).value();
             final ImmutableList.Builder<String> endpoints = ImmutableList.builder();
             for (AnnotatedMethod method : annotatedMethods(klass)) {
-                final StringBuilder pathBuilder = new StringBuilder(path);
+                String rootPath = configuration.getHttpConfiguration().getRootPath();
+                if (rootPath.endsWith("/*")) {
+                    rootPath = rootPath.substring(0, rootPath.length()-2);
+                }
+                final StringBuilder pathBuilder = new StringBuilder()
+                        .append(rootPath)
+                        .append(path);
                 if (method.isAnnotationPresent(Path.class)) {
                     final String methodPath = method.getAnnotation(Path.class).value();
                     if (!methodPath.startsWith("/") && !path.endsWith("/")) {


### PR DESCRIPTION
Presently it can be a bit confusing when starting a Dropwizard service that overrides the HTTP rootPath in the config file because Dropwizard logs the end point paths, but doesn't include the rootPath.  For example:

```
INFO  [2012-11-08 02:54:20,356] com.yammer.dropwizard.config.Environment: 

    GET     /resource1 (com.example.Resource1)
    GET     /resource2 (com.example.Resource2)
```

The implication is that hitting http://localhost:8080/resource1 will result in the Resource1 resource being used to service the request.  In reality if a rootPath is specified, a 404 will be returned instead.

This change causes the rootPath to be emitted with the end points so that what ends up being logged is the complete path necessary to reach the resource.  For example, if rootPath were specified as `/api/*` then the preceding example would log:

```
INFO  [2012-11-08 02:54:20,356] com.yammer.dropwizard.config.Environment: 

    GET     /api/resource1 (com.example.Resource1)
    GET     /api/resource2 (com.example.Resource2)
```
