### PR TITLE
(shortterm) fix for case-problems in logging

### DIFF
--- a/dropwizard-core/src/test/java/com/yammer/dropwizard/jetty/tests/AsyncRequestLogTest.java
+++ b/dropwizard-core/src/test/java/com/yammer/dropwizard/jetty/tests/AsyncRequestLogTest.java
@@ -73,7 +73,7 @@ public class AsyncRequestLogTest {
         final ILoggingEvent event = logAndCapture();
 
         assertThat(event.getFormattedMessage())
-                .isEqualTo("10.0.0.1 - - [16/Nov/2012:05:00:47 +0000] \"GET /test/things?yay HTTP/1.1\" 200 8290 1000 2000");
+                .isEqualToIgnoringCase("10.0.0.1 - - [16/Nov/2012:05:00:47 +0000] \"GET /test/things?yay HTTP/1.1\" 200 8290 1000 2000");
 
         assertThat(event.getLevel())
                 .isEqualTo(Level.INFO);
@@ -85,7 +85,7 @@ public class AsyncRequestLogTest {
 
         final ILoggingEvent event = logAndCapture();
         assertThat(event.getFormattedMessage())
-                .isEqualTo("123.123.123.123 - - [16/Nov/2012:05:00:47 +0000] \"GET /test/things?yay HTTP/1.1\" 200 8290 1000 2000");
+                .isEqualToIgnoringCase("123.123.123.123 - - [16/Nov/2012:05:00:47 +0000] \"GET /test/things?yay HTTP/1.1\" 200 8290 1000 2000");
     }
 
     @Test
@@ -103,7 +103,7 @@ public class AsyncRequestLogTest {
 
         final ILoggingEvent event = logAndCapture();
         assertThat(event.getFormattedMessage())
-                .isEqualTo("10.0.0.1 - coda [16/Nov/2012:05:00:47 +0000] \"GET /test/things?yay HTTP/1.1\" 200 8290 1000 2000");
+                .isEqualToIgnoringCase("10.0.0.1 - coda [16/Nov/2012:05:00:47 +0000] \"GET /test/things?yay HTTP/1.1\" 200 8290 1000 2000");
     }
 
     @Test
@@ -113,7 +113,7 @@ public class AsyncRequestLogTest {
         final ILoggingEvent event = logAndCapture();
 
         assertThat(event.getFormattedMessage())
-                .isEqualTo("10.0.0.1 - - [16/Nov/2012:05:00:47 +0000] \"GET /test/things?yay HTTP/1.1\" Async 8290 1000 2000");
+                .isEqualToIgnoringCase("10.0.0.1 - - [16/Nov/2012:05:00:47 +0000] \"GET /test/things?yay HTTP/1.1\" Async 8290 1000 2000");
     }
 
     private ILoggingEvent logAndCapture() {


### PR DESCRIPTION
In norway the months are legally written in lower case, which I suspect is the case here. I guess other locales might get other proclems, not solvable by ignoring case though.

I haven't dug deep enough to solve by forcing locale for the tests, though that might be a better long-term solution.

```
Failed tests: 
  logsRequests(com.yammer.dropwizard.jetty.tests.AsyncRequestLogTest): expected:<'10.0.0.1 - - [16/[N]ov/2012:05:00:47 +00...> but was:<'10.0.0.1 - - [16/[n]ov/2012:05:00:47 +00...>
  logsPrincipal(com.yammer.dropwizard.jetty.tests.AsyncRequestLogTest): expected:<...10.0.0.1 - coda [16/[N]ov/2012:05:00:47 +00...> but was:<...10.0.0.1 - coda [16/[n]ov/2012:05:00:47 +00...>
  logsForwardedFor(com.yammer.dropwizard.jetty.tests.AsyncRequestLogTest): expected:<...123.123.123 - - [16/[N]ov/2012:05:00:47 +00...> but was:<...123.123.123 - - [16/[n]ov/2012:05:00:47 +00...>
  logsAsyncContinuations(com.yammer.dropwizard.jetty.tests.AsyncRequestLogTest): expected:<'10.0.0.1 - - [16/[N]ov/2012:05:00:47 +00...> but was:<'10.0.0.1 - - [16/[n]ov/2012:05:00:47 +00...> 
```
