### PR TITLE
Updating Jackson to 2.4.0

### DIFF
--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationFactory.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationFactory.java
@@ -209,7 +209,7 @@ public class ConfigurationFactory<T> {
                 child = obj.get(key);
                 if (child == null) {
                     child = obj.objectNode();
-                    obj.put(key, child);
+                    obj.set(key, child);
                 }
                 if (child.isArray()) {
                     throw new IllegalArgumentException("Unable to override " + name + "; target is an array but no index specified");

--- a/dropwizard-jackson/pom.xml
+++ b/dropwizard-jackson/pom.xml
@@ -34,6 +34,11 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk7</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-guava</artifactId>
             <version>${jackson.version}</version>
             <exclusions>

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/GuavaExtrasModule.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/GuavaExtrasModule.java
@@ -5,19 +5,10 @@ import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.deser.Deserializers;
 import com.google.common.cache.CacheBuilderSpec;
-import com.google.common.net.HostAndPort;
 
 import java.io.IOException;
 
 public class GuavaExtrasModule extends Module {
-    private static class HostAndPortDeserializer extends JsonDeserializer<HostAndPort> {
-        @Override
-        public HostAndPort deserialize(JsonParser jp,
-                                       DeserializationContext ctxt) throws IOException {
-            return HostAndPort.fromString(jp.getText());
-        }
-    }
-
     private static class CacheBuilderSpecDeserializer extends JsonDeserializer<CacheBuilderSpec> {
         @Override
         public CacheBuilderSpec deserialize(JsonParser jp,
@@ -37,10 +28,6 @@ public class GuavaExtrasModule extends Module {
                                                         BeanDescription beanDesc) throws JsonMappingException {
             if (CacheBuilderSpec.class.isAssignableFrom(type.getRawClass())) {
                 return new CacheBuilderSpecDeserializer();
-            }
-
-            if (HostAndPort.class.isAssignableFrom(type.getRawClass())) {
-                return new HostAndPortDeserializer();
             }
 
             return super.findBeanDeserializer(type, config, beanDesc);

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
@@ -2,6 +2,7 @@ package io.dropwizard.jackson;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.jdk7.Jdk7Module;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 
@@ -23,6 +24,7 @@ public class Jackson {
         mapper.registerModule(new JodaModule());
         mapper.registerModule(new AfterburnerModule());
         mapper.registerModule(new FuzzyEnumModule());
+        mapper.registerModule(new Jdk7Module());
         mapper.setPropertyNamingStrategy(new AnnotationSensitivePropertyNamingStrategy());
         mapper.setSubtypeResolver(new DiscoverableSubtypeResolver());
         return mapper;

--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <metrics3.version>3.0.2</metrics3.version>
         <jersey.version>1.18.1</jersey.version>
-        <jackson.api.version>2.3.0</jackson.api.version>
-        <jackson.version>2.3.3</jackson.version>
+        <jackson.api.version>2.4.0</jackson.api.version><!-- internally Jackson doesn't do bug fix releases for its API modules -->
+        <jackson.version>2.4.1</jackson.version>
         <logback.version>1.1.2</logback.version>
         <slf4j.version>1.7.6</slf4j.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>


### PR DESCRIPTION
Minor release with new functionality but backwards compatible.
- Official support for Guava HostAndPort (removed Dropwizards deserializer)
- Jdk7Module with support for Path
- Bunch of misc improvements

https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.4
## 

It looks like Jackson 2.4.0 actually has a [couple regressions](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.4.1) from 2.3.x, so it may be worth holding off merging this until 2.4.1 is out and going straight to that. Thoughts?
