### PR TITLE
ConstraintViolationException should not always be thrown for empty request entities

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProvider.java
@@ -66,14 +66,14 @@ public class JacksonMessageBodyProvider extends JacksonJaxbJsonProvider {
     }
 
     private Object validate(Annotation[] annotations, Object value) {
-        if(null == value) {
-            throw new ConstraintViolationException("The request entity was empty",
-                    Collections.<ConstraintViolation<Object>>emptySet());
-        }
-
         final Class<?>[] classes = findValidationGroups(annotations);
 
         if (classes != null) {
+            if(null == value) {
+                throw new ConstraintViolationException("The request entity was empty",
+                        Collections.<ConstraintViolation<Object>>emptySet());
+            }
+
             Set<ConstraintViolation<Object>> violations = null;
 
             if(value instanceof Map) {


### PR DESCRIPTION
The `ConstraintViolationException` with an empty request entity should only be thrown
if the entity should be validated at all and is annotated with `@Valid` or `@Validated`.