### PR TITLE
Updating Guava to 17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <slf4j.version>1.7.6</slf4j.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <jetty.version>9.0.7.v20131107</jetty.version>
-        <guava.version>16.0.1</guava.version>
+        <guava.version>17.0</guava.version>
         <h2.version>1.3.175</h2.version>
         <findbugs.skip>false</findbugs.skip>
     </properties>


### PR DESCRIPTION
Fixes some issues with Bloomfilters. Bloomfilters created with Guava 17 are not readable by pre Guava 17.

https://code.google.com/p/guava-libraries/wiki/Release17
