### PR TITLE
Make ValidatorFactory available on Bootstrap

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/cli/ConfiguredCommand.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/ConfiguredCommand.java
@@ -62,6 +62,7 @@ public abstract class ConfiguredCommand<T extends Configuration> extends Command
     public final void run(Bootstrap<?> bootstrap, Namespace namespace) throws Exception {
         configuration = parseConfiguration(((Bootstrap<T>)bootstrap).getConfigurationFactoryFactory(),
                                            bootstrap.getConfigurationSourceProvider(),
+                                           bootstrap.getValidatorFactory().getValidator(),
                                            namespace.getString("file"),
                                            getConfigurationClass(),
                                            bootstrap.getObjectMapper());
@@ -104,10 +105,10 @@ public abstract class ConfiguredCommand<T extends Configuration> extends Command
 
     private T parseConfiguration(ConfigurationFactoryFactory<T> configurationFactoryFactory,
                                  ConfigurationSourceProvider provider,
+                                 Validator validator,
                                  String path,
                                  Class<T> klass,
                                  ObjectMapper objectMapper) throws IOException, ConfigurationException {
-        final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
         final ConfigurationFactory<T> configurationFactory = configurationFactoryFactory.create(klass, validator, objectMapper, "dw");
         if (path != null) {
             return configurationFactory.build(provider, path);

--- a/dropwizard-core/src/main/java/io/dropwizard/cli/EnvironmentCommand.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/EnvironmentCommand.java
@@ -33,8 +33,7 @@ public abstract class EnvironmentCommand<T extends Configuration> extends Config
     protected final void run(Bootstrap<T> bootstrap, Namespace namespace, T configuration) throws Exception {
         final Environment environment = new Environment(bootstrap.getApplication().getName(),
                                                         bootstrap.getObjectMapper(),
-                                                        Validation.buildDefaultValidatorFactory()
-                                                                  .getValidator(),
+                                                        bootstrap.getValidatorFactory().getValidator(),
                                                         bootstrap.getMetricRegistry(),
                                                         bootstrap.getClassLoader());
         configuration.getMetricsFactory().configure(environment.lifecycle(),

--- a/dropwizard-core/src/main/java/io/dropwizard/setup/Bootstrap.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/Bootstrap.java
@@ -25,6 +25,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
+import javax.validation.Validation;
+import javax.validation.ValidatorFactory;
+
 /**
  * The pre-start application environment, containing everything required to bootstrap a Dropwizard
  * command.
@@ -38,6 +41,7 @@ public class Bootstrap<T extends Configuration> {
     private final List<ConfiguredBundle<? super T>> configuredBundles;
     private final List<Command> commands;
     private final MetricRegistry metricRegistry;
+    private final ValidatorFactory validatorFactory;
 
     private ConfigurationSourceProvider configurationSourceProvider;
     private ClassLoader classLoader;
@@ -55,6 +59,7 @@ public class Bootstrap<T extends Configuration> {
         this.configuredBundles = Lists.newArrayList();
         this.commands = Lists.newArrayList();
         this.metricRegistry = new MetricRegistry();
+        this.validatorFactory = Validation.buildDefaultValidatorFactory();
         metricRegistry.register("jvm.buffers", new BufferPoolMetricSet(ManagementFactory
                                                                                .getPlatformMBeanServer()));
         metricRegistry.register("jvm.gc", new GarbageCollectorMetricSet());
@@ -174,6 +179,13 @@ public class Bootstrap<T extends Configuration> {
      */
     public MetricRegistry getMetricRegistry() {
         return metricRegistry;
+    }
+
+    /**
+     * Returns the application's validator factory.
+     */
+    public ValidatorFactory getValidatorFactory() {
+        return validatorFactory;
     }
 
     public ConfigurationFactoryFactory<T> getConfigurationFactoryFactory() {


### PR DESCRIPTION
`ValidatorFactory` is used to obtain `Validator` instances in several places (including configuration validation).

Instead of using a singleton instance, let's make this available on `Bootstrap`, so that validation may be customised (e.g. by `Bundle`s).
