### PR TITLE
Fix compilation errors on Java 6 (1.6.0_37)

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/cli/ConfiguredCommand.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/cli/ConfiguredCommand.java
@@ -29,9 +29,8 @@ public abstract class ConfiguredCommand<T extends Configuration> extends Command
      *
      * @return the {@link Class} of the configuration type
      */
-    @SuppressWarnings("unchecked")
     protected Class<T> getConfigurationClass() {
-        return (Class<T>) Generics.getTypeParameter(getClass(), Configuration.class);
+        return Generics.getTypeParameter(getClass(), Configuration.class);
     }
 
     /**

--- a/dropwizard-migrations/src/main/java/com/yammer/dropwizard/migrations/MigrationsBundle.java
+++ b/dropwizard-migrations/src/main/java/com/yammer/dropwizard/migrations/MigrationsBundle.java
@@ -10,8 +10,7 @@ import com.yammer.dropwizard.util.Generics;
 public abstract class MigrationsBundle<T extends Configuration> implements Bundle, ConfigurationStrategy<T> {
     @Override
     public final void initialize(Bootstrap<?> bootstrap) {
-        @SuppressWarnings("unchecked")
-        final Class<T> klass = (Class<T>) Generics.getTypeParameter(getClass(), Configuration.class);
+        final Class<T> klass = Generics.getTypeParameter(getClass(), Configuration.class);
         bootstrap.addCommand(new DbCommand<T>(this, klass));
     }
 


### PR DESCRIPTION
Compiling on Java 6 fails with errors such as the following:

<pre>
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.5:compile (default-compile) on project dropwizard-core: Compilation failure
[ERROR] [...]/dropwizard/dropwizard-core/src/main/java/com/yammer/dropwizard/cli/ConfiguredCommand.java:[34,51] inconvertible types
[ERROR] found   : java.lang.Class&lt;java.lang.Object&gt;
[ERROR] required: java.lang.Class&lt;T&gt;
[ERROR] -> [Help 1]
</pre>
