### PR TITLE
Cannot use indexFile when the assets are mapped on "/" and the service is started from JAR file

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/assets/AssetServlet.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/assets/AssetServlet.java
@@ -156,7 +156,8 @@ public class AssetServlet extends HttpServlet {
     private CachedAsset loadAsset(String key) throws URISyntaxException, IOException {
         Preconditions.checkArgument(key.startsWith(uriPath));
         final String requestedResourcePath = CharMatcher.is('/').trimFrom(key.substring(uriPath.length()));
-        final String absoluteRequestedResourcePath = this.resourcePath + requestedResourcePath;
+        final String absoluteRequestedResourcePath = CharMatcher.is('/').trimFrom(
+        		this.resourcePath + requestedResourcePath);
         
         URL requestedResourceURL = Resources.getResource(absoluteRequestedResourcePath);
 


### PR DESCRIPTION
In AssetServlet the path to the indexFile was built this way :  

``` java
absoluteRequestedResourcePath + '/' + indexFile
```

When the assets are mapped on "/", this leads to :

``` java
 "my/resource/path/" + '/' + "myindex.html".
```

And when trying to get a resource url with a double slash (//) in path, it works from filesystem ("exploded jar"), when starting the service from Eclipse for example, but not within a JAR.

The fix simply trims "/" from absoluteRequestedResourcePath to make sure we never get a double slash.
