### PR TITLE
Handle deserialization when enums are lower-/mixed case

### DIFF
--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/FuzzyEnumModule.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/FuzzyEnumModule.java
@@ -18,8 +18,8 @@ import java.util.Locale;
  * This deserializer is more permissive in the following ways:
  * <ul>
  * <li>Whitespace is permitted but stripped from the input.</li>
- * <li>Lower-case characters are permitted and automatically translated to upper-case.</li>
  * <li>Dashes in the value are converted to underscores.</li>
+ * <li>Matching against the enum values is case insensitive.</li>
  * </ul>
  */
 public class FuzzyEnumModule extends Module {
@@ -42,10 +42,9 @@ public class FuzzyEnumModule extends Module {
         public Enum<?> deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
             final String text = CharMatcher.WHITESPACE
                                            .removeFrom(jp.getText())
-                                           .replace('-', '_')
-                                           .toUpperCase(Locale.ENGLISH);
+                                           .replace('-', '_');
             for (Enum<?> constant : constants) {
-                if (constant.name().equals(text)) {
+                if (constant.name().equalsIgnoreCase(text)) {
                     return constant;
                 }
             }

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/FuzzyEnumModuleTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/FuzzyEnumModuleTest.java
@@ -13,6 +13,8 @@ import static org.fest.assertions.api.Assertions.failBecauseExceptionWasNotThrow
 
 public class FuzzyEnumModuleTest {
     private final ObjectMapper mapper = new ObjectMapper();
+    
+    private enum EnumWithLowercase {lower_case_enum, mixedCaseEnum};
 
     @Before
     public void setUp() throws Exception {
@@ -56,7 +58,20 @@ public class FuzzyEnumModuleTest {
             failBecauseExceptionWasNotThrown(JsonMappingException.class);
         } catch (JsonMappingException e) {
             assertThat(e.getOriginalMessage())
-                    .isEqualTo("WRONG was not one of [NANOSECONDS, MICROSECONDS, MILLISECONDS, SECONDS, MINUTES, HOURS, DAYS]");
+                    .isEqualTo("wrong was not one of [NANOSECONDS, MICROSECONDS, MILLISECONDS, SECONDS, MINUTES, HOURS, DAYS]");
         }
     }
+ 
+    @Test
+    public void mapsToLowerCaseEnums() throws Exception {
+        assertThat(mapper.readValue("\"lower_case_enum\"", EnumWithLowercase.class))
+                .isEqualTo(EnumWithLowercase.lower_case_enum);
+    }
+    
+    @Test
+    public void mapsMixedCaseEnums() throws Exception {
+        assertThat(mapper.readValue("\"mixedCaseEnum\"", EnumWithLowercase.class))
+                .isEqualTo(EnumWithLowercase.mixedCaseEnum);
+    }
+   
 }


### PR DESCRIPTION
FuzzyEnumModule fails to deserialize when the enum being deserialized to is not all UPPER_CASE.

See: https://github.com/dropwizard/dropwizard/pull/436
