### PR TITLE
Removing maximum limit on archivedFileCount for file logging.

### DIFF
--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.dropwizard.validation.ValidationMethod;
 
-import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import java.util.TimeZone;
@@ -62,7 +61,7 @@ import java.util.TimeZone;
  *         <td>{@code archivedFileCount}</td>
  *         <td>{@code 5}</td>
  *         <td>
- *             The number of archived files to keep. Must be between {@code 1} and {@code 50}.
+ *             The number of archived files to keep. Must be greater than {@code 0}.
  *         </td>
  *     </tr>
  *     <tr>
@@ -93,7 +92,6 @@ public class FileAppenderFactory extends AbstractAppenderFactory {
     private String archivedLogFilenamePattern;
 
     @Min(1)
-    @Max(50)
     private int archivedFileCount = 5;
 
     @NotNull


### PR DESCRIPTION
In some systems we want to keep a history of logs for 1 year. As far as I can tell the maximum of 50 here is an arbitrary decision; Logback itself imposes no such limit.
