### PR TITLE
Make DropwizardResourceConfigTest cross-platform

### DIFF
--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
@@ -41,10 +41,10 @@ public class DropwizardResourceConfigTest {
         final DropwizardResourceConfig rc = DropwizardResourceConfig.forTesting(new MetricRegistry());
         rc.init(new PackageNamesScanner(new String[]{DummyResource.class.getPackage().getName()}));
 
-        assertThat(rc.getEndpointsInfo()).isEqualTo("The following paths were found for the configured resources:\n" +
-                "\n" +
+        assertThat(rc.getEndpointsInfo()).isEqualTo(String.format("The following paths were found for the configured resources:%n" +
+                "%n" +
                 "    GET     / (io.dropwizard.jersey.dummy.DummyResource)" +
-                "\n");
+                "%n"));
     }
 
     @Path("/dummy")


### PR DESCRIPTION
Update testGetEndpointsInfo to use a cross-platform `%n` in
`String.format` instead of the hardcoded `\n`. This allows the maven
build to work on Windows.
