### PR TITLE
Upgrade to SLF4J 1.7.6 and Logback 1.1.1

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -79,7 +79,7 @@ v0.7.0-SNAPSHOT
 * Upgraded to Logback 1.1.1.
 * Upgraded to Metrics 3.0.1.
 * Upgraded to Mustache 0.8.14.
-* Upgraded to SLF4J 1.7.5.
+* Upgraded to SLF4J 1.7.6.
 * Upgraded to Jersey 1.18.
 * Upgraded to Apache HttpClient 4.3.2.
 * Upgraded to tomcat-jdbc 7.0.50.

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <jersey.version>1.18</jersey.version>
         <jackson.version>2.3.1</jackson.version>
         <logback.version>1.1.1</logback.version>
-        <slf4j.version>1.7.5</slf4j.version>
+        <slf4j.version>1.7.6</slf4j.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <jetty.version>9.0.7.v20131107</jetty.version>
         <guava.version>16.0.1</guava.version>
@@ -172,6 +172,11 @@
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
                 <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Another janitorial pull request.
- [[qos.ch-announce] Release of SLF4J version 1.7.6](http://mailman.qos.ch/pipermail/announce/2014/000125.html)
- Logback 1.1.1: http://jira.qos.ch/browse/LOGBACK-942 and http://jira.qos.ch/browse/LOGBACK-943
