### PR TITLE
replace ConcurrentArrayBlockingQueue with BlockingArrayQueue

### DIFF
--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/AsyncAppender.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/AsyncAppender.java
@@ -6,10 +6,11 @@ import ch.qos.logback.core.AppenderBase;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
 import io.dropwizard.util.Duration;
-import org.eclipse.jetty.util.ConcurrentArrayBlockingQueue;
 
 import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -75,11 +76,11 @@ public class AsyncAppender extends AppenderBase<ILoggingEvent> {
         setName("async-" + delegate.getName());
     }
 
-    private ConcurrentArrayBlockingQueue<ILoggingEvent> buildQueue(int batchSize, boolean bounded) {
+    private BlockingQueue<ILoggingEvent> buildQueue(int batchSize, boolean bounded) {
         if (bounded) {
-            return new ConcurrentArrayBlockingQueue.Bounded<>(batchSize * 2);
+            return new ArrayBlockingQueue<ILoggingEvent>(batchSize * 2);
         }
-        return new ConcurrentArrayBlockingQueue.Unbounded<>();
+        return new LinkedBlockingQueue<ILoggingEvent>();
     }
 
     @Override


### PR DESCRIPTION
The jetty project has been slowly removing all usages of ConcurrentArrayBlockingQueue.

http://git.eclipse.org/c/jetty/org.eclipse.jetty.project.git/log/?qt=grep&q=ConcurrentArrayBlockingQueue

The commit messages imply the implementation might not be correct or performant. Following their lead, I tried replacing its usage with `org.eclipse.jetty.util.BlockingArrayQueue`. Unfortunately their documentation for `org.eclipse.jetty.util.BlockingArrayQueue` is a lie:

```
Unlike {@link java.util.concurrent.ArrayBlockingQueue}, this class is able to grow and provides a blocking put call.
```

and the implementation of this amazing blocking put call:

```
    @Override
    public void put(E o) throws InterruptedException
    {
        // The mechanism to await and signal when the queue is full is not implemented
        throw new UnsupportedOperationException();
    }
```

I've chosen to fall back on the tried and true java.concurrent queues. Something like this change will be required for Jetty 9.1 as they've removed ConcurrentArrayBlockingQueue entirely https://bugs.eclipse.org/bugs/show_bug.cgi?id=403591.
