### PR TITLE
Updating Hibernate to 4.3.5.Final.

### DIFF
--- a/dropwizard-hibernate/pom.xml
+++ b/dropwizard-hibernate/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
-            <version>4.3.1.Final</version>
+            <version>4.3.5.Final</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.jboss.logging</groupId>


### PR DESCRIPTION
Collection of misc improvements and bug fixes.
- 4.3.2 was a bunch of misc improvements and bug fixes, but introduced a critical bug.
- 4.3.3 was released by mistake and == 4.3.2.
- 4.3.4 is just a revert of the commit in 4.3.2 that introduced the bug.
- 4.3.5 is more misc improvements and bug fixes.

[Change log](https://hibernate.atlassian.net/issues/?jql=project%20%3D%20HHH%20AND%20fixVersion%20in%20%284.3.2%2C%204.3.3%2C%204.3.4%2C%204.3.5%29%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC%2C%20created%20ASC)
