### PR TITLE
Adding a configurable AllowedMethodsFilter

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -27,32 +27,38 @@ Servers
 All
 ----
 
-====================== ===========  ===========
-Name                   Default      Description
-====================== ===========  ===========
-type                   default      - default
-                                    - simple	
-maxThreads             1024         The maximum number of threads to use for requests.
-minThreads             8            The minimum number of threads to use for requests.
-maxQueuedRequests      1024         The maximum number of requests to queue before blocking the acceptors.
-idleThreadTimeout      1 minute     The amount of time a worker thread can be idle before being stopped.
-nofileSoftLimit        (none)       The number of open file descriptors before a soft error is issued.
-                                    Requires Jetty's ``libsetuid.so`` on ``java.library.path``.
-nofileHardLimit        (none)       The number of open file descriptors before a hard error is issued.
-                                    Requires Jetty's ``libsetuid.so`` on ``java.library.path``.
-gid                    (none)       The group ID to switch to once the connectors have started.
-                                    Requires Jetty's ``libsetuid.so`` on ``java.library.path``.
-uid                    (none)       The user ID to switch to once the connectors have started.
-                                    Requires Jetty's ``libsetuid.so`` on ``java.library.path``.
-user                   (none)       The username to switch to once the connectors have started.
-                                    Requires Jetty's ``libsetuid.so`` on ``java.library.path``.
-group                  (none)       The group to switch to once the connectors have started.
-                                    Requires Jetty's ``libsetuid.so`` on ``java.library.path``.
-umask                  (none)       The umask to switch to once the connectors have started.
-                                    Requires Jetty's ``libsetuid.so`` on ``java.library.path``.
-startsAsRoot           (none)       Whether or not the Dropwizard application is started as a root user.
-                                    Requires Jetty's ``libsetuid.so`` on ``java.library.path``.
-====================== ===========  ===========
+====================== ===============================================  =============================================================================
+Name                   Default                                          Description
+====================== ===============================================  =============================================================================
+type                   default                                          - default
+                                                                        - simple
+maxThreads             1024                                             The maximum number of threads to use for requests.
+minThreads             8                                                The minimum number of threads to use for requests.
+maxQueuedRequests      1024                                             The maximum number of requests to queue before blocking
+                                                                        the acceptors.
+idleThreadTimeout      1 minute                                         The amount of time a worker thread can be idle before
+                                                                        being stopped.
+nofileSoftLimit        (none)                                           The number of open file descriptors before a soft error is issued.
+                                                                        Requires Jetty's ``libsetuid.so`` on ``java.library.path``.
+nofileHardLimit        (none)                                           The number of open file descriptors before a hard error is issued.
+                                                                        Requires Jetty's ``libsetuid.so`` on ``java.library.path``.
+gid                    (none)                                           The group ID to switch to once the connectors have started.
+                                                                        Requires Jetty's ``libsetuid.so`` on ``java.library.path``.
+uid                    (none)                                           The user ID to switch to once the connectors have started.
+                                                                        Requires Jetty's ``libsetuid.so`` on ``java.library.path``.
+user                   (none)                                           The username to switch to once the connectors have started.
+                                                                        Requires Jetty's ``libsetuid.so`` on ``java.library.path``.
+group                  (none)                                           The group to switch to once the connectors have started.
+                                                                        Requires Jetty's ``libsetuid.so`` on ``java.library.path``.
+umask                  (none)                                           The umask to switch to once the connectors have started.
+                                                                        Requires Jetty's ``libsetuid.so`` on ``java.library.path``.
+startsAsRoot           (none)                                           Whether or not the Dropwizard application is started as a root user.
+                                                                        Requires Jetty's ``libsetuid.so`` on ``java.library.path``.
+shutdownGracePeriod    30 seconds                                       The maximum time to wait for Jetty, and all Managed instances,
+                                                                        to cleanly shutdown before forcibly terminating them.
+allowedMethods         ``GET``, ``POST``, ``PUT``, ``DELETE``,          The set of allowed HTTP methods. Others will be rejected with a
+                       ``HEAD``, ``OPTIONS``, ``PATCH``                 405 Method Not Allowed response.
+====================== ===============================================  =============================================================================
 
 
 .. _man-configuration-gzip:

--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -829,8 +829,12 @@ Methods
 -------
 
 Methods on a resource class which accept incoming requests are annotated with the HTTP methods they
-handle: ``@GET``, ``@POST``, ``@PUT``, ``@DELETE``, ``@HEAD``, ``@OPTIONS``, and even
-``@HttpMethod`` for arbitrary new methods.
+handle: ``@GET``, ``@POST``, ``@PUT``, ``@DELETE``, ``@HEAD``, ``@OPTIONS``, ``@PATCH``.
+
+Support for arbitrary new methods can be added via the ``@HttpMethod`` annotation. They also must
+to be added to the :ref:`list of allowed methods <man-configuration-all>`. This means, by default,
+methods such as ``CONNECT`` and ``TRACE`` are blocked, and will return a ``405 Method Not Allowed``
+response.
 
 If a request comes in which matches a resource class's path but has a method which the class doesn't
 support, Jersey will automatically return a ``405 Method Not Allowed`` to the client.

--- a/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
@@ -11,8 +11,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Charsets;
+import com.google.common.base.Joiner;
 import com.google.common.io.Resources;
-import javax.servlet.Servlet;
+import io.dropwizard.jersey.filter.AllowedMethodsFilter;
 import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
 import io.dropwizard.jetty.GzipFilterFactory;
@@ -39,12 +40,14 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.servlet.DispatcherType;
+import javax.servlet.Servlet;
 import javax.validation.Valid;
 import javax.validation.Validator;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import java.io.IOException;
 import java.util.EnumSet;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.regex.Pattern;
 
@@ -162,6 +165,14 @@ import java.util.regex.Pattern;
  *             before forcibly terminating them.
  *         </td>
  *     </tr>
+ *     <tr>
+ *         <td>{@code allowedMethods}</td>
+ *         <td>GET, POST, PUT, DELETE, HEAD, OPTIONS, PATCH</td>
+ *         <td>
+ *             The set of allowed HTTP methods. Others will be rejected with a
+ *             405 Method Not Allowed response.
+ *         </td>
+ *     </tr>
  * </table>
  *
  * @see DefaultServerFactory
@@ -209,6 +220,9 @@ public abstract class AbstractServerFactory implements ServerFactory {
     private Boolean startsAsRoot;
 
     private Duration shutdownGracePeriod = Duration.seconds(30);
+
+    @NotNull
+    private Set<String> allowedMethods = AllowedMethodsFilter.DEFAULT_ALLOWED_METHODS;
 
     @JsonIgnore
     @ValidationMethod(message = "must have a smaller minThreads than maxThreads")
@@ -366,6 +380,16 @@ public abstract class AbstractServerFactory implements ServerFactory {
         this.shutdownGracePeriod = shutdownGracePeriod;
     }
 
+    @JsonProperty
+    public Set<String> getAllowedMethods() {
+        return allowedMethods;
+    }
+
+    @JsonProperty
+    public void setAllowedMethods(Set<String> allowedMethods) {
+        this.allowedMethods = allowedMethods;
+    }
+
     protected Handler createAdminServlet(Server server,
                                          MutableServletContextHandler handler,
                                          MetricRegistry metrics,
@@ -375,6 +399,8 @@ public abstract class AbstractServerFactory implements ServerFactory {
         handler.getServletContext().setAttribute(MetricsServlet.METRICS_REGISTRY, metrics);
         handler.getServletContext().setAttribute(HealthCheckServlet.HEALTH_CHECK_REGISTRY, healthChecks);
         handler.addServlet(new NonblockingServletHolder(new AdminServlet()), "/*");
+        handler.addFilter(AllowedMethodsFilter.class, "/*", EnumSet.of(DispatcherType.REQUEST))
+                .setInitParameter(AllowedMethodsFilter.ALLOWED_METHODS_PARAM, Joiner.on(',').join(allowedMethods));
         return handler;
     }
 
@@ -395,6 +421,8 @@ public abstract class AbstractServerFactory implements ServerFactory {
                                        @Nullable Servlet jerseyContainer,
                                        MetricRegistry metricRegistry) {
         configureSessionsAndSecurity(handler, server);
+        handler.addFilter(AllowedMethodsFilter.class, "/*", EnumSet.of(DispatcherType.REQUEST))
+                .setInitParameter(AllowedMethodsFilter.ALLOWED_METHODS_PARAM, Joiner.on(',').join(allowedMethods));
         handler.addFilter(ThreadNameFilter.class, "/*", EnumSet.of(DispatcherType.REQUEST));
         if (gzip.isEnabled()) {
             final FilterHolder holder = new FilterHolder(gzip.build());

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/AllowedMethodsFilter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/AllowedMethodsFilter.java
@@ -1,0 +1,56 @@
+package io.dropwizard.jersey.filter;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Set;
+
+public class AllowedMethodsFilter implements Filter {
+
+    public static final String ALLOWED_METHODS_PARAM = "allowedMethods";
+    public static final Set<String> DEFAULT_ALLOWED_METHODS = ImmutableSet.of(
+            "GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH"
+    );
+
+    private static final Logger LOG = LoggerFactory.getLogger(AllowedMethodsFilter.class);
+
+    private Set<String> allowedMethods = Sets.newHashSet();
+
+    @Override
+    public void init(FilterConfig config) {
+        final String allowedMethodsConfig = config.getInitParameter(ALLOWED_METHODS_PARAM);
+        if (allowedMethodsConfig == null) {
+            allowedMethods.addAll(DEFAULT_ALLOWED_METHODS);
+        }
+        else {
+            allowedMethods.addAll(Arrays.asList(allowedMethodsConfig.split(",")));
+        }
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        handle((HttpServletRequest)request, (HttpServletResponse)response, chain);
+    }
+
+    private void handle(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
+        if (allowedMethods.contains(request.getMethod())) {
+            chain.doFilter(request, response);
+        }
+        else {
+            LOG.debug("Request with disallowed method {} blocked", request.getMethod());
+            response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+        }
+    }
+
+    @Override
+    public void destroy() {
+        allowedMethods.clear();
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/AllowedMethodsFilterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/AllowedMethodsFilterTest.java
@@ -1,0 +1,106 @@
+package io.dropwizard.jersey.filter;
+
+import com.google.common.collect.ImmutableMap;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.test.framework.AppDescriptor;
+import com.sun.jersey.test.framework.JerseyTest;
+import com.sun.jersey.test.framework.WebAppDescriptor;
+import io.dropwizard.logging.LoggingFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class AllowedMethodsFilterTest extends JerseyTest {
+    static {
+        LoggingFactory.bootstrap();
+    }
+
+    private static final int DISALLOWED_STATUS_CODE = ClientResponse.Status.METHOD_NOT_ALLOWED.getStatusCode();
+    private static final int OK_STATUS_CODE = ClientResponse.Status.OK.getStatusCode();
+
+    private final HttpServletRequest request = mock(HttpServletRequest.class);
+    private final HttpServletResponse response = mock(HttpServletResponse.class);
+    private final FilterChain chain = mock(FilterChain.class);
+    private final FilterConfig config = mock(FilterConfig.class);
+    private final AllowedMethodsFilter filter = new AllowedMethodsFilter();
+
+    @Before
+    public void setUp() {
+        filter.init(config);
+    }
+
+    @Override
+    protected AppDescriptor configure() {
+        return new WebAppDescriptor.Builder("io.dropwizard.jersey.filter")
+                .addFilter(AllowedMethodsFilter.class, "allowedMethods", ImmutableMap.of(AllowedMethodsFilter.ALLOWED_METHODS_PARAM, "GET,POST"))
+                .build();
+    }
+
+    private int getResponseStatusForRequestMethod(String method) {
+        final ClientResponse response = resource().path("/ping").method(method, ClientResponse.class);
+
+        try {
+            return response.getStatus();
+        }
+        finally {
+            response.close();
+        }
+    }
+
+    @Test
+    public void testGetRequestAllowed() {
+        assertEquals(OK_STATUS_CODE, getResponseStatusForRequestMethod("GET"));
+    }
+
+    @Test
+    public void testPostRequestAllowed() {
+        assertEquals(OK_STATUS_CODE, getResponseStatusForRequestMethod("POST"));
+    }
+
+    @Test
+    public void testPutRequestBlocked() {
+        assertEquals(DISALLOWED_STATUS_CODE, getResponseStatusForRequestMethod("PUT"));
+    }
+
+    @Test
+    public void testDeleteRequestBlocked() {
+        assertEquals(DISALLOWED_STATUS_CODE, getResponseStatusForRequestMethod("DELETE"));
+    }
+
+    @Test
+    public void testTraceRequestBlocked() {
+        assertEquals(DISALLOWED_STATUS_CODE, getResponseStatusForRequestMethod("TRACE"));
+    }
+
+    @Test
+    public void allowsAllowedMethod() throws Exception {
+        when(request.getMethod()).thenReturn("GET");
+        filter.doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    public void blocksDisallowedMethod() throws Exception {
+        when(request.getMethod()).thenReturn("TRACE");
+        filter.doFilter(request, response, chain);
+
+        verify(chain, never()).doFilter(request, response);
+    }
+
+    @Test
+    public void disallowedMethodCausesMethodNotAllowedResponse() throws IOException, ServletException {
+        when(request.getMethod()).thenReturn("TRACE");
+        filter.doFilter(request, response, chain);
+        verify(response).sendError(eq(DISALLOWED_STATUS_CODE));
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/DummyResource.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/DummyResource.java
@@ -1,0 +1,34 @@
+package io.dropwizard.jersey.filter;
+
+import io.dropwizard.jersey.PATCH;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+
+@Path("/ping")
+public class DummyResource {
+    @GET
+    public Response get() {
+        return Response.ok().build();
+    }
+
+    @POST
+    public Response post() {
+        return Response.ok().build();
+    }
+
+    @PATCH
+    public Response patch() {
+        return Response.ok().build();
+    }
+
+    @PUT
+    public Response put() {
+        return Response.ok().build();
+    }
+
+    @DELETE
+    public Response delete() {
+        return Response.ok().build();
+    }
+}


### PR DESCRIPTION
By default this allows GET, POST, PUT, DELETE, HEAD, and OPTIONS. In other words, TRACE and CONNECT are blocked. This is enabled on both the application servlet and admin servlet.
