### PR TITLE
Ignore dependency-reduced-pom.xml file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ logs
 .settings/
 .classpath
 .project
+#Maven shade plugin
+dependency-reduced-pom.xml


### PR DESCRIPTION
dependency-reduced-pom.xml file is auto-generated by maven shade plugin (in
the dropwizard-example) and should be not be tracked in the repo.
