### PR TITLE
A collection of minor version bumps for dependencies

### DIFF
--- a/dropwizard-client/pom.xml
+++ b/dropwizard-client/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.2</version>
+            <version>4.3.3</version>
         </dependency>
         <dependency>
             <groupId>com.codahale.metrics</groupId>

--- a/dropwizard-hibernate/pom.xml
+++ b/dropwizard-hibernate/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
-            <version>2.3.1</version>
+            <version>2.3.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/dropwizard-views-mustache/pom.xml
+++ b/dropwizard-views-mustache/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.github.spullara.mustache.java</groupId>
             <artifactId>compiler</artifactId>
-            <version>0.8.14</version>
+            <version>0.8.15</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,11 +51,11 @@
         <dropwizard.url>http://www.dropwizard.io/${project.version}</dropwizard.url>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <metrics3.version>3.0.1</metrics3.version>
+        <metrics3.version>3.0.2</metrics3.version>
         <jersey.version>1.18.1</jersey.version>
         <jackson.api.version>2.3.0</jackson.api.version>
         <jackson.version>2.3.3</jackson.version>
-        <logback.version>1.1.1</logback.version>
+        <logback.version>1.1.2</logback.version>
         <slf4j.version>1.7.6</slf4j.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <jetty.version>9.0.7.v20131107</jetty.version>


### PR DESCRIPTION
**HttpClient 4.3.3** (GA) is a bug fix release that fixes a regression introduced by the previous release causing a significant performance degradation in compressed content processing.

**hsqldb 2.3.2** [Misc bug fixes/improvements](http://hsqldb.org/doc/2.0/changelist_2_0.txt).

**mustache.java** Misc bug fixes and updating to Guava 16.

**Metrics 3.0.2** Misc bug fixes, including correcting swapping of m1 and m15 rates in the MetricsModule.

**Logback 1.1.2** Misc improvements, including [using fair locking in OutputStreamAppender](http://jira.qos.ch/browse/LOGBACK-268).
