### PR TITLE
Added support for HttpClientBuilder and JerseyClientBuilder configurable...

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
@@ -3,8 +3,10 @@ package io.dropwizard.client;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.httpclient.InstrumentedClientConnManager;
 import com.codahale.metrics.httpclient.InstrumentedHttpClient;
+
 import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Duration;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.HttpRequestRetryHandler;
@@ -44,6 +46,7 @@ public class HttpClientBuilder {
     private final MetricRegistry metricRegistry;
     private HttpClientConfiguration configuration = new HttpClientConfiguration();
     private DnsResolver resolver = new SystemDefaultDnsResolver();
+    private HttpRequestRetryHandler httpRequestRetryHandler;
     private SchemeRegistry registry = SchemeRegistryFactory.createSystemDefault();
 
     public HttpClientBuilder(MetricRegistry metricRegistry) {
@@ -76,6 +79,17 @@ public class HttpClientBuilder {
         return this;
     }
 
+    /**
+     * Uses the {@link httpRequestRetryHandler} for handling request retries.
+     *
+     * @param httpRequestRetryHandler an httpRequestRetryHandler
+     * @return {@code this}
+     */
+    public HttpClientBuilder using(HttpRequestRetryHandler httpRequestRetryHandler) {
+        this.httpRequestRetryHandler = httpRequestRetryHandler;
+        return this;
+    }
+    
     /**
      * Use the given {@link SchemeRegistry} instance.
      *
@@ -128,6 +142,8 @@ public class HttpClientBuilder {
 
         if (configuration.getRetries() == 0) {
             client.setHttpRequestRetryHandler(NO_RETRIES);
+        } else if (httpRequestRetryHandler != null) {
+            client.setHttpRequestRetryHandler(httpRequestRetryHandler);
         } else {
             client.setHttpRequestRetryHandler(new DefaultHttpRequestRetryHandler(configuration.getRetries(),
                                                                                  false));

--- a/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
@@ -1,5 +1,20 @@
 package io.dropwizard.client;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
+import io.dropwizard.setup.Environment;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+
+import javax.validation.Validation;
+import javax.validation.Validator;
+
+import org.apache.http.client.HttpRequestRetryHandler;
+import org.apache.http.conn.DnsResolver;
+import org.apache.http.conn.scheme.SchemeRegistry;
+
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
@@ -10,18 +25,6 @@ import com.sun.jersey.client.apache4.ApacheHttpClient4;
 import com.sun.jersey.client.apache4.ApacheHttpClient4Handler;
 import com.sun.jersey.client.apache4.config.ApacheHttpClient4Config;
 import com.sun.jersey.client.apache4.config.DefaultApacheHttpClient4Config;
-import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
-import io.dropwizard.setup.Environment;
-import org.apache.http.conn.DnsResolver;
-import org.apache.http.conn.scheme.SchemeRegistry;
-
-import javax.validation.Validation;
-import javax.validation.Validator;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutorService;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * A convenience class for building {@link Client} instances.
@@ -104,6 +107,17 @@ public class JerseyClientBuilder {
      */
     public JerseyClientBuilder withProperty(String propertyName, Object propertyValue) {
         properties.put(propertyName, propertyValue);
+        return this;
+    }
+    
+    /**
+     * Uses the {@link httpRequestRetryHandler} for handling request retries.
+     *
+     * @param httpRequestRetryHandler an httpRequestRetryHandler
+     * @return {@code this}
+     */
+    public JerseyClientBuilder using(HttpRequestRetryHandler httpRequestRetryHandler) {
+        builder.using(httpRequestRetryHandler);
         return this;
     }
 

--- a/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
@@ -2,11 +2,14 @@ package io.dropwizard.client;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
+
 import io.dropwizard.util.Duration;
+
 import org.apache.http.Header;
 import org.apache.http.HeaderIterator;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpRequestRetryHandler;
 import org.apache.http.client.params.AllClientPNames;
 import org.apache.http.client.params.CookiePolicy;
 import org.apache.http.conn.DnsResolver;
@@ -24,6 +27,7 @@ import org.apache.http.protocol.HTTP;
 import org.apache.http.protocol.HttpContext;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
 
 import static org.fest.assertions.api.Assertions.assertThat;
@@ -210,5 +214,20 @@ public class HttpClientBuilderTest {
 
         assertThat(client.getConnectionManager().getSchemeRegistry())
                 .isEqualTo(registry);
+    }
+    
+    @Test
+    public void usesACustomHttpRequestRetryHandler() throws Exception {
+        HttpRequestRetryHandler customHandler = new HttpRequestRetryHandler() {
+            @Override
+            public boolean retryRequest(IOException exception, int executionCount, HttpContext context) {
+                return false;
+            }
+        };
+        HttpClientConfiguration config = new HttpClientConfiguration();
+        config.setRetries(1);
+        AbstractHttpClient client = (AbstractHttpClient) builder.using(config).using(customHandler).build("test");
+        
+        assertThat(client.getHttpRequestRetryHandler()).isEqualTo(customHandler);
     }
 }


### PR DESCRIPTION
... HttpRequestRetryHandlers. Handlers are only used when HttpClientConfiguration retries are > 0.

To fix issue #522.
