### PR TITLE
Use mockito-core rather than mockito-all

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,9 +154,15 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <version>1.9.5</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.easytesting</groupId>


### PR DESCRIPTION
mockito-core is packaged with an old version of hamcrest which conflicts with
JUnit 4.11, which means you can't use things like ExpectedException rules when you're depending on dropwizard-testing without explicitly excluding its mockito dependencies.

Just replacing mockito-core with mockito-all ends up with enforcer failures, because mockito-core depends on hamcrest 1.1 and JUnit 4.11 depends on hamcrest 1.3, but a bit of googling suggests that excluding the mockito-core dependency and running with hamcrest 1.3 works fine.
