### PR TITLE
TaskServlet properly returns 500 on exceptions now

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/tasks/TaskServlet.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/tasks/TaskServlet.java
@@ -44,17 +44,18 @@ public class TaskServlet extends HttpServlet {
                           HttpServletResponse resp) throws ServletException, IOException {
         final Task task = tasks.get(req.getPathInfo());
         if (task != null) {
+            resp.setContentType(MediaType.TEXT_PLAIN);
+            final PrintWriter output = resp.getWriter();
             try {
-                resp.setContentType(MediaType.TEXT_PLAIN);
-                final PrintWriter output = resp.getWriter();
-                try {
-                    task.execute(getParams(req), output);
-                } finally {
-                    output.close();
-                }
+                task.execute(getParams(req), output);
             } catch (Exception e) {
                 LOGGER.error("Error running {}", task.getName(), e);
-                resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                output.println();
+                output.println(e.getMessage());
+                e.printStackTrace(output);
+            } finally {
+                output.close();
             }
         } else {
             resp.sendError(HttpServletResponse.SC_NOT_FOUND);

--- a/dropwizard-core/src/test/java/com/yammer/dropwizard/tasks/tests/TaskServletTest.java
+++ b/dropwizard-core/src/test/java/com/yammer/dropwizard/tasks/tests/TaskServletTest.java
@@ -81,6 +81,6 @@ public class TaskServletTest {
         
         servlet.service(request, response);
 
-        verify(response).sendError(500);
+        verify(response).setStatus(500);
     }
 }


### PR DESCRIPTION
Fixing TaskServlet to properly return 500 when an exception is thrown by a Task. Exceptions were only being handled after the output stream was being closed, which results in Jetty committing the response and disallowing further modification (e.g. sending an error.)
