### PR TITLE
GZip's compressedMimeTypes is not working

### DIFF
--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/BiDiGzipFilter.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/BiDiGzipFilter.java
@@ -72,6 +72,7 @@ public class BiDiGzipFilter extends IncludableGzipFilter {
     public void setMimeTypes(Set<String> mimeTypes) {
         _mimeTypes.clear();
         _mimeTypes.addAll(mimeTypes);
+        _excludeMimeTypes = false;
     }
 
     public void setBufferSize(int bufferSize) {


### PR DESCRIPTION
Dropwizard's compressedMimeTypes is a whitelist but Jetty is defaulting it's _mimeTypes to a blacklist if `FilterConfig#getInitParameter("mimeTypes");` returns null. See GzipFilter at line ~202 and 304.
