### PR TITLE
Cleaning dropwizard-example's README.md and removing unused code

### DIFF
--- a/dropwizard-example/README.md
+++ b/dropwizard-example/README.md
@@ -13,8 +13,7 @@ This database example is comprised of the following classes.
 * The `PersonDAO` illustrates using the [SQL Object Queries](http://jdbi.org/sql_object_api_queries/) and string template
 features in JDBI.
 
-* The `PeopleDAO.sql.stg` stores all the SQL statements for use in the `PersonDAO`, note this is located in the
-src/resources under the same path as the `PersonDAO` class file.
+* All the SQL statements for use in the `PersonDAO` are located in the `Person` class.
 
 * `migrations.xml` illustrates the usage of `dropwizard-migrations` which can create your database prior to running
 your application for the first time.

--- a/dropwizard-example/src/main/java/com/example/helloworld/core/Person.java
+++ b/dropwizard-example/src/main/java/com/example/helloworld/core/Person.java
@@ -8,10 +8,6 @@ import javax.persistence.*;
     @NamedQuery(
         name = "com.example.helloworld.core.Person.findAll",
         query = "SELECT p FROM Person p"
-    ),
-    @NamedQuery(
-        name = "com.example.helloworld.core.Person.findById",
-        query = "SELECT p FROM Person p WHERE p.id = :id"
     )
 })
 public class Person {


### PR DESCRIPTION
README.md was pointing to an already removed file.
Person class defined a NamedQuery which wasn't used anywhere
