### PR TITLE
Simplify HibernateBundle constructor

### DIFF
--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/HibernateBundle.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/HibernateBundle.java
@@ -16,13 +16,22 @@ public abstract class HibernateBundle<T extends Configuration> implements Config
     private final ImmutableList<Class<?>> entities;
     private final SessionFactoryFactory sessionFactoryFactory;
 
-    protected HibernateBundle(Class<?> entity, Class<?>... entities) {
-        this(ImmutableList.<Class<?>>builder().add(entity).add(entities).build(),
+    protected HibernateBundle(Class<?>... entities) {
+        this(ImmutableList.<Class<?>>builder().add(entities).build(),
              new SessionFactoryFactory());
     }
 
     protected HibernateBundle(ImmutableList<Class<?>> entities,
                               SessionFactoryFactory sessionFactoryFactory) {
+        if (entities.isEmpty()) {
+            throw new RuntimeException("Must have at least one entity");
+        }
+        for (Class entity : entities) {
+            if (entity.getAnnotation(javax.persistence.Entity.class) == null) {
+                throw new RuntimeException("Class " + entity + " was expected to be annotated with javax.persistence.Entity, but wasn't.");
+            }
+        }
+
         this.entities = entities;
         this.sessionFactoryFactory = sessionFactoryFactory;
     }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/HibernateBundleTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/HibernateBundleTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
 import static org.mockito.Mockito.*;
 
 public class HibernateBundleTest {
@@ -99,5 +100,48 @@ public class HibernateBundleTest {
         bundle.run(configuration, environment);
 
         assertThat(bundle.getSessionFactory()).isEqualTo(sessionFactory);
+    }
+
+    @Test
+    public void shouldFailIfEntityIsNotAnEntity() {
+        Class[] entities = {};
+
+        try {
+            new HibernateBundle<Configuration>(entities) {
+                @Override
+                public DataSourceFactory getDataSourceFactory(Configuration configuration) {
+                    return null;
+                }
+            };
+        } catch (RuntimeException rte) {
+            // Expected
+        }
+
+        entities = new Class[]{Person.class, String.class};
+        try {
+            new HibernateBundle<Configuration>(entities) {
+                @Override
+                public DataSourceFactory getDataSourceFactory(Configuration configuration) {
+                    return null;
+                }
+            };
+        } catch (RuntimeException rte) {
+            // Expected
+            return;
+        }
+
+        entities = new Class[]{Person.class};
+        try {
+            new HibernateBundle<Configuration>(entities) {
+                @Override
+                public DataSourceFactory getDataSourceFactory(Configuration configuration) {
+                    return null;
+                }
+            };
+        } catch (RuntimeException rte) {
+            fail("Unexpected RuntimeException");
+        }
+
+        fail("Expected RuntimeException but didn't get one.");
     }
 }


### PR DESCRIPTION
One of the constructors for HibernateBundle is somewhat clumsy. This is an attempt to simplify it. The current signature for it is:

```
protected HibernateBundle(Class<?> entity, Class<?>... entities)
```

A concrete call to this would look something like:

```
new HibernateBundle(Person.class, Email.class, Attachment.class)...
```

A (debatably) cleaner way to to this would be to simply remove the first parameter of the existing constructor, simplifying it to:

```
protected HibernateBundle(Class<?>... entities)
```

The concrete call to it could then look like:

```
Class[] entities = new Class[]{Person.class, Email.class, Attachment.class};
new HibernateBundle(entities);
```

This constructor was last modified in 2012, and originally had the signature that is being proposed as part of this pull request. The comment from them mentions Hibernate requiring at least one entity, so to add this protection some code was put into place which checks for this.
