### PR TITLE
Fix incorrect handling of entity tags

### DIFF
--- a/dropwizard-servlets/pom.xml
+++ b/dropwizard-servlets/pom.xml
@@ -25,6 +25,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jetty.orbit</groupId>
             <artifactId>javax.servlet</artifactId>
             <version>${servlet.version}</version>

--- a/dropwizard-servlets/src/main/java/com/codahale/dropwizard/servlets/assets/AssetServlet.java
+++ b/dropwizard-servlets/src/main/java/com/codahale/dropwizard/servlets/assets/AssetServlet.java
@@ -5,6 +5,7 @@ import com.google.common.hash.Hashing;
 import com.google.common.io.Resources;
 import com.google.common.net.HttpHeaders;
 import com.google.common.net.MediaType;
+import org.eclipse.jetty.util.QuotedStringTokenizer;
 
 import javax.servlet.ServletException;
 import javax.servlet.ServletOutputStream;
@@ -113,7 +114,7 @@ public class AssetServlet extends HttpServlet {
             }
 
             resp.setDateHeader(HttpHeaders.LAST_MODIFIED, cachedAsset.getLastModifiedTime());
-            resp.setHeader(HttpHeaders.ETAG, cachedAsset.getETag());
+            resp.setHeader(HttpHeaders.ETAG, QuotedStringTokenizer.quote(cachedAsset.getETag()));
 
             final String mimeTypeOfExtension = req.getServletContext()
                                                   .getMimeType(req.getRequestURI());
@@ -169,7 +170,7 @@ public class AssetServlet extends HttpServlet {
     }
 
     private boolean isCachedClientSide(HttpServletRequest req, CachedAsset cachedAsset) {
-        return cachedAsset.getETag().equals(req.getHeader(HttpHeaders.IF_NONE_MATCH)) ||
+        return cachedAsset.getETag().equals(QuotedStringTokenizer.unquote(req.getHeader(HttpHeaders.IF_NONE_MATCH))) ||
                 (req.getDateHeader(HttpHeaders.IF_MODIFIED_SINCE) >= cachedAsset.getLastModifiedTime());
     }
 }

--- a/dropwizard-servlets/src/test/java/com/codahale/dropwizard/servlets/assets/AssetServletTest.java
+++ b/dropwizard-servlets/src/test/java/com/codahale/dropwizard/servlets/assets/AssetServletTest.java
@@ -4,6 +4,7 @@ import com.google.common.base.Charsets;
 import com.google.common.net.HttpHeaders;
 import org.eclipse.jetty.http.*;
 import org.eclipse.jetty.servlet.ServletTester;
+import org.eclipse.jetty.util.QuotedStringTokenizer;
 import org.fest.assertions.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
@@ -126,10 +127,10 @@ public class AssetServletTest {
     @Test
     public void consistentlyAssignsETags() throws Exception {
         response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
-        final String firstEtag = response.get(HttpHeaders.ETAG);
+        final String firstEtag = QuotedStringTokenizer.unquote(response.get(HttpHeaders.ETAG));
 
         response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
-        final String secondEtag = response.get(HttpHeaders.ETAG);
+        final String secondEtag = QuotedStringTokenizer.unquote(response.get(HttpHeaders.ETAG));
 
         Assertions.assertThat(firstEtag)
                   .isNotNull();
@@ -142,11 +143,11 @@ public class AssetServletTest {
     @Test
     public void assignsDifferentETagsForDifferentFiles() throws Exception {
         response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
-        final String firstEtag = response.get(HttpHeaders.ETAG);
+        final String firstEtag = QuotedStringTokenizer.unquote(response.get(HttpHeaders.ETAG));
 
         request.setURI(DUMMY_SERVLET + "foo.bar");
         response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
-        final String secondEtag = response.get(HttpHeaders.ETAG);
+        final String secondEtag = QuotedStringTokenizer.unquote(response.get(HttpHeaders.ETAG));
 
         Assertions.assertThat(firstEtag)
                   .isNotEqualTo(secondEtag);
@@ -155,13 +156,13 @@ public class AssetServletTest {
     @Test
     public void supportsIfNoneMatchRequests() throws Exception {
         response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
-        final String correctEtag = response.get(HttpHeaders.ETAG);
+        final String correctEtag = QuotedStringTokenizer.unquote(response.get(HttpHeaders.ETAG));
 
-        request.setHeader(HttpHeaders.IF_NONE_MATCH, correctEtag);
+        request.setHeader(HttpHeaders.IF_NONE_MATCH, QuotedStringTokenizer.quote(correctEtag));
         response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
         final int statusWithMatchingEtag = response.getStatus();
 
-        request.setHeader(HttpHeaders.IF_NONE_MATCH, correctEtag + "FOO");
+        request.setHeader(HttpHeaders.IF_NONE_MATCH, QuotedStringTokenizer.quote(correctEtag + "FOO"));
         response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
         final int statusWithNonMatchingEtag = response.getStatus();
 


### PR DESCRIPTION
Entity tags aren't plain strings; they are quoted strings.

This code uses some Jetty utility functions to handle the quoting/unquoting. Using `javax.ws.rs.core.EntityTag` is arguably a better approach, but that would introduce an otherwise unnecessary dependency to the servlets module. Adding a dependency on jetty-util seemed less onerous.
