### PR TITLE
Renaming 0.7.0-SNAPSHOT to 0.7.0

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -6,7 +6,7 @@ Release Notes
 
 .. _rel-0.7.0:
 
-v0.7.0-SNAPSHOT
+v0.7.0
 ===============
 
 * Upgraded to Java 7.


### PR DESCRIPTION
The change log ought to be for released versions only.
