### PR TITLE
Only use the PermissiveEnumDeserializer if there is no JsonCreator

### DIFF
--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/FuzzyEnumModule.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/FuzzyEnumModule.java
@@ -1,16 +1,19 @@
 package io.dropwizard.jackson;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.deser.Deserializers;
+import com.fasterxml.jackson.databind.deser.std.EnumDeserializer;
 import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
 import com.google.common.base.CharMatcher;
 import com.google.common.collect.Lists;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
-import java.util.Locale;
 
 /**
  * A module for deserializing enums that is more permissive than the default.
@@ -18,7 +21,7 @@ import java.util.Locale;
  * This deserializer is more permissive in the following ways:
  * <ul>
  * <li>Whitespace is permitted but stripped from the input.</li>
- * <li>Dashes in the value are converted to underscores.</li>
+ * <li>Dashes and periods in the value are converted to underscores.</li>
  * <li>Matching against the enum values is case insensitive.</li>
  * </ul>
  */
@@ -41,8 +44,9 @@ public class FuzzyEnumModule extends Module {
 
         public Enum<?> deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
             final String text = CharMatcher.WHITESPACE
-                                           .removeFrom(jp.getText())
-                                           .replace('-', '_');
+                    .removeFrom(jp.getText())
+                    .replace('-', '_')
+                    .replace('.', '_');
             for (Enum<?> constant : constants) {
                 if (constant.name().equalsIgnoreCase(text)) {
                     return constant;
@@ -59,6 +63,17 @@ public class FuzzyEnumModule extends Module {
         public JsonDeserializer<?> findEnumDeserializer(Class<?> type,
                                                         DeserializationConfig config,
                                                         BeanDescription desc) throws JsonMappingException {
+            // If there is a JsonCreator annotation we should use that instead of the PermissiveEnumDeserializer
+            final Collection<AnnotatedMethod> factoryMethods = desc.getFactoryMethods();
+            if (factoryMethods != null) {
+                for (AnnotatedMethod am : factoryMethods) {
+                    final JsonCreator creator = am.getAnnotation(JsonCreator.class);
+                    if (creator != null) {
+                        return EnumDeserializer.deserializerForCreator(config, type, am);
+                    }
+                }
+            }
+
             return new PermissiveEnumDeserializer((Class<Enum<?>>) type);
         }
     }

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/FuzzyEnumModuleTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/FuzzyEnumModuleTest.java
@@ -1,5 +1,6 @@
 package io.dropwizard.jackson;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
@@ -14,7 +15,16 @@ import static org.fest.assertions.api.Assertions.failBecauseExceptionWasNotThrow
 public class FuzzyEnumModuleTest {
     private final ObjectMapper mapper = new ObjectMapper();
     
-    private enum EnumWithLowercase {lower_case_enum, mixedCaseEnum};
+    private enum EnumWithLowercase { lower_case_enum, mixedCaseEnum }
+
+    private enum EnumWithCreator {
+        TEST;
+
+        @JsonCreator
+        public static EnumWithCreator fromString(String value) {
+            return EnumWithCreator.TEST;
+        }
+    }
 
     @Before
     public void setUp() throws Exception {
@@ -49,6 +59,18 @@ public class FuzzyEnumModuleTest {
     public void mapsDashedEnums() throws Exception {
         assertThat(mapper.readValue("\"REASON-UNKNOWN\"", ClientInfoStatus.class))
                 .isEqualTo(ClientInfoStatus.REASON_UNKNOWN);
+    }
+
+    @Test
+    public void mapsDottedEnums() throws Exception {
+        assertThat(mapper.readValue("\"REASON.UNKNOWN\"", ClientInfoStatus.class))
+                .isEqualTo(ClientInfoStatus.REASON_UNKNOWN);
+    }
+
+    @Test
+    public void mapsWhenEnumHasCreator() throws Exception {
+        assertThat(mapper.readValue("\"BLA\"", EnumWithCreator.class))
+                .isEqualTo(EnumWithCreator.TEST);
     }
 
     @Test


### PR DESCRIPTION
This is a fix for #549 based on the code in a comment by @chrsan. It also adds conversion from periods to underscores for fuzzy enums.
