### PR TITLE
Add tasks for invalidating authentication caches

### DIFF
--- a/dropwizard-auth/src/main/java/com/yammer/dropwizard/auth/AuthCacheInvalidationTask.java
+++ b/dropwizard-auth/src/main/java/com/yammer/dropwizard/auth/AuthCacheInvalidationTask.java
@@ -1,0 +1,46 @@
+package com.yammer.dropwizard.auth;
+
+import java.io.PrintWriter;
+import com.google.common.collect.ImmutableMultimap;
+import com.yammer.dropwizard.tasks.Task;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Invalidates an authentication cache.
+ */
+public class AuthCacheInvalidationTask<C> extends Task {
+
+    protected final CachingAuthenticator<C, ?> authenticator;
+
+    /**
+     * Creates a new AuthCacheInvalidationTask with the given {@link CachingAuthenticator} instance.
+     *
+     * @param authenticator a {@link CachingAuthenticator} instance
+     */
+    public AuthCacheInvalidationTask(CachingAuthenticator<C, ?> authenticator) {
+        this("authCacheInvalidation", authenticator);
+    }
+
+    /**
+     * Creates a new AuthCacheInvalidationTask with the given {@link CachingAuthenticator} instance.
+     *
+     * @param name the task's name
+     * @param authenticator a {@link CachingAuthenticator} instance
+     */
+    public AuthCacheInvalidationTask(String name, CachingAuthenticator<C, ?> authenticator) {
+        super(name);
+        this.authenticator = checkNotNull(authenticator);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void execute(ImmutableMultimap<String, String> parameters, PrintWriter output) {
+        output.printf("Invalidating approximately %d cached principals...", this.authenticator.size());
+        output.flush();
+        this.authenticator.invalidateAll();
+        output.println("Done!");
+    }
+}

--- a/dropwizard-auth/src/main/java/com/yammer/dropwizard/auth/oauth/OAuthCacheInvalidationTask.java
+++ b/dropwizard-auth/src/main/java/com/yammer/dropwizard/auth/oauth/OAuthCacheInvalidationTask.java
@@ -1,0 +1,38 @@
+package com.yammer.dropwizard.auth.oauth;
+
+import java.io.PrintWriter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
+import com.yammer.dropwizard.auth.AuthCacheInvalidationTask;
+import com.yammer.dropwizard.auth.CachingAuthenticator;
+
+/**
+ * Invalidates an OAuth authentication cache.
+ */
+public class OAuthCacheInvalidationTask extends AuthCacheInvalidationTask<String> {
+
+    /**
+     * Creates a new OAuthCacheInvalidationTask with the given {@link CachingAuthenticator} instance.
+     *
+     * @param authenticator a {@link CachingAuthenticator} instance
+     */
+    public OAuthCacheInvalidationTask(CachingAuthenticator<String, ?> authenticator) {
+        super("oauthCacheInvalidation", authenticator);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void execute(ImmutableMultimap<String, String> parameters, PrintWriter output) {
+        final ImmutableList<String> credentials = parameters.get("credentials").asList();
+        if (credentials.isEmpty()) {
+            super.execute(parameters, output);
+        } else {
+            output.printf("Invalidating approximately %d cached principals...", credentials.size());
+            output.flush();
+            super.authenticator.invalidateAll(credentials);
+            output.println("Done!");
+        }
+    }
+}

--- a/dropwizard-auth/src/test/java/com/yammer/dropwizard/auth/oauth/tests/OAuthCacheInvalidationTaskTest.java
+++ b/dropwizard-auth/src/test/java/com/yammer/dropwizard/auth/oauth/tests/OAuthCacheInvalidationTaskTest.java
@@ -1,0 +1,39 @@
+package com.yammer.dropwizard.auth.oauth.tests;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
+import com.yammer.dropwizard.auth.CachingAuthenticator;
+import com.yammer.dropwizard.auth.oauth.OAuthCacheInvalidationTask;
+import com.yammer.dropwizard.tasks.Task;
+import org.junit.Test;
+
+import java.io.PrintWriter;
+
+import static org.mockito.Mockito.*;
+
+public class OAuthCacheInvalidationTaskTest {
+    private final CachingAuthenticator<String, ?> auth = mock(CachingAuthenticator.class);
+    private final PrintWriter output = mock(PrintWriter.class);
+    private final Task task = new OAuthCacheInvalidationTask(auth);
+
+    @Test
+    public void runsWithNoParameters() throws Exception {
+        task.execute(ImmutableMultimap.<String, String>of(), output);
+
+        verify(auth).invalidateAll();
+    }
+
+    @Test
+    public void runsWithSingleParameter() throws Exception {
+        task.execute(ImmutableMultimap.of("credentials", "foobar"), output);
+
+        verify(auth).invalidateAll(ImmutableList.of("foobar"));
+    }
+
+    @Test
+    public void runsWithMultipleParameters() throws Exception {
+        task.execute(ImmutableMultimap.of("credentials", "foobar", "credentials", "barbaz"), output);
+
+        verify(auth).invalidateAll(ImmutableList.of("foobar", "barbaz"));
+    }
+}

--- a/dropwizard-auth/src/test/java/com/yammer/dropwizard/auth/tests/AuthCacheInvalidationTaskTest.java
+++ b/dropwizard-auth/src/test/java/com/yammer/dropwizard/auth/tests/AuthCacheInvalidationTaskTest.java
@@ -1,0 +1,24 @@
+package com.yammer.dropwizard.auth.tests;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.yammer.dropwizard.auth.AuthCacheInvalidationTask;
+import com.yammer.dropwizard.auth.CachingAuthenticator;
+import com.yammer.dropwizard.tasks.Task;
+import org.junit.Test;
+
+import java.io.PrintWriter;
+
+import static org.mockito.Mockito.*;
+
+public class AuthCacheInvalidationTaskTest {
+    private final CachingAuthenticator auth = mock(CachingAuthenticator.class);
+    private final PrintWriter output = mock(PrintWriter.class);
+    private final Task task = new AuthCacheInvalidationTask(auth);
+
+    @Test
+    public void runsWithNoParameters() throws Exception {
+        task.execute(ImmutableMultimap.<String, String>of(), output);
+
+        verify(auth).invalidateAll();
+    }
+}


### PR DESCRIPTION
OAuthCacheInvalidationTask is perhaps misnamed, because there's nothing OAuth-specific about it. It offers parameter support for authenticators which use simple string credentials (notably OAuthProvider).
