### PR TITLE
Update jDBI to 2.48.2

### DIFF
--- a/dropwizard-jdbi/pom.xml
+++ b/dropwizard-jdbi/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi</artifactId>
-            <version>2.41</version>
+            <version>2.48.2</version>
         </dependency>
         <dependency>
             <groupId>com.yammer.metrics</groupId>


### PR DESCRIPTION
2.48.2 fixes a bug where using sqlObject.begin() followed by a call to an @Transaction annotated method would cause an unexpected early commit on return from the method.
