### PR TITLE
Extended hibernate configuration.

### DIFF
--- a/dropwizard-hibernate/src/main/java/com/yammer/dropwizard/hibernate/HibernateBundle.java
+++ b/dropwizard-hibernate/src/main/java/com/yammer/dropwizard/hibernate/HibernateBundle.java
@@ -35,7 +35,7 @@ public abstract class HibernateBundle<T extends Configuration> implements Config
     @Override
     public final void run(T configuration, Environment environment) throws Exception {
         final DatabaseConfiguration dbConfig = getDatabaseConfiguration(configuration);
-        this.sessionFactory = sessionFactoryFactory.build(environment, dbConfig, entities);
+        this.sessionFactory = sessionFactoryFactory.build(this, environment, dbConfig, entities);
         environment.addProvider(new UnitOfWorkResourceMethodDispatchAdapter(sessionFactory));
         environment.addHealthCheck(new SessionFactoryHealthCheck("hibernate",
                                                                  sessionFactory,
@@ -44,5 +44,8 @@ public abstract class HibernateBundle<T extends Configuration> implements Config
 
     public SessionFactory getSessionFactory() {
         return sessionFactory;
+    }
+
+    public void configure(org.hibernate.cfg.Configuration configuration) {
     }
 }

--- a/dropwizard-hibernate/src/main/java/com/yammer/dropwizard/hibernate/SessionFactoryFactory.java
+++ b/dropwizard-hibernate/src/main/java/com/yammer/dropwizard/hibernate/SessionFactoryFactory.java
@@ -26,13 +26,15 @@ public class SessionFactoryFactory {
 
     private final ManagedDataSourceFactory dataSourceFactory = new ManagedDataSourceFactory();
 
-    public SessionFactory build(Environment environment,
+    public SessionFactory build(HibernateBundle bundle,
+                                Environment environment,
                                 DatabaseConfiguration dbConfig,
                                 List<Class<?>> entities) throws ClassNotFoundException {
         final ManagedDataSource dataSource = dataSourceFactory.build(dbConfig);
         final ConnectionProvider provider = buildConnectionProvider(dataSource,
                                                                     dbConfig.getProperties());
-        final SessionFactory factory = buildSessionFactory(dbConfig,
+        final SessionFactory factory = buildSessionFactory(bundle,
+                                                           dbConfig,
                                                            provider,
                                                            dbConfig.getProperties(),
                                                            entities);
@@ -49,7 +51,8 @@ public class SessionFactoryFactory {
         return connectionProvider;
     }
 
-    private SessionFactory buildSessionFactory(DatabaseConfiguration dbConfig,
+    private SessionFactory buildSessionFactory(HibernateBundle bundle,
+                                               DatabaseConfiguration dbConfig,
                                                ConnectionProvider connectionProvider,
                                                ImmutableMap<String, String> properties,
                                                List<Class<?>> entities) {
@@ -68,6 +71,7 @@ public class SessionFactoryFactory {
         }
 
         addAnnotatedClasses(configuration, entities);
+        bundle.configure(configuration);
 
         final ServiceRegistry registry = new ServiceRegistryBuilder()
                 .addService(ConnectionProvider.class, connectionProvider)

--- a/dropwizard-hibernate/src/test/java/com/yammer/dropwizard/hibernate/tests/HibernateBundleTest.java
+++ b/dropwizard-hibernate/src/test/java/com/yammer/dropwizard/hibernate/tests/HibernateBundleTest.java
@@ -37,7 +37,8 @@ public class HibernateBundleTest {
     @Before
     @SuppressWarnings("unchecked")
     public void setUp() throws Exception {
-        when(factory.build(any(Environment.class),
+        when(factory.build(eq(bundle),
+                           any(Environment.class),
                            any(DatabaseConfiguration.class),
                            anyList())).thenReturn(sessionFactory);
     }
@@ -61,7 +62,7 @@ public class HibernateBundleTest {
     public void buildsASessionFactory() throws Exception {
         bundle.run(configuration, environment);
 
-        verify(factory).build(environment, dbConfig, entities);
+        verify(factory).build(bundle, environment, dbConfig, entities);
     }
 
     @Test

--- a/dropwizard-hibernate/src/test/java/com/yammer/dropwizard/hibernate/tests/JerseyIntegrationTest.java
+++ b/dropwizard-hibernate/src/test/java/com/yammer/dropwizard/hibernate/tests/JerseyIntegrationTest.java
@@ -9,6 +9,7 @@ import com.sun.jersey.test.framework.LowLevelAppDescriptor;
 import com.yammer.dropwizard.config.Environment;
 import com.yammer.dropwizard.db.DatabaseConfiguration;
 import com.yammer.dropwizard.hibernate.AbstractDAO;
+import com.yammer.dropwizard.hibernate.HibernateBundle;
 import com.yammer.dropwizard.hibernate.SessionFactoryFactory;
 import com.yammer.dropwizard.hibernate.UnitOfWork;
 import com.yammer.dropwizard.hibernate.UnitOfWorkResourceMethodDispatchAdapter;
@@ -91,6 +92,7 @@ public class JerseyIntegrationTest extends JerseyTest {
         final SessionFactoryFactory factory = new SessionFactoryFactory();
         final DatabaseConfiguration dbConfig = new DatabaseConfiguration();
         final ImmutableList<String> packages = ImmutableList.of("com.yammer.dropwizard.hibernate.tests");
+        final HibernateBundle bundle = mock(HibernateBundle.class);
         final Environment environment = mock(Environment.class);
 
         dbConfig.setUrl("jdbc:hsqldb:mem:DbTest-" + System.nanoTime());
@@ -99,7 +101,8 @@ public class JerseyIntegrationTest extends JerseyTest {
         dbConfig.setValidationQuery("SELECT 1 FROM INFORMATION_SCHEMA.SYSTEM_USERS");
 
         try {
-            this.sessionFactory = factory.build(environment,
+            this.sessionFactory = factory.build(bundle,
+                                                environment,
                                                 dbConfig,
                                                 ImmutableList.<Class<?>>of(Person.class));
         } catch (ClassNotFoundException e) {

--- a/dropwizard-hibernate/src/test/java/com/yammer/dropwizard/hibernate/tests/SessionFactoryFactoryTest.java
+++ b/dropwizard-hibernate/src/test/java/com/yammer/dropwizard/hibernate/tests/SessionFactoryFactoryTest.java
@@ -3,10 +3,12 @@ package com.yammer.dropwizard.hibernate.tests;
 import com.google.common.collect.ImmutableList;
 import com.yammer.dropwizard.config.Environment;
 import com.yammer.dropwizard.db.DatabaseConfiguration;
+import com.yammer.dropwizard.hibernate.HibernateBundle;
 import com.yammer.dropwizard.hibernate.ManagedSessionFactory;
 import com.yammer.dropwizard.hibernate.SessionFactoryFactory;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.cfg.Configuration;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.After;
@@ -25,6 +27,7 @@ public class SessionFactoryFactoryTest {
 
     private final SessionFactoryFactory factory = new SessionFactoryFactory();
 
+    private final HibernateBundle bundle = mock(HibernateBundle.class);
     private final Environment environment = mock(Environment.class);
     private final DatabaseConfiguration config = new DatabaseConfiguration();
 
@@ -53,6 +56,13 @@ public class SessionFactoryFactoryTest {
     }
 
     @Test
+    public void callsBundleToConfigure() throws Exception {
+      build();
+
+      verify(bundle).configure(any(Configuration.class));
+    }
+
+    @Test
     public void buildsAWorkingSessionFactory() throws Exception {
         build();
 
@@ -78,7 +88,8 @@ public class SessionFactoryFactoryTest {
     }
 
     private void build() throws ClassNotFoundException {
-        this.sessionFactory = factory.build(environment,
+        this.sessionFactory = factory.build(bundle,
+                                            environment,
                                             config,
                                             ImmutableList.<Class<?>>of(Person.class));
     }


### PR DESCRIPTION
Allows HibernateBundle to configure the SessionFactory in ways that are
not possible using standard properties.

Specifically NamingStrategy and any other configuration outside of
org.hibernate.cfg.Environment.
