### PR TITLE
Upgrade to use Jackson 2.3.3

### DIFF
--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryTest.java
@@ -212,16 +212,12 @@ public class ConfigurationFactoryTest {
         }
     }
 
-    @Test
+    @Test(expected = ConfigurationParsingException.class)
     public void throwsAnExceptionOnArrayOverrideWithInvalidType() throws Exception {
         System.setProperty("dw.servers", "one,two");
-        try {
-            factory.build(validFile);
-            failBecauseExceptionWasNotThrown(ConfigurationParsingException.class);
-        } catch (ConfigurationParsingException e) {
-            assertThat(e.getMessage())
-                    .containsOnlyOnce("Can not instantiate value of type java.lang.String");
-        }
+
+        factory.build(validFile);
+        failBecauseExceptionWasNotThrown(ConfigurationParsingException.class);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <metrics3.version>3.0.1</metrics3.version>
         <jersey.version>1.18.1</jersey.version>
         <jackson.api.version>2.3.0</jackson.api.version>
-        <jackson.version>2.3.2</jackson.version>
+        <jackson.version>2.3.3</jackson.version>
         <logback.version>1.1.1</logback.version>
         <slf4j.version>1.7.6</slf4j.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>


### PR DESCRIPTION
Upgrading the Jackson libraries to 2.3.3. This is in reference to an issue seen during an upgrade to 0.7.0: https://github.com/FasterXML/jackson-module-afterburner/issues/28.

One of the tests was failing due to the error message being different due to the change in Jackson 2.3.3. Should the tests be relying on a specific error message? Isn't it good enough to know that a ConfigurationParsingException was thrown?
