### PR TITLE
Add ability to define custom MIME mappings (for servlets)

### DIFF
--- a/dropwizard-jetty/src/main/java/com/codahale/dropwizard/jetty/setup/ServletEnvironment.java
+++ b/dropwizard-jetty/src/main/java/com/codahale/dropwizard/jetty/setup/ServletEnvironment.java
@@ -118,4 +118,8 @@ public class ServletEnvironment {
     public void setSecurityHandler(SecurityHandler securityHandler) {
         handler.setSecurityHandler(securityHandler);
     }
+
+    public void addMimeMapping(String extension, String type) {
+        handler.getMimeTypes().addMimeMapping(extension, type);
+    }
 }

--- a/dropwizard-jetty/src/test/java/com/codahale/dropwizard/jetty/setup/ServletEnvironmentTest.java
+++ b/dropwizard-jetty/src/test/java/com/codahale/dropwizard/jetty/setup/ServletEnvironmentTest.java
@@ -1,6 +1,7 @@
 package com.codahale.dropwizard.jetty.setup;
 
 import org.eclipse.jetty.continuation.ContinuationFilter;
+import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.security.SecurityHandler;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlet.FilterHolder;
@@ -16,6 +17,7 @@ import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class ServletEnvironmentTest {
     private final ServletContextHandler handler = mock(ServletContextHandler.class);
@@ -129,5 +131,15 @@ public class ServletEnvironmentTest {
         environment.setSecurityHandler(securityHandler);
 
         verify(handler).setSecurityHandler(securityHandler);
+    }
+
+    @Test
+    public void addsMimeMapping() {
+        final MimeTypes mimeTypes = mock(MimeTypes.class);
+        when(handler.getMimeTypes()).thenReturn(mimeTypes);
+
+        environment.addMimeMapping("example/foo", "foo");
+
+        verify(mimeTypes).addMimeMapping("example/foo", "foo");
     }
 }


### PR DESCRIPTION
Intended primarily for use with AssetServlet. Analogous to `<mime-mapping>` in a deployment descriptor, so didn't seem necessary to expose `MimeTypes` directly.
