### PR TITLE
Return JSON errors when parameter validation fails.

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/AbstractParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/AbstractParam.java
@@ -5,6 +5,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import io.dropwizard.jersey.errors.ErrorMessage;
+
 /**
  * An abstract base class from which to build Jersey parameter classes.
  *
@@ -40,7 +42,7 @@ public abstract class AbstractParam<T> {
      */
     protected Response error(String input, Exception e) {
         return Response.status(getErrorStatus())
-                       .entity(errorMessage(input, e))
+                       .entity(new ErrorMessage(errorMessage(input, e)))
                        .type(mediaType())
                        .build();
     }
@@ -51,7 +53,7 @@ public abstract class AbstractParam<T> {
      * @return the media type of the error message entity
      */
     protected MediaType mediaType() {
-        return MediaType.TEXT_PLAIN_TYPE;
+        return MediaType.APPLICATION_JSON_TYPE;
     }
 
     /**

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/BooleanParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/BooleanParamTest.java
@@ -1,5 +1,6 @@
 package io.dropwizard.jersey.params;
 
+import io.dropwizard.jersey.errors.ErrorMessage;
 import org.junit.Test;
 
 import javax.ws.rs.WebApplicationException;
@@ -53,7 +54,8 @@ public class BooleanParamTest {
             assertThat(response.getStatus())
                     .isEqualTo(400);
 
-            assertThat((String) response.getEntity())
+            ErrorMessage entity = (ErrorMessage) response.getEntity();
+            assertThat(entity.getMessage())
                     .isEqualTo("\"null\" must be \"true\" or \"false\".");
         }
     }
@@ -70,7 +72,8 @@ public class BooleanParamTest {
             assertThat(response.getStatus())
                     .isEqualTo(400);
 
-            assertThat(response.getEntity())
+            ErrorMessage entity = (ErrorMessage) response.getEntity();
+            assertThat(entity.getMessage())
                     .isEqualTo("\"foo\" must be \"true\" or \"false\".");
         }
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/IntParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/IntParamTest.java
@@ -1,5 +1,6 @@
 package io.dropwizard.jersey.params;
 
+import io.dropwizard.jersey.errors.ErrorMessage;
 import org.junit.Test;
 
 import javax.ws.rs.WebApplicationException;
@@ -29,7 +30,8 @@ public class IntParamTest {
             assertThat(response.getStatus())
                     .isEqualTo(400);
 
-            assertThat(response.getEntity())
+            ErrorMessage entity = (ErrorMessage) response.getEntity();
+            assertThat(entity.getMessage())
                     .isEqualTo("\"foo\" is not a number.");
         }
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/LongParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/LongParamTest.java
@@ -1,5 +1,6 @@
 package io.dropwizard.jersey.params;
 
+import io.dropwizard.jersey.errors.ErrorMessage;
 import org.junit.Test;
 
 import javax.ws.rs.WebApplicationException;
@@ -29,7 +30,8 @@ public class LongParamTest {
             assertThat(response.getStatus())
                     .isEqualTo(400);
 
-            assertThat((String) response.getEntity())
+            ErrorMessage entity = (ErrorMessage) response.getEntity();
+            assertThat(entity.getMessage())
                     .isEqualTo("\"foo\" is not a number.");
         }
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/UUIDParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/UUIDParamTest.java
@@ -1,5 +1,6 @@
 package io.dropwizard.jersey.params;
 
+import io.dropwizard.jersey.errors.ErrorMessage;
 import org.junit.Test;
 
 import javax.ws.rs.WebApplicationException;
@@ -33,7 +34,8 @@ public class UUIDParamTest {
             assertThat(response.getStatus())
                     .isEqualTo(400);
 
-            assertThat((String) response.getEntity())
+            ErrorMessage entity = (ErrorMessage) response.getEntity();
+            assertThat(entity.getMessage())
                     .isEqualTo("\"foo\" is not a UUID.");
         }
     }


### PR DESCRIPTION
In common with other errors, parameter validation errors should be in JSON format (currently they are in plain text).
