### PR TITLE
Add support for JaCoCo and Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ install: echo "I trust Maven."
 # don't just run the tests, also run Findbugs and friends
 script: mvn verify
 
+after_success: mvn jacoco:report coveralls:jacoco
+
 jdk:
   - oraclejdk7
   - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-Dropwizard [![Build Status](https://travis-ci.org/dropwizard/dropwizard.png?branch=master)](https://travis-ci.org/dropwizard/dropwizard)
+Dropwizard
 ==========
+[![Build Status](https://travis-ci.org/dropwizard/dropwizard.png?branch=master)](https://travis-ci.org/dropwizard/dropwizard)
+[![Coverage Status](https://img.shields.io/coveralls/dropwizard/dropwizard.svg)](https://coveralls.io/r/dropwizard/dropwizard)
 
 *Dropwizard is a sneaky way of making fast Java web applications.*
 

--- a/pom.xml
+++ b/pom.xml
@@ -415,6 +415,24 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.7.1.201405082137</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
+                <version>2.2.0</version>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This PR adds support for [JaCoCo](http://www.eclemma.org/jacoco/) and [Coveralls](https://coveralls.io/) to record code coverage metrics for Dropwizard. It should help to keep an eye on our overall test coverage and how it develops over time.

Example output for one of my projects: https://coveralls.io/builds/898210

Before this PR is merged, a contributor with the required permissions should add and activate the dropwizard/dropwizard project in Coveralls. Other than that, the configuration should just work™.
