### PR TITLE
Skip deployment of io.dropwizard:docs

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -31,6 +31,14 @@
                     <sourceDirectory>${basedir}/source</sourceDirectory>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.1</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </reporting>
 </project>


### PR DESCRIPTION
This PR disables the deployment of the [`docs` JAR artifact](http://search.maven.org/#artifactdetails|io.dropwizard|docs|0.7.1|jar) to Maven Central.
