### PR TITLE
Upgrade to commons-lang3.

### DIFF
--- a/dropwizard-configuration/pom.xml
+++ b/dropwizard-configuration/pom.xml
@@ -28,9 +28,9 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.3.2</version>
         </dependency>
     </dependencies>
 </project>

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationParsingException.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationParsingException.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.dataformat.yaml.snakeyaml.error.Mark;
 import com.google.common.collect.ImmutableSet;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
@@ -11,7 +11,7 @@ import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.Test;
 
 import com.google.common.base.Function;


### PR DESCRIPTION
This is a minor change to use the non-legacy version of commons-lang. No
functional change expected, but it does make more sense to use the
latest in this case.
