### PR TITLE
Use next available tcp port when starting server in unit tests, not default port

### DIFF
--- a/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
@@ -1,9 +1,6 @@
 package io.dropwizard.server;
 
-import com.codahale.metrics.MetricRegistry;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.io.CharStreams;
-import com.google.common.io.Resources;
+import static org.fest.assertions.api.Assertions.assertThat;
 import io.dropwizard.configuration.ConfigurationFactory;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
 import io.dropwizard.jackson.Jackson;
@@ -12,25 +9,36 @@ import io.dropwizard.logging.ConsoleAppenderFactory;
 import io.dropwizard.logging.FileAppenderFactory;
 import io.dropwizard.logging.SyslogAppenderFactory;
 import io.dropwizard.setup.Environment;
-import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.server.NetworkConnector;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.AbstractNetworkConnector;
-import org.junit.Before;
-import org.junit.Test;
+
+import java.io.File;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import java.io.File;
-import java.io.InputStreamReader;
-import java.net.URL;
-import java.net.URLConnection;
-import java.util.concurrent.*;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import org.eclipse.jetty.server.AbstractNetworkConnector;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.NetworkConnector;
+import org.eclipse.jetty.server.Server;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.CharStreams;
+import com.google.common.io.Resources;
 
 public class DefaultServerFactoryTest {
     private DefaultServerFactory http;
@@ -89,6 +97,8 @@ public class DefaultServerFactoryTest {
 
         final ScheduledExecutorService executor = Executors.newScheduledThreadPool(3);
         final Server server = http.build(environment);
+        
+        ((AbstractNetworkConnector)server.getConnectors()[0]).setPort(0);
 
         ScheduledFuture<Void> cleanup = executor.schedule(new Callable<Void>() {
             @Override


### PR DESCRIPTION
Currently the tests will fail in CI because of other builds running on the same machine. Since the test is not dependent on which port is actually used, it should just use the next available port.
