### PR TITLE
Double slashes in AssetServlet.java causes 404 when pulling assets from jar

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/assets/AssetServlet.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/assets/AssetServlet.java
@@ -162,7 +162,7 @@ public class AssetServlet extends HttpServlet {
 
         if (ResourceURL.isDirectory(requestedResourceURL)) {
             if (indexFile != null) {
-                requestedResourceURL = Resources.getResource(absoluteRequestedResourcePath + '/' + indexFile);
+                requestedResourceURL = Resources.getResource(absoluteRequestedResourcePath.replaceAll("/+$", "") + '/' + indexFile);
             } else {
                 // directory requested but no index file defined
                 return null;


### PR DESCRIPTION
AssetServlet.java

when using AssetsBundle:
bootstrap.addBundle(new AssetsBundle("/assets", "/", "/index.htm"));

a trailing '/' is tacked on in AssetServlet:

this.resourcePath = trimmedPath.isEmpty() ? trimmedPath : trimmedPath + "/";

When the asset is requested from:
requestedResourceURL = Resources.getResource(absoluteRequestedResourcePath + '/' + indexFile);

another '/' is tacked on making it:
assets//index.htm

this works fine for files in the Unix filesystem
but fails when trying to load resources from the jar
and ends up throwing a 404.

I am not sure of the impact, so I focused a patch on the smallest isolated area of my issue.
