### PR TITLE
Update views.rst

### DIFF
--- a/docs/source/manual/views.rst
+++ b/docs/source/manual/views.rst
@@ -16,7 +16,6 @@ To enable views for your :ref:`Application <man-core-application>`, add the ``Vi
 .. code-block:: java
 
     public void initialize(Bootstrap<MyConfiguration> bootstrap) {
-        bootstrap.setName("my-service");
         bootstrap.addBundle(new ViewBundle());
     }
 


### PR DESCRIPTION
In 0.7.x you do not set the Application name property via Bootstrap. It defaults to the simple class name or can be overridden `@Override public String getName()` in the Application class.
