### PR TITLE
Added support for configurable view encodings. 

### DIFF
--- a/dropwizard-example/pom.xml
+++ b/dropwizard-example/pom.xml
@@ -39,6 +39,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.yammer.dropwizard</groupId>
+            <artifactId>dropwizard-views</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>1.3.170</version>

--- a/dropwizard-example/src/main/java/com/example/helloworld/HelloWorldService.java
+++ b/dropwizard-example/src/main/java/com/example/helloworld/HelloWorldService.java
@@ -7,10 +7,7 @@ import com.example.helloworld.core.Template;
 import com.example.helloworld.core.User;
 import com.example.helloworld.db.PersonDAO;
 import com.example.helloworld.health.TemplateHealthCheck;
-import com.example.helloworld.resources.HelloWorldResource;
-import com.example.helloworld.resources.PeopleResource;
-import com.example.helloworld.resources.PersonResource;
-import com.example.helloworld.resources.ProtectedResource;
+import com.example.helloworld.resources.*;
 import com.yammer.dropwizard.Service;
 import com.yammer.dropwizard.assets.AssetsBundle;
 import com.yammer.dropwizard.auth.basic.BasicAuthProvider;
@@ -19,6 +16,7 @@ import com.yammer.dropwizard.config.Environment;
 import com.yammer.dropwizard.db.DatabaseConfiguration;
 import com.yammer.dropwizard.hibernate.HibernateBundle;
 import com.yammer.dropwizard.migrations.MigrationsBundle;
+import com.yammer.dropwizard.views.ViewBundle;
 
 public class HelloWorldService extends Service<HelloWorldConfiguration> {
     public static void main(String[] args) throws Exception {
@@ -45,6 +43,7 @@ public class HelloWorldService extends Service<HelloWorldConfiguration> {
             }
         });
         bootstrap.addBundle(hibernateBundle);
+        bootstrap.addBundle(new ViewBundle());
     }
 
     @Override
@@ -59,6 +58,7 @@ public class HelloWorldService extends Service<HelloWorldConfiguration> {
 
         environment.addHealthCheck(new TemplateHealthCheck(template));
         environment.addResource(new HelloWorldResource(template));
+        environment.addResource(new ViewResource());
         environment.addResource(new ProtectedResource());
 
         environment.addResource(new PeopleResource(dao));

--- a/dropwizard-example/src/main/java/com/example/helloworld/resources/ViewResource.java
+++ b/dropwizard-example/src/main/java/com/example/helloworld/resources/ViewResource.java
@@ -1,0 +1,43 @@
+package com.example.helloworld.resources;
+
+import com.google.common.base.Charsets;
+import com.yammer.dropwizard.views.View;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+@Path("/views")
+public class ViewResource {
+    @GET
+    @Produces("text/html;charset=UTF-8")
+    @Path("/utf8.ftl")
+    public View freemarkerUTF8() {
+        return new View("/views/ftl/utf8.ftl", Charsets.UTF_8) {
+        };
+    }
+
+    @GET
+    @Produces("text/html;charset=ISO-8859-1")
+    @Path("/iso88591.ftl")
+    public View freemarkerISO88591() {
+        return new View("/views/ftl/iso88591.ftl", Charsets.ISO_8859_1) {
+        };
+    }
+
+    @GET
+    @Produces("text/html;charset=UTF-8")
+    @Path("/utf8.mustache")
+    public View mustacheUTF8() {
+        return new View("/views/ftl/utf8.ftl", Charsets.UTF_8) {
+        };
+    }
+
+    @GET
+    @Produces("text/html;charset=ISO-8859-1")
+    @Path("/iso88591.mustache")
+    public View mustacheISO88591() {
+        return new View("/views/ftl/iso88591.ftl", Charsets.ISO_8859_1) {
+        };
+    }
+}

--- a/dropwizard-example/src/main/resources/views/ftl/iso88591.ftl
+++ b/dropwizard-example/src/main/resources/views/ftl/iso88591.ftl
@@ -1,0 +1,10 @@
+<html>
+<body>
+
+<h1>This is an example of a view containing ISO-8859-1 characters</h1>
+
+¢¢¢¢¢¢¢¢¢¢¢¢¢¢¢¢¢¢¢¢¢¢¢¢¢¢¢
+
+</body>
+</html>
+

--- a/dropwizard-example/src/main/resources/views/ftl/utf8.ftl
+++ b/dropwizard-example/src/main/resources/views/ftl/utf8.ftl
@@ -1,0 +1,9 @@
+<html>
+<body>
+
+<h1>This is an example of a view containing UTF-8 characters</h1>
+
+€€€€€€€€€€€€€€€€€€
+
+</body>
+</html>

--- a/dropwizard-example/src/main/resources/views/mustache/iso88591.mustache
+++ b/dropwizard-example/src/main/resources/views/mustache/iso88591.mustache
@@ -1,0 +1,10 @@
+<html>
+<body>
+
+<h1>This is an example of a view containing ISO-8859-1 characters</h1>
+
+¢¢¢¢¢¢¢¢¢¢¢¢¢¢¢¢¢¢¢¢¢¢¢¢¢¢¢
+
+</body>
+</html>
+

--- a/dropwizard-example/src/main/resources/views/mustache/utf8.mustache
+++ b/dropwizard-example/src/main/resources/views/mustache/utf8.mustache
@@ -1,0 +1,9 @@
+<html>
+<body>
+
+<h1>This is an example of a view containing UTF-8 characters</h1>
+
+€€€€€€€€€€€€€€€€€€
+
+</body>
+</html>

--- a/dropwizard-views/src/main/java/com/yammer/dropwizard/views/View.java
+++ b/dropwizard-views/src/main/java/com/yammer/dropwizard/views/View.java
@@ -1,16 +1,24 @@
 package com.yammer.dropwizard.views;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.base.Optional;
 import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Timer;
 
+import java.nio.charset.Charset;
+
 public abstract class View {
     private final String templateName;
+    private final Charset charset;
     private final Timer renderingTimer;
 
     protected View(String templateName) {
+        this(templateName, null);
+    }
 
+    protected View(String templateName, Charset charset) {
         this.templateName = resolveName(templateName);
+        this.charset = charset;
         this.renderingTimer = Metrics.defaultRegistry().newTimer(getClass(), "rendering");
     }
 
@@ -25,6 +33,11 @@ public abstract class View {
     @JsonIgnore
     public String getTemplateName() {
         return templateName;
+    }
+
+    @JsonIgnore
+    public Optional<Charset> getCharset() {
+        return charset != null ? Optional.of(charset) : Optional.<Charset>absent();
     }
 
     @JsonIgnore

--- a/dropwizard-views/src/main/java/com/yammer/dropwizard/views/freemarker/FreemarkerViewRenderer.java
+++ b/dropwizard-views/src/main/java/com/yammer/dropwizard/views/freemarker/FreemarkerViewRenderer.java
@@ -16,6 +16,7 @@ import javax.ws.rs.WebApplicationException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
 import java.util.Locale;
 
 public class FreemarkerViewRenderer implements ViewRenderer {
@@ -50,7 +51,8 @@ public class FreemarkerViewRenderer implements ViewRenderer {
                        OutputStream output) throws IOException, WebApplicationException {
         try {
             final Configuration configuration = configurationCache.getUnchecked(view.getClass());
-            final Template template = configuration.getTemplate(view.getTemplateName(), locale);
+            final Charset charset = view.getCharset().or(Charset.forName(configuration.getEncoding(locale)));
+            final Template template = configuration.getTemplate(view.getTemplateName(), locale, charset.name());
             template.process(view, new OutputStreamWriter(output, template.getEncoding()));
         } catch (TemplateException e) {
             throw new ContainerException(e);

--- a/dropwizard-views/src/main/java/com/yammer/dropwizard/views/mustache/MustacheViewRenderer.java
+++ b/dropwizard-views/src/main/java/com/yammer/dropwizard/views/mustache/MustacheViewRenderer.java
@@ -35,7 +35,7 @@ public class MustacheViewRenderer implements ViewRenderer {
 
     @Override
     public void render(View view, Locale locale, OutputStream output) throws IOException, WebApplicationException {
-        final OutputStreamWriter writer = new OutputStreamWriter(output, Charsets.UTF_8);
+        final OutputStreamWriter writer = new OutputStreamWriter(output, view.getCharset().or(Charsets.UTF_8));
         try {
             final Mustache template = factories.getUnchecked(view.getClass())
                                                .compile(view.getTemplateName());


### PR DESCRIPTION
The View class will now allow the specification of the encoding Charset as part of it's constructor, and addresses an issue raised on dropwizard-user.  

Anyone who wishes to override the default language -> encoding mappings (in Freemarker) can now easily do so.  

Also added a quick multi-charset example to dropwizard-example.
