### PR TITLE
fix for bug in FileAppenderFactory where even if archive is set to true it returns a regular file appender instead of rolling file appender

### DIFF
--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
@@ -192,6 +192,7 @@ public class FileAppenderFactory extends AbstractAppenderFactory {
 
             rollingPolicy.setParent(appender);
             rollingPolicy.start();
+            return appender;
         }
         return new FileAppender<>();
     }

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
@@ -1,5 +1,8 @@
 package io.dropwizard.logging;
 
+import java.lang.reflect.Method;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.core.rolling.RollingFileAppender;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
 import org.junit.Test;
 
@@ -10,5 +13,16 @@ public class FileAppenderFactoryTest {
     public void isDiscoverable() throws Exception {
         assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
                 .contains(FileAppenderFactory.class);
+    }
+
+    @Test
+    public void isRolling() throws Exception {
+        FileAppenderFactory fileAppenderFactory = new FileAppenderFactory ();
+        fileAppenderFactory.setCurrentLogFilename("logfile.log");
+        fileAppenderFactory.setArchive(true);
+        fileAppenderFactory.setArchivedLogFilenamePattern("example-%d.log.gz");
+        Method method = FileAppenderFactory.class.getDeclaredMethod("buildAppender", LoggerContext.class);
+        method.setAccessible (true);
+        assertThat (RollingFileAppender.class.isAssignableFrom (method.invoke (fileAppenderFactory, new LoggerContext ()).getClass ()));
     }
 }


### PR DESCRIPTION
I tried to add a unit test but the best I could come up with was to peek at the internals of a private method. Please suggest a better unit test and I can resubmit.
