### PR TITLE
Enable validation of Optional values

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/setup/Bootstrap.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/Bootstrap.java
@@ -26,6 +26,8 @@ import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import io.dropwizard.validation.valuehandling.OptionalValidatedValueUnwrapper;
+import org.hibernate.validator.HibernateValidator;
 
 import javax.validation.Validation;
 import javax.validation.ValidatorFactory;
@@ -61,7 +63,11 @@ public class Bootstrap<T extends Configuration> {
         this.configuredBundles = Lists.newArrayList();
         this.commands = Lists.newArrayList();
         this.metricRegistry = new MetricRegistry();
-        this.validatorFactory = Validation.buildDefaultValidatorFactory();
+        this.validatorFactory = Validation
+                .byProvider(HibernateValidator.class)
+                .configure()
+                .addValidatedValueHandler(new OptionalValidatedValueUnwrapper())
+                .buildValidatorFactory();
         getMetricRegistry().register("jvm.buffers", new BufferPoolMetricSet(ManagementFactory
                                                                                .getPlatformMBeanServer()));
         getMetricRegistry().register("jvm.gc", new GarbageCollectorMetricSet());

--- a/dropwizard-validation/pom.xml
+++ b/dropwizard-validation/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>5.0.2.Final</version>
+            <version>5.1.1.Final</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.web</groupId>

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/valuehandling/OptionalValidatedValueUnwrapper.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/valuehandling/OptionalValidatedValueUnwrapper.java
@@ -1,0 +1,29 @@
+package io.dropwizard.validation.valuehandling;
+
+import com.fasterxml.classmate.ResolvedType;
+import com.fasterxml.classmate.TypeResolver;
+import com.google.common.base.Optional;
+import org.hibernate.validator.spi.valuehandling.ValidatedValueUnwrapper;
+
+import java.lang.reflect.Type;
+
+/**
+ * A {@link ValidatedValueUnwrapper} for Guava's {@link Optional}.
+ * <p/>
+ * Extracts the value contained by the {@link Optional} for validation, or produces {@code null}.
+ */
+public class OptionalValidatedValueUnwrapper extends ValidatedValueUnwrapper<Optional<?>> {
+
+    private final TypeResolver resolver = new TypeResolver();
+
+    @Override
+    public Object handleValidatedValue(final Optional<?> optional) {
+        return optional.orNull();
+    }
+
+    @Override
+    public Type getValidatedValueType(final Type type) {
+        ResolvedType resolvedType = resolver.resolve(type);
+        return resolvedType.typeParametersFor(Optional.class).get(0).getErasedType();
+    }
+}

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/valuehandling/OptionalValidatedValueUnwrapperTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/valuehandling/OptionalValidatedValueUnwrapperTest.java
@@ -1,0 +1,84 @@
+package io.dropwizard.validation.valuehandling;
+
+import com.google.common.base.Optional;
+import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.valuehandling.UnwrapValidatedValue;
+import org.junit.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+import java.util.Set;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+public class OptionalValidatedValueUnwrapperTest {
+
+    public static class Example {
+
+        @Min(3)
+        @UnwrapValidatedValue
+        public Optional<Integer> three = Optional.absent();
+
+        @NotNull
+        @UnwrapValidatedValue
+        public Optional<Integer> notNull = Optional.of(123);
+    }
+
+    private final Validator validator = Validation
+            .byProvider(HibernateValidator.class)
+            .configure()
+            .addValidatedValueHandler(new OptionalValidatedValueUnwrapper())
+            .buildValidatorFactory()
+            .getValidator();
+
+    @Test
+    public void succeedsWhenAbsent() {
+        Example example = new Example();
+        Set<ConstraintViolation<Example>> violations = validator.validate(example);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void failsWhenFailingConstraint() {
+        Example example = new Example();
+        example.three = Optional.of(2);
+        Set<ConstraintViolation<Example>> violations = validator.validate(example);
+        assertThat(violations).hasSize(1);
+    }
+
+    @Test
+    public void succeedsWhenPresentButNull() {
+        Example example = new Example();
+        example.three = Optional.fromNullable(null);
+        Set<ConstraintViolation<Example>> violations = validator.validate(example);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void succeedsWhenConstraintsMet() {
+        Example example = new Example();
+        example.three = Optional.of(10);
+        Set<ConstraintViolation<Example>> violations = validator.validate(example);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void notNullFailsWhenAbsent() {
+        Example example = new Example();
+        example.notNull = Optional.absent();
+        Set<ConstraintViolation<Example>> violations = validator.validate(example);
+        assertThat(violations).hasSize(1);
+    }
+
+    @Test
+    public void notNullFailsWhenPresentButNull() {
+        Example example = new Example();
+        example.notNull = Optional.fromNullable(null);
+        Set<ConstraintViolation<Example>> violations = validator.validate(example);
+        assertThat(violations).hasSize(1);
+    }
+}


### PR DESCRIPTION
To validate values contained in an `Optional` type, we need to use a new feature in Hibernate Validator 5.1, so this introduces a dependency version bump to 5.1.1.

This makes use of an _experimental_ feature in Hibernate Validator, so I'm not 100% sure we'll want to make use of it yet.

To validate the contents of an `Optional`, you need to include an `@UnwrapValidatedValue` annotation on the property being validated:

``` java
@Length(min = 32, max = 32)
@UnwrapValidatedValue
private Optional<String> md5 = Optional.absent();
```

Absent values are considered `null` when validated, so their behaviour depends on your chosen constraints' handling of `null` values.

We have to register this inside `Bootstrap`, and I noticed that we don't (currently) expose a way for users to register more validation behaviour through `Bootstrap`, so we should probably look in to that.
