### PR TITLE
nullify jettyServer on stop() 

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
@@ -58,6 +58,7 @@ public class DropwizardAppRule<C extends Configuration> implements TestRule {
                 } finally {
                     resetConfigOverrides();
                     jettyServer.stop();
+                    jettyServer = null;
                 }
             }
         };


### PR DESCRIPTION
nullify jettyServer on stop() so that shared test base-classes with a @BeforeClass DropWizardAppRule can start new jetty servers.
