### PR TITLE
Dropwizard-JDBI Version Bump: 2.50 - > 2.53

### DIFF
--- a/dropwizard-jdbi/pom.xml
+++ b/dropwizard-jdbi/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi</artifactId>
-            <version>2.50</version>
+            <version>2.53</version>
         </dependency>
         <dependency>
             <groupId>com.codahale.metrics</groupId>


### PR DESCRIPTION
`dropwizard-jdbi` was left out of #429 and there are couple of changes especially in the `StringTemplate3StatementLocator` that I'm currently using that requires jdbi version `2.53`
