### PR TITLE
Fixed org.eclipse.jetty.server.handler.AbstractHandler warnings

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
@@ -371,6 +371,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
                                          MetricRegistry metrics,
                                          HealthCheckRegistry healthChecks) {
         configureSessionsAndSecurity(handler, server);
+        handler.setServer(server);  
         handler.getServletContext().setAttribute(MetricsServlet.METRICS_REGISTRY, metrics);
         handler.getServletContext().setAttribute(HealthCheckServlet.HEALTH_CHECK_REGISTRY, healthChecks);
         handler.addServlet(new NonblockingServletHolder(new AdminServlet()), "/*");
@@ -404,6 +405,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
             handler.addServlet(new NonblockingServletHolder(jerseyContainer), jersey.getUrlPattern());
         }
         final InstrumentedHandler instrumented = new InstrumentedHandler(metricRegistry);
+        instrumented.setServer(server);
         instrumented.setHandler(handler);
         return instrumented;
     }
@@ -423,6 +425,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
         server.addLifeCycleListener(buildSetUIDListener());
         lifecycle.attach(server);
         final ErrorHandler errorHandler = new ErrorHandler();
+        errorHandler.setServer(server);
         errorHandler.setShowStacks(false);
         server.addBean(errorHandler);
         server.setStopAtShutdown(true);


### PR DESCRIPTION
This fixes the warnings that occur when `org.eclipse.jetty.server.handler.AbstractHandler` instances do not have a Server set, such as:

```
WARN  [2014-02-28 03:24:31,674] org.eclipse.jetty.server.handler.AbstractHandler: No Server set for org.eclipse.jetty.server.handler.ErrorHandler@63b7e77
WARN  [2014-02-28 03:24:31,687] org.eclipse.jetty.server.handler.AbstractHandler: No Server set for com.codahale.metrics.jetty9.InstrumentedHandler@3fdd2ed5
WARN  [2014-02-28 03:24:31,696] org.eclipse.jetty.server.handler.AbstractHandler: No Server set for i.d.j.MutableServletContextHandler@2edfbe28{/,null,STARTING}
WARN  [2014-02-28 03:24:31,696] org.eclipse.jetty.server.handler.AbstractHandler: No Server set for org.eclipse.jetty.servlet.ServletHandler@633d4c22
WARN  [2014-02-28 03:24:32,166] org.eclipse.jetty.server.handler.AbstractHandler: No Server set for i.d.j.MutableServletContextHandler@515dd9a7{/,null,STARTING}
WARN  [2014-02-28 03:24:32,166] org.eclipse.jetty.server.handler.AbstractHandler: No Server set for org.eclipse.jetty.servlet.ServletHandler@687c8cac
```

These normally occur on server startup.
