### PR TITLE
add http patch annotation

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/PATCH.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/PATCH.java
@@ -1,0 +1,12 @@
+package io.dropwizard.jersey;
+
+import javax.ws.rs.HttpMethod;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@HttpMethod("PATCH")
+public @interface PATCH { }


### PR DESCRIPTION
Included here for convenience http://tools.ietf.org/html/rfc5789

> The difference between the PUT and PATCH requests is reflected in the way the server processes the enclosed entity to modify the resource identified by the Request-URI.  In a PUT request, the enclosed entity is considered to be a modified version of the resource stored on the origin server, and the client is requesting that the stored version be replaced.  With PATCH, however, the enclosed entity contains a set of instructions describing how a resource currently residing on the origin server should be modified to produce a new version.
