### PR TITLE
Added new exception mapper for when a client disconnecting in the middle...

### DIFF
--- a/dropwizard-core/src/main/java/com/codahale/dropwizard/server/errors/EarlyEOFExceptionMapper.java
+++ b/dropwizard-core/src/main/java/com/codahale/dropwizard/server/errors/EarlyEOFExceptionMapper.java
@@ -1,0 +1,29 @@
+package com.codahale.dropwizard.server.errors;
+
+import org.eclipse.jetty.io.EofException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/**
+* This class is intended to catch Early EOF errors that occur when the client disconnects while the server is reading
+* from the input stream.
+*
+* We catch the org.ecplise.jetty.io.EofException rather than the more generic java.io.EOFException to ensure that we're
+* only catching jetty server based errors where the client disconnects, as specified by {@link EofException}.
+*/
+@Provider
+public class EarlyEOFExceptionMapper implements ExceptionMapper<EofException> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EarlyEOFExceptionMapper.class);
+
+    @Override
+    public Response toResponse(EofException e) {
+        LOGGER.debug("EOF Exception encountered - client disconnected during stream processing.", e);
+
+        return Response.noContent().build();
+    }
+}

--- a/dropwizard-core/src/main/java/com/codahale/dropwizard/setup/Environment.java
+++ b/dropwizard-core/src/main/java/com/codahale/dropwizard/setup/Environment.java
@@ -6,6 +6,7 @@ import com.codahale.dropwizard.jersey.setup.JerseyEnvironment;
 import com.codahale.dropwizard.jetty.MutableServletContextHandler;
 import com.codahale.dropwizard.jetty.setup.ServletEnvironment;
 import com.codahale.dropwizard.lifecycle.setup.LifecycleEnvironment;
+import com.codahale.dropwizard.server.errors.EarlyEOFExceptionMapper;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -67,6 +68,9 @@ public class Environment {
         this.lifecycleEnvironment = new LifecycleEnvironment();
 
         final DropwizardResourceConfig jerseyConfig = new DropwizardResourceConfig(metricRegistry);
+        //Add the Early EOF Exception Mapper for when the client disconnects whilst reading the input stream.
+        jerseyConfig.getSingletons().add(new EarlyEOFExceptionMapper());
+
         this.jerseyServletContainer = new JerseyContainerHolder(new ServletContainer(jerseyConfig));
         this.jerseyEnvironment = new JerseyEnvironment(jerseyServletContainer, jerseyConfig);
     }

--- a/dropwizard-core/src/test/java/com/codahale/dropwizard/server/errors/EarlyEOFExceptionMapperTest.java
+++ b/dropwizard-core/src/test/java/com/codahale/dropwizard/server/errors/EarlyEOFExceptionMapperTest.java
@@ -1,0 +1,18 @@
+package com.codahale.dropwizard.server.errors;
+
+import org.eclipse.jetty.io.EofException;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+
+public class EarlyEOFExceptionMapperTest {
+
+    @Test
+    public void testToReponse() {
+        EarlyEOFExceptionMapper mapper = new EarlyEOFExceptionMapper();
+        Response reponse = mapper.toResponse(new EofException());
+
+        Assert.assertEquals(Response.Status.NO_CONTENT.getStatusCode(), reponse.getStatus());
+    }
+}


### PR DESCRIPTION
... of parsing the input stream causes a jetty Early EOF/500. This is just a normal disconnect so it shouldn't return a 500

Issue:
In a range of drop wizard services we are seeing, in the log files, exceptions relating to EarlyEOFException (org.eclipse.jetty.io.EofException: early EOF).

Reproduce:
This exception has been reproduced consistently in a sample drop wizard service as follows:
1)Start the service in debug which is a simple message storing service and break before exception is thrown in JacksonMessageBodyProvider readfrom method
2)In the terminal - use curl to do a put with a large json file:
curl -vvv -H "Content-Type: application/json" -X PUT --data-binary "@json_load.json" localhost:8080/v1/messages/12
3) Ctrl C in the terminal to try and simulate disconnecting the client.
4) Continue program running from the breakpoint in Step 1) and the exception occurs as follows:

ERROR [2013-09-03 19:45:53,783] com.yammer.dropwizard.jersey.LoggingExceptionMapper: Error handling a request: 507b398b2dc34feb
! org.eclipse.jetty.io.EofException: early EOF
! at org.eclipse.jetty.server.HttpInput.read(HttpInput.java:65) ~[jetty-server-8.1.10.v20130312.jar:8.1.10.v20130312]
! at com.fasterxml.jackson.core.json.UTF8StreamJsonParser.loadMore(UTF8StreamJsonParser.java:174) ~[jackson-core-2.1.4.jar:2.1.4]
! at com.fasterxml.jackson.core.base.ParserBase.loadMoreGuaranteed(ParserBase.java:431) ~[jackson-core-2.1.4.jar:2.1.4]
! at com.fasterxml.jackson.core.json.UTF8StreamJsonParser._finishString2(UTF8StreamJsonParser.java:2111) ~[jackson-core-2.1.4.jar:2.1.4]
! at com.fasterxml.jackson.core.json.UTF8StreamJsonParser._finishString(UTF8StreamJsonParser.java:2092) ~[jackson-core-2.1.4.jar:2.1.4]
! at com.fasterxml.jackson.core.json.UTF8StreamJsonParser.getValueAsString(UTF8StreamJsonParser.java:291) ~[jackson-core-2.1.4.jar:2.1.4]
! at com.fasterxml.jackson.databind.deser.std.StringDeserializer.deserialize(StringDeserializer.java:24) ~[jackson-databind-2.1.4.jar:2.1.4]
! at com.fasterxml.jackson.databind.deser.std.StringDeserializer.deserialize(StringDeserializer.java:11) ~[jackson-databind-2.1.4.jar:2.1.4]
! at com.fasterxml.jackson.databind.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:375) ~[jackson-databind-2.1.4.jar:2.1.4]
! at com.fasterxml.jackson.databind.deser.impl.FieldProperty.deserializeAndSet(FieldProperty.java:107) ~[jackson-databind-2.1.4.jar:2.1.4]
! at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:308) ~[jackson-databind-2.1.4.jar:2.1.4]
! at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:121) ~[jackson-databind-2.1.4.jar:2.1.4]
! at com.fasterxml.jackson.databind.ObjectReader._bind(ObjectReader.java:1169) ~[jackson-databind-2.1.4.jar:2.1.4]
! at com.fasterxml.jackson.databind.ObjectReader.readValue(ObjectReader.java:625) ~[jackson-databind-2.1.4.jar:2.1.4]
! at com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider.readFrom(JacksonJsonProvider.java:448) ~[jackson-jaxrs-json-provider-2.1.4.jar:2.1.4]
! at com.yammer.dropwizard.jersey.JacksonMessageBodyProvider.readFrom(JacksonMessageBodyProvider.java:61) ~[dropwizard-core-0.6.2.jar:na]
………

Summary:
So it appears that LogExceptionMapper returns a server error 500 in this case.  

Request:
We would like to request the addition of an Exception mapper to handle the timeout/disconnect whilst in the middle of JSON processing to return a NO_CONTENT response rather than a 500. 

I have added the registration of the EarlyEOFExceptionMapper to the Environment class : e.g 
 jerseyConfig.getSingletons().add(new EarlyEOFExceptionMapper());
due to the fact that Jersey and Jetty are both referenced within the mapper registration.

@64BitChris
