### PR TITLE
Fixing double definition of guava version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,6 @@
         <slf4j.version>1.7.6</slf4j.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <jetty.version>9.0.7.v20131107</jetty.version>
-        <guava.version>16.0.1</guava.version>
         <guava.version>17.0</guava.version>
         <h2.version>1.4.178</h2.version>
         <findbugs.skip>false</findbugs.skip>


### PR DESCRIPTION
Looks like this was from an incorrect merge conflict resolution.
