### PR TITLE
Add ObjectMapperFactory#configure

### DIFF
--- a/dropwizard-core/src/main/java/com/yammer/dropwizard/json/ObjectMapperFactory.java
+++ b/dropwizard-core/src/main/java/com/yammer/dropwizard/json/ObjectMapperFactory.java
@@ -489,8 +489,26 @@ public class ObjectMapperFactory {
      * @return a configured {@link ObjectMapper} instance
      */
     public ObjectMapper build(JsonFactory factory) {
-        final ObjectMapper mapper = new ObjectMapper(factory);
+        return configure(new ObjectMapper(factory));
+    }
 
+    /**
+     * Builds a new {@link ObjectMapper} instance with a default {@link JsonFactory} instance.
+     *
+     * @return a configured {@link ObjectMapper} instance
+     */
+    public ObjectMapper build() {
+        return build(new JsonFactory());
+    }
+
+    /**
+     * Configures the given {@link ObjectMapper} instance according to the configuration of this
+     * {@code ObjectMapperFactory}.
+     *
+     * @param mapper the {@link ObjectMapper} to configure.
+     * @return the configured {@link ObjectMapper}
+     */
+    public ObjectMapper configure(ObjectMapper mapper) {
         for (Module module : modules) {
             mapper.registerModule(module);
         }
@@ -593,15 +611,6 @@ public class ObjectMapperFactory {
 
 
         return mapper;
-    }
-
-    /**
-     * Builds a new {@link ObjectMapper} instance with a default {@link JsonFactory} instance.
-     *
-     * @return a configured {@link ObjectMapper} instance
-     */
-    public ObjectMapper build() {
-        return build(new JsonFactory());
     }
 
     /**


### PR DESCRIPTION
Provides a means to configure existing `ObjectMapper` instances using the Dropwizard `ObjectMapperFactory`.

Breaks out the code to configure instances from `ObjectMapperFactory#build()` in to `ObjectMapperFactory#configure()`.

This is also useful for sub-classes that override `ObjectMapper#build()` to create a sub-classed instance of `ObjectMapper`, but configured according to the `ObjectMapperFactory`.
