### PR TITLE
Enable Java 8 build in travis (in addition to Java 7)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ script: mvn verify
 
 jdk:
   - oraclejdk7
+  - oraclejdk8

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
         <jetty.version>9.0.7.v20131107</jetty.version>
         <guava.version>16.0.1</guava.version>
         <h2.version>1.3.175</h2.version>
+        <findbugs.skip>false</findbugs.skip>
     </properties>
 
     <developers>
@@ -168,6 +169,16 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>java8-disable-strict-javadoc-and-findbugs</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <javadoc.doclint.none>-Xdoclint:none</javadoc.doclint.none>
+                <findbugs.skip>true</findbugs.skip>
+            </properties>
+        </profile>
     </profiles>
 
     <dependencies>
@@ -271,6 +282,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.9.1</version>
+                <configuration>
+                    <additionalparam>${javadoc.doclint.none}</additionalparam>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
Java 8 is out, so it'd be good to start working towards supporting it properly. Here's a travis and maven change to enable builds on a JDK8 (not taking advantage of any Java8 features). 

There are 2 incompatibilities which I've resolved using profiles:
- findbugs doesn't yet support Java 8, so I've introduced a profile which disables it under Java8.
- JDK8 introduces a new strict mode to javadoc which makes Java7 compatible javadoc break the build, so I've introduced a profile which disables it under Java8.
