### PR TITLE
Add ability to black list cipher suites

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -328,10 +328,17 @@ supportedProtocols               (none)              A list of protocols (e.g., 
                                                      other protocols will be refused.
 supportedCipherSuites            (none)              A list of cipher suites (e.g., ``TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256``) which
                                                      are supported. All other cipher suites will be refused
+excludedCipherSuites             (none)              A list of cipher suites (e.g., ``TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256``) which
+                                                     are excluded. These cipher suites will be refused and exclusion takes higher 
+                                                     precedence than inclusion, such that if a cipher suite is listed in 
+                                                     ``supportedCipherSuites`` and ``excludedCipherSuitse``, the cipher suite will be
+                                                     excluded. To verify that the proper cipher suites are being whitelisted and
+                                                     blacklisted, it is recommended to use the tool `sslyze`_.
 allowRenegotiation               true                Whether or not TLS renegotiation is allowed.
 endpointIdentificationAlgorithm  (none)              Which endpoint identification algorithm, if any, to use during the TLS handshake.
 ================================ ==================  ======================================================================================
 
+.. _sslyze: https://github.com/iSECPartners/sslyze
 
 .. _man-configuration-spdy:
 

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
@@ -174,6 +174,14 @@ import static com.codahale.metrics.MetricRegistry.name;
  *             are supported. All other cipher suites will be refused
  *         </td>
  *     </tr>
+ *    <tr>
+ *         <td>{@code excludedCipherSuites}</td>
+ *         <td>(none)</td>
+ *         <td>
+ *             A list of cipher suites (e.g., {@code TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256}) which
+ *             are excluded. These cipher suites will be refused.
+ *         </td>
+ *     </tr>
  *     <tr>
  *         <td>{@code allowRenegotiation}</td>
  *         <td>true</td>
@@ -232,6 +240,7 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
     private boolean validatePeers = true;
     private List<String> supportedProtocols;
     private List<String> supportedCipherSuites;
+    private List<String> excludedCipherSuites;
     private boolean allowRenegotiation = true;
     private String endpointIdentificationAlgorithm;
 
@@ -459,6 +468,16 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
     public List<String> getSupportedCipherSuites() {
         return supportedCipherSuites;
     }
+    
+    @JsonProperty
+    public List<String> getExcludedCipherSuites() {
+        return excludedCipherSuites;
+    }
+
+    @JsonProperty
+    public void setExcludedCipherSuites(List<String> excludedCipherSuites) {
+        this.excludedCipherSuites = excludedCipherSuites;
+    }
 
     @JsonProperty
     public void setSupportedCipherSuites(List<String> supportedCipherSuites) {
@@ -607,6 +626,10 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
 
         if (supportedCipherSuites != null) {
             factory.setIncludeCipherSuites(Iterables.toArray(supportedCipherSuites, String.class));
+        }
+        
+        if (excludedCipherSuites != null) {
+            factory.setExcludeCipherSuites(Iterables.toArray(excludedCipherSuites, String.class));
         }
 
         return factory;


### PR DESCRIPTION
This would close #489 (or at least it satisfies my constraints)

Allows a configuration such as the following contrived example

``` yaml

server:
  applicationConnectors:
    - type: https
      port: 8443
      # [snip]
      supportedCipherSuites: ['.*NULL.*']
      excludedCipherSuites: ['TLS_ECDHE_RSA_WITH_NULL_SHA']

```

And using [sslyze](https://github.com/iSECPartners/sslyze), I was able to verify that excluded cipher suite was actually excluded. This means that I decided, arbitrarily, to have exclusion have the higher precedence, so if a suite is both supported and excluded, it will be excluded.
