### PR TITLE
Support bring-your-own MetricsRegistry in Bootstrap.

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/setup/Bootstrap.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/Bootstrap.java
@@ -60,11 +60,11 @@ public class Bootstrap<T extends Configuration> {
         this.commands = Lists.newArrayList();
         this.metricRegistry = new MetricRegistry();
         this.validatorFactory = Validation.buildDefaultValidatorFactory();
-        metricRegistry.register("jvm.buffers", new BufferPoolMetricSet(ManagementFactory
+        getMetricRegistry().register("jvm.buffers", new BufferPoolMetricSet(ManagementFactory
                                                                                .getPlatformMBeanServer()));
-        metricRegistry.register("jvm.gc", new GarbageCollectorMetricSet());
-        metricRegistry.register("jvm.memory", new MemoryUsageGaugeSet());
-        metricRegistry.register("jvm.threads", new ThreadStatesGaugeSet());
+        getMetricRegistry().register("jvm.gc", new GarbageCollectorMetricSet());
+        getMetricRegistry().register("jvm.memory", new MemoryUsageGaugeSet());
+        getMetricRegistry().register("jvm.threads", new ThreadStatesGaugeSet());
 
         this.configurationSourceProvider = new FileConfigurationSourceProvider();
         this.classLoader = Thread.currentThread().getContextClassLoader();

--- a/dropwizard-core/src/test/java/io/dropwizard/setup/BootstrapTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/setup/BootstrapTest.java
@@ -1,5 +1,6 @@
 package io.dropwizard.setup;
 
+import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.configuration.DefaultConfigurationFactoryFactory;
@@ -55,5 +56,19 @@ public class BootstrapTest {
     public void defaultsToDefaultConfigurationFactoryFactory() throws Exception {
         assertThat(bootstrap.getConfigurationFactoryFactory())
                 .isInstanceOf(DefaultConfigurationFactoryFactory.class);
+    }
+    
+    @Test
+    public void testBYOMetrics() {
+        final MetricRegistry newRegistry = new MetricRegistry();
+        Bootstrap<Configuration> newBootstrap = new Bootstrap<Configuration>(application) {
+            @Override
+            public MetricRegistry getMetricRegistry() {
+                return super.getMetricRegistry();
+            }
+        };
+        
+        assertThat(newBootstrap.getMetricRegistry().getNames())
+                .contains("jvm.buffers.mapped.capacity", "jvm.threads.count", "jvm.memory.heap.usage");
     }
 }


### PR DESCRIPTION
Bootstrap takes the newly constructed registry and registers a few JVM metrics. The way this is done makes it difficult to bring your own registry (say, if you are embedding a DW app within another app).

This PR uses the registry getter in the constructor to add those JVM metrics.
