### PR TITLE
Updating httpclient to 4.3.4

### DIFF
--- a/dropwizard-client/pom.xml
+++ b/dropwizard-client/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.3</version>
+            <version>4.3.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>


### PR DESCRIPTION
Improved performance under high concurrency.

> This version replaces dynamic proxies with custom proxy classes and eliminates thread contention in java.reflect.Proxy.newInstance() when leasing connections from the connection pool and processing response messages.

http://hc.apache.org/news.html
