### PR TITLE
Add support for date-time offset values in configuration files

### DIFF
--- a/dropwizard-util/src/main/java/io/dropwizard/util/DateTimeOffset.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/DateTimeOffset.java
@@ -1,0 +1,197 @@
+package io.dropwizard.util;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.collect.ImmutableMap;
+import org.joda.time.DateTime;
+
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class DateTimeOffset {
+    private static final Pattern PATTERN = Pattern.compile("([-+]?[\\d]+)[\\s]*(" +
+        "ms|msec(s)?|millisecond(s)?|" +
+        "s|sec(s)?|second(s)?|" +
+        "m|min(s)?|minute(s)?|" +
+        "h||hr(s)?|hour(s)?|" +
+        "d|day(s)?|" +
+        "w|wk(s)?|week(s)?|" +
+        "mo(s)?|month(s)?|" +
+        "y|yr(s)?|year(s)?" +
+        ')');
+    private static final ImmutableMap<String, OffsetUnit> SUFFIXES;
+
+    static {
+        final ImmutableMap.Builder<String, OffsetUnit> suffixes = ImmutableMap.builder();
+
+        suffixes.put("ms", OffsetUnit.MILLISECONDS);
+        suffixes.put("msec", OffsetUnit.MILLISECONDS);
+        suffixes.put("msecs", OffsetUnit.MILLISECONDS);
+        suffixes.put("millisecond", OffsetUnit.MILLISECONDS);
+        suffixes.put("milliseconds", OffsetUnit.MILLISECONDS);
+
+        suffixes.put("s", OffsetUnit.SECONDS);
+        suffixes.put("sec", OffsetUnit.SECONDS);
+        suffixes.put("secs", OffsetUnit.SECONDS);
+        suffixes.put("second", OffsetUnit.SECONDS);
+        suffixes.put("seconds", OffsetUnit.SECONDS);
+
+        suffixes.put("m", OffsetUnit.MINUTES);
+        suffixes.put("min", OffsetUnit.MINUTES);
+        suffixes.put("mins", OffsetUnit.MINUTES);
+        suffixes.put("minute", OffsetUnit.MINUTES);
+        suffixes.put("minutes", OffsetUnit.MINUTES);
+
+        suffixes.put("h", OffsetUnit.HOURS);
+        suffixes.put("hr", OffsetUnit.HOURS);
+        suffixes.put("hrs", OffsetUnit.HOURS);
+        suffixes.put("hour", OffsetUnit.HOURS);
+        suffixes.put("hours", OffsetUnit.HOURS);
+
+        suffixes.put("d", OffsetUnit.DAYS);
+        suffixes.put("day", OffsetUnit.DAYS);
+        suffixes.put("days", OffsetUnit.DAYS);
+
+        suffixes.put("w", OffsetUnit.WEEKS);
+        suffixes.put("wk", OffsetUnit.WEEKS);
+        suffixes.put("wks", OffsetUnit.WEEKS);
+        suffixes.put("week", OffsetUnit.WEEKS);
+        suffixes.put("weeks", OffsetUnit.WEEKS);
+
+        suffixes.put("mo", OffsetUnit.MONTHS);
+        suffixes.put("mos", OffsetUnit.MONTHS);
+        suffixes.put("month", OffsetUnit.MONTHS);
+        suffixes.put("months", OffsetUnit.MONTHS);
+
+        suffixes.put("y", OffsetUnit.YEARS);
+        suffixes.put("yr", OffsetUnit.YEARS);
+        suffixes.put("yrs", OffsetUnit.YEARS);
+        suffixes.put("year", OffsetUnit.YEARS);
+        suffixes.put("years", OffsetUnit.YEARS);
+
+        SUFFIXES = suffixes.build();
+    }
+
+    public static DateTimeOffset milliseconds(int count) {
+        return new DateTimeOffset(count, OffsetUnit.MILLISECONDS);
+    }
+
+    public static DateTimeOffset seconds(int count) {
+        return new DateTimeOffset(count, OffsetUnit.SECONDS);
+    }
+
+    public static DateTimeOffset minutes(int count) {
+        return new DateTimeOffset(count, OffsetUnit.MINUTES);
+    }
+
+    public static DateTimeOffset hours(int count) {
+        return new DateTimeOffset(count, OffsetUnit.HOURS);
+    }
+
+    public static DateTimeOffset days(int count) {
+        return new DateTimeOffset(count, OffsetUnit.DAYS);
+    }
+
+    public static DateTimeOffset weeks(int count) {
+        return new DateTimeOffset(count, OffsetUnit.WEEKS);
+    }
+
+    public static DateTimeOffset months(int count) {
+        return new DateTimeOffset(count, OffsetUnit.MONTHS);
+    }
+
+    public static DateTimeOffset years(int count) {
+        return new DateTimeOffset(count, OffsetUnit.YEARS);
+    }
+
+    private static int parseCount(Matcher matcher) {
+        return Integer.parseInt(matcher.group(1));
+    }
+
+    private static OffsetUnit parseUnit(Matcher matcher) {
+        return SUFFIXES.get(matcher.group(2));
+    }
+
+    @JsonCreator
+    public static DateTimeOffset parse(String offset) {
+        Matcher matcher = PATTERN.matcher(offset);
+        checkArgument(matcher.matches(), "Invalid date-time offset: %s", offset);
+        return new DateTimeOffset(parseCount(matcher), parseUnit(matcher));
+    }
+
+    private final int count;
+    private final OffsetUnit unit;
+
+    private DateTimeOffset(int count, OffsetUnit unit) {
+        this.count = count;
+        this.unit = checkNotNull(unit);
+    }
+
+    public long getQuantity() {
+        return count;
+    }
+
+    public OffsetUnit getUnit() {
+        return unit;
+    }
+
+    public DateTime apply(DateTime dateTime) {
+        switch (unit) {
+            case MILLISECONDS:
+                return dateTime.plusMillis(count);
+
+            case SECONDS:
+                return dateTime.plusSeconds(count);
+
+            case MINUTES:
+                return dateTime.plusMinutes(count);
+
+            case HOURS:
+                return dateTime.plusHours(count);
+
+            case DAYS:
+                return dateTime.plusDays(count);
+
+            case WEEKS:
+                return dateTime.plusWeeks(count);
+
+            case MONTHS:
+                return dateTime.plusMonths(count);
+
+            case YEARS:
+                return dateTime.plusYears(count);
+        }
+
+        throw new UnsupportedOperationException("invalid unit value");
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) { return true; }
+        if ((obj == null) || (getClass() != obj.getClass())) { return false; }
+        final DateTimeOffset duration = (DateTimeOffset) obj;
+        return (count == duration.count) && (unit == duration.unit);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = count;
+        result = 31 * result + (unit != null ? unit.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        String units = unit.toString().toLowerCase(Locale.ENGLISH);
+        if (count == 1 || count == -1) {
+            units = units.substring(0, units.length() - 1);
+        }
+        return Long.toString(count) + ' ' + units;
+    }
+}

--- a/dropwizard-util/src/main/java/io/dropwizard/util/OffsetUnit.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/OffsetUnit.java
@@ -1,0 +1,12 @@
+package io.dropwizard.util;
+
+public enum OffsetUnit {
+    MILLISECONDS,
+    SECONDS,
+    MINUTES,
+    HOURS,
+    DAYS,
+    WEEKS,
+    MONTHS,
+    YEARS
+}

--- a/dropwizard-util/src/test/java/io/dropwizard/util/DateTimeOffsetTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/DateTimeOffsetTest.java
@@ -1,0 +1,456 @@
+package io.dropwizard.util;
+
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+public class DateTimeOffsetTest {
+    @Test
+    public void parseYears() throws Exception {
+        assertThat(DateTimeOffset.parse("1yr"))
+            .isEqualTo(DateTimeOffset.years(1));
+
+        assertThat(DateTimeOffset.parse("2yrs"))
+            .isEqualTo(DateTimeOffset.years(2));
+
+        assertThat(DateTimeOffset.parse("1 year"))
+            .isEqualTo(DateTimeOffset.years(1));
+
+        assertThat(DateTimeOffset.parse("2 years"))
+            .isEqualTo(DateTimeOffset.years(2));
+
+        assertThat(DateTimeOffset.parse("+1yr"))
+            .isEqualTo(DateTimeOffset.years(1));
+
+        assertThat(DateTimeOffset.parse("+2yrs"))
+            .isEqualTo(DateTimeOffset.years(2));
+
+        assertThat(DateTimeOffset.parse("+1 year"))
+            .isEqualTo(DateTimeOffset.years(1));
+
+        assertThat(DateTimeOffset.parse("+2 years"))
+            .isEqualTo(DateTimeOffset.years(2));
+
+        assertThat(DateTimeOffset.parse("-1yr"))
+            .isEqualTo(DateTimeOffset.years(-1));
+
+        assertThat(DateTimeOffset.parse("-2yrs"))
+            .isEqualTo(DateTimeOffset.years(-2));
+
+        assertThat(DateTimeOffset.parse("-1 year"))
+            .isEqualTo(DateTimeOffset.years(-1));
+
+        assertThat(DateTimeOffset.parse("-2 years"))
+            .isEqualTo(DateTimeOffset.years(-2));
+    }
+
+    @Test
+    public void parsesMonths() throws Exception {
+        assertThat(DateTimeOffset.parse("1mo"))
+            .isEqualTo(DateTimeOffset.months(1));
+
+        assertThat(DateTimeOffset.parse("2mos"))
+            .isEqualTo(DateTimeOffset.months(2));
+
+        assertThat(DateTimeOffset.parse("1 month"))
+            .isEqualTo(DateTimeOffset.months(1));
+
+        assertThat(DateTimeOffset.parse("2 months"))
+            .isEqualTo(DateTimeOffset.months(2));
+
+        assertThat(DateTimeOffset.parse("+1mo"))
+            .isEqualTo(DateTimeOffset.months(1));
+
+        assertThat(DateTimeOffset.parse("+2mos"))
+            .isEqualTo(DateTimeOffset.months(2));
+
+        assertThat(DateTimeOffset.parse("+1 month"))
+            .isEqualTo(DateTimeOffset.months(1));
+
+        assertThat(DateTimeOffset.parse("+2 months"))
+            .isEqualTo(DateTimeOffset.months(2));
+
+        assertThat(DateTimeOffset.parse("-1mo"))
+            .isEqualTo(DateTimeOffset.months(-1));
+
+        assertThat(DateTimeOffset.parse("-2mos"))
+            .isEqualTo(DateTimeOffset.months(-2));
+
+        assertThat(DateTimeOffset.parse("-1 month"))
+            .isEqualTo(DateTimeOffset.months(-1));
+
+        assertThat(DateTimeOffset.parse("-2 months"))
+            .isEqualTo(DateTimeOffset.months(-2));
+    }
+
+    @Test
+    public void parsesWeeks() throws Exception {
+        assertThat(DateTimeOffset.parse("1w"))
+            .isEqualTo(DateTimeOffset.weeks(1));
+
+        assertThat(DateTimeOffset.parse("1wk"))
+            .isEqualTo(DateTimeOffset.weeks(1));
+
+        assertThat(DateTimeOffset.parse("2wks"))
+            .isEqualTo(DateTimeOffset.weeks(2));
+
+        assertThat(DateTimeOffset.parse("1 week"))
+            .isEqualTo(DateTimeOffset.weeks(1));
+
+        assertThat(DateTimeOffset.parse("2 weeks"))
+            .isEqualTo(DateTimeOffset.weeks(2));
+
+        assertThat(DateTimeOffset.parse("+1w"))
+            .isEqualTo(DateTimeOffset.weeks(1));
+
+        assertThat(DateTimeOffset.parse("+1wk"))
+            .isEqualTo(DateTimeOffset.weeks(1));
+
+        assertThat(DateTimeOffset.parse("+2wks"))
+            .isEqualTo(DateTimeOffset.weeks(2));
+
+        assertThat(DateTimeOffset.parse("+1 week"))
+            .isEqualTo(DateTimeOffset.weeks(1));
+
+        assertThat(DateTimeOffset.parse("+2 weeks"))
+            .isEqualTo(DateTimeOffset.weeks(2));
+
+        assertThat(DateTimeOffset.parse("-1w"))
+            .isEqualTo(DateTimeOffset.weeks(-1));
+
+        assertThat(DateTimeOffset.parse("-1wk"))
+            .isEqualTo(DateTimeOffset.weeks(-1));
+
+        assertThat(DateTimeOffset.parse("-2wks"))
+            .isEqualTo(DateTimeOffset.weeks(-2));
+
+        assertThat(DateTimeOffset.parse("-1 week"))
+            .isEqualTo(DateTimeOffset.weeks(-1));
+
+        assertThat(DateTimeOffset.parse("-2 weeks"))
+            .isEqualTo(DateTimeOffset.weeks(-2));
+    }
+    @Test
+    public void parsesDays() throws Exception {
+        assertThat(DateTimeOffset.parse("1d"))
+            .isEqualTo(DateTimeOffset.days(1));
+
+        assertThat(DateTimeOffset.parse("1 day"))
+            .isEqualTo(DateTimeOffset.days(1));
+
+        assertThat(DateTimeOffset.parse("2 days"))
+            .isEqualTo(DateTimeOffset.days(2));
+
+        assertThat(DateTimeOffset.parse("+1d"))
+            .isEqualTo(DateTimeOffset.days(1));
+
+        assertThat(DateTimeOffset.parse("+1 day"))
+            .isEqualTo(DateTimeOffset.days(1));
+
+        assertThat(DateTimeOffset.parse("+2 days"))
+            .isEqualTo(DateTimeOffset.days(2));
+
+        assertThat(DateTimeOffset.parse("-1d"))
+            .isEqualTo(DateTimeOffset.days(-1));
+
+        assertThat(DateTimeOffset.parse("-1 day"))
+            .isEqualTo(DateTimeOffset.days(-1));
+
+        assertThat(DateTimeOffset.parse("-2 days"))
+            .isEqualTo(DateTimeOffset.days(-2));
+    }
+
+    @Test
+    public void parsesHours() throws Exception {
+        assertThat(DateTimeOffset.parse("1h"))
+            .isEqualTo(DateTimeOffset.hours(1));
+
+        assertThat(DateTimeOffset.parse("1hr"))
+            .isEqualTo(DateTimeOffset.hours(1));
+
+        assertThat(DateTimeOffset.parse("2hrs"))
+            .isEqualTo(DateTimeOffset.hours(2));
+
+        assertThat(DateTimeOffset.parse("1 hour"))
+            .isEqualTo(DateTimeOffset.hours(1));
+
+        assertThat(DateTimeOffset.parse("2 hours"))
+            .isEqualTo(DateTimeOffset.hours(2));
+
+        assertThat(DateTimeOffset.parse("+1h"))
+            .isEqualTo(DateTimeOffset.hours(1));
+
+        assertThat(DateTimeOffset.parse("+1hr"))
+            .isEqualTo(DateTimeOffset.hours(1));
+
+        assertThat(DateTimeOffset.parse("+2hrs"))
+            .isEqualTo(DateTimeOffset.hours(2));
+
+        assertThat(DateTimeOffset.parse("+1 hour"))
+            .isEqualTo(DateTimeOffset.hours(1));
+
+        assertThat(DateTimeOffset.parse("+2 hours"))
+            .isEqualTo(DateTimeOffset.hours(2));
+
+        assertThat(DateTimeOffset.parse("-1h"))
+            .isEqualTo(DateTimeOffset.hours(-1));
+
+        assertThat(DateTimeOffset.parse("-1hr"))
+            .isEqualTo(DateTimeOffset.hours(-1));
+
+        assertThat(DateTimeOffset.parse("-2hrs"))
+            .isEqualTo(DateTimeOffset.hours(-2));
+
+        assertThat(DateTimeOffset.parse("-1 hour"))
+            .isEqualTo(DateTimeOffset.hours(-1));
+
+        assertThat(DateTimeOffset.parse("-2 hours"))
+            .isEqualTo(DateTimeOffset.hours(-2));
+    }
+
+    @Test
+    public void parsesMinutes() throws Exception {
+        assertThat(DateTimeOffset.parse("1m"))
+            .isEqualTo(DateTimeOffset.minutes(1));
+
+        assertThat(DateTimeOffset.parse("1min"))
+            .isEqualTo(DateTimeOffset.minutes(1));
+
+        assertThat(DateTimeOffset.parse("2mins"))
+            .isEqualTo(DateTimeOffset.minutes(2));
+
+        assertThat(DateTimeOffset.parse("1 minute"))
+            .isEqualTo(DateTimeOffset.minutes(1));
+
+        assertThat(DateTimeOffset.parse("2 minutes"))
+            .isEqualTo(DateTimeOffset.minutes(2));
+
+        assertThat(DateTimeOffset.parse("+1m"))
+            .isEqualTo(DateTimeOffset.minutes(1));
+
+        assertThat(DateTimeOffset.parse("+1min"))
+            .isEqualTo(DateTimeOffset.minutes(1));
+
+        assertThat(DateTimeOffset.parse("+2mins"))
+            .isEqualTo(DateTimeOffset.minutes(2));
+
+        assertThat(DateTimeOffset.parse("+1 minute"))
+            .isEqualTo(DateTimeOffset.minutes(1));
+
+        assertThat(DateTimeOffset.parse("+2 minutes"))
+            .isEqualTo(DateTimeOffset.minutes(2));
+
+        assertThat(DateTimeOffset.parse("-1m"))
+            .isEqualTo(DateTimeOffset.minutes(-1));
+
+        assertThat(DateTimeOffset.parse("-1min"))
+            .isEqualTo(DateTimeOffset.minutes(-1));
+
+        assertThat(DateTimeOffset.parse("-2mins"))
+            .isEqualTo(DateTimeOffset.minutes(-2));
+
+        assertThat(DateTimeOffset.parse("-1 minute"))
+            .isEqualTo(DateTimeOffset.minutes(-1));
+
+        assertThat(DateTimeOffset.parse("-2 minutes"))
+            .isEqualTo(DateTimeOffset.minutes(-2));
+    }
+
+    @Test
+    public void parsesSeconds() throws Exception {
+        assertThat(DateTimeOffset.parse("1s"))
+            .isEqualTo(DateTimeOffset.seconds(1));
+
+        assertThat(DateTimeOffset.parse("1sec"))
+            .isEqualTo(DateTimeOffset.seconds(1));
+
+        assertThat(DateTimeOffset.parse("2secs"))
+            .isEqualTo(DateTimeOffset.seconds(2));
+
+        assertThat(DateTimeOffset.parse("1 second"))
+            .isEqualTo(DateTimeOffset.seconds(1));
+
+        assertThat(DateTimeOffset.parse("2 seconds"))
+            .isEqualTo(DateTimeOffset.seconds(2));
+
+        assertThat(DateTimeOffset.parse("+1s"))
+            .isEqualTo(DateTimeOffset.seconds(1));
+
+        assertThat(DateTimeOffset.parse("+1sec"))
+            .isEqualTo(DateTimeOffset.seconds(1));
+
+        assertThat(DateTimeOffset.parse("+2secs"))
+            .isEqualTo(DateTimeOffset.seconds(2));
+
+        assertThat(DateTimeOffset.parse("+1 second"))
+            .isEqualTo(DateTimeOffset.seconds(1));
+
+        assertThat(DateTimeOffset.parse("+2 seconds"))
+            .isEqualTo(DateTimeOffset.seconds(2));
+
+        assertThat(DateTimeOffset.parse("-1s"))
+            .isEqualTo(DateTimeOffset.seconds(-1));
+
+        assertThat(DateTimeOffset.parse("-1sec"))
+            .isEqualTo(DateTimeOffset.seconds(-1));
+
+        assertThat(DateTimeOffset.parse("-2secs"))
+            .isEqualTo(DateTimeOffset.seconds(-2));
+
+        assertThat(DateTimeOffset.parse("-1 second"))
+            .isEqualTo(DateTimeOffset.seconds(-1));
+
+        assertThat(DateTimeOffset.parse("-2 seconds"))
+            .isEqualTo(DateTimeOffset.seconds(-2));
+    }
+
+    @Test
+    public void parsesMilliseconds() throws Exception {
+        assertThat(DateTimeOffset.parse("1ms"))
+            .isEqualTo(DateTimeOffset.milliseconds(1));
+
+        assertThat(DateTimeOffset.parse("1msec"))
+            .isEqualTo(DateTimeOffset.milliseconds(1));
+
+        assertThat(DateTimeOffset.parse("2msecs"))
+            .isEqualTo(DateTimeOffset.milliseconds(2));
+
+        assertThat(DateTimeOffset.parse("1 millisecond"))
+            .isEqualTo(DateTimeOffset.milliseconds(1));
+
+        assertThat(DateTimeOffset.parse("2 milliseconds"))
+            .isEqualTo(DateTimeOffset.milliseconds(2));
+
+        assertThat(DateTimeOffset.parse("+1ms"))
+            .isEqualTo(DateTimeOffset.milliseconds(1));
+
+        assertThat(DateTimeOffset.parse("+1msec"))
+            .isEqualTo(DateTimeOffset.milliseconds(1));
+
+        assertThat(DateTimeOffset.parse("+2msecs"))
+            .isEqualTo(DateTimeOffset.milliseconds(2));
+
+        assertThat(DateTimeOffset.parse("+1 millisecond"))
+            .isEqualTo(DateTimeOffset.milliseconds(1));
+
+        assertThat(DateTimeOffset.parse("+2 milliseconds"))
+            .isEqualTo(DateTimeOffset.milliseconds(2));
+
+        assertThat(DateTimeOffset.parse("-1ms"))
+            .isEqualTo(DateTimeOffset.milliseconds(-1));
+
+        assertThat(DateTimeOffset.parse("-1msec"))
+            .isEqualTo(DateTimeOffset.milliseconds(-1));
+
+        assertThat(DateTimeOffset.parse("-2msecs"))
+            .isEqualTo(DateTimeOffset.milliseconds(-2));
+
+        assertThat(DateTimeOffset.parse("-1 millisecond"))
+            .isEqualTo(DateTimeOffset.milliseconds(-1));
+
+        assertThat(DateTimeOffset.parse("-2 milliseconds"))
+            .isEqualTo(DateTimeOffset.milliseconds(-2));
+    }
+
+    @Test
+    public void isHumanReadable() throws Exception {
+        assertThat(DateTimeOffset.milliseconds(1).toString())
+            .isEqualTo("1 millisecond");
+
+        assertThat(DateTimeOffset.milliseconds(3).toString())
+            .isEqualTo("3 milliseconds");
+    }
+
+    @Test
+    public void hasAQuantity() throws Exception {
+        assertThat(DateTimeOffset.milliseconds(12).getQuantity())
+            .isEqualTo(12);
+    }
+
+    @Test
+    public void hasAUnit() throws Exception {
+        assertThat(DateTimeOffset.milliseconds(1).getUnit())
+            .isEqualTo(OffsetUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void applyYears() {
+        assertThat(DateTimeOffset.years(1).apply(DateTime.parse("2000-1-1TZ")))
+            .isEqualTo(DateTime.parse("2001-1-1TZ"));
+        assertThat(DateTimeOffset.years(-1).apply(DateTime.parse("2000-1-1TZ")))
+            .isEqualTo(DateTime.parse("1999-1-1TZ"));
+        assertThat(DateTimeOffset.years(0).apply(DateTime.parse("2000-1-1TZ")))
+            .isEqualTo(DateTime.parse("2000-1-1TZ"));
+    }
+
+    @Test
+    public void applyMonths() {
+        assertThat(DateTimeOffset.months(1).apply(DateTime.parse("2000-1-1TZ")))
+            .isEqualTo(DateTime.parse("2000-2-1TZ"));
+        assertThat(DateTimeOffset.months(-1).apply(DateTime.parse("2000-1-1TZ")))
+            .isEqualTo(DateTime.parse("1999-12-1TZ"));
+        assertThat(DateTimeOffset.months(0).apply(DateTime.parse("2000-1-1TZ")))
+            .isEqualTo(DateTime.parse("2000-1-1TZ"));
+    }
+
+    @Test
+    public void applyWeeks() {
+        assertThat(DateTimeOffset.weeks(1).apply(DateTime.parse("2000-1-10TZ")))
+            .isEqualTo(DateTime.parse("2000-1-17TZ"));
+        assertThat(DateTimeOffset.weeks(-1).apply(DateTime.parse("2000-1-10TZ")))
+            .isEqualTo(DateTime.parse("2000-1-3TZ"));
+        assertThat(DateTimeOffset.months(0).apply(DateTime.parse("2000-1-10TZ")))
+            .isEqualTo(DateTime.parse("2000-1-10TZ"));
+    }
+
+    @Test
+    public void applyDays() {
+        assertThat(DateTimeOffset.days(1).apply(DateTime.parse("2000-1-10TZ")))
+            .isEqualTo(DateTime.parse("2000-1-11TZ"));
+        assertThat(DateTimeOffset.days(-1).apply(DateTime.parse("2000-1-10TZ")))
+            .isEqualTo(DateTime.parse("2000-1-9TZ"));
+        assertThat(DateTimeOffset.days(0).apply(DateTime.parse("2000-1-10TZ")))
+            .isEqualTo(DateTime.parse("2000-1-10TZ"));
+    }
+
+    @Test
+    public void applyHours() {
+        assertThat(DateTimeOffset.hours(1).apply(DateTime.parse("2000-1-10T05:00:00Z")))
+            .isEqualTo(DateTime.parse("2000-1-10T06:00:00Z"));
+        assertThat(DateTimeOffset.hours(-1).apply(DateTime.parse("2000-1-10T05:00:00Z")))
+            .isEqualTo(DateTime.parse("2000-1-10T04:00:00Z"));
+        assertThat(DateTimeOffset.hours(0).apply(DateTime.parse("2000-1-10T05:00:00Z")))
+            .isEqualTo(DateTime.parse("2000-1-10T05:00:00Z"));
+    }
+
+    @Test
+    public void applyMinutes() {
+        assertThat(DateTimeOffset.minutes(1).apply(DateTime.parse("2000-1-10T05:30:00Z")))
+            .isEqualTo(DateTime.parse("2000-1-10T05:31:00Z"));
+        assertThat(DateTimeOffset.minutes(-1).apply(DateTime.parse("2000-1-10T05:30:00Z")))
+            .isEqualTo(DateTime.parse("2000-1-10T05:29:00Z"));
+        assertThat(DateTimeOffset.minutes(0).apply(DateTime.parse("2000-1-10T05:30:00Z")))
+            .isEqualTo(DateTime.parse("2000-1-10T05:30:00Z"));
+    }
+
+    @Test
+    public void applySeconds() {
+        assertThat(DateTimeOffset.seconds(1).apply(DateTime.parse("2000-1-10T05:30:30Z")))
+            .isEqualTo(DateTime.parse("2000-1-10T05:30:31Z"));
+        assertThat(DateTimeOffset.seconds(-1).apply(DateTime.parse("2000-1-10T05:30:30Z")))
+            .isEqualTo(DateTime.parse("2000-1-10T05:30:29Z"));
+        assertThat(DateTimeOffset.seconds(0).apply(DateTime.parse("2000-1-10T05:30:30Z")))
+            .isEqualTo(DateTime.parse("2000-1-10T05:30:30Z"));
+    }
+
+    @Test
+    public void applyMilliseconds() {
+        assertThat(DateTimeOffset.milliseconds(100).apply(DateTime.parse("2000-1-10T05:30:30.500Z")))
+            .isEqualTo(DateTime.parse("2000-1-10T05:30:30.600Z"));
+        assertThat(DateTimeOffset.milliseconds(-100).apply(DateTime.parse("2000-1-10T05:30:30.500Z")))
+            .isEqualTo(DateTime.parse("2000-1-10T05:30:30.400Z"));
+        assertThat(DateTimeOffset.milliseconds(0).apply(DateTime.parse("2000-1-10T05:30:30.500Z")))
+            .isEqualTo(DateTime.parse("2000-1-10T05:30:30.500Z"));
+    }
+}


### PR DESCRIPTION
I'd like to add the ability to specify something I'd like to call date time offset, which relates directly to JodaTime's plusDays(), plusWeeks(), etc. functions.  I had a need to be able to specify an offset value in the format '+1 day', and '-1 day', etc.  At first I attempted to use Duration.  Duration doesn't support negative values or explicit positive values, and after giving it some more thought, I decided that this type of thing is an entirely different concept than Duration anyways and the units Duration supports isn't directly in line with what JodaTime allows you to plus/minus from DateTime instances.  I've left out the ability to convert between units for now as this can get fairly complex for cases like converting days to months, etc.  I wanted to keep the functionality simply for representing an offset and applying it, not much more.

Examples:

MyConfiguration.java:

public class MyConfiguration extends Configuration {
   private DateTimeOffset start;
   // public getStart()/setStart()...
   private DateTimeOffset end;
   // public getEnd()/setEnd()...
}

config.yaml:
start: -1 day
end: +5 days

Usage:
MyConfiguration configuration = ...;
configuration.getStart().apply(DateTime.now()); // calls plusDays(-1) on instance
