### PR TITLE
Add '--configtest' parameter to ConfiguredCommand

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/cli/ConfiguredCommand.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/cli/ConfiguredCommand.java
@@ -4,6 +4,7 @@ import com.yammer.dropwizard.config.*;
 import com.yammer.dropwizard.json.ObjectMapperFactory;
 import com.yammer.dropwizard.util.Generics;
 import com.yammer.dropwizard.validation.Validator;
+import net.sourceforge.argparse4j.impl.Arguments;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 
@@ -43,6 +44,7 @@ public abstract class ConfiguredCommand<T extends Configuration> extends Command
     @Override
     public void configure(Subparser subparser) {
         subparser.addArgument("file").nargs("?").help("service configuration file");
+        subparser.addArgument("-T", "--configtest").action(Arguments.storeTrue()).help("validate configuration file and exit");
     }
 
     @Override
@@ -51,6 +53,11 @@ public abstract class ConfiguredCommand<T extends Configuration> extends Command
         final T configuration = parseConfiguration(namespace.getString("file"),
                                                    getConfigurationClass(),
                                                    bootstrap.getObjectMapperFactory().copy());
+
+        if(namespace.getBoolean("configtest")) {
+            return;
+        }
+
         if (configuration != null) {
             new LoggingFactory(configuration.getLoggingConfiguration(),
                                bootstrap.getName()).configure();

--- a/dropwizard-testing/src/main/java/com/yammer/dropwizard/testing/junit/DropwizardServiceRule.java
+++ b/dropwizard-testing/src/main/java/com/yammer/dropwizard/testing/junit/DropwizardServiceRule.java
@@ -68,7 +68,7 @@ public class DropwizardServiceRule<C extends Configuration> implements TestRule 
 
             service.initialize(bootstrap);
             final ServerCommand<C> command = new ServerCommand<C>(service);
-            final Namespace namespace = new Namespace(ImmutableMap.<String, Object>of("file", configPath));
+            final Namespace namespace = new Namespace(ImmutableMap.<String, Object>of("file", configPath, "configtest", false));
             command.run(bootstrap, namespace);
         } catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
The optional `--configtest` (or `-T`) command line argument runs the command until the configuration file has been parsed and validated and quits the command after that.

This is useful for could be useful in init scripts or whenever a new configuration file should be validated without restarting.
