### PR TITLE
Invalidate credentials by predicate

### DIFF
--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/CachingAuthenticator.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/CachingAuthenticator.java
@@ -4,7 +4,9 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
 import com.google.common.cache.*;
+import com.google.common.collect.Sets;
 
 import java.util.concurrent.ExecutionException;
 
@@ -88,6 +90,15 @@ public class CachingAuthenticator<C, P> implements Authenticator<C, P> {
         cache.invalidateAll(credentials);
     }
 
+    /**
+     * Discards any cached principal for the collection of credentials satisfying the given predicate.
+     *
+     * @param predicate a predicate to filter credentials
+     */
+    public void invalidateAll(Predicate<? super C> predicate) {
+    	cache.invalidateAll(Sets.filter(cache.asMap().keySet(), predicate));
+    }
+    
     /**
      * Discards all cached principals.
      */

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/CachingAuthenticatorTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/CachingAuthenticatorTest.java
@@ -2,9 +2,11 @@ package io.dropwizard.auth;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
 import com.google.common.cache.CacheBuilderSpec;
 import com.google.common.cache.CacheStats;
 import com.google.common.collect.ImmutableSet;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -65,6 +67,22 @@ public class CachingAuthenticatorTest {
         verify(underlying, times(2)).authenticate("credentials");
     }
 
+    @Test
+    public void invalidatesCredentialsMatchingGivenPredicate() throws Exception {
+    	Predicate<String> predicate = new Predicate<String>() {
+			@Override
+			public boolean apply(String c) {
+				return c.equals("credentials");
+			}
+		}; 
+    	
+    	cached.authenticate("credentials");
+    	cached.invalidateAll(predicate);
+    	cached.authenticate("credentials");
+    	
+    	verify(underlying, times(2)).authenticate("credentials");
+    }
+    
     @Test
     public void invalidatesAllCredentials() throws Exception {
         cached.authenticate("credentials");


### PR DESCRIPTION
Allow discarding any cached principal for a collection of credentials satisfying a given predicate.
