### PR TITLE
Fix package name for GangliaReporterFactoryTest

### DIFF
--- a/dropwizard-metrics-ganglia/src/test/java/com/codahale/dropwizard/metrics/ganglia/GangliaReporterFactoryTest.java
+++ b/dropwizard-metrics-ganglia/src/test/java/com/codahale/dropwizard/metrics/ganglia/GangliaReporterFactoryTest.java
@@ -1,7 +1,6 @@
-package com.codahale.dropwizard.metrics.reporters.ganglia;
+package com.codahale.dropwizard.metrics.ganglia;
 
 import com.codahale.dropwizard.jackson.DiscoverableSubtypeResolver;
-import com.codahale.dropwizard.metrics.ganglia.GangliaReporterFactory;
 import org.fest.assertions.api.Assertions;
 import org.junit.Test;
 


### PR DESCRIPTION
It apparently didn't get moved along with GangliaReporterFactory.
