### PR TITLE
Add route capabilities to hibernate module.

### DIFF
--- a/dropwizard-db/src/main/java/com/codahale/dropwizard/db/DataSourceRoute.java
+++ b/dropwizard-db/src/main/java/com/codahale/dropwizard/db/DataSourceRoute.java
@@ -1,0 +1,44 @@
+package com.codahale.dropwizard.db;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * Route-capable {@link DataSourceFactory}.
+ */
+public class DataSourceRoute {
+    @NotNull
+    private String routeName;
+
+    @NotNull
+    private DataSourceFactory database;
+
+    /**
+     * @return the routeName
+     */
+    public String getRouteName() {
+        return routeName;
+    }
+
+    /**
+     * @param routeName
+     *            the routeName to set
+     */
+    public void setRouteName(String routeName) {
+        this.routeName = routeName;
+    }
+
+    /**
+     * @return the database
+     */
+    public DataSourceFactory getDatabase() {
+        return database;
+    }
+
+    /**
+     * @param database
+     *            the database to set
+     */
+    public void setDatabase(DataSourceFactory database) {
+        this.database = database;
+    }
+}

--- a/dropwizard-db/src/main/java/com/codahale/dropwizard/db/RouteCapableDatabaseConfiguration.java
+++ b/dropwizard-db/src/main/java/com/codahale/dropwizard/db/RouteCapableDatabaseConfiguration.java
@@ -1,0 +1,15 @@
+package com.codahale.dropwizard.db;
+
+import com.codahale.dropwizard.Configuration;
+import com.google.common.collect.ImmutableList;
+
+public interface RouteCapableDatabaseConfiguration<T extends Configuration> {
+    /**
+     * First entry will be default route.
+     * 
+     * @param configuration
+     *            service configuration
+     * @return the list of {@link DataSourceRoute}
+     */
+    ImmutableList<DataSourceRoute> getDataSourceRoutes(T configuration);
+}

--- a/dropwizard-hibernate/src/main/java/com/codahale/dropwizard/hibernate/HibernateBundle.java
+++ b/dropwizard-hibernate/src/main/java/com/codahale/dropwizard/hibernate/HibernateBundle.java
@@ -13,8 +13,8 @@ import org.hibernate.SessionFactory;
 public abstract class HibernateBundle<T extends Configuration> implements ConfiguredBundle<T>, DatabaseConfiguration<T> {
     private SessionFactory sessionFactory;
 
-    private final ImmutableList<Class<?>> entities;
-    private final SessionFactoryFactory sessionFactoryFactory;
+    protected final ImmutableList<Class<?>> entities;
+    protected final SessionFactoryFactory sessionFactoryFactory;
 
     protected HibernateBundle(Class<?> entity, Class<?>... entities) {
         this(ImmutableList.<Class<?>>builder().add(entity).add(entities).build(),
@@ -33,7 +33,7 @@ public abstract class HibernateBundle<T extends Configuration> implements Config
     }
 
     @Override
-    public final void run(T configuration, Environment environment) throws Exception {
+    public void run(T configuration, Environment environment) throws Exception {
         final DataSourceFactory dbConfig = getDataSourceFactory(configuration);
         this.sessionFactory = sessionFactoryFactory.build(this, environment, dbConfig, entities);
         environment.jersey().register(new UnitOfWorkResourceMethodDispatchAdapter(sessionFactory));

--- a/dropwizard-hibernate/src/main/java/com/codahale/dropwizard/hibernate/RouteCapableHibernateBundle.java
+++ b/dropwizard-hibernate/src/main/java/com/codahale/dropwizard/hibernate/RouteCapableHibernateBundle.java
@@ -1,0 +1,60 @@
+package com.codahale.dropwizard.hibernate;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.codahale.dropwizard.Configuration;
+import com.codahale.dropwizard.db.DataSourceFactory;
+import com.codahale.dropwizard.db.DataSourceRoute;
+import com.codahale.dropwizard.db.RouteCapableDatabaseConfiguration;
+import com.codahale.dropwizard.setup.Environment;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import org.hibernate.SessionFactory;
+
+public abstract class RouteCapableHibernateBundle<T extends Configuration> extends HibernateBundle<T> implements
+        RouteCapableDatabaseConfiguration<T> {
+    private ImmutableMap<Optional<String>, SessionFactory> sessionFactoryMap;
+
+    public ImmutableMap<Optional<String>, SessionFactory> getSessionFactories() {
+        return sessionFactoryMap;
+    }
+
+    public RouteCapableHibernateBundle(Class<?> entity, Class<?>... entities) {
+        super(entity, entities);
+    }
+
+    public RouteCapableHibernateBundle(ImmutableList<Class<?>> entities, SessionFactoryFactory sessionFactoryFactory) {
+        super(entities, sessionFactoryFactory);
+    }
+
+    @Override
+    public final void run(T configuration, Environment environment) throws Exception {
+        final Map<Optional<String>, SessionFactory> sessionFactories = new LinkedHashMap<>();
+        for (DataSourceRoute route : getDataSourceRoutes(configuration)) {
+            final String routeKey = route.getRouteName();
+            final DataSourceFactory dbConfig = route.getDatabase();
+
+            final SessionFactory sessionFactory = sessionFactoryFactory.build(this, environment, dbConfig, entities,
+                    routeKey);
+            environment.healthChecks().register(routeKey,
+                    new SessionFactoryHealthCheck(sessionFactory, dbConfig.getValidationQuery()));
+
+            // the primary url will be the default route when no route key is provided
+            if (sessionFactories.isEmpty()) {
+                sessionFactories.put(Optional.<String> absent(), sessionFactory);
+            }
+            sessionFactories.put(Optional.of(routeKey), sessionFactory);
+        }
+
+        this.sessionFactoryMap = ImmutableMap.copyOf(sessionFactories);
+        environment.jersey().register(new UnitOfWorkResourceMethodDispatchAdapter(this.sessionFactoryMap));
+    }
+
+    @Override
+    public final DataSourceFactory getDataSourceFactory(T configuration) {
+        return null; // no-op
+    }
+}

--- a/dropwizard-hibernate/src/main/java/com/codahale/dropwizard/hibernate/SessionFactoryFactory.java
+++ b/dropwizard-hibernate/src/main/java/com/codahale/dropwizard/hibernate/SessionFactoryFactory.java
@@ -31,6 +31,14 @@ public class SessionFactoryFactory {
     }
 
     public SessionFactory build(HibernateBundle<?> bundle,
+            Environment environment, DataSourceFactory dbConfig,
+            List<Class<?>> entities, String name) throws ClassNotFoundException {
+        final ManagedDataSource dataSource = dbConfig.build(
+                environment.metrics(), name);
+        return build(bundle, environment, dbConfig, dataSource, entities);
+    }
+
+    public SessionFactory build(HibernateBundle<?> bundle,
                                 Environment environment,
                                 DataSourceFactory dbConfig,
                                 ManagedDataSource dataSource,

--- a/dropwizard-hibernate/src/main/java/com/codahale/dropwizard/hibernate/UnitOfWorkResourceMethodDispatchAdapter.java
+++ b/dropwizard-hibernate/src/main/java/com/codahale/dropwizard/hibernate/UnitOfWorkResourceMethodDispatchAdapter.java
@@ -1,5 +1,7 @@
 package com.codahale.dropwizard.hibernate;
 
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 import com.sun.jersey.spi.container.ResourceMethodDispatchAdapter;
 import com.sun.jersey.spi.container.ResourceMethodDispatchProvider;
 import org.hibernate.SessionFactory;
@@ -8,18 +10,28 @@ import javax.ws.rs.ext.Provider;
 
 @Provider
 public class UnitOfWorkResourceMethodDispatchAdapter implements ResourceMethodDispatchAdapter {
-    private final SessionFactory sessionFactory;
+    private final ImmutableMap<Optional<String>, SessionFactory> sessionFactoryMap;
 
     public UnitOfWorkResourceMethodDispatchAdapter(SessionFactory sessionFactory) {
-        this.sessionFactory = sessionFactory;
+        final ImmutableMap.Builder<Optional<String>, SessionFactory> bldr = new ImmutableMap.Builder<>();
+        bldr.put(Optional.<String> absent(), sessionFactory);
+        sessionFactoryMap = bldr.build();
     }
 
-    public SessionFactory getSessionFactory() {
-        return sessionFactory;
+    public UnitOfWorkResourceMethodDispatchAdapter(ImmutableMap<Optional<String>, SessionFactory> sessionFactoryMap) {
+        this.sessionFactoryMap = sessionFactoryMap;
+    }
+
+    public ImmutableMap<Optional<String>, SessionFactory> getSessionFactoryMap() {
+        return sessionFactoryMap;
+    }
+
+    public SessionFactory getDefaultSessionFactory() {
+        return sessionFactoryMap.get(Optional.absent());
     }
 
     @Override
     public ResourceMethodDispatchProvider adapt(ResourceMethodDispatchProvider provider) {
-        return new UnitOfWorkResourceMethodDispatchProvider(provider, sessionFactory);
+        return new UnitOfWorkResourceMethodDispatchProvider(provider, sessionFactoryMap);
     }
 }

--- a/dropwizard-hibernate/src/test/java/com/codahale/dropwizard/hibernate/HibernateBundleTest.java
+++ b/dropwizard-hibernate/src/test/java/com/codahale/dropwizard/hibernate/HibernateBundleTest.java
@@ -76,7 +76,7 @@ public class HibernateBundleTest {
                 ArgumentCaptor.forClass(UnitOfWorkResourceMethodDispatchAdapter.class);
         verify(jerseyEnvironment).register(captor.capture());
 
-        assertThat(captor.getValue().getSessionFactory()).isEqualTo(sessionFactory);
+        assertThat(captor.getValue().getDefaultSessionFactory()).isEqualTo(sessionFactory);
     }
 
     @Test

--- a/dropwizard-hibernate/src/test/java/com/codahale/dropwizard/hibernate/RouteCapableHibernateBundleTest.java
+++ b/dropwizard-hibernate/src/test/java/com/codahale/dropwizard/hibernate/RouteCapableHibernateBundleTest.java
@@ -1,0 +1,127 @@
+package com.codahale.dropwizard.hibernate;
+
+import com.codahale.dropwizard.Configuration;
+import com.codahale.dropwizard.db.DataSourceFactory;
+import com.codahale.dropwizard.db.DataSourceRoute;
+import com.codahale.dropwizard.jersey.setup.JerseyEnvironment;
+import com.codahale.dropwizard.setup.Bootstrap;
+import com.codahale.dropwizard.setup.Environment;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.hibernate4.Hibernate4Module;
+import com.google.common.collect.ImmutableList;
+
+import org.hibernate.SessionFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class RouteCapableHibernateBundleTest {
+    private static final String ROUTE_ONE = "RouteOne";
+    private static final String ROUTE_TWO = "RouteTwo";
+    private final DataSourceFactory dbConfigRouteOne = new DataSourceFactory();
+    private final DataSourceFactory dbConfigRouteTwo = new DataSourceFactory();
+    private final SessionFactory sessionFactoryRouteOne = mock(SessionFactory.class);
+    private final SessionFactory sessionFactoryRouteTwo = mock(SessionFactory.class);
+    private final ImmutableList<Class<?>> entities = ImmutableList.<Class<?>> of(Person.class);
+    private final SessionFactoryFactory factory = mock(SessionFactoryFactory.class);
+    private final Configuration configuration = mock(Configuration.class);
+    private final HealthCheckRegistry healthChecks = mock(HealthCheckRegistry.class);
+    private final JerseyEnvironment jerseyEnvironment = mock(JerseyEnvironment.class);
+    private final Environment environment = mock(Environment.class);
+    private final HibernateBundle<Configuration> bundle = new RouteCapableHibernateBundle<Configuration>(entities,
+            factory) {
+        @Override
+        public ImmutableList<DataSourceRoute> getDataSourceRoutes(Configuration configuration) {
+            final ImmutableList.Builder<DataSourceRoute> bldr = new ImmutableList.Builder<>();
+
+            final DataSourceRoute dsRouteOne = new DataSourceRoute();
+            dsRouteOne.setDatabase(dbConfigRouteOne);
+            dsRouteOne.setRouteName(ROUTE_ONE);
+            bldr.add(dsRouteOne);
+
+            final DataSourceRoute dsRouteTwo = new DataSourceRoute();
+            dsRouteTwo.setDatabase(dbConfigRouteTwo);
+            dsRouteTwo.setRouteName(ROUTE_TWO);
+            bldr.add(dsRouteTwo);
+            return bldr.build();
+        }
+    };
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setUp() throws Exception {
+        when(environment.healthChecks()).thenReturn(healthChecks);
+        when(environment.jersey()).thenReturn(jerseyEnvironment);
+
+        when(factory.build(eq(bundle), any(Environment.class), eq(dbConfigRouteOne), anyList(), eq(ROUTE_ONE)))
+                .thenReturn(sessionFactoryRouteOne);
+        when(factory.build(eq(bundle), any(Environment.class), eq(dbConfigRouteTwo), anyList(), eq(ROUTE_TWO)))
+                .thenReturn(sessionFactoryRouteTwo);
+    }
+
+    @Test
+    public void addsHibernateSupportToJackson() throws Exception {
+        final ObjectMapper objectMapperFactory = mock(ObjectMapper.class);
+
+        final Bootstrap<?> bootstrap = mock(Bootstrap.class);
+        when(bootstrap.getObjectMapper()).thenReturn(objectMapperFactory);
+
+        bundle.initialize(bootstrap);
+
+        final ArgumentCaptor<Module> captor = ArgumentCaptor.forClass(Module.class);
+        verify(objectMapperFactory).registerModule(captor.capture());
+
+        assertThat(captor.getValue()).isInstanceOf(Hibernate4Module.class);
+    }
+
+    @Test
+    public void buildsSessionFactories() throws Exception {
+        bundle.run(configuration, environment);
+
+        verify(factory).build(bundle, environment, dbConfigRouteOne, entities, ROUTE_ONE);
+        verify(factory).build(bundle, environment, dbConfigRouteTwo, entities, ROUTE_TWO);
+    }
+
+    @Test
+    public void registersATransactionalAdapter() throws Exception {
+        bundle.run(configuration, environment);
+
+        final ArgumentCaptor<UnitOfWorkResourceMethodDispatchAdapter> captor = ArgumentCaptor
+                .forClass(UnitOfWorkResourceMethodDispatchAdapter.class);
+        verify(jerseyEnvironment).register(captor.capture());
+
+        assertThat(captor.getValue().getSessionFactoryMap()).containsValue(sessionFactoryRouteOne);
+        assertThat(captor.getValue().getSessionFactoryMap()).containsValue(sessionFactoryRouteTwo);
+        assertThat(captor.getValue().getDefaultSessionFactory()).isEqualTo(sessionFactoryRouteOne);
+    }
+
+    @Test
+    public void registersSessionFactoryHealthChecks() throws Exception {
+        dbConfigRouteOne.setValidationQuery("SELECT something RouteOne");
+        dbConfigRouteTwo.setValidationQuery("SELECT something RouteTwo");
+
+        bundle.run(configuration, environment);
+
+        final ArgumentCaptor<SessionFactoryHealthCheck> captor = ArgumentCaptor
+                .forClass(SessionFactoryHealthCheck.class);
+        verify(healthChecks).register(eq(ROUTE_ONE), captor.capture());
+        assertThat(captor.getValue().getSessionFactory()).isEqualTo(sessionFactoryRouteOne);
+        assertThat(captor.getValue().getValidationQuery()).isEqualTo("SELECT something RouteOne");
+
+        verify(healthChecks).register(eq(ROUTE_TWO), captor.capture());
+        assertThat(captor.getValue().getSessionFactory()).isEqualTo(sessionFactoryRouteTwo);
+        assertThat(captor.getValue().getValidationQuery()).isEqualTo("SELECT something RouteTwo");
+    }
+
+    @Test
+    public void noOpSessionFactory() throws Exception {
+        bundle.run(configuration, environment);
+
+        assertThat(bundle.getSessionFactory()).isNull();
+    }
+}

--- a/dropwizard-hibernate/src/test/java/com/codahale/dropwizard/hibernate/UnitOfWorkResourceMethodDispatchAdapterTest.java
+++ b/dropwizard-hibernate/src/test/java/com/codahale/dropwizard/hibernate/UnitOfWorkResourceMethodDispatchAdapterTest.java
@@ -14,7 +14,7 @@ public class UnitOfWorkResourceMethodDispatchAdapterTest {
 
     @Test
     public void hasASessionFactory() throws Exception {
-        assertThat(adapter.getSessionFactory())
+        assertThat(adapter.getDefaultSessionFactory())
                 .isEqualTo(sessionFactory);
     }
 
@@ -28,7 +28,7 @@ public class UnitOfWorkResourceMethodDispatchAdapterTest {
         assertThat(decorator.getProvider())
                 .isEqualTo(provider);
 
-        assertThat(decorator.getSessionFactory())
+        assertThat(decorator.getDefaultSessionFactory())
                 .isEqualTo(sessionFactory);
     }
 }

--- a/dropwizard-hibernate/src/test/java/com/codahale/dropwizard/hibernate/UnitOfWorkResourceMethodDispatchProviderTest.java
+++ b/dropwizard-hibernate/src/test/java/com/codahale/dropwizard/hibernate/UnitOfWorkResourceMethodDispatchProviderTest.java
@@ -1,5 +1,7 @@
 package com.codahale.dropwizard.hibernate;
 
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 import com.sun.jersey.api.model.AbstractResourceMethod;
 import com.sun.jersey.spi.container.ResourceMethodDispatchProvider;
 import com.sun.jersey.spi.dispatch.RequestDispatcher;
@@ -27,8 +29,13 @@ public class UnitOfWorkResourceMethodDispatchProviderTest {
     private final ResourceMethodDispatchProvider underlying =
             mock(ResourceMethodDispatchProvider.class);
     private final SessionFactory sessionFactory = mock(SessionFactory.class);
-    private final UnitOfWorkResourceMethodDispatchProvider provider =
-            new UnitOfWorkResourceMethodDispatchProvider(underlying, sessionFactory);
+    private final UnitOfWorkResourceMethodDispatchProvider provider;
+    
+    public UnitOfWorkResourceMethodDispatchProviderTest() {
+        final ImmutableMap.Builder<Optional<String>, SessionFactory> bldr = new ImmutableMap.Builder<>();
+        bldr.put(Optional.<String> absent(), sessionFactory);
+        provider = new UnitOfWorkResourceMethodDispatchProvider(underlying, bldr.build());
+    }
 
     @Test
     public void ignoresNonAnnotatedMethods() throws Exception {
@@ -53,7 +60,7 @@ public class UnitOfWorkResourceMethodDispatchProviderTest {
 
         final UnitOfWorkRequestDispatcher decorator = (UnitOfWorkRequestDispatcher) provider.create(resourceMethod);
 
-        assertThat(decorator.getSessionFactory())
+        assertThat(decorator.getDefaultSessionFactory())
                 .isEqualTo(sessionFactory);
 
         assertThat(decorator.getDispatcher())


### PR DESCRIPTION
Adds database routing ability (via 'RouteKey' HTTP header) for Hibernate.

In Configuration Class:

``` java
@Valid
@NotNull
private ImmutableList<DataSourceRoute> databases;
```

In yaml file:

``` yaml
# Database settings.
databases:
  - routeName: routeone
    database:
      # the name of your JDBC driver
      driverClass: com.mysql.jdbc.Driver

      # the username
      user: userone

      # the password
      password: password

      # the database url
      url: jdbc:mysql://hostone.com:3306/myapp
  - routeName: routetwo
    database:
      # the name of your JDBC driver
      driverClass: com.mysql.jdbc.Driver

      # the username
      user: usertwo

      # the password
      password: password

      # the database url
      url: jdbc:mysql://hosttwo.com:3306/myapp
```

During bootstrap retrieve the session factory map from the RouteCapableHibernateBundle and create all your DAOs keyed by the routeName. For Example
In Service:

``` java
router = new DAORouter(hibernateBundle.getSessionFactories());
```

``` java
public class DAORouter {
    private final ImmutableMap<Optional<String>, DAO> daos;
    public DAORouter(
            final ImmutableMap<Optional<String>, SessionFactory> sessionFactoryMap) {
        checkNotNull(sessionFactoryMap);
        checkState(!sessionFactoryMap.isEmpty());

        final Map<Optional<String>, DAO> daos = new LinkedHashMap<>();
        for (Entry<Optional<String>, SessionFactory> e : sessionFactoryMap
                .entrySet()) {
            SessionFactory factory = checkNotNull(e.getValue());

            // if you have multiple DAOs you can make this an collection of DAOs based on route name
            daos.put(e.getKey(), new DAO(factory));
        }

        this.daos = ImmutableMap.copyOf(daos);
    }

    public DAO getDAO(String routeName) {
        return daos.get(Optional.fromNullable(routeName));
    }
}
```

Now you can pass that router to your resources and retrieve the appropriate DAO via the HttpHeader 'RouteKey' for each request in your resources:

``` java
private final DAORouter router;

@Context
private HttpHeaders headers;

public Resource(DAORouter router) {
    this.router = router;
}

@POST
@UnitOfWork
public void doSomething() {
  router.getDAO(getRouteName()).doSomething();
}

private String getRouteName() {
    return headers.getRequestHeaders().getFirst(UnitOfWorkRequestDispatcher.ROUTE_KEY_HEADER_NAME);
}
```
