### PR TITLE
Updating h2 to 1.4.178

### DIFF
--- a/dropwizard-example/example.yml
+++ b/dropwizard-example/example.yml
@@ -15,7 +15,7 @@ database:
   password: sa
 
   # the JDBC URL
-  url: jdbc:h2:target/example
+  url: jdbc:h2:./target/example
 
 # use the simple server factory if you only want to run on a single port
 #server:

--- a/dropwizard-example/pom.xml
+++ b/dropwizard-example/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.3.175</version>
+            <version>1.4.178</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <jetty.version>9.0.7.v20131107</jetty.version>
         <guava.version>16.0.1</guava.version>
-        <h2.version>1.3.175</h2.version>
+        <h2.version>1.4.178</h2.version>
         <findbugs.skip>false</findbugs.skip>
     </properties>
 


### PR DESCRIPTION
This has a bunch of changes, but considering h2 is only used in tests and the example, which are both still working fine, why not?

http://www.h2database.com/html/changelog.html
