### PR TITLE
Adding the project version into the footer of all the docs pages

### DIFF
--- a/docs/source/_themes/dropwizard/layout.html
+++ b/docs/source/_themes/dropwizard/layout.html
@@ -104,6 +104,7 @@
         </div>
         <hr/>
         <footer>
+            <p style="float: left">
             {%- if show_copyright %}
             {%- if hasdoc('copyright') %}
             {% trans path=pathto('copyright'), copyright=copyright|e %}&copy; <a href="{{ path }}">Copyright</a>
@@ -119,6 +120,8 @@
             {% trans sphinx_version=sphinx_version|e %}Created using <a href="http://sphinx.pocoo.org/">Sphinx</a>
             {{ sphinx_version }}.{% endtrans %}
             {%- endif %}
+            </p>
+            <p style="float: right">Dropwizard v{{ release }}</p>
         </footer>
     </div>
 </body>


### PR DESCRIPTION
Since we are looking to have multiple versions of the docs, it will be helpful to display the version in the footer as a reference.
