### PR TITLE
Adds support for services which wrap other services.

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/util/Generics.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/util/Generics.java
@@ -2,6 +2,7 @@ package com.yammer.dropwizard.util;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -11,6 +12,16 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class Generics {
     private Generics() { /* singleton */ }
+
+    /**
+     * Finds the type parameter for the given class.
+     *
+     * @param klass    a parameterized class
+     * @return the class's type parameter
+     */
+    public static Class<?> getTypeParameter(Class<?> klass) {
+        return getTypeParameter(klass, Object.class);
+    }
 
     /**
      * Finds the type parameter for the given class which is assignable to the bound class.
@@ -35,9 +46,15 @@ public class Generics {
             // should typically have one of type parameters (first one) that matches:
             for (Type param : ((ParameterizedType) t).getActualTypeArguments()) {
                 if (param instanceof Class<?>) {
-                    final Class<?> cls = (Class<?>) param;
-                    if (bound.isAssignableFrom(cls)) {
-                        return (Class<T>) cls;
+                    final Class<T> cls = determineClass(bound, param);
+                    if (cls != null) { return cls; }
+                }
+                else if (param instanceof TypeVariable) {
+                    for (Type paramBound : ((TypeVariable) param).getBounds()) {
+                        if (paramBound instanceof Class<?>) {
+                            final Class<T> cls = determineClass(bound, paramBound);
+                            if (cls != null) { return cls; }
+                        }
                     }
                 }
             }
@@ -45,13 +62,14 @@ public class Generics {
         throw new IllegalStateException("Cannot figure out type parameterization for " + klass.getName());
     }
 
-    /**
-     * Finds the type parameter for the given class.
-     *
-     * @param klass    a parameterized class
-     * @return the class's type parameter
-     */
-    public static Class<?> getTypeParameter(Class<?> klass) {
-        return getTypeParameter(klass, Object.class);
+    private static <T> Class<T> determineClass(Class<? super T> bound, Type candidate) {
+        if (candidate instanceof Class<?>) {
+            final Class<?> cls = (Class<?>) candidate;
+            if (bound.isAssignableFrom(cls)) {
+                return (Class<T>) cls;
+            }
+        }
+
+        return null;
     }
 }

--- a/dropwizard-core/src/test/java/com/yammer/dropwizard/tests/ServiceTest.java
+++ b/dropwizard-core/src/test/java/com/yammer/dropwizard/tests/ServiceTest.java
@@ -13,17 +13,31 @@ public class ServiceTest {
 
     private static class FakeService extends Service<FakeConfiguration> {
         @Override
-        public void initialize(Bootstrap<FakeConfiguration> bootstrap) {
-
-        }
+        public void initialize(Bootstrap<FakeConfiguration> bootstrap) {}
 
         @Override
-        public void run(FakeConfiguration configuration,
-                           Environment environment) {
-        }
+        public void run(FakeConfiguration configuration, Environment environment) {}
     }
 
     private static class PoserService extends FakeService {}
+
+    private static class WrapperService<C extends Configuration> extends Service<C> {
+        private Service<C> service;
+
+        public WrapperService(Service<C> service) {
+            this.service = service;
+        }
+
+        @Override
+        public void initialize(Bootstrap<C> bootstrap) {
+            this.service.initialize(bootstrap);
+        }
+
+        @Override
+        public void run(C configuration, Environment environment) throws Exception {
+            this.service.run(configuration, environment);
+        }
+    }
 
     @Test
     public void hasAReferenceToItsTypeParameter() throws Exception {
@@ -35,5 +49,12 @@ public class ServiceTest {
     public void canDetermineConfiguration() throws Exception {
         assertThat(new PoserService().getConfigurationClass())
                 .isSameAs(FakeConfiguration.class);
+    }
+
+    @Test
+    public void canDetermineWrappedConfiguration() throws Exception {
+        PoserService service = new PoserService();
+        assertThat(new WrapperService(service).getConfigurationClass())
+                .isSameAs(Configuration.class);
     }
 }


### PR DESCRIPTION
First and foremost, thank you for publishing this library and your continual work in improving and supporting it.  My company over the past few months has found it invaluable.

This small modification was required as if one wishes to add bundles, resources, etc. in a generic fashion to a Dropwizard service and is using version 0.6.0 or later, one needs to establish an AOP-style cutpoint on the abstract initialize and run methods.

In previous versions of Dropwizard (namely 0.4.x and 0.5.x), this procedure was a bit more straight forward.

While I realize this may be a somewhat esoteric use case, this patch enables support for this functionality in a way which is completely opaque to users of Dropwizard, and hopefully shouldn't be a maintenance burden.

Cheers,

Brett
