### PR TITLE
Generalize DropwizardAppRule for other test frameworks

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/ConfigOverride.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/ConfigOverride.java
@@ -1,4 +1,4 @@
-package io.dropwizard.testing.junit;
+package io.dropwizard.testing;
 
 public class ConfigOverride {
 

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
@@ -1,0 +1,192 @@
+package io.dropwizard.testing;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.cli.ServerCommand;
+import io.dropwizard.lifecycle.Managed;
+import io.dropwizard.lifecycle.ServerLifecycleListener;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import net.sourceforge.argparse4j.inf.Namespace;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Set;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Throwables.propagate;
+
+/**
+ * A test support class for starting and stopping your application at the start and end of a test class.
+ * <p>
+ * By default, the {@link Application} will be constructed using reflection to invoke the nullary
+ * constructor. If your application does not provide a public nullary constructor, you will need to
+ * override the {@link #newApplication()} method to provide your application instance(s).
+ * </p>
+ *
+ * @param <C> the configuration type
+ */
+public class DropwizardTestSupport<C extends Configuration> {
+    private final Class<? extends Application<C>> applicationClass;
+    private final String configPath;
+    private final Set<ConfigOverride> configOverrides;
+
+    private C configuration;
+    private Application<C> application;
+    private Environment environment;
+    private Server jettyServer;
+    private List<ServiceListener> listeners = Lists.newArrayList();
+
+    public DropwizardTestSupport(Class<? extends Application<C>> applicationClass,
+                             @Nullable String configPath,
+                             ConfigOverride... configOverrides) {
+        this.applicationClass = applicationClass;
+        this.configPath = configPath;
+        this.configOverrides = ImmutableSet.copyOf(firstNonNull(configOverrides, new ConfigOverride[0]));
+    }
+
+    public DropwizardTestSupport<C> addListener(ServiceListener<C> listener) {
+        this.listeners.add(listener);
+        return this;
+    }
+
+    public DropwizardTestSupport<C> manage(final Managed managed) {
+        return addListener(new ServiceListener<C>() {
+            @Override
+            public void onRun(C configuration, Environment environment, DropwizardTestSupport<C> rule) throws Exception {
+                environment.lifecycle().manage(managed);
+            }
+        });
+    }
+
+    public void before() {
+        applyConfigOverrides();
+        startIfRequired();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void after() {
+        for (ServiceListener listener : listeners) {
+            try {
+                listener.onStop(this);
+            } catch (Exception ignored) {
+            }
+        }
+        resetConfigOverrides();
+        try {
+            jettyServer.stop();
+        } catch (Exception e) {
+            throw propagate(e);
+        } finally {
+            jettyServer = null;
+        }
+    }
+
+    private void applyConfigOverrides() {
+        for (ConfigOverride configOverride : configOverrides) {
+            configOverride.addToSystemProperties();
+        }
+    }
+
+    private void resetConfigOverrides() {
+        for (ConfigOverride configOverride : configOverrides) {
+            configOverride.removeFromSystemProperties();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void startIfRequired() {
+        if (jettyServer != null) {
+            return;
+        }
+
+        try {
+            application = newApplication();
+
+            final Bootstrap<C> bootstrap = new Bootstrap<C>(application) {
+                @Override
+                public void run(C configuration, Environment environment) throws Exception {
+                    environment.lifecycle().addServerLifecycleListener(new ServerLifecycleListener() {
+                        @Override
+                        public void serverStarted(Server server) {
+                            jettyServer = server;
+                        }
+                    });
+                    DropwizardTestSupport.this.configuration = configuration;
+                    DropwizardTestSupport.this.environment = environment;
+                    super.run(configuration, environment);
+                    for (ServiceListener listener : listeners) {
+                        try {
+                            listener.onRun(configuration, environment, DropwizardTestSupport.this);
+                        } catch (Exception ex) {
+                            throw new RuntimeException("Error running app rule start listener", ex);
+                        }
+                    }
+                }
+            };
+
+            application.initialize(bootstrap);
+            final ServerCommand<C> command = new ServerCommand<>(application);
+
+            ImmutableMap.Builder<String, Object> file = ImmutableMap.builder();
+            if (!Strings.isNullOrEmpty(configPath)) {
+                file.put("file", configPath);
+            }
+            final Namespace namespace = new Namespace(file.build());
+
+            command.run(bootstrap, namespace);
+        } catch (Exception e) {
+            throw propagate(e);
+        }
+    }
+
+    public C getConfiguration() {
+        return configuration;
+    }
+
+    public int getLocalPort() {
+        return ((ServerConnector) jettyServer.getConnectors()[0]).getLocalPort();
+    }
+
+    public int getAdminPort() {
+        return ((ServerConnector) jettyServer.getConnectors()[1]).getLocalPort();
+    }
+
+    public Application<C> newApplication() {
+        try {
+            return applicationClass.newInstance();
+        } catch (Exception e) {
+            throw propagate(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public <A extends Application<C>> A getApplication() {
+        return (A) application;
+    }
+
+    public Environment getEnvironment() {
+        return environment;
+    }
+
+    public ObjectMapper getObjectMapper() {
+        return getEnvironment().getObjectMapper();
+    }
+
+    public abstract static class ServiceListener<T extends Configuration> {
+        public void onRun(T configuration, Environment environment, DropwizardTestSupport<T> rule) throws Exception {
+            // Default NOP
+        }
+
+        public void onStop(DropwizardTestSupport<T> rule) throws Exception {
+            // Default NOP
+        }
+    }
+}

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardClientRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardClientRule.java
@@ -6,6 +6,7 @@ import io.dropwizard.Configuration;
 import io.dropwizard.jetty.HttpConnectorFactory;
 import io.dropwizard.server.SimpleServerFactory;
 import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.DropwizardTestSupport;
 import org.junit.rules.ExternalResource;
 
 import java.net.URI;
@@ -52,10 +53,10 @@ import java.net.URL;
  */
 public class DropwizardClientRule extends ExternalResource {
     private final Object[] resources;
-    private final DropwizardAppRule<Configuration> appRule;
+    private final DropwizardTestSupport<Configuration> testSupport;
 
     public DropwizardClientRule(Object... resources) {
-        appRule = new DropwizardAppRule<Configuration>(null, null) {
+        testSupport = new DropwizardTestSupport<Configuration>(null, null) {
             @Override
             public Application<Configuration> newApplication() {
                 return new FakeApplication();
@@ -65,17 +66,17 @@ public class DropwizardClientRule extends ExternalResource {
     }
 
     public URI baseUri() {
-        return URI.create("http://localhost:" + appRule.getLocalPort() + "/application");
+        return URI.create("http://localhost:" + testSupport.getLocalPort() + "/application");
     }
 
     @Override
     protected void before() throws Throwable {
-        appRule.before();
+        testSupport.before();
     }
 
     @Override
     protected void after() {
-        appRule.after();
+        testSupport.after();
     }
 
     private static class DummyHealthCheck extends HealthCheck {

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportTest.java
@@ -1,0 +1,133 @@
+package io.dropwizard.testing;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableMultimap;
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.servlets.tasks.Task;
+import io.dropwizard.setup.Environment;
+import org.hibernate.validator.constraints.NotEmpty;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import java.io.PrintWriter;
+
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+public class DropwizardTestSupportTest {
+
+    public static final DropwizardTestSupport<TestConfiguration> TEST_SUPPORT =
+            new DropwizardTestSupport<>(TestApplication.class, resourceFilePath("test-config.yaml"));
+
+    @BeforeClass
+    public static void setUp(){
+        TEST_SUPPORT.before();
+    }
+
+    @AfterClass
+    public static void tearDown(){
+        TEST_SUPPORT.after();
+    }
+
+    @Test
+    public void canGetExpectedResourceOverHttp() {
+        final String content = ClientBuilder.newClient().target("http://localhost:" +
+                TEST_SUPPORT.getLocalPort()
+                +"/test")
+                .request().get(String.class);
+
+        assertThat(content, is("Yes, it's here"));
+    }
+
+    @Test
+    public void returnsConfiguration() {
+        final TestConfiguration config = TEST_SUPPORT.getConfiguration();
+        assertThat(config.getMessage(), is("Yes, it's here"));
+    }
+
+    @Test
+    public void returnsApplication() {
+        final TestApplication application = TEST_SUPPORT.getApplication();
+        assertNotNull(application);
+    }
+
+    @Test
+    public void returnsEnvironment() {
+        final Environment environment = TEST_SUPPORT.getEnvironment();
+        assertThat(environment.getName(), is("TestApplication"));
+    }
+
+    @Test
+    public void canPerformAdminTask() {
+        final String response
+                = ClientBuilder.newClient().target("http://localhost:"
+                + TEST_SUPPORT.getAdminPort() + "/tasks/hello?name=test_user")
+                .request()
+                .post(Entity.entity("", MediaType.TEXT_PLAIN), String.class);
+
+        assertThat(response, is("Hello has been said to test_user"));
+    }
+
+    public static class TestApplication extends Application<TestConfiguration> {
+        @Override
+        public void run(TestConfiguration configuration, Environment environment) throws Exception {
+            environment.jersey().register(new TestResource(configuration.getMessage()));
+            environment.admin().addTask(new HelloTask());
+        }
+    }
+
+    @Path("/")
+    public static class TestResource {
+
+        private final String message;
+
+        public TestResource(String message) {
+            this.message = message;
+        }
+
+        @Path("test")
+        @GET
+        public String test() {
+            return message;
+        }
+    }
+
+    public static class TestConfiguration extends Configuration {
+        @NotEmpty
+        @JsonProperty
+        private String message;
+
+        @NotEmpty
+        @JsonProperty
+        private String extra;
+
+        public String getMessage() {
+            return message;
+        }
+    }
+
+    public static class HelloTask extends Task {
+
+        public HelloTask() {
+            super("hello");
+        }
+
+        @Override
+        public void execute(ImmutableMultimap<String, String> parameters, PrintWriter output) throws Exception {
+            ImmutableCollection<String> names = parameters.get("name");
+            String name = !names.isEmpty() ? names.asList().get(0) : "Anonymous";
+            output.print("Hello has been said to " + name);
+            output.flush();
+        }
+    }
+}

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleConfigOverrideTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleConfigOverrideTest.java
@@ -6,15 +6,15 @@ import org.junit.Test;
 import javax.ws.rs.client.ClientBuilder;
 
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
-import static io.dropwizard.testing.junit.ConfigOverride.config;
+import static io.dropwizard.testing.ConfigOverride.config;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
-public class DropwizardServiceRuleConfigOverrideTest {
+public class DropwizardAppRuleConfigOverrideTest {
 
     @ClassRule
     public static final DropwizardAppRule<TestConfiguration> RULE =
-            new DropwizardAppRule<TestConfiguration>(TestApplication.class, resourceFilePath("test-config.yaml"),
+            new DropwizardAppRule<>(TestApplication.class, resourceFilePath("test-config.yaml"),
                     config("message", "A new way to say Hooray!"));
 
     @Test

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleResetConfigOverrideTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleResetConfigOverrideTest.java
@@ -7,7 +7,7 @@ import static io.dropwizard.testing.ConfigOverride.config;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DropwizardAppRuleResetConfigOverrideTest {
-    public final DropwizardAppRule<TestConfiguration> dropwizardAppRule = new DropwizardAppRule<>(
+    private final DropwizardAppRule<TestConfiguration> dropwizardAppRule = new DropwizardAppRule<>(
             TestApplication.class,
             resourceFilePath("test-config.yaml"),
             config("message", "A new way to say Hooray!"));
@@ -27,5 +27,6 @@ public class DropwizardAppRuleResetConfigOverrideTest {
 
         assertThat(System.getProperty("dw.message")).isNull();
         assertThat(System.getProperty("dw.extra")).isEqualTo("Some extra system property");
+        System.clearProperty("dw.extra");
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleResetConfigOverrideTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleResetConfigOverrideTest.java
@@ -3,10 +3,10 @@ package io.dropwizard.testing.junit;
 import org.junit.Test;
 
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
-import static io.dropwizard.testing.junit.ConfigOverride.config;
+import static io.dropwizard.testing.ConfigOverride.config;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DropwizardServiceRuleResetConfigOverrideTest {
+public class DropwizardAppRuleResetConfigOverrideTest {
     public final DropwizardAppRule<TestConfiguration> dropwizardAppRule = new DropwizardAppRule<>(
             TestApplication.class,
             resourceFilePath("test-config.yaml"),

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleWithoutConfigTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleWithoutConfigTest.java
@@ -3,7 +3,6 @@ package io.dropwizard.testing.junit;
 import com.google.common.collect.ImmutableMap;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
-import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import java.util.Map;
 import javax.ws.rs.GET;
@@ -32,7 +31,7 @@ public class DropwizardAppRuleWithoutConfigTest {
         Assert.assertEquals(ImmutableMap.of("color", "orange"), response);
     }
 
-    static class TestApplication extends Application<Configuration> {
+    public static class TestApplication extends Application<Configuration> {
         @Override
         public void run(Configuration configuration, Environment environment) throws Exception {
             environment.jersey().register(new TestResource());


### PR DESCRIPTION
Hi,

I was looking at starting/stopping a Dropwizard app in Cucumber tests and DropwizardAppRule has all the functionality I need but obviously it doesn't expose startIfRequired and stop methods.

I'd happy to extract a DropWizardAppTestSupport class from DropwizardAppRule and make the DropwizardAppRule depend on that and contribute the code if there's any interest.

What do you think?

Thanks,
Csaba