### PR TITLE
Deprecate the defaultReadOnly property in favor of readOnlyByDefault

### DIFF
--- a/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
+++ b/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
@@ -334,8 +334,6 @@ public class DataSourceFactory {
 
     private boolean checkConnectionOnReturn = false;
 
-    private boolean defaultReadOnly = false;
-
     private boolean autoCommentsEnabled = true;
 
     @NotNull
@@ -456,14 +454,16 @@ public class DataSourceFactory {
         this.checkConnectionWhileIdle = checkConnectionWhileIdle;
     }
 
+    @Deprecated
     @JsonProperty
     public boolean isDefaultReadOnly() {
-        return defaultReadOnly;
+        return Boolean.TRUE.equals(readOnlyByDefault);
     }
 
+    @Deprecated
     @JsonProperty
     public void setDefaultReadOnly(boolean defaultReadOnly) {
-        this.defaultReadOnly = defaultReadOnly;
+        readOnlyByDefault = Boolean.valueOf(defaultReadOnly);
     }
 
     @JsonIgnore


### PR DESCRIPTION
317f2e5cd4 introduced `DataSourceFactory.readOnlyByDefault` and made the existing `defaultReadOnly` property a no-op.
