### PR TITLE
Close Liquibase database connection on shutdown.

### DIFF
--- a/dropwizard-migrations/src/main/java/com/yammer/dropwizard/migrations/ManagedLiquibase.java
+++ b/dropwizard-migrations/src/main/java/com/yammer/dropwizard/migrations/ManagedLiquibase.java
@@ -30,6 +30,7 @@ public class ManagedLiquibase extends Liquibase implements Managed {
         @Override
         public void stop() throws Exception {
             dataSource.stop();
+            close();
         }
 
         @Override
@@ -59,9 +60,6 @@ public class ManagedLiquibase extends Liquibase implements Managed {
         final DatabaseConnection connection = getDatabase().getConnection();
         if (connection instanceof ManagedJdbcConnection) {
             ((ManagedJdbcConnection) connection).stop();
-        }
-        if (connection != null) {
-            connection.close();
         }
     }
 }


### PR DESCRIPTION
Make sure to close down the underlying Liquibase database connection on shutdown of the ManagedLiquibase service.
