### PR TITLE
Throw a ConstraintViolationException for empty resources

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProvider.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.Set;
 
 /**
@@ -66,6 +67,11 @@ public class JacksonMessageBodyProvider extends JacksonJaxbJsonProvider {
     }
 
     private Object validate(Annotation[] annotations, Object value) {
+        if(null == value) {
+            throw new ConstraintViolationException("The request entity was empty",
+                    Collections.<ConstraintViolation<Object>>emptySet());
+        }
+
         final Class<?>[] classes = findValidationGroups(annotations);
 
         if (classes != null) {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProviderTest.java
@@ -28,7 +28,10 @@ import static org.fest.assertions.api.Assertions.assertThat;
 import static org.fest.assertions.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assume.assumeThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 // TODO: 4/24/13 <coda> -- move JacksonMessageBodyProviderTest to JerseyTest
 
@@ -286,5 +289,19 @@ public class JacksonMessageBodyProviderTest {
 
         assertThat(output.toString())
                 .isEqualTo("{\"id\":500}");
+    }
+
+    @Test(expected = ConstraintViolationException.class)
+    public void throwsAConstraintViolationExceptionForEmptyRequestEntities() throws Exception {
+        final Annotation valid = mock(Annotation.class);
+        doReturn(Valid.class).when(valid).annotationType();
+
+        final Class<?> klass = Example.class;
+        provider.readFrom((Class<Object>) klass,
+                Example.class,
+                new Annotation[]{valid},
+                MediaType.APPLICATION_JSON_TYPE,
+                new MultivaluedMapImpl(),
+                null);
     }
 }


### PR DESCRIPTION
Throw a `ConstraintViolationException` (although with no `ConstraintViolation<>` at all) if an empty resource is being validated. At least a response with status 422 (Unprocessable Entity) is being generated by `ConstraintViolationExceptionMapper`. This kind of fixes #431.

Unfortunately it seems to be very hard to create proper `ConstraintViolation<T>` instances without rewriting half of the validation framework.
