### PR TITLE
updates for jetty 9.1

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
@@ -357,6 +357,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
     }
 
     private void configureSessionsAndSecurity(MutableServletContextHandler handler, Server server) {
+        handler.setServer(server);
         if (handler.isSecurityEnabled()) {
             handler.getSecurityHandler().setServer(server);
         }
@@ -383,6 +384,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
             handler.addServlet(new NonblockingServletHolder(jerseyContainer), jersey.getUrlPattern());
         }
         final InstrumentedHandler instrumented = new InstrumentedHandler(metricRegistry);
+        instrumented.setServer(server);
         instrumented.setHandler(handler);
         return instrumented;
     }

--- a/dropwizard-core/src/test/java/io/dropwizard/setup/AdminEnvironmentTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/setup/AdminEnvironmentTest.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.health.HealthCheckRegistry;
 import com.google.common.collect.ImmutableMultimap;
 import io.dropwizard.jetty.MutableServletContextHandler;
 import io.dropwizard.servlets.tasks.Task;
+import org.eclipse.jetty.server.Server;
 import org.junit.Test;
 
 import javax.servlet.ServletRegistration;
@@ -25,6 +26,7 @@ public class AdminEnvironmentTest {
         };
         env.addTask(task);
 
+        handler.setServer(new Server());
         handler.start();
 
         final ServletRegistration registration = handler.getServletHandler()

--- a/dropwizard-jetty/pom.xml
+++ b/dropwizard-jetty/pom.xml
@@ -20,6 +20,17 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <!-- this is required because jetty-server pom
+            put servlet-api into default scope when it should
+            always be provided scope so it doesn't get compiled.
+            without this there are security exceptions because
+            javax.servlet-api jar is not signed -->
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.codahale.metrics</groupId>
             <artifactId>metrics-jetty9</artifactId>
             <version>${metrics3.version}</version>

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/BiDiGzipFilter.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/BiDiGzipFilter.java
@@ -234,5 +234,26 @@ public class BiDiGzipFilter extends IncludableGzipFilter {
         public int read(byte[] b) throws IOException {
             return input.read(b);
         }
+
+        @Override
+        public boolean isFinished() {
+            try {
+                return input.available() == 0;
+            } catch (IOException ignored) {}
+            return true;
+        }
+
+        @Override
+        public boolean isReady() {
+            try {
+                return input.available() > 0;
+            } catch (IOException ignored) {}
+            return false;
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+            throw new IllegalStateException("not supported");
+        }
     }
 }

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/RoutingHandlerTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/RoutingHandlerTest.java
@@ -1,10 +1,7 @@
 package io.dropwizard.jetty;
 
 import com.google.common.collect.ImmutableMap;
-import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.server.Handler;
-import org.eclipse.jetty.server.HttpChannel;
-import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.*;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.junit.Test;
 
@@ -27,6 +24,8 @@ public class RoutingHandlerTest {
 
     @Test
     public void startsAndStopsAllHandlers() throws Exception {
+        handler1.setServer(mock(Server.class));
+        handler2.setServer(mock(Server.class));
         handler.start();
         try {
             assertThat(handler1.isStarted())

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/AsyncAppender.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/AsyncAppender.java
@@ -6,10 +6,11 @@ import ch.qos.logback.core.AppenderBase;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
 import io.dropwizard.util.Duration;
-import org.eclipse.jetty.util.ConcurrentArrayBlockingQueue;
 
 import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -75,11 +76,11 @@ public class AsyncAppender extends AppenderBase<ILoggingEvent> {
         setName("async-" + delegate.getName());
     }
 
-    private ConcurrentArrayBlockingQueue<ILoggingEvent> buildQueue(int batchSize, boolean bounded) {
+    private BlockingQueue<ILoggingEvent> buildQueue(int batchSize, boolean bounded) {
         if (bounded) {
-            return new ConcurrentArrayBlockingQueue.Bounded<>(batchSize * 2);
+            return new ArrayBlockingQueue<ILoggingEvent>(batchSize * 2);
         }
-        return new ConcurrentArrayBlockingQueue.Unbounded<>();
+        return new LinkedBlockingQueue<ILoggingEvent>();
     }
 
     @Override

--- a/dropwizard-servlets/pom.xml
+++ b/dropwizard-servlets/pom.xml
@@ -25,6 +25,17 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <!-- this is required because jetty-server pom
+            put servlet-api into default scope when it should
+            always be provided scope so it doesn't get compiled.
+            without this there are security exceptions because
+            javax.servlet-api jar is not signed -->
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jetty.orbit</groupId>
             <artifactId>javax.servlet</artifactId>
             <version>${servlet.version}</version>

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/assets/AssetServletTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/assets/AssetServletTest.java
@@ -191,17 +191,17 @@ public class AssetServletTest {
         final long lastModifiedTime = response.getDateField(HttpHeaders.LAST_MODIFIED);
 
 
-        request.setHeader(HttpHeaders.IF_MODIFIED_SINCE, HttpFields.formatDate(lastModifiedTime));
+        request.putDateField(HttpHeaders.IF_MODIFIED_SINCE, lastModifiedTime);
         response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
         final int statusWithMatchingLastModifiedTime = response.getStatus();
 
-        request.setHeader(HttpHeaders.IF_MODIFIED_SINCE,
-                          HttpFields.formatDate(lastModifiedTime - 100));
+        request.putDateField(HttpHeaders.IF_MODIFIED_SINCE,
+                          lastModifiedTime - 100);
         response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
         final int statusWithStaleLastModifiedTime = response.getStatus();
 
-        request.setHeader(HttpHeaders.IF_MODIFIED_SINCE,
-                          HttpFields.formatDate(lastModifiedTime + 100));
+        request.putDateField(HttpHeaders.IF_MODIFIED_SINCE,
+                          lastModifiedTime + 100);
         response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
         final int statusWithRecentLastModifiedTime = response.getStatus();
 

--- a/dropwizard-testing/pom.xml
+++ b/dropwizard-testing/pom.xml
@@ -26,6 +26,10 @@
                     <groupId>junit</groupId>
                     <artifactId>junit</artifactId>
                 </exclusion>
+                 <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <logback.version>1.0.13</logback.version>
         <slf4j.version>1.7.5</slf4j.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
-        <jetty.version>9.0.7.v20131107</jetty.version>
+        <jetty.version>9.1.1.v20140108</jetty.version>
         <guava.version>15.0</guava.version>
         <h2.version>1.3.174</h2.version>
     </properties>


### PR DESCRIPTION
The test suite passes for me, but I wouldn't consider this ready for merge yet. I think it would be nice to add support for Jetty's HTTP/SPDY client. I had some issues with the jetty 9.1 jars because they seem to default depend on javax.servlet-api which as far as I can tell is a bad thing and caused me to learn about all kinds of things I would prefer not to know. I worked around it the best I could after some hellish debugging of tests failing with java class loader security exceptions.
