### PR TITLE
fix small typo in testing docs

### DIFF
--- a/docs/source/manual/testing.rst
+++ b/docs/source/manual/testing.rst
@@ -150,7 +150,7 @@ loads a given resource instance in an in-memory Jersey server:
 
         @Override
         protected void setUpResources() {
-            when(store.fetchPerson(anyString())).thenReturn(person);
+            when(dao.fetchPerson(anyString())).thenReturn(person);
             addResource(new PersonResource(dao));
         }
 
@@ -159,7 +159,7 @@ loads a given resource instance in an in-memory Jersey server:
             assertThat(client().resource("/person/blah").get(Person.class))
                        .isEqualTo(person);
 
-            verify(store).fetchPerson("blah");
+            verify(dao).fetchPerson("blah");
         }
     }
 


### PR DESCRIPTION
looks like in 3b0561efa5d96b4b8a1d3abb0379e5510e2d5290 @simoncollins forgot to change store -> dao in 2 places
