### PR TITLE
Added getter for Jersey Properties

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/config/Environment.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/config/Environment.java
@@ -339,6 +339,7 @@ public class Environment extends AbstractLifeCycle {
      * @param name     the name of the Jersey property
      * @see ResourceConfig
      */
+    @SuppressWarnings("unchecked")
     public <T> T getJerseyProperty(String name) {
         return (T) config.getProperties().get(name);
     }


### PR DESCRIPTION
A getter for Jersey properties is necessary to register filters to existing registered lists as this.  

```
(List<ResourceFilterFactory>) environment.getJerseyProperty(DefaultResourceConfig.PROPERTY_RESOURCE_FILTER_FACTORIES);
```

This is essential for especially bundles which are not aware of other parts of the application. If there is an existing resource list, it must be taken and added filter to end of list.
