### PR TITLE
Provide Duration APIs as well as (long, TimeUnit)

### DIFF
--- a/dropwizard-client/src/main/java/com/codahale/dropwizard/client/HttpClientBuilder.java
+++ b/dropwizard-client/src/main/java/com/codahale/dropwizard/client/HttpClientBuilder.java
@@ -1,6 +1,7 @@
 package com.codahale.dropwizard.client;
 
 import com.codahale.dropwizard.setup.Environment;
+import com.codahale.dropwizard.util.Duration;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.httpclient.InstrumentedClientConnManager;
 import com.codahale.metrics.httpclient.InstrumentedHttpClient;
@@ -170,12 +171,12 @@ public class HttpClientBuilder {
      * @return a InstrumentedClientConnManger instance
      */
     protected InstrumentedClientConnManager createConnectionManager(SchemeRegistry registry, String name) {
-        final long ttl = configuration.getTimeToLive().toMilliseconds();
+        final Duration ttl = configuration.getTimeToLive();
         final InstrumentedClientConnManager manager =
                 new InstrumentedClientConnManager(metricRegistry,
                                                   registry,
-                                                  ttl,
-                                                  TimeUnit.MILLISECONDS,
+                                                  ttl.getQuantity(),
+                                                  ttl.getUnit(),
                                                   resolver,
                                                   name);
         manager.setDefaultMaxPerRoute(configuration.getMaxConnectionsPerRoute());

--- a/dropwizard-lifecycle/pom.xml
+++ b/dropwizard-lifecycle/pom.xml
@@ -31,6 +31,11 @@
         </dependency>
         <dependency>
             <groupId>com.codahale.dropwizard</groupId>
+            <artifactId>dropwizard-util</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.codahale.dropwizard</groupId>
             <artifactId>dropwizard-logging</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/dropwizard-lifecycle/src/main/java/com/codahale/dropwizard/lifecycle/ExecutorServiceManager.java
+++ b/dropwizard-lifecycle/src/main/java/com/codahale/dropwizard/lifecycle/ExecutorServiceManager.java
@@ -1,5 +1,7 @@
 package com.codahale.dropwizard.lifecycle;
 
+import com.codahale.dropwizard.util.Duration;
+
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -8,6 +10,10 @@ public class ExecutorServiceManager implements Managed {
     private final long shutdownPeriod;
     private final TimeUnit unit;
     private final String poolName;
+
+    public ExecutorServiceManager(ExecutorService executor, Duration shutdownPeriod, String poolName) {
+        this(executor, shutdownPeriod.getQuantity(), shutdownPeriod.getUnit(), poolName);
+    }
 
     public ExecutorServiceManager(ExecutorService executor, long shutdownPeriod, TimeUnit unit, String poolName) {
         this.executor = executor;

--- a/dropwizard-lifecycle/src/main/java/com/codahale/dropwizard/lifecycle/setup/ExecutorServiceBuilder.java
+++ b/dropwizard-lifecycle/src/main/java/com/codahale/dropwizard/lifecycle/setup/ExecutorServiceBuilder.java
@@ -1,6 +1,7 @@
 package com.codahale.dropwizard.lifecycle.setup;
 
 import com.codahale.dropwizard.lifecycle.ExecutorServiceManager;
+import com.codahale.dropwizard.util.Duration;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import java.util.concurrent.*;
@@ -42,10 +43,18 @@ public class ExecutorServiceBuilder {
         return this;
     }
 
+    public ExecutorServiceBuilder keepAliveTime(Duration time) {
+        return keepAliveTime(time.getQuantity(), time.getUnit());
+    }
+
     public ExecutorServiceBuilder keepAliveTime(long time, TimeUnit unit) {
         this.keepAliveTime = time;
         this.keepAliveUnit = unit;
         return this;
+    }
+
+    public ExecutorServiceBuilder shutdownTime(Duration time) {
+        return shutdownTime(time.getQuantity(), time.getUnit());
     }
 
     public ExecutorServiceBuilder shutdownTime(long time, TimeUnit unit) {

--- a/dropwizard-lifecycle/src/main/java/com/codahale/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilder.java
+++ b/dropwizard-lifecycle/src/main/java/com/codahale/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilder.java
@@ -1,6 +1,7 @@
 package com.codahale.dropwizard.lifecycle.setup;
 
 import com.codahale.dropwizard.lifecycle.ExecutorServiceManager;
+import com.codahale.dropwizard.util.Duration;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import java.util.concurrent.*;
@@ -25,6 +26,10 @@ public class ScheduledExecutorServiceBuilder {
     public ScheduledExecutorServiceBuilder threads(int threads) {
         this.poolSize = threads;
         return this;
+    }
+
+    public ScheduledExecutorServiceBuilder shutdownTime(Duration time) {
+        return shutdownTime(time.getQuantity(), time.getUnit());
     }
 
     public ScheduledExecutorServiceBuilder shutdownTime(long time, TimeUnit unit) {


### PR DESCRIPTION
Several components require setting a duration (for timeouts etc.) that require a `long` and `TimeUnit` pair. Lets provide an API that accepts a `Duration` instead, as it's often less cumbersome to work with, especially when working with a `Configuration` that already provides the value as a `Duration`.

Note: this adds `dropwizard-util` as a dependency of `dropwizard-lifecycle`.
