### PR TITLE
Connectors shouldn't try to manage the same thread pool

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/server/SimpleServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/SimpleServerFactory.java
@@ -118,7 +118,7 @@ public class SimpleServerFactory extends AbstractServerFactory {
         final Connector conn = connector.build(server,
                                                environment.metrics(),
                                                environment.getName(),
-                                               server.getThreadPool());
+                                               null);
 
         server.addConnector(conn);
 


### PR DESCRIPTION
- app connectors use the server thread pool (null means inherit thread
  pool from server)
- admin connectors have their own shared thread pool that is now managed
  by the server instead of the individual connectors

Having multiple connectors manage the same thread pool was problematic.

To reproduce, run the example application and send a SIGTERM to the process after it starts. It will timeout and give up stopping the admin thread pool after 30 seconds instead of stopping cleanly right away.
