### PR TITLE
A JUnit Rule to start and stop your service

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/Service.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/Service.java
@@ -54,12 +54,8 @@ public abstract class Service<T extends Configuration> {
      * @throws Exception if something goes wrong
      */
     public final void run(String[] arguments) throws Exception {
-        run(arguments, true);
-    }
-
-    public final void run(String[] arguments, boolean blocking) throws Exception {
         final Bootstrap<T> bootstrap = new Bootstrap<T>(this);
-        bootstrap.addCommand(new ServerCommand<T>(this, blocking));
+        bootstrap.addCommand(new ServerCommand<T>(this));
         initialize(bootstrap);
         final Cli cli = new Cli(this.getClass(), bootstrap);
         cli.run(arguments);

--- a/dropwizard-testing/src/main/java/com/yammer/dropwizard/testing/junit/DropwizardServiceRule.java
+++ b/dropwizard-testing/src/main/java/com/yammer/dropwizard/testing/junit/DropwizardServiceRule.java
@@ -1,7 +1,6 @@
 package com.yammer.dropwizard.testing.junit;
 
 import com.google.common.collect.ImmutableMap;
-import com.yammer.dropwizard.Bundle;
 import com.yammer.dropwizard.Service;
 import com.yammer.dropwizard.cli.ServerCommand;
 import com.yammer.dropwizard.config.Bootstrap;
@@ -16,12 +15,13 @@ import org.junit.runners.model.Statement;
 
 public class DropwizardServiceRule<C extends Configuration> implements TestRule {
 
-    private final Class<? extends Service> serviceClass;
+    private final Class<? extends Service<C>> serviceClass;
     private final String configPath;
 
+    private C configuration;
     private Server jettyServer;
 
-    public DropwizardServiceRule(Class<? extends Service> serviceClass, Class<C> configClass, String configPath) {
+    public DropwizardServiceRule(Class<? extends Service<C>> serviceClass, String configPath) {
         this.serviceClass = serviceClass;
         this.configPath = configPath;
     }
@@ -48,28 +48,32 @@ public class DropwizardServiceRule<C extends Configuration> implements TestRule 
 
         try {
             Service<C> service = serviceClass.newInstance();
-            final Bootstrap<C> bootstrap = new Bootstrap<C>(service);
-            bootstrap.addBundle(new Bundle() {
-                @Override
-                public void initialize(Bootstrap<?> bootstrap) {
-                }
 
+            final Bootstrap<C> bootstrap = new Bootstrap<C>(service) {
                 @Override
-                public void run(Environment environment) {
+                public void runWithBundles(C config, Environment environment) throws Exception {
                     environment.addServerLifecycleListener(new ServerLifecycleListener() {
                         @Override
                         public void serverStarted(Server server) {
                             jettyServer = server;
                         }
                     });
+                    configuration = config;
+                    super.runWithBundles(config, environment);
                 }
-            });
+            };
+
             service.initialize(bootstrap);
-            ServerCommand<C> command = new ServerCommand<C>(service, false);
+            ServerCommand<C> command = new ServerCommand<C>(service);
             Namespace namespace = new Namespace(ImmutableMap.<String, Object>of("file", configPath));
             command.run(bootstrap, namespace);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
+
+    public C getConfiguration() {
+        return configuration;
+    }
+
 }

--- a/dropwizard-testing/src/test/java/com/yammer/dropwizard/testing/tests/junit/DropwizardServiceRuleTest.java
+++ b/dropwizard-testing/src/test/java/com/yammer/dropwizard/testing/tests/junit/DropwizardServiceRuleTest.java
@@ -22,10 +22,8 @@ import static org.junit.Assert.assertThat;
 public class DropwizardServiceRuleTest {
 
     @ClassRule
-    public static DropwizardServiceRule dropwizardServiceRule = new DropwizardServiceRule(
-            TestService.class,
-            TestConfiguration.class,
-            resourceFilePath("test-config.yaml"));
+    public static DropwizardServiceRule<TestConfiguration> dropwizardServiceRule =
+            new DropwizardServiceRule<TestConfiguration>(TestService.class, resourceFilePath("test-config.yaml"));
 
     @Test
     public void canGetExpectedResourceOverHttp() {
@@ -34,7 +32,12 @@ public class DropwizardServiceRuleTest {
         assertThat(content, is("Yes, it's here"));
     }
 
-
+    @Test
+    public void returnsConfiguration() {
+        TestConfiguration config = dropwizardServiceRule.getConfiguration();
+        assertThat(config.getMessage(), is("Yes, it's here"));
+        assertThat(config.getHttpConfiguration().getPort(), is(8080));
+    }
 
 
     public static class TestService extends Service<TestConfiguration> {


### PR DESCRIPTION
On both systems I've built with Dropwizard I've ended up building a mechanism for starting and stopping the app from JUnit to allow in-memory acceptance testing.

This is slightly awkward to do currently due to the fact that the server command blocks (on server.join()) after startup and provides no hook for getting at the server to stop it. This patch provides a JUnit Rule along with some changes to a couple of core classes to resolve the above issues.
