### PR TITLE
Upgrade to jackson-databind 2.4.1.1

### DIFF
--- a/dropwizard-hibernate/pom.xml
+++ b/dropwizard-hibernate/pom.xml
@@ -21,6 +21,12 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-hibernate4</artifactId>
             <version>${jackson.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jadira.usertype</groupId>

--- a/dropwizard-jackson/pom.xml
+++ b/dropwizard-jackson/pom.xml
@@ -30,12 +30,22 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.databind.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk7</artifactId>
             <version>${jackson.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <jersey.version>1.18.1</jersey.version>
         <jackson.api.version>2.4.0</jackson.api.version><!-- internally Jackson doesn't do bug fix releases for its API modules -->
         <jackson.version>2.4.1</jackson.version>
+        <jackson.databind.version>2.4.1.1</jackson.databind.version>
         <logback.version>1.1.2</logback.version>
         <slf4j.version>1.7.6</slf4j.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>


### PR DESCRIPTION
Upgrade to `jackson-databind` 2.4.1.1 due to a bug in `jackson-databind` (see FasterXML/jackson-databind#490) which potentially affects our users.

Mailing list announcement: https://groups.google.com/forum/#!topic/jackson-dev/F-y4iQnxh1Q
