### PR TITLE
Allow application to replace the default pattern for all log appenders

### DIFF
--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/DropwizardLayout.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/DropwizardLayout.java
@@ -14,13 +14,47 @@ import java.util.TimeZone;
  * </ul>
  */
 public class DropwizardLayout extends PatternLayout {
+
+    private static volatile PatternFactory defaultPatternFactory = new PatternFactory();
+
     public DropwizardLayout(LoggerContext context, TimeZone timeZone) {
         super();
         setOutputPatternAsHeader(false);
         getDefaultConverterMap().put("ex", PrefixedThrowableProxyConverter.class.getName());
         getDefaultConverterMap().put("xEx", PrefixedExtendedThrowableProxyConverter.class.getName());
         getDefaultConverterMap().put("rEx", PrefixedRootCauseFirstThrowableProxyConverter.class.getName());
-        setPattern("%-5p [%d{ISO8601," + timeZone.getID() + "}] %c: %m%n%rEx");
+        setPattern(defaultPatternFactory.build(timeZone));
         setContext(context);
+    }
+
+    /**
+     * Sets the factory that provides the default log format pattern for <em>new</em> instances
+     * of {@link DropwizardLayout}.  This allows an application to define its own default log
+     * format pattern, but patterns explicitly set in the configuration YAML file will always
+     * override this behavior.  Applications must invoke this method <em>before anything
+     * initializes the logging subsystem</em>; a good place is early in the {@code main} method.
+     *
+     * @param factory pattern factory instance that has already been initialized and configured
+     */
+    public static void setDefaultPattern(PatternFactory factory) {
+        defaultPatternFactory = factory;
+    }
+
+    static PatternFactory getDefaultPattern() {
+        return defaultPatternFactory;
+    }
+
+    /** Provides methods for generating Logback-compatible format patterns. */
+    public static class PatternFactory {
+        /**
+         * Generates a log format based on the provided {@code TimeZone}.
+         * Implementations of this method are expected to be thread-safe.
+         *
+         * @param timeZone the time zone configured for the target log appender
+         * @return a Logback-compatible format pattern
+         */
+        public String build(TimeZone timeZone) {
+            return "%-5p [%d{ISO8601," + timeZone.getID() + "}] %c: %m%n%rEx";
+        }
     }
 }

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/DropwizardLayoutTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/DropwizardLayoutTest.java
@@ -36,4 +36,24 @@ public class DropwizardLayoutTest {
         assertThat(layout.getPattern())
                 .isEqualTo("%-5p [%d{ISO8601,UTC}] %c: %m%n%rEx");
     }
+
+    @Test
+    public void canOverrideDefaultPattern() throws Exception {
+        DropwizardLayout.PatternFactory oldDefault = DropwizardLayout.getDefaultPattern();
+        try {
+            final String format = "DropwizardLayoutTest - overridden default format";
+            DropwizardLayout.setDefaultPattern(
+                new DropwizardLayout.PatternFactory() {
+                    @Override public String build(TimeZone timeZone) {
+                        return format;
+                    }
+                }
+            );
+            DropwizardLayout layout2 = new DropwizardLayout(context, timeZone);
+            assertThat(layout2.getPattern())
+                    .isEqualTo(format);
+        } finally {
+            DropwizardLayout.setDefaultPattern(oldDefault);
+        }
+    }
 }


### PR DESCRIPTION
Allows the single, default pattern to be customized by the application (e.g. to include certain MDC values)
without requiring individual deployments to copy-paste the same format override in their YAML files.