### PR TITLE
add gauges for number of active and idle connections in pool

### DIFF
--- a/dropwizard-db/src/main/java/com/yammer/dropwizard/db/ManagedDataSourceFactory.java
+++ b/dropwizard-db/src/main/java/com/yammer/dropwizard/db/ManagedDataSourceFactory.java
@@ -36,7 +36,7 @@ public class ManagedDataSourceFactory {
                                                                                           true);
         connectionFactory.setPool(pool);
 
-        setupGauges(pool);
+        setupGauges(pool, configuration.getUrl());
 
         return new ManagedPooledDataSource(pool);
     }
@@ -56,15 +56,15 @@ public class ManagedDataSourceFactory {
         return pool;
     }
 
-    private void setupGauges(final GenericObjectPool pool) {
-        Metrics.newGauge(ManagedPooledDataSource.class, "numActive", new Gauge<Integer>() {
+    private void setupGauges(final GenericObjectPool pool, String scope) {
+        Metrics.newGauge(ManagedPooledDataSource.class, "numActive", scope, new Gauge<Integer>() {
             @Override
             public Integer value() {
                 return pool.getNumActive();
             }
         });
 
-        Metrics.newGauge(ManagedPooledDataSource.class, "numIdle", new Gauge<Integer>() {
+        Metrics.newGauge(ManagedPooledDataSource.class, "numIdle", scope, new Gauge<Integer>() {
             @Override
             public Integer value() {
                 return pool.getNumIdle();

--- a/dropwizard-db/src/test/java/com/yammer/dropwizard/db/tests/ManagedDataSourceFactoryTest.java
+++ b/dropwizard-db/src/test/java/com/yammer/dropwizard/db/tests/ManagedDataSourceFactoryTest.java
@@ -21,6 +21,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 import static org.fest.assertions.api.Assertions.assertThat;
+import static org.fest.assertions.api.Assertions.extractProperty;
 import static org.junit.Assert.assertEquals;
 
 public class ManagedDataSourceFactoryTest {
@@ -78,11 +79,20 @@ public class ManagedDataSourceFactoryTest {
                 return metric instanceof Gauge && fullName.equals(className);
             }
         });
-        return gauges.containsKey(className) ? gauges.get(className) : new TreeMap<MetricName, Metric>();
+
+        //flatten the map
+        SortedMap<MetricName, Metric> results = new TreeMap<MetricName, Metric>();
+        for (SortedMap<MetricName, Metric> map : gauges.values()) {
+            results.putAll(map);
+        }
+        return results;
     }
 
     @Test
-    public void createGauges() throws Exception {
-        assertEquals(2, getDataSourceGauges().size());
+    public void createsGauges() throws Exception {
+        SortedMap<MetricName, Metric> gauges = getDataSourceGauges();
+        assertEquals(2, gauges.size());
+
+        assertThat(extractProperty("name").from(gauges.keySet())).contains("numActive", "numIdle");
     }
 }


### PR DESCRIPTION
From https://groups.google.com/d/topic/dropwizard-user/zwsXxWrlj-Y/discussion 

When databaseConfiguration.connectionGaugesEnabled is added, will add gauges on "numActive" and "numIdle" for the pool.
