### PR TITLE
`DropwizardAppRule` more strict in resetting config overrides

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ConfigOverride.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ConfigOverride.java
@@ -17,4 +17,8 @@ public class ConfigOverride {
     public void addToSystemProperties() {
         System.setProperty("dw." + key, value);
     }
+
+    public void removeFromSystemProperties() {
+        System.clearProperty("dw." + key);
+    }
 }

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
@@ -1,8 +1,8 @@
 package io.dropwizard.testing.junit;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.cli.ServerCommand;
@@ -44,7 +44,7 @@ public class DropwizardAppRule<C extends Configuration> implements TestRule {
                              ConfigOverride... configOverrides) {
         this.applicationClass = applicationClass;
         this.configPath = configPath;
-        this.configOverrides = Lists.newArrayList(configOverrides);
+        this.configOverrides = ImmutableList.copyOf(configOverrides);
     }
 
     @Override

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
@@ -44,7 +44,9 @@ public class DropwizardAppRule<C extends Configuration> implements TestRule {
                              ConfigOverride... configOverrides) {
         this.applicationClass = applicationClass;
         this.configPath = configPath;
-        this.configOverrides = ImmutableList.copyOf(configOverrides);
+        this.configOverrides = (configOverrides == null)
+                ? ImmutableList.<ConfigOverride>of()
+                : ImmutableList.copyOf(configOverrides);
     }
 
     @Override
@@ -66,13 +68,13 @@ public class DropwizardAppRule<C extends Configuration> implements TestRule {
     }
 
     private void applyConfigOverrides() {
-        for (ConfigOverride configOverride: configOverrides) {
+        for (ConfigOverride configOverride : configOverrides) {
             configOverride.addToSystemProperties();
         }
     }
 
     private void resetConfigOverrides() {
-        for (ConfigOverride configOverride: configOverrides) {
+        for (ConfigOverride configOverride : configOverrides) {
             configOverride.removeFromSystemProperties();
         }
     }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleTest.java
@@ -97,6 +97,10 @@ public class DropwizardAppRuleTest {
         @JsonProperty
         private String message;
 
+        @NotEmpty
+        @JsonProperty
+        private String extra;
+
         public String getMessage() {
             return message;
         }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardServiceRuleResetConfigOverrideTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardServiceRuleResetConfigOverrideTest.java
@@ -1,0 +1,35 @@
+package io.dropwizard.testing.junit;
+
+import org.junit.FixMethodOrder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+import static io.dropwizard.testing.junit.ConfigOverride.config;
+import static io.dropwizard.testing.junit.DropwizardAppRuleTest.resourceFilePath;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class DropwizardServiceRuleResetConfigOverrideTest {
+
+    @Rule
+    public final DropwizardAppRule<TestConfiguration> RULE =
+            new DropwizardAppRule<TestConfiguration>(TestApplication.class,
+                                                     resourceFilePath("test-config.yaml"),
+                                                     config("message", "A new way to say Hooray!"));
+
+    @Test
+    public void test1() throws Exception {
+        // in this test we set a NEW system property
+        System.setProperty("dw.extra", "Some extra system property");
+    }
+
+    @Test
+    public void test2() throws Exception {
+        // now we check that the property set in the previous test is still in effect
+        assertThat(System.getProperty("dw.extra")).isEqualTo("Some extra system property");
+
+        // but the override we configured in our DropwizardAppRule is still correct
+        assertThat(System.getProperty("dw.message")).isEqualTo("A new way to say Hooray!");
+    }
+}

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/TestConfiguration.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/TestConfiguration.java
@@ -10,7 +10,15 @@ public class TestConfiguration extends Configuration {
     @NotEmpty
     private String message;
 
+    @JsonProperty
+    @NotEmpty
+    private String extra;
+
     public String getMessage() {
         return message;
+    }
+
+    public String getExtra() {
+        return extra;
     }
 }

--- a/dropwizard-testing/src/test/resources/test-config.yaml
+++ b/dropwizard-testing/src/test/resources/test-config.yaml
@@ -1,4 +1,5 @@
 message: "Yes, it's here"
+extra: "Something extra"
 server:
   applicationConnectors:
     - type: http


### PR DESCRIPTION
Prior to this change, `DropwizardAppRule` would clear *ALL* system properties that start with `dw.`, regardless of whether they were defined as `ConfigOverride` values in the test. This caused problems with tests that relied on a combination of command-line overrides (that should not be reset) and test-specific overrides (that should be reset).

An example of where this might be useful is dynamic port allocation, where the build system (Maven, Jenkins, etc.) dynamically allocates port numbers to the app and provides these via command-line overrides (e.g. `-Ddw.cassandra.port=${SOME_DYNAMIC_PORT}`). These values should be retained (otherwise subsequent tests fail), but the configuration that was explicitly overridden using `ConfigOverride` in the test should be reset.

Note that this does _not_ revert the original value of the system property if you override an already-overridden property.