### PR TITLE
adminPort isn't used with dynamic http.port and http.adminPort

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/config/ServerFactory.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/config/ServerFactory.java
@@ -325,7 +325,7 @@ public class ServerFactory {
         handler.addServlet(new ServletHolder(new TaskServlet(env.getTasks())), "/tasks/*");
         handler.addServlet(new ServletHolder(new AdminServlet()), "/*");
 
-        if (config.getAdminPort() == config.getPort()) {
+        if (config.getAdminPort() != 0 && config.getAdminPort() == config.getPort()) {
             handler.setContextPath("/admin");
             handler.setConnectorNames(new String[]{"main"});
         } else {


### PR DESCRIPTION
If `http.adminPort` and `http.port` are both set to `0`, the `internal` servlet is added to the `main` connector at context path `/admin` and the `internal` connector is unused.

[ServerFactory.java#L317](https://github.com/codahale/dropwizard/blob/v0.6.1/dropwizard-core/src/main/java/com/yammer/dropwizard/config/ServerFactory.java#L317) should be changed to match [ServerFactory.java#L100](https://github.com/codahale/dropwizard/blob/v0.6.1/dropwizard-core/src/main/java/com/yammer/dropwizard/config/ServerFactory.java#L100). Maybe adding something like `HttpConfiguration#hasSeparateAdminPort` would be helpful?
