### PR TITLE
Added two missing imports for HelloWorldApplication

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -271,7 +271,7 @@ commands which provide basic functionality. (More on that later.) For now, thoug
     import io.dropwizard.setup.Bootstrap;
     import io.dropwizard.setup.Environment;
     import com.example.helloworld.resources.HelloWorldResource;
-	import com.example.helloworld.health.TemplateHealthCheck;
+    import com.example.helloworld.health.TemplateHealthCheck;
 
     public class HelloWorldApplication extends Application<HelloWorldConfiguration> {
         public static void main(String[] args) throws Exception {


### PR DESCRIPTION
HelloWorld was missing imports for the HelloWorldResource and
TemplateHealthCheck classes, causing a compile error in the Getting
Started application.   This was related to issue #460 - which can be closed.
