### PR TITLE
Access to endpoints information from DropwizardResourceConfig

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -26,6 +26,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.ext.Provider;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class DropwizardResourceConfig extends ScanningResourceConfig {
     private static final String NEWLINE = String.format("%n");
@@ -60,9 +61,9 @@ public class DropwizardResourceConfig extends ScanningResourceConfig {
     public void validate() {
         super.validate();
 
-        logResources();
-        logProviders();
-        logEndpoints();
+        LOGGER.debug("resources = {}", getResources());
+        LOGGER.debug("providers = {}", getProviders());
+        LOGGER.info(getEndpointsInfo());;
     }
 
     public String getUrlPattern() {
@@ -73,7 +74,7 @@ public class DropwizardResourceConfig extends ScanningResourceConfig {
         this.urlPattern = urlPattern;
     }
 
-    private void logResources() {
+    private Set<String> getResources() {
         final ImmutableSet.Builder<String> builder = ImmutableSet.builder();
 
         for (Class<?> klass : getClasses()) {
@@ -96,10 +97,10 @@ public class DropwizardResourceConfig extends ScanningResourceConfig {
             }
         }
 
-        LOGGER.debug("resources = {}", builder.build());
+        return builder.build();
     }
 
-    private void logProviders() {
+    private Set<String> getProviders() {
         final ImmutableSet.Builder<String> builder = ImmutableSet.builder();
 
         for (Class<?> klass : getClasses()) {
@@ -114,10 +115,10 @@ public class DropwizardResourceConfig extends ScanningResourceConfig {
             }
         }
 
-        LOGGER.debug("providers = {}", builder.build());
+        return builder.build();
     }
 
-    private void logEndpoints() {
+    public String getEndpointsInfo() {
         final StringBuilder msg = new StringBuilder(1024);
         msg.append("The following paths were found for the configured resources:");
         msg.append(NEWLINE).append(NEWLINE);
@@ -163,7 +164,7 @@ public class DropwizardResourceConfig extends ScanningResourceConfig {
             }
         }
 
-        LOGGER.info(msg.toString());
+        return msg.toString();
     }
 
     private void populateEndpoints(List<String> endpoints, String basePath, Class<?> klass,

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/setup/JerseyEnvironment.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/setup/JerseyEnvironment.java
@@ -107,7 +107,7 @@ public class JerseyEnvironment {
         config.setUrlPattern(urlPattern);
     }
 
-    public ResourceConfig getResourceConfig() {
+    public DropwizardResourceConfig getResourceConfig() {
         return config;
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
@@ -36,6 +36,17 @@ public class DropwizardResourceConfigTest {
                         (DummyResource.class, TestResource.class);
     }
 
+    @Test
+    public void testGetEndpointsInfo() {
+        final DropwizardResourceConfig rc = DropwizardResourceConfig.forTesting(new MetricRegistry());
+        rc.init(new PackageNamesScanner(new String[]{DummyResource.class.getPackage().getName()}));
+
+        assertThat(rc.getEndpointsInfo()).isEqualTo("The following paths were found for the configured resources:\n" +
+                "\n" +
+                "    GET     / (io.dropwizard.jersey.dummy.DummyResource)" +
+                "\n");
+    }
+
     @Path("/dummy")
     public static class TestResource {
         @GET


### PR DESCRIPTION
When Dropwizard starts, it prints into a log very useful information about configured endpoints in the application.  It gives some basic form of a documentation about API.
I believe, it would be very convenient to access this information not just from the log, but from the application code too. So we can print it, say, as an HTML page.

![screenshot from 2014-07-05 23 46 05](https://cloud.githubusercontent.com/assets/1717632/3487443/21e06e90-047e-11e4-9d5c-7e095ce56903.png)
I know there special tools for that goal like Swagger, but sometimes minimal information is quite enough.

To achieve this goal, I divided logging and constructing a message in the method _logEndpoints_, set a new name for the method and made it public (it doesn't expose any internal state, so from the security point of view it's fine, I believe). 
I didn't make _getResources_ and _getProviders_ public because I don't see a practical value for that.
