### PR TITLE
Log nested Exception traces in a sane order.

### DIFF
--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/DropwizardLayout.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/DropwizardLayout.java
@@ -19,7 +19,8 @@ public class DropwizardLayout extends PatternLayout {
         setOutputPatternAsHeader(false);
         getDefaultConverterMap().put("ex", PrefixedThrowableProxyConverter.class.getName());
         getDefaultConverterMap().put("xEx", PrefixedExtendedThrowableProxyConverter.class.getName());
-        setPattern("%-5p [%d{ISO8601," + timeZone.getID() + "}] %c: %m%n%xEx");
+        getDefaultConverterMap().put("rEx", PrefixedRootCauseFirstThrowableProxyConverter.class.getName());
+        setPattern("%-5p [%d{ISO8601," + timeZone.getID() + "}] %c: %m%n%rEx");
         setContext(context);
     }
 }

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/PrefixedRootCauseFirstThrowableProxyConverter.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/PrefixedRootCauseFirstThrowableProxyConverter.java
@@ -1,0 +1,81 @@
+package io.dropwizard.logging;
+
+import ch.qos.logback.classic.pattern.RootCauseFirstThrowableProxyConverter;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.StackTraceElementProxy;
+import ch.qos.logback.core.CoreConstants;
+
+/**
+ * A {@link RootCauseFirstThrowableProxyConverter} that prefixes stack traces with {@code !}.
+ */
+public class PrefixedRootCauseFirstThrowableProxyConverter
+        extends RootCauseFirstThrowableProxyConverter {
+
+    private static final String PREFIX = "! ";
+
+    private int maxDepth = Integer.MAX_VALUE;
+
+    @Override
+    public void start() {
+        super.start();
+
+        final String depth = getFirstOption();
+        if (null == depth || "full".equalsIgnoreCase(depth)) {
+            maxDepth = Integer.MAX_VALUE;
+        } else if ("short".equalsIgnoreCase(depth)) {
+            maxDepth = 2;
+        } else {
+            try {
+                maxDepth = Integer.parseInt(depth) + 1;
+            } catch (NumberFormatException e) {
+                addError("Could not parse [" + depth + "] as an integer");
+                maxDepth = Integer.MAX_VALUE;
+            }
+        }
+    }
+
+    @Override
+    protected String throwableProxyToString(IThrowableProxy tp) {
+        StringBuilder buf = new StringBuilder(2048);
+        subjoinRootCauseFirst(tp, buf);
+        return buf.toString();
+    }
+
+    private void subjoinRootCauseFirst(IThrowableProxy tp, StringBuilder buf) {
+        if (tp.getCause() != null)
+            subjoinRootCauseFirst(tp.getCause(), buf);
+        subjoinRootCause(tp, buf);
+    }
+
+    private void subjoinRootCause(IThrowableProxy tp, StringBuilder buf) {
+        subjoinFirstLineRootCauseFirst(buf, tp);
+        buf.append(CoreConstants.LINE_SEPARATOR);
+        StackTraceElementProxy[] stepArray = tp.getStackTraceElementProxyArray();
+        int commonFrames = tp.getCommonFrames();
+
+        boolean unrestrictedPrinting = maxDepth > stepArray.length;
+
+
+        int maxIndex = (unrestrictedPrinting) ? stepArray.length : maxDepth;
+        if (commonFrames > 0 && unrestrictedPrinting) {
+            maxIndex -= commonFrames;
+        }
+
+        for (int i = 0; i < maxIndex; i++) {
+            String string = stepArray[i].toString();
+            buf.append(PREFIX);
+            buf.append(string);
+            extraData(buf, stepArray[i]); // allow other data to be added
+            buf.append(CoreConstants.LINE_SEPARATOR);
+        }
+    }
+
+    private static void subjoinFirstLineRootCauseFirst(StringBuilder buf, IThrowableProxy tp) {
+        buf.append(PREFIX);
+        if (tp.getCause() != null) {
+            buf.append("Causing: ");
+        }
+
+        buf.append(tp.getClassName()).append(": ").append(tp.getMessage());
+    }
+}

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/DropwizardLayoutTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/DropwizardLayoutTest.java
@@ -34,6 +34,6 @@ public class DropwizardLayoutTest {
     @Test
     public void hasAPatternWithATimeZoneAndExtendedThrowables() throws Exception {
         assertThat(layout.getPattern())
-                .isEqualTo("%-5p [%d{ISO8601,UTC}] %c: %m%n%xEx");
+                .isEqualTo("%-5p [%d{ISO8601,UTC}] %c: %m%n%rEx");
     }
 }

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/PrefixedRootCauseFirstThrowableProxyConverterTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/PrefixedRootCauseFirstThrowableProxyConverterTest.java
@@ -1,0 +1,76 @@
+package io.dropwizard.logging;
+
+import ch.qos.logback.classic.spi.ThrowableProxy;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+/**
+ * Tests {@link PrefixedRootCauseFirstThrowableProxyConverter}.
+ */
+public class PrefixedRootCauseFirstThrowableProxyConverterTest {
+
+    private final PrefixedRootCauseFirstThrowableProxyConverter converter
+            = new PrefixedRootCauseFirstThrowableProxyConverter();
+
+    private final ThrowableProxy proxy = new ThrowableProxy(getException());
+
+    private Exception getException() {
+        try {
+            throwOuterWrapper();
+        } catch (Exception e) {
+            return e;
+        }
+
+        return null; // unpossible, tell the type-system
+    }
+
+    private void throwRoot() throws SocketTimeoutException {
+        throw new SocketTimeoutException("Timed-out reading from socket");
+    }
+
+    private void throwInnerWrapper() throws IOException {
+        try {
+            throwRoot();
+        } catch (SocketTimeoutException ste) {
+            throw new IOException("Fairly general error doing some IO", ste);
+        }
+    }
+
+    private void throwOuterWrapper() {
+        try {
+            throwInnerWrapper();
+        } catch (IOException e) {
+            throw new RuntimeException("Very general error doing something", e);
+        }
+    }
+
+    @Test
+    public void prefixesExceptionsWithExclamationMarks() throws Exception {
+        assertThat(converter.throwableProxyToString(proxy))
+                .startsWith(String.format(
+                        "! java.net.SocketTimeoutException: Timed-out reading from socket%n" +
+                        "! at io.dropwizard.logging.PrefixedRootCauseFirstThrowableProxyConverterTest.throwRoot(PrefixedRootCauseFirstThrowableProxyConverterTest.java:32)%n" +
+                        "! at io.dropwizard.logging.PrefixedRootCauseFirstThrowableProxyConverterTest.throwInnerWrapper(PrefixedRootCauseFirstThrowableProxyConverterTest.java:37)%n" +
+                        "! Causing: java.io.IOException: Fairly general error doing some IO%n" +
+                        "! at io.dropwizard.logging.PrefixedRootCauseFirstThrowableProxyConverterTest.throwInnerWrapper(PrefixedRootCauseFirstThrowableProxyConverterTest.java:39)%n" +
+                        "! at io.dropwizard.logging.PrefixedRootCauseFirstThrowableProxyConverterTest.throwOuterWrapper(PrefixedRootCauseFirstThrowableProxyConverterTest.java:45)%n" +
+                        "! Causing: java.lang.RuntimeException: Very general error doing something%n" +
+                        "! at io.dropwizard.logging.PrefixedRootCauseFirstThrowableProxyConverterTest.throwOuterWrapper(PrefixedRootCauseFirstThrowableProxyConverterTest.java:47)%n" +
+                        "! at io.dropwizard.logging.PrefixedRootCauseFirstThrowableProxyConverterTest.getException(PrefixedRootCauseFirstThrowableProxyConverterTest.java:23)%n" +
+                        "! at io.dropwizard.logging.PrefixedRootCauseFirstThrowableProxyConverterTest.<init>(PrefixedRootCauseFirstThrowableProxyConverterTest.java:19)%n"));
+    }
+
+    /**
+     * This test uses a regular expression to ensure that the final frame in the printed stack trace
+     * is the "main" function.
+     */
+    @Test
+    public void finalFrameIsMain() throws Exception {
+        assertThat(converter.throwableProxyToString(proxy))
+                .matches(String.format("^[\\s\\S]+! at \\S+\\.([^.]+)\\.main\\(\\1\\.java:\\d+\\)\\s*$"));
+    }
+}


### PR DESCRIPTION
When an Exception is wrapped by another Exception, Java and Logback format the traces such that the root cause is the last trace output:

```
! java.lang.RuntimeException: Very general error doing something
! at io.dropwizard.logging.PrefixedRootCauseFirstThrowableProxyConverterTest.throwOuterWrapper(PrefixedRootCauseFirstThrowableProxyConverterTest.java:48)
! at io.dropwizard.logging.PrefixedRootCauseFirstThrowableProxyConverterTest.getException(PrefixedRootCauseFirstThrowableProxyConverterTest.java:24)
! at io.dropwizard.logging.PrefixedRootCauseFirstThrowableProxyConverterTest.<init>(PrefixedRootCauseFirstThrowableProxyConverterTest.java:20)
! at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
<SNIP>
! at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:68)
Caused by: ! java.io.IOException: Fairly general error doing some IO
! at io.dropwizard.logging.PrefixedRootCauseFirstThrowableProxyConverterTest.throwInnerWrapper(PrefixedRootCauseFirstThrowableProxyConverterTest.java:40)
! at io.dropwizard.logging.PrefixedRootCauseFirstThrowableProxyConverterTest.throwOuterWrapper(PrefixedRootCauseFirstThrowableProxyConverterTest.java:46)
!... 30 common frames omitted
Caused by: ! java.net.SocketTimeoutException: Timed-out reading from socket
! at io.dropwizard.logging.PrefixedRootCauseFirstThrowableProxyConverterTest.throwRoot(PrefixedRootCauseFirstThrowableProxyConverterTest.java:33)
! at io.dropwizard.logging.PrefixedRootCauseFirstThrowableProxyConverterTest.throwInnerWrapper(PrefixedRootCauseFirstThrowableProxyConverterTest.java:38)
!... 31 common frames omitted
```

Instead, the root cause should be the first Exception, with the trace ascending up through the wrapping exceptions.

This makes identifying the root cause of a problem simpler, because it's usually described in more detail by the root cause. Also, the stack trace now ascends linearly, in one pass, without the need for any messy "N common frames omitted"; the first frame is the frame where the error occurred, and the last is the `main` entry-point to the program.

```
! java.net.SocketTimeoutException: Timed-out reading from socket
! at io.dropwizard.logging.PrefixedRootCauseFirstThrowableProxyConverterTest.throwRoot(PrefixedRootCauseFirstThrowableProxyConverterTest.java:32)
! at io.dropwizard.logging.PrefixedRootCauseFirstThrowableProxyConverterTest.throwInnerWrapper(PrefixedRootCauseFirstThrowableProxyConverterTest.java:37)
! Causing: java.io.IOException: Fairly general error doing some IO
! at io.dropwizard.logging.PrefixedRootCauseFirstThrowableProxyConverterTest.throwInnerWrapper(PrefixedRootCauseFirstThrowableProxyConverterTest.java:39)
! at io.dropwizard.logging.PrefixedRootCauseFirstThrowableProxyConverterTest.throwOuterWrapper(PrefixedRootCauseFirstThrowableProxyConverterTest.java:45)
! Causing: java.lang.RuntimeException: Very general error doing something
! at io.dropwizard.logging.PrefixedRootCauseFirstThrowableProxyConverterTest.throwOuterWrapper(PrefixedRootCauseFirstThrowableProxyConverterTest.java:47)
! at io.dropwizard.logging.PrefixedRootCauseFirstThrowableProxyConverterTest.getException(PrefixedRootCauseFirstThrowableProxyConverterTest.java:23)
! at io.dropwizard.logging.PrefixedRootCauseFirstThrowableProxyConverterTest.<init>(PrefixedRootCauseFirstThrowableProxyConverterTest.java:19)
! at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
<SNIP>
! at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:68)
```

Since Logback provides this functionality via the `%rEx` pattern (instead of `%ex` or `%xEx`), users may enable/disable this behaviour by configuring `logFormat`.
