### PR TITLE
Add support for using Optional<DateTime> in dropwizard-jdbi

### DIFF
--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/JodaDateTimeMapper.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/JodaDateTimeMapper.java
@@ -5,6 +5,7 @@ import org.skife.jdbi.v2.util.TypedMapper;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 
 /**
  * A {@link TypedMapper} to map Joda {@link DateTime} objects.
@@ -13,11 +14,19 @@ public class JodaDateTimeMapper extends TypedMapper<DateTime> {
 
     @Override
     protected DateTime extractByName(final ResultSet r, final String name) throws SQLException {
-        return new DateTime(r.getTimestamp(name).getTime());
+        final Timestamp timestamp = r.getTimestamp(name);
+        if (timestamp == null) {
+            return null;
+        }
+        return new DateTime(timestamp.getTime());
     }
 
     @Override
     protected DateTime extractByIndex(final ResultSet r, final int index) throws SQLException {
-        return new DateTime(r.getTimestamp(index).getTime());
+        final Timestamp timestamp = r.getTimestamp(index);
+        if (timestamp == null) {
+            return null;
+        }
+        return new DateTime(timestamp.getTime());
     }
 }

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/JDBITest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/JDBITest.java
@@ -85,6 +85,12 @@ public class JDBITest {
                   .bind(2, 99)
                   .bind(3, new Timestamp(1365465078000L))
                   .execute();
+            handle.createStatement("INSERT INTO people VALUES (?, ?, ?, ?)")
+                  .bind(0, "Alice Example")
+                  .bind(1, "alice@example.org")
+                  .bind(2, 99)
+                  .bindNull(3, Types.TIMESTAMP)
+                  .execute();
         }
     }
 
@@ -125,7 +131,7 @@ public class JDBITest {
         final PersonDAO dao = dbi.open(PersonDAO.class);
 
         assertThat(dao.findAllNames())
-                .containsOnly("Coda Hale", "Kris Gale", "Old Guy");
+                .containsOnly("Coda Hale", "Kris Gale", "Old Guy", "Alice Example");
     }
 
     @Test
@@ -133,7 +139,7 @@ public class JDBITest {
         final PersonDAO dao = dbi.open(PersonDAO.class);
 
         assertThat(dao.findAllUniqueNames())
-                .containsOnly("Coda Hale", "Kris Gale", "Old Guy");
+                .containsOnly("Coda Hale", "Kris Gale", "Old Guy", "Alice Example");
     }
 
     @Test
@@ -160,5 +166,16 @@ public class JDBITest {
         assertThat(found).isNotNull();
         assertThat(found.getMillis()).isEqualTo(1365465078000L);
         assertThat(found).isEqualTo(new DateTime(1365465078000L));
+
+        final DateTime notFound = dao.getCreatedAtByEmail("alice@example.org");
+        assertThat(notFound).isNull();
+
+        final Optional<DateTime> absentDateTime = dao.getCreatedAtByName("Alice Example");
+        assertThat(absentDateTime).isNotNull();
+        assertThat(absentDateTime.isPresent()).isFalse();
+
+        final Optional<DateTime> presentDateTime = dao.getCreatedAtByName("Coda Hale");
+        assertThat(presentDateTime).isNotNull();
+        assertThat(presentDateTime.isPresent()).isTrue();
     }
 }

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/PersonDAO.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/PersonDAO.java
@@ -24,4 +24,11 @@ public interface PersonDAO {
 
     @SqlQuery("SELECT created_at FROM people WHERE created_at > :from ORDER BY created_at DESC LIMIT 1")
     public DateTime getLatestCreatedAt(@Bind("from") DateTime from);
+
+    @SqlQuery("SELECT created_at FROM people WHERE name = :name")
+    @SingleValueResult(DateTime.class)
+    public Optional<DateTime> getCreatedAtByName(@Bind("name") String name);
+
+    @SqlQuery("SELECT created_at FROM people WHERE email = :email")
+    public DateTime getCreatedAtByEmail(@Bind("email") String email);
 }


### PR DESCRIPTION
Add support for Optional<DateTime> in dropwizard-jdbi by handling NULL-values
in JodaDateTimeMapper. This also fixes a NPE-occuring when using the
existing mapper to plain DateTime-object if extracted column is NULL.
