### PR TITLE
Example project health check fails for hsqldb

### DIFF
--- a/dropwizard-example/example.yml
+++ b/dropwizard-example/example.yml
@@ -17,6 +17,10 @@ database:
   # the JDBC URL
   url: jdbc:hsqldb:target/example
 
+  # override health check query for hsqldb
+  # taken from http://javasplitter.blogspot.com/2011/01/keep-alive-query-in-hsqldb.html
+  validationQuery: SELECT * FROM INFORMATION_SCHEMA.SYSTEM_TABLES
+
 # use the simple server factory if you only want to run on a single port
 #server:
 #  type: simple


### PR DESCRIPTION
"SELECT 1" doesn't seem to work for hsqldb. So I replaced it with "SELECT \* FROM INFORMATION_SCHEMA.SYSTEM_TABLES" which I found here: http://javasplitter.blogspot.com/2011/01/keep-alive-query-in-hsqldb.html 
