### PR TITLE
AsyncAppender now flushes log events when the application shuts down

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
@@ -451,10 +451,14 @@ public abstract class AbstractServerFactory implements ServerFactory {
         return listener;
     }
 
-    protected Handler addRequestLog(Handler handler, String name) {
+    protected Handler addRequestLog(Server server, Handler handler, String name) {
         if (requestLog.isEnabled()) {
             final RequestLogHandler requestLogHandler = new RequestLogHandler();
             requestLogHandler.setRequestLog(requestLog.build(name));
+            // server should own the request log's lifecycle since it's already started,
+            // the handler might not become managed in case of an error which would leave
+            // the request log stranded
+            server.addBean(requestLogHandler.getRequestLog(), true);
             requestLogHandler.setHandler(handler);
             return requestLogHandler;
         }

--- a/dropwizard-core/src/main/java/io/dropwizard/server/DefaultServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/DefaultServerFactory.java
@@ -141,7 +141,7 @@ public class DefaultServerFactory extends AbstractServerFactory {
                                                                   server,
                                                                   applicationHandler,
                                                                   adminHandler);
-        server.setHandler(addRequestLog(routingHandler, environment.getName()));
+        server.setHandler(addRequestLog(server, routingHandler, environment.getName()));
         return server;
     }
 

--- a/dropwizard-core/src/main/java/io/dropwizard/server/SimpleServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/SimpleServerFactory.java
@@ -126,7 +126,7 @@ public class SimpleServerFactory extends AbstractServerFactory {
                 applicationContextPath, applicationHandler,
                 adminContextPath, adminHandler
         ));
-        server.setHandler(addRequestLog(routingHandler, environment.getName()));
+        server.setHandler(addRequestLog(server, routingHandler, environment.getName()));
 
         return server;
     }

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/Slf4jRequestLog.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/Slf4jRequestLog.java
@@ -29,6 +29,13 @@ public class Slf4jRequestLog extends AbstractNCSARequestLog {
         setLogTimeZone(timeZone);
         setExtended(true);
         setPreferProxiedForAddress(true);
+
+        // the appenders already started
+        try {
+            start();
+        } catch (Exception e) {
+            throw new IllegalStateException("Should have succeeded doing a noop start", e);
+        }
     }
 
     @Override
@@ -48,5 +55,11 @@ public class Slf4jRequestLog extends AbstractNCSARequestLog {
 
     public void setLogTimeZone(TimeZone tz) {
         setLogTimeZone(tz.getID());
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        appenders.detachAndStopAllAppenders();
+        super.doStop();
     }
 }

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/LoggingFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/LoggingFactory.java
@@ -2,6 +2,7 @@ package io.dropwizard.logging;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.filter.ThresholdFilter;
 import ch.qos.logback.classic.jmx.JMXConfigurator;
 import ch.qos.logback.classic.jul.LevelChangePropagator;
@@ -12,6 +13,7 @@ import com.codahale.metrics.logback.InstrumentedAppender;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.slf4j.ILoggerFactory;
 import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
@@ -123,6 +125,14 @@ public class LoggingFactory {
         }
 
         configureInstrumentation(root, metricRegistry);
+    }
+
+    public void stop() {
+        ILoggerFactory loggerFactory = LoggerFactory.getILoggerFactory();
+        if (loggerFactory instanceof LoggerContext) {
+            LoggerContext context = (LoggerContext) loggerFactory;
+            context.stop();
+        }
     }
 
     private void configureInstrumentation(Logger root, MetricRegistry metricRegistry) {


### PR DESCRIPTION
- async appender workers are no longer daemon threads so they can flush
  partially buffered events to their delegates before stopping
- SLF4J request log stops the appenders when it's closed
- configured command stops the appenders when the execution finishes
- configured commands that execute asynchronously (e.g. ServerCommand)
  must now call cleanup when they finish execution
