### PR TITLE
Adding missing exclusions for the slf4j-api dependency

### DIFF
--- a/dropwizard-servlets/pom.xml
+++ b/dropwizard-servlets/pom.xml
@@ -26,11 +26,23 @@
             <groupId>com.codahale.metrics</groupId>
             <artifactId>metrics-annotation</artifactId>
             <version>${metrics3.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.codahale.metrics</groupId>
             <artifactId>metrics-core</artifactId>
             <version>${metrics3.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.orbit</groupId>


### PR DESCRIPTION
Excluding the slf4j-api dependency from the metrics project as it is causing the maven dependency enforcer to fail. https://github.com/dropwizard/dropwizard/pull/484
