### PR TITLE
Support alternate log classes for request logging.

### DIFF
--- a/dropwizard-jetty/src/main/java/com/codahale/dropwizard/jetty/AbstractRequestLog.java
+++ b/dropwizard-jetty/src/main/java/com/codahale/dropwizard/jetty/AbstractRequestLog.java
@@ -1,0 +1,23 @@
+package com.codahale.dropwizard.jetty;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.spi.AppenderAttachableImpl;
+import org.eclipse.jetty.server.AbstractNCSARequestLog;
+
+import java.util.TimeZone;
+
+/**
+ * A base class to allow alternate request log implementations to be used. Really only needed to define
+ * a common constructor signature.
+ */
+public abstract class AbstractRequestLog extends AbstractNCSARequestLog {
+
+  private final AppenderAttachableImpl<ILoggingEvent> appenders;
+  private final TimeZone timeZone;
+
+  protected AbstractRequestLog( AppenderAttachableImpl<ILoggingEvent> appenders, TimeZone timeZone ) {
+    this.appenders = appenders;
+    this.timeZone = timeZone;
+  }
+
+}

--- a/dropwizard-jetty/src/main/java/com/codahale/dropwizard/jetty/Slf4jRequestLog.java
+++ b/dropwizard-jetty/src/main/java/com/codahale/dropwizard/jetty/Slf4jRequestLog.java
@@ -13,7 +13,7 @@ import java.util.TimeZone;
 /**
  * A SLF4J-backed {@link RequestLog} implementation of {@link AbstractNCSARequestLog}.
  */
-public class Slf4jRequestLog extends AbstractNCSARequestLog {
+public class Slf4jRequestLog extends AbstractRequestLog {
     private final AppenderAttachableImpl<ILoggingEvent> appenders;
 
     /**
@@ -23,6 +23,7 @@ public class Slf4jRequestLog extends AbstractNCSARequestLog {
      * @param timeZone      the timezone to which timestamps will be converted
      */
     public Slf4jRequestLog(AppenderAttachableImpl<ILoggingEvent> appenders, TimeZone timeZone) {
+        super(appenders, timeZone);
         this.appenders = appenders;
 
         setLogDispatch(true);

--- a/dropwizard-jetty/src/test/java/com/codahale/dropwizard/jetty/RequestLogFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/com/codahale/dropwizard/jetty/RequestLogFactoryTest.java
@@ -1,5 +1,7 @@
 package com.codahale.dropwizard.jetty;
 
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.spi.AppenderAttachableImpl;
 import com.codahale.dropwizard.configuration.ConfigurationFactory;
 import com.codahale.dropwizard.jackson.Jackson;
 import com.codahale.dropwizard.logging.ConsoleAppenderFactory;
@@ -32,9 +34,36 @@ public class RequestLogFactoryTest {
                 .build(new File(Resources.getResource("yaml/requestLog.yml").toURI()));
     }
 
-    @Test
-    public void defaultTimeZoneIsUTC() {
-        assertThat(requestLog.getTimeZone())
-            .isEqualTo(TimeZone.getTimeZone("UTC"));
-    }
+  @Test
+  public void defaultTimeZoneIsUTC() {
+    assertThat(requestLog.getTimeZone())
+        .isEqualTo(TimeZone.getTimeZone("UTC"));
+  }
+
+  @Test
+  public void logClassIsDefault() {
+    assertThat(requestLog.build("test").getClass().getName())
+        .isEqualTo( Slf4jRequestLog.class.getName() );
+  }
+
+  @Test
+  public void alternateLogClass() throws Exception {
+    RequestLogFactory customRequestLog = new ConfigurationFactory<>(
+        RequestLogFactory.class,
+        Validation.buildDefaultValidatorFactory().getValidator(),
+        Jackson.newObjectMapper(), "dw" )
+        .build( new File( Resources.getResource( "yaml/requestLog-alternateLogClass.yml" ).toURI() ) );
+
+    assertThat( customRequestLog.build( "test" ).getClass().getName() )
+        .isEqualTo( AlternateRequestLog.class.getName() );
+  }
+
+}
+
+class AlternateRequestLog extends Slf4jRequestLog {
+
+  AlternateRequestLog( AppenderAttachableImpl<ILoggingEvent> appenders, TimeZone timeZone ) {
+    super( appenders, timeZone );
+  }
+
 }

--- a/dropwizard-jetty/src/test/resources/yaml/requestLog-alternateLogClass.yml
+++ b/dropwizard-jetty/src/test/resources/yaml/requestLog-alternateLogClass.yml
@@ -1,0 +1,1 @@
+alternateLogClass: com.codahale.dropwizard.jetty.AlternateRequestLog


### PR DESCRIPTION
Allows an alternate log class to be specified via configuration. Specifically needed to customize the request log format.
