### PR TITLE
Fix issue364

### DIFF
--- a/dropwizard-testing/pom.xml
+++ b/dropwizard-testing/pom.xml
@@ -48,15 +48,20 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>1.9.5</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.objenesis</groupId>
+                    <artifactId>objenesis</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
 	        <groupId>org.objenesis</groupId>
 	        <artifactId>objenesis</artifactId>
-	        <version>1.3</version>
-        </dependency>
-        <dependency>
-	        <groupId>org.hamcrest</groupId>
-	        <artifactId>hamcrest-all</artifactId>
 	        <version>1.3</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
Fixes #364 by specifying the latest version of objenesis. Hamcrest's latest version is included in the Junit dependency.

Exclusions are added to the mockito artifact.
