### PR TITLE
Use Logback token for platform line endings

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/logging/LogFormatter.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/logging/LogFormatter.java
@@ -13,7 +13,7 @@ public class LogFormatter extends PatternLayout {
         super();
         setOutputPatternAsHeader(false);
         getDefaultConverterMap().put("ex", PrefixedThrowableProxyConverter.class.getName());
-        setPattern("%-5p [%d{ISO8601," + timeZone.getID() + "}] %c: %m\n%ex");
+        setPattern("%-5p [%d{ISO8601," + timeZone.getID() + "}] %c: %m%n%ex");
         setContext(context);
     }
 }


### PR DESCRIPTION
This change updates the logging pattern to use the logback escape sequence for a new line rather than a raw newline. This allows Logback to choose the platform-specific line separator so that Windows logs are readable by native text editors.
