### PR TITLE
Let HttpClientBuilder obey JSSE system properties

### DIFF
--- a/dropwizard-client/src/main/java/com/yammer/dropwizard/client/HttpClientBuilder.java
+++ b/dropwizard-client/src/main/java/com/yammer/dropwizard/client/HttpClientBuilder.java
@@ -42,7 +42,7 @@ public class HttpClientBuilder {
 
     private HttpClientConfiguration configuration = new HttpClientConfiguration();
     private DnsResolver resolver = new SystemDefaultDnsResolver();
-    private SchemeRegistry registry = SchemeRegistryFactory.createDefault();
+    private SchemeRegistry registry = SchemeRegistryFactory.createSystemDefault();
 
     /**
      * Use the given {@link HttpClientConfiguration} instance.

--- a/dropwizard-client/src/test/java/com/yammer/dropwizard/client/tests/HttpClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/com/yammer/dropwizard/client/tests/HttpClientBuilderTest.java
@@ -202,7 +202,7 @@ public class HttpClientBuilderTest {
         final AbstractHttpClient client = (AbstractHttpClient) builder.using(configuration).build();
 
         assertThat(client.getConnectionManager().getSchemeRegistry().getSchemeNames())
-                .isEqualTo(SchemeRegistryFactory.createDefault().getSchemeNames());
+                .isEqualTo(SchemeRegistryFactory.createSystemDefault().getSchemeNames());
     }
 
     @Test


### PR DESCRIPTION
The SchemeRegistry which has been used in HttpClientBuilder doesn't support
JSSE related system properties which would allow setting key and trust stores
and other relevant properties through Java system properties.

The following system properties are taken into account by this method:
- ssl.TrustManagerFactory.algorithm
- javax.net.ssl.trustStoreType
- javax.net.ssl.trustStore
- javax.net.ssl.trustStoreProvider
- javax.net.ssl.trustStorePassword
- java.home
- ssl.KeyManagerFactory.algorithm
- javax.net.ssl.keyStoreType
- javax.net.ssl.keyStore
- javax.net.ssl.keyStoreProvider
- javax.net.ssl.keyStorePassword

Also see http://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/conn/ssl/SSLSocketFactory.html#getSystemSocketFactory%28%29

The change will not break anything in old clients of HttpClientBuilder but it will enable users to override the default SSL settings without implementing their own org.apache.http.conn.scheme.SchemeRegistry.
