### PR TITLE
nested custom config needs explicit JonsProperty defined

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -171,6 +171,10 @@ command you need). There is a test keystore you can use in the
         # optional, JKS is default. JCEKS is another likely candidate.
         keyStoreType: JKS
 
+.. note::
+
+    If using SSL you will also need to set ``connectorType`` to one of the ``+ssl`` options.
+
 Bootstrapping
 =============
 


### PR DESCRIPTION
If you have a custom nested config directive, you need to explicitly call out the parent level string in the @JsonPropery in the base Configuration class.
