### PR TITLE
Updating jdbi to 2.55

### DIFF
--- a/dropwizard-jdbi/pom.xml
+++ b/dropwizard-jdbi/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi</artifactId>
-            <version>2.53</version>
+            <version>2.55</version>
         </dependency>
         <dependency>
             <groupId>com.codahale.metrics</groupId>


### PR DESCRIPTION
Fixes a race condition in which queries could be directed to the wrong database.

https://www.twilio.com/engineering/2014/06/03/jdbi-race-condition
