### PR TITLE
Syslog Appender + Custom logFormat Is Broken 

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/logging/LogbackFactory.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/logging/LogbackFactory.java
@@ -22,20 +22,17 @@ public class LogbackFactory {
                                                      LoggerContext context,
                                                      String name,
                                                      Optional<String> logFormat) {
-        final SyslogFormatter layout = new SyslogFormatter(context, syslog.getTimeZone(), name);
-        layout.setOutputPatternAsHeader(false);
-        layout.setContext(context);
-        for (String format : logFormat.asSet()) {
-            layout.setPattern(format);
-        }
-        layout.start();
-
         final SyslogAppender appender = new SyslogAppender();
+        appender.setName(name);
         appender.setContext(context);
-        appender.setLayout(layout);
         appender.setSyslogHost(syslog.getHost());
         appender.setFacility(syslog.getFacility().toString());
         addThresholdFilter(appender, syslog.getThreshold());
+
+        for (String format : logFormat.asSet()) {
+            appender.setSuffixPattern(format);
+        }
+
         appender.start();
 
         return appender;


### PR DESCRIPTION
The SyslogAppender in Logback does not emit a layout (http://logback.qos.ch/codes.html#syslog_layout), instead should be using the suffixPattern.
