### PR TITLE
Fix null shutdown timeout in ExecutorServices

### DIFF
--- a/dropwizard-lifecycle/src/main/java/com/codahale/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilder.java
+++ b/dropwizard-lifecycle/src/main/java/com/codahale/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilder.java
@@ -19,6 +19,8 @@ public class ScheduledExecutorServiceBuilder {
         this.nameFormat = nameFormat;
         this.poolSize = 1;
         this.threadFactory = new ThreadFactoryBuilder().setNameFormat(nameFormat).build();
+        this.shutdownTime = 5;
+        this.shutdownUnit = TimeUnit.SECONDS;
         this.handler = new ThreadPoolExecutor.AbortPolicy();
     }
 


### PR DESCRIPTION
`ScheduledExecutorServiceBuilder` defines no default `shutdownTime` or `shutdownUnit`. These are passed to `ExecutorServiceManager` which in turn uses them verbatim on `ExecutorService#awaitTermination(long, TimeUnit)`, potentially causing a `NullPointerException`.

Adding default values resolves this problem.
