### PR TITLE
Check for null reference when validating objects

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/validation/Validator.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/validation/Validator.java
@@ -50,18 +50,24 @@ public class Validator {
     */
     public <T> ImmutableList<String> validate(T o, Class<?>... groups) {
         final Set<String> errors = Sets.newHashSet();
-        final Set<ConstraintViolation<T>> violations = factory.getValidator().validate(o,groups);
-        for (ConstraintViolation<T> v : violations) {
-            if (v.getConstraintDescriptor().getAnnotation() instanceof ValidationMethod) {
-                final ImmutableList<Path.Node> nodes = ImmutableList.copyOf(v.getPropertyPath());
-                final ImmutableList<Path.Node> usefulNodes = nodes.subList(0, nodes.size() - 1);
-                final String msg = v.getMessage().startsWith(".") ? "%s%s" : "%s %s";
-                errors.add(format(msg, Joiner.on('.').join(usefulNodes), v.getMessage()).trim());
-            } else {
-                errors.add(format("%s %s (was %s)",
-                                  v.getPropertyPath(),
-                                  v.getMessage(),
-                                  v.getInvalidValue()));
+
+        if (o == null) {
+            errors.add("request entity required");
+        }
+        else {
+            final Set<ConstraintViolation<T>> violations = factory.getValidator().validate(o,groups);
+            for (ConstraintViolation<T> v : violations) {
+                if (v.getConstraintDescriptor().getAnnotation() instanceof ValidationMethod) {
+                    final ImmutableList<Path.Node> nodes = ImmutableList.copyOf(v.getPropertyPath());
+                    final ImmutableList<Path.Node> usefulNodes = nodes.subList(0, nodes.size() - 1);
+                    final String msg = v.getMessage().startsWith(".") ? "%s%s" : "%s %s";
+                    errors.add(format(msg, Joiner.on('.').join(usefulNodes), v.getMessage()).trim());
+                } else {
+                    errors.add(format("%s %s (was %s)",
+                                      v.getPropertyPath(),
+                                      v.getMessage(),
+                                      v.getInvalidValue()));
+                }
             }
         }
         return ImmutableList.copyOf(Ordering.natural().sortedCopy(errors));

--- a/dropwizard-core/src/test/java/com/yammer/dropwizard/validation/tests/ValidatorTest.java
+++ b/dropwizard-core/src/test/java/com/yammer/dropwizard/validation/tests/ValidatorTest.java
@@ -39,6 +39,12 @@ public class ValidatorTest {
     }
 
     @Test
+    public void returnsASetOfErrorsForNull() throws Exception {
+        assertThat(validator.validate(null))
+                .containsOnly("request entity required");
+    }
+
+    @Test
     public void returnsAnEmptySetForAValidObject() throws Exception {
         final Example example = new Example();
         example.setNotNull("woo");


### PR DESCRIPTION
Null references cannot be validated. Check for null and return
an error message.
