### PR TITLE
Upgrade to Guava 16.0.1

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -70,7 +70,7 @@ v0.7.0-SNAPSHOT
 * Fixed formatting of "Caused by" lines not being prefixed when logging nested Exceptions.
 * Fixed not all available Jersey endpoints were being logged at startup.
 * Upgraded to argparse4j 0.4.2.
-* Upgraded to Guava 15.
+* Upgraded to Guava 16.0.1.
 * Upgraded to Hibernate Validator 5.0.2.
 * Upgraded to Jackson 2.3.0.
 * Upgraded to JDBI 2.53.

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <slf4j.version>1.7.5</slf4j.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <jetty.version>9.0.7.v20131107</jetty.version>
-        <guava.version>15.0</guava.version>
+        <guava.version>16.0.1</guava.version>
         <h2.version>1.3.174</h2.version>
     </properties>
 


### PR DESCRIPTION
The Reflection utilities in Google Guava prior to version 16.0.1 do not work with the latest stable Oracle JDK 7u51. An upgrade to Guava 16.0.1 solves this problem.

IMHO Dropwizard 0.7.0 shouldn't ship with (direct) dependencies known to be broken with the latest version of the Oracle JDK.

Bug report at Google Guava:
[Issue 1635: JDK and Guava TypeVariable implementations are no longer compatible under 1.7.0_51-b13](https://code.google.com/p/guava-libraries/issues/detail?id=1635)
