### PR TITLE
Updated dependency on liquibase-slf4j to 1.2.0

### DIFF
--- a/dropwizard-migrations/pom.xml
+++ b/dropwizard-migrations/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.mattbertolini</groupId>
             <artifactId>liquibase-slf4j</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Fixes problems with missing methods in 1.1.0 (https://github.com/mattbertolini/liquibase-slf4j/issues/2)
