### PR TITLE
Added dropwizard-embedded module, to embed a service in a daemon

### DIFF
--- a/dropwizard-embedded/pom.xml
+++ b/dropwizard-embedded/pom.xml
@@ -23,7 +23,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.3</version>
+                <version>2.6</version>
                 <configuration>
                     <check>
                         <haltOnFailure>false</haltOnFailure><!-- optional -->

--- a/dropwizard-embedded/pom.xml
+++ b/dropwizard-embedded/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.dropwizard</groupId>
+        <artifactId>dropwizard-parent</artifactId>
+        <version>0.7.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>dropwizard-embedded</artifactId>
+    <name>Dropwizard Embedded</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
+                <version>2.3</version>
+                <configuration>
+                    <check>
+                        <haltOnFailure>false</haltOnFailure><!-- optional -->
+                        <!-- Per-class thresholds -->
+                        <lineRate>40</lineRate>
+                        <branchRate>80</branchRate>
+                        <!-- Project-wide thresholds -->
+                        <totalLineRate>40</totalLineRate>
+                        <totalBranchRate>40</totalBranchRate>
+                    </check>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>clean</goal>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/dropwizard-embedded/pom.xml
+++ b/dropwizard-embedded/pom.xml
@@ -26,13 +26,13 @@
                 <version>2.6</version>
                 <configuration>
                     <check>
-                        <haltOnFailure>false</haltOnFailure><!-- optional -->
+                        <haltOnFailure>true</haltOnFailure><!-- optional -->
                         <!-- Per-class thresholds -->
-                        <lineRate>40</lineRate>
+                        <lineRate>80</lineRate>
                         <branchRate>80</branchRate>
                         <!-- Project-wide thresholds -->
-                        <totalLineRate>40</totalLineRate>
-                        <totalBranchRate>40</totalBranchRate>
+                        <totalLineRate>80</totalLineRate>
+                        <totalBranchRate>80</totalBranchRate>
                     </check>
                 </configuration>
                 <executions>

--- a/dropwizard-embedded/src/main/java/io/dropwizard/embedded/EmbeddedBootstrap.java
+++ b/dropwizard-embedded/src/main/java/io/dropwizard/embedded/EmbeddedBootstrap.java
@@ -1,0 +1,38 @@
+package io.dropwizard.embedded;
+
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.cli.ConfiguredCommand;
+import io.dropwizard.setup.Bootstrap;
+
+/**
+ * A class for bootstrapping a {@link Service} with Bundles.
+ * @see io.dropwizard.setup.Bootstrap
+ */
+public class EmbeddedBootstrap<T extends Configuration> extends Bootstrap<T> {
+    private String name;
+
+    /**
+     * Creates a new {@link Bootstrap} for the given application.
+     *
+     * @param service a Dropwizard embedded {@link Service}
+     */
+    public EmbeddedBootstrap(Service service) {
+        super(null);
+        this.name = service.getName();
+    }
+
+    public String getName() { return name; }
+
+    public void setName(String name) { this.name = name; }
+
+    @Override
+    public Application<T> getApplication() {
+        throw new UnsupportedOperationException("not applicable");
+    }
+
+    @Override
+    public void addCommand(ConfiguredCommand<T> command) {
+        throw new UnsupportedOperationException("not applicable");
+    }
+}

--- a/dropwizard-embedded/src/main/java/io/dropwizard/embedded/EmbeddedServer.java
+++ b/dropwizard-embedded/src/main/java/io/dropwizard/embedded/EmbeddedServer.java
@@ -1,8 +1,6 @@
 package io.dropwizard.embedded;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Charsets;
-import com.google.common.io.Resources;
 import io.dropwizard.Configuration;
 
 import io.dropwizard.configuration.ConfigurationException;

--- a/dropwizard-embedded/src/main/java/io/dropwizard/embedded/EmbeddedServer.java
+++ b/dropwizard-embedded/src/main/java/io/dropwizard/embedded/EmbeddedServer.java
@@ -1,0 +1,112 @@
+package io.dropwizard.embedded;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import io.dropwizard.Configuration;
+
+import io.dropwizard.configuration.ConfigurationException;
+import io.dropwizard.configuration.ConfigurationFactory;
+import io.dropwizard.configuration.ConfigurationFactoryFactory;
+import io.dropwizard.configuration.ConfigurationSourceProvider;
+import io.dropwizard.setup.Environment;
+import org.eclipse.jetty.server.Server;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import javax.validation.Validator;
+
+/**
+ * Runs the HTTP server behind an embedded Dropwizard Service.
+ * This class is a facade to replace io.dropwizard.cli.ServerCommand and all of Dropwizard's CLI
+ * In this way it makes Service easily embeddable into an existing daemon service.
+ *
+ * @param <T> the {@link io.dropwizard.Configuration} subclass which is loaded from the configuration file
+ */
+public class EmbeddedServer<T extends Configuration> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(EmbeddedServer.class);
+
+    private final Service<T> service;
+    private final Class<T> configurationClass;
+
+    private Server server;
+    private Environment environment;
+
+    public EmbeddedServer(Service<T> service) {
+        this.service = service;
+        this.configurationClass = service.getConfigurationClass();
+    }
+
+    public final void start(EmbeddedBootstrap<T> bootstrap, String configFile) throws Exception {
+        T configuration = parseConfiguration(bootstrap.getConfigurationFactoryFactory(),
+                                            bootstrap.getConfigurationSourceProvider(),
+                                            bootstrap.getValidatorFactory().getValidator(),
+                                            configFile,
+                                            configurationClass,
+                                            bootstrap.getObjectMapper());
+        start(bootstrap, configuration);
+    }
+
+    public final void start(EmbeddedBootstrap<T> bootstrap, T configuration) throws Exception {
+        environment = new Environment(bootstrap.getName(),
+                                        bootstrap.getObjectMapper(),
+                                        bootstrap.getValidatorFactory().getValidator(),
+                                        bootstrap.getMetricRegistry(),
+                                        bootstrap.getClassLoader());
+        configuration.getMetricsFactory().configure(environment.lifecycle(),
+                                                    bootstrap.getMetricRegistry());
+        bootstrap.run(configuration, environment);
+        service.start(configuration, environment);
+        startServer(configuration);
+    }
+
+    private void startServer(T configuration) throws Exception {
+        this.server = configuration.getServerFactory().build(environment);
+        try {
+            server.start();
+        } catch (Exception e) {
+            LOGGER.error("Unable to start server, shutting down", e);
+            server.stop();
+        }
+    }
+
+    public final void stop() throws Exception {
+        if (server == null) {
+            LOGGER.error("Attempted to stop server, but was never created");
+            return;
+        } else if (server.isStopped()) {
+            LOGGER.error("Attempted to stop server, but was already stopped");
+            return;
+        }
+
+        try {
+            server.stop();
+
+            if (!server.isStopped() || server.getThreadPool().getThreads() > 0) {
+                throw new Exception(
+                        String.format("Failed to stop server after graceful shutdown period, still %d threads alive",
+                                    server.getThreadPool().getThreads()));
+            }
+
+            service.stop(environment);
+        } catch (Exception e) {
+            LOGGER.error("Failed to stop server", e);
+            throw e;
+        }
+    }
+
+    protected T parseConfiguration(ConfigurationFactoryFactory<T> configurationFactoryFactory,
+                                       ConfigurationSourceProvider provider,
+                                       Validator validator,
+                                       String path,
+                                       Class<T> klass,
+                                       ObjectMapper objectMapper) throws IOException, ConfigurationException {
+        final ConfigurationFactory<T> configurationFactory =
+                configurationFactoryFactory.create(klass, validator, objectMapper, "dw");
+        if (path != null) {
+            return configurationFactory.build(provider, path);
+        }
+        return configurationFactory.build();
+    }
+}

--- a/dropwizard-embedded/src/main/java/io/dropwizard/embedded/Service.java
+++ b/dropwizard-embedded/src/main/java/io/dropwizard/embedded/Service.java
@@ -1,0 +1,91 @@
+package io.dropwizard.embedded;
+
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.util.Generics;
+
+/**
+ * Runs an embeddable HTTP service powered by Dropwizard
+ * This class is the main interface for embedding and controlling the service,
+ * and replaces io.dropwizard.Application in a fairly straightforward manner.
+ * The Dropwizard CLI has been replaced with start() and stop() methods, though
+ * configuration and other elements remain the same.
+ *
+ * @param <T> the type of {@link io.dropwizard.Configuration} class for this application
+ */
+public abstract class Service<T extends Configuration> {
+    private EmbeddedBootstrap<T> bootstrap;
+    private EmbeddedServer<T> server;
+    private String configurationFile;
+
+    public Service(String configFile) {
+        this.configurationFile = configFile;
+    }
+
+    /**
+     * Returns the {@link Class} of the configuration class type parameter.
+     *
+     * @return the configuration class
+     * @see io.dropwizard.util.Generics#getTypeParameter(Class, Class)
+     */
+    public final Class<T> getConfigurationClass() {
+        return Generics.getTypeParameter(getClass(), Configuration.class);
+    }
+
+    /**
+     * Returns the name of the service.
+     *
+     * @return the service's name
+     */
+    public String getName() {
+        return getClass().getSimpleName();
+    }
+
+    /**
+     * Initializes the application bootstrap.
+     *
+     * @param bootstrap the application bootstrap
+     */
+    public abstract void initialize(EmbeddedBootstrap<T> bootstrap);
+
+    /**
+     * When the service starts, this is called after the {@link io.dropwizard.Bundle}s are run. Override it to add
+     * providers, resources, etc. for your application.
+     *
+     * @param configuration the parsed {@link Configuration} object
+     * @param environment   the application's {@link Environment}
+     * @throws Exception if something goes wrong
+     */
+    protected abstract void start(T configuration, Environment environment) throws Exception;
+
+    /**
+     * Called when the service is shutting down.  It is not necessary to override this function.
+     *
+     * @param environment   the service's {@link io.dropwizard.setup.Environment}
+     * @throws Exception if something goes wrong
+     */
+    protected void stop(Environment environment) throws Exception {}
+
+    /**
+     * Starts the Dropwizard service.  This is the main entry point.
+     *
+     * @throws Exception if something goes wrong
+     */
+    public final void start() throws Exception {
+        this.bootstrap = new EmbeddedBootstrap<>(this);
+        initialize(bootstrap);
+        this.server = new EmbeddedServer<>(this);
+        this.server.start(bootstrap, configurationFile);
+    }
+
+    /**
+     * Stops the Dropwizard service.
+     *
+     * @throws Exception if something goes wrong
+     */
+    public final void stop() throws Exception {
+        if(this.server != null)
+            this.server.stop();
+    }
+}

--- a/dropwizard-embedded/src/test/java/io/dropwizard/embedded/EmbeddedBootstrapTest.java
+++ b/dropwizard-embedded/src/test/java/io/dropwizard/embedded/EmbeddedBootstrapTest.java
@@ -1,0 +1,106 @@
+package io.dropwizard.embedded;
+
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.cli.ConfiguredCommand;
+import io.dropwizard.configuration.DefaultConfigurationFactoryFactory;
+import io.dropwizard.configuration.FileConfigurationSourceProvider;
+
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import net.sourceforge.argparse4j.inf.Namespace;
+import org.junit.Test;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.fest.assertions.api.Assertions.failBecauseExceptionWasNotThrown;
+
+public class EmbeddedBootstrapTest {
+    private final Service<Configuration> service = new Service<Configuration>("./yaml/server.yml") {
+        @Override
+        public void initialize(EmbeddedBootstrap<Configuration> bootstrap) {
+            // no bundles
+        }
+
+        @Override
+        protected void start(Configuration configuration, Environment environment) throws Exception {
+            // start does nothing
+        }
+    };
+
+    private final EmbeddedBootstrap<Configuration> bootstrap = new EmbeddedBootstrap<>(service);
+
+    @Test
+    public void hasNoApplication() {
+        try {
+            Application<Configuration> app = bootstrap.getApplication();
+            failBecauseExceptionWasNotThrown(UnsupportedOperationException.class);
+        } catch (Exception e) {
+            assertThat(e).isInstanceOf(UnsupportedOperationException.class)
+                    .hasMessage("not applicable")
+                    .hasNoCause();
+        }
+    }
+
+    @Test
+    public void cannotAddCommands() {
+        try {
+            ConfiguredCommand<Configuration> cmd = new ConfiguredCommand<Configuration>("example", "example") {
+                @Override
+                protected void run(Bootstrap<Configuration> bootstrap, Namespace namespace, Configuration configuration) throws Exception {
+                    // run does nothing
+                }
+            };
+            bootstrap.addCommand(cmd);
+            failBecauseExceptionWasNotThrown(UnsupportedOperationException.class);
+        } catch (Exception e) {
+            assertThat(e).isInstanceOf(UnsupportedOperationException.class)
+                    .hasMessage("not applicable")
+                    .hasNoCause();
+        }
+    }
+
+    @Test
+    public void hasAnObjectMapper() throws Exception {
+        assertThat(bootstrap.getObjectMapper())
+                .isNotNull();
+    }
+
+    @Test
+    public void defaultsToUsingFilesForConfiguration() throws Exception {
+        assertThat(bootstrap.getConfigurationSourceProvider())
+                .isInstanceOfAny(FileConfigurationSourceProvider.class);
+    }
+
+    @Test
+    public void defaultsToUsingTheDefaultClassLoader() throws Exception {
+        assertThat(bootstrap.getClassLoader())
+                .isEqualTo(Thread.currentThread().getContextClassLoader());
+    }
+
+    @Test
+    public void comesWithJvmInstrumentation() throws Exception {
+        assertThat(bootstrap.getMetricRegistry().getNames())
+                .contains("jvm.buffers.mapped.capacity", "jvm.threads.count", "jvm.memory.heap.usage");
+    }
+
+    @Test
+    public void defaultsToDefaultConfigurationFactoryFactory() throws Exception {
+        assertThat(bootstrap.getConfigurationFactoryFactory())
+                .isInstanceOf(DefaultConfigurationFactoryFactory.class);
+    }
+
+    @Test
+    public void testBYOMetrics() {
+        final MetricRegistry newRegistry = new MetricRegistry();
+        Bootstrap<Configuration> newBootstrap = new EmbeddedBootstrap<Configuration>(service) {
+            @Override
+            public MetricRegistry getMetricRegistry() {
+                return super.getMetricRegistry();
+            }
+        };
+
+        assertThat(newBootstrap.getMetricRegistry().getNames())
+                .contains("jvm.buffers.mapped.capacity", "jvm.threads.count", "jvm.memory.heap.usage");
+    }
+}

--- a/dropwizard-embedded/src/test/java/io/dropwizard/embedded/EmbeddedServerTest.java
+++ b/dropwizard-embedded/src/test/java/io/dropwizard/embedded/EmbeddedServerTest.java
@@ -4,8 +4,6 @@ import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.io.Resources;
 import io.dropwizard.Configuration;
-import io.dropwizard.configuration.DefaultConfigurationFactoryFactory;
-import io.dropwizard.configuration.FileConfigurationSourceProvider;
 import io.dropwizard.jetty.HttpConnectorFactory;
 import io.dropwizard.metrics.MetricsFactory;
 import io.dropwizard.server.DefaultServerFactory;
@@ -98,7 +96,7 @@ public class EmbeddedServerTest {
         embeddedServer.stop();
         embeddedServer.stop();
 
-        verify(spyServer, times(1)).stop();
+        verify(spyServer, times(3)).isStopped();
     }
 
     @Test

--- a/dropwizard-embedded/src/test/java/io/dropwizard/embedded/EmbeddedServerTest.java
+++ b/dropwizard-embedded/src/test/java/io/dropwizard/embedded/EmbeddedServerTest.java
@@ -1,0 +1,183 @@
+package io.dropwizard.embedded;
+
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.io.Resources;
+import io.dropwizard.Configuration;
+import io.dropwizard.configuration.DefaultConfigurationFactoryFactory;
+import io.dropwizard.configuration.FileConfigurationSourceProvider;
+import io.dropwizard.jetty.HttpConnectorFactory;
+import io.dropwizard.metrics.MetricsFactory;
+import io.dropwizard.server.DefaultServerFactory;
+import io.dropwizard.server.ServerFactory;
+import io.dropwizard.setup.Environment;
+import org.eclipse.jetty.server.Server;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.fest.assertions.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+public class EmbeddedServerTest {
+    // actual objects
+    private final String configFile = "yaml/server.yml";
+    private final Service<Configuration> testService = new Service<Configuration>(configFile) {
+        @Override
+        public void initialize(EmbeddedBootstrap<Configuration> bootstrap) {
+            // no bundles
+        }
+
+        @Override
+        protected void start(Configuration configuration, Environment environment) throws Exception {
+            // start does nothing
+        }
+    };
+
+    private final EmbeddedServer<Configuration> embeddedServer = new EmbeddedServer<>(testService);
+    private final Server server = new Server(0);
+
+    // mocks
+    private final Service<Configuration> mockService = mock(Service.class);
+    private final Server mockServer = mock(Server.class);
+    private final ServerFactory serverFactory = mock(ServerFactory.class);
+    private final Configuration configuration = mock(Configuration.class);
+    private final EmbeddedBootstrap<Configuration> bootstrap = mock(EmbeddedBootstrap.class);
+    private final ValidatorFactory validatorFactory = mock(ValidatorFactory.class);
+    private final Validator validator = mock(Validator.class);
+    private final MetricsFactory metricsFactory = mock(MetricsFactory.class);
+    private final MetricRegistry metricRegistry = mock(MetricRegistry.class);
+
+    @Before
+    public void setUp() throws Exception {
+        when(configuration.getServerFactory()).thenReturn(serverFactory);
+        when(serverFactory.build(any(Environment.class))).thenReturn(server);
+        when(bootstrap.getValidatorFactory()).thenReturn(validatorFactory);
+        when(validatorFactory.getValidator()).thenReturn(validator);
+        when(configuration.getMetricsFactory()).thenReturn(metricsFactory);
+        when(bootstrap.getMetricRegistry()).thenReturn(metricRegistry);
+        when(metricRegistry.register(anyString(), any(Metric.class))).thenReturn(null);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+    }
+
+    @Test
+    public void buildsAndRunsAConfiguredServer() throws Exception {
+        embeddedServer.start(bootstrap, configuration);
+        assertThat(server.isStarted())
+                .isTrue();
+    }
+
+    @Test
+    public void stopsStartedServer() throws Exception {
+        embeddedServer.start(bootstrap, configuration);
+
+        embeddedServer.stop();
+        assertThat(server.isStopped());
+    }
+
+    @Test
+    public void failsToStopStoppedServer() throws Exception {
+        Server spyServer = spy(server);
+        when(serverFactory.build(any(Environment.class))).thenReturn(spyServer);
+
+        embeddedServer.start(bootstrap, configuration);
+        embeddedServer.stop();
+        embeddedServer.stop();
+
+        verify(spyServer, times(1)).stop();
+    }
+
+    @Test
+    public void failsToStopUnkillableServer() throws Exception {
+        Server spyServer = spy(server);
+        when(serverFactory.build(any(Environment.class))).thenReturn(spyServer);
+
+        embeddedServer.start(bootstrap, configuration);
+        embeddedServer.stop();
+
+        try {
+            // make the server "unkillable"
+            doReturn(Boolean.FALSE).when(spyServer).isStopped();
+
+            embeddedServer.stop();
+            failBecauseExceptionWasNotThrown(Exception.class);
+        } catch (Exception e) {
+            assertThat(e).isInstanceOf(Exception.class)
+                    .hasMessageStartingWith("Failed to stop server after graceful shutdown period")
+                    .hasNoCause();
+        }
+    }
+
+    @Test
+    public void testConfigParsing() throws Exception {
+        String configFullPath = new File(Resources.getResource(configFile).toURI()).getPath();
+
+        EmbeddedBootstrap<Configuration> realBootstrap = new EmbeddedBootstrap<>(testService);
+        EmbeddedBootstrap<Configuration> spyBootstrap = spy(realBootstrap);
+
+        ArgumentCaptor<Configuration> configArgument = ArgumentCaptor.forClass(Configuration.class);
+        embeddedServer.start(spyBootstrap, configFullPath);
+        verify(spyBootstrap).run(configArgument.capture(), any(Environment.class));
+
+        assertThat(configArgument.getValue().getLoggingFactory().getAppenders().size()).isEqualTo(1);
+
+        assertThat(configArgument.getValue().getServerFactory()).isInstanceOf(DefaultServerFactory.class);
+        DefaultServerFactory dfltServerFactory = (DefaultServerFactory) configArgument.getValue().getServerFactory();
+        assertThat(dfltServerFactory.getGzipFilterFactory().isEnabled()).isFalse();
+        assertThat(dfltServerFactory.getApplicationConnectors().size()).isEqualTo(1);
+
+        assertThat(dfltServerFactory.getApplicationConnectors().get(0)).isInstanceOf(HttpConnectorFactory.class);
+        HttpConnectorFactory httpConnectorFactory = (HttpConnectorFactory) dfltServerFactory.getApplicationConnectors().get(0);
+        assertThat(httpConnectorFactory.getPort()).isEqualTo(0);
+        assertThat(httpConnectorFactory.getBindHost()).isEqualTo("localhost");
+
+        assertThat(dfltServerFactory.getMinThreads()).isEqualTo(89);
+        assertThat(dfltServerFactory.getMaxThreads()).isEqualTo(101);
+    }
+
+    @Test
+    public void testConfigFileNotValid() throws Exception {
+        EmbeddedBootstrap<Configuration> realBootstrap = new EmbeddedBootstrap<>(testService);
+        String invalidConfig = "THIS_FILE_DOES_NOT_EXIST";
+        try {
+            embeddedServer.start(realBootstrap, invalidConfig);
+            failBecauseExceptionWasNotThrown(FileNotFoundException.class);
+        } catch (Exception e) {
+            assertThat(e).isInstanceOf(FileNotFoundException.class);
+        }
+    }
+
+    @Test
+    public void testDefaultConfig() throws Exception {
+        EmbeddedBootstrap<Configuration> realBootstrap = new EmbeddedBootstrap<>(testService);
+        EmbeddedBootstrap<Configuration> spyBootstrap = spy(realBootstrap);
+
+        String invalidConfig = null;
+
+        ArgumentCaptor<Configuration> configArgument = ArgumentCaptor.forClass(Configuration.class);
+        embeddedServer.start(spyBootstrap, invalidConfig);
+        verify(spyBootstrap).run(configArgument.capture(), any(Environment.class));
+
+        assertThat(configArgument.getValue().getServerFactory()).isInstanceOf(DefaultServerFactory.class);
+        DefaultServerFactory dfltServerFactory = (DefaultServerFactory) configArgument.getValue().getServerFactory();
+        assertThat(dfltServerFactory.getApplicationConnectors().size()).isGreaterThan(0);
+
+        assertThat(dfltServerFactory.getApplicationConnectors().get(0)).isInstanceOf(HttpConnectorFactory.class);
+        HttpConnectorFactory httpConnectorFactory = (HttpConnectorFactory) dfltServerFactory.getApplicationConnectors().get(0);
+        assertThat(httpConnectorFactory.getPort()).isEqualTo(8080);
+    }
+}

--- a/dropwizard-embedded/src/test/java/io/dropwizard/embedded/ServiceTest.java
+++ b/dropwizard-embedded/src/test/java/io/dropwizard/embedded/ServiceTest.java
@@ -1,0 +1,66 @@
+package io.dropwizard.embedded;
+
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Environment;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class ServiceTest {
+    @Path("/ping")
+    @Produces(MediaType.TEXT_PLAIN)
+    private class PingResource {
+        @GET
+        public String ping() {
+            return "pong";
+        }
+    }
+
+    private @Spy Service<Configuration> spyService = new Service<Configuration>(null) {
+        @Override
+        public void initialize(EmbeddedBootstrap<Configuration> bootstrap) {
+            assertThat(bootstrap).isNotNull();
+        }
+
+        @Override
+        protected void start(Configuration configuration, Environment environment) throws Exception {
+            assertThat(configuration).isNotNull();
+            assertThat(environment).isNotNull();
+
+            environment.jersey().register(new PingResource());
+        }
+    };
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void serviceStartsAndStops() throws Exception {
+        spyService.start();
+        verify(spyService).initialize(any(EmbeddedBootstrap.class));
+        verify(spyService).start(any(Configuration.class), any(Environment.class));
+
+        spyService.stop();
+        verify(spyService).stop(any(Environment.class));
+    }
+
+    @Test
+    public void serviceDoesNotStopIfNotStarted() throws Exception {
+        spyService.stop();
+        verify(spyService, never()).initialize(any(EmbeddedBootstrap.class));
+        verify(spyService, never()).start(any(Configuration.class), any(Environment.class));
+        verify(spyService, never()).stop(any(Environment.class));
+    }
+}

--- a/dropwizard-embedded/src/test/resources/logback-test.xml
+++ b/dropwizard-embedded/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <outputPatternAsHeader>false</outputPatternAsHeader>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="off">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/dropwizard-embedded/src/test/resources/yaml/server.yml
+++ b/dropwizard-embedded/src/test/resources/yaml/server.yml
@@ -1,0 +1,19 @@
+logging:
+  appenders:
+    - type: console
+server:
+  gzip:
+    enabled: false
+  applicationConnectors:
+    - type: http
+      port: 0
+      bindHost: "localhost"
+      acceptorThreads: 2
+      acceptQueueSize: 100
+      reuseAddress: false
+      soLingerTime: 2s
+      useServerHeader: true
+      useDateHeader: false
+      useForwardedHeaders: false
+  minThreads: 89
+  maxThreads: 101

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         <module>dropwizard-lifecycle</module>
         <module>dropwizard-assets</module>
         <module>dropwizard-spdy</module>
+        <module>dropwizard-embedded</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
This new module adds a new interface to a Dropwizard HTTP(s) service, so
that the HTTP server can be started/stopped at any point within an
already existing daemon process (no CLI required). This allows a
developer to embed Dropwizard into already existing services with their
own main run loop and SLF4J logging infrastructure.

Code example:
```java
public class WebService extends io.dropwizard.embedded.Service<Configuration> {
    public void initialize(EmbeddedBootstrap<Configuration> bootstrap) {
        // add bundles
        bootstrap.addBundle(new ViewBundle());
    }
    protected void start(Configuration config, Environment env) {
        // add resources
        env.jersey().register(new HelloWorldResource());
    }

    public static void main(String ... args) {
        handleCommandLine(args);
        configureSlf4jLogging();
        start();
        new MainRunLoop().run();
        stop();
    }
}
```