### PR TITLE
Fix absence of metrics logging to JMX

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/setup/Bootstrap.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/Bootstrap.java
@@ -1,6 +1,8 @@
 package io.dropwizard.setup;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.codahale.metrics.JmxReporter;
 import io.dropwizard.Application;
 import io.dropwizard.Bundle;
 import io.dropwizard.Configuration;
@@ -58,17 +60,22 @@ public class Bootstrap<T extends Configuration> {
         this.bundles = Lists.newArrayList();
         this.configuredBundles = Lists.newArrayList();
         this.commands = Lists.newArrayList();
-        this.metricRegistry = new MetricRegistry();
+        this.metricRegistry = buildDefaultMetricRegistry();
         this.validatorFactory = Validation.buildDefaultValidatorFactory();
-        metricRegistry.register("jvm.buffers", new BufferPoolMetricSet(ManagementFactory
-                                                                               .getPlatformMBeanServer()));
-        metricRegistry.register("jvm.gc", new GarbageCollectorMetricSet());
-        metricRegistry.register("jvm.memory", new MemoryUsageGaugeSet());
-        metricRegistry.register("jvm.threads", new ThreadStatesGaugeSet());
-
         this.configurationSourceProvider = new FileConfigurationSourceProvider();
         this.classLoader = Thread.currentThread().getContextClassLoader();
         this.configurationFactoryFactory = new DefaultConfigurationFactoryFactory<T>();
+    }
+
+    private static MetricRegistry buildDefaultMetricRegistry() {
+        MetricRegistry metricRegistry = new MetricRegistry();
+        JmxReporter.forRegistry(metricRegistry).build().start();
+        metricRegistry.register("jvm.buffers", new BufferPoolMetricSet(ManagementFactory
+            .getPlatformMBeanServer()));
+        metricRegistry.register("jvm.gc", new GarbageCollectorMetricSet());
+        metricRegistry.register("jvm.memory", new MemoryUsageGaugeSet());
+        metricRegistry.register("jvm.threads", new ThreadStatesGaugeSet());
+        return metricRegistry;
     }
 
     /**


### PR DESCRIPTION
I recently ran into an issue using dropwizard 0.7.0: metrics are no longer being logged to JMX.

I did some digging and it turns out this is due to the fact that at one point the metrics library was revamped to no longer contain a default metrics registry.  Dropwizard used to use this default metrics registry, which was always configured to use JmxReporter to configure reporting of metrics to JMX.  You can see the original code below:

https://github.com/dropwizard/metrics/commit/934dbc95c605299999ad68bd63afa61d0c17f22f#diff-9e111793422e2f47ca2e35936c8a66e7

This pull request will add back support for logging metrics to JMX.

I tried writing a unit test for this pull request, but there's no easy way to get a list of listeners added to a MetricRegistry (unless you can mock it yourself to intercept addListener), and there's no easy way to detect that the listener with a given type was added (because JmxListener is private, unless you use getEnclosingClass() to check it against JmxReporter, but then you assume JmxListener will always be an inner class of JmxReporter).

Another possibility was to allow specifying a MetricRegistryFactory or something similar that will allow you to change how MetricRegistry is created/configured, but, this would greatly change Bootstrap, and I didn't want to introduce a breaking change if people already rely on Bootstrap to have getMetricRegistry()
