### PR TITLE
Added `LogConfigurationTask` to allow runtime changes to log levels

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -460,10 +460,11 @@ Tasks
 =====
 
 A ``Task`` is a run-time action your application provides access to on the administrative port via HTTP.
-All Dropwizard applications start with the ``gc`` task, which explicitly triggers the JVM's garbage
-collection. (This is useful, for example, for running full garbage collections during off-peak times
-or while the given application is out of rotation.) The execute method of a ``Task`` can be annotated
-with ``@Timed``, ``@Metered``, and ``@ExceptionMetered``. Dropwizard will automatically
+All Dropwizard applications start with: the ``gc`` task, which explicitly triggers the JVM's garbage
+collection (This is useful, for example, for running full garbage collections during off-peak times
+or while the given application is out of rotation.); and the ``log-level`` task, which configures the level
+of any number of loggers at runtime (akin to Logback's ``JmxConfigurator``). The execute method of a ``Task``
+can be annotated with ``@Timed``, ``@Metered``, and ``@ExceptionMetered``. Dropwizard will automatically
 record runtime information about your tasks. Here's a basic task class:
 
 .. code-block:: java

--- a/dropwizard-core/src/main/java/io/dropwizard/setup/AdminEnvironment.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/AdminEnvironment.java
@@ -5,6 +5,7 @@ import com.codahale.metrics.health.HealthCheckRegistry;
 import com.codahale.metrics.health.jvm.ThreadDeadlockHealthCheck;
 import io.dropwizard.jetty.MutableServletContextHandler;
 import io.dropwizard.jetty.setup.ServletEnvironment;
+import io.dropwizard.logging.tasks.LogConfigurationTask;
 import io.dropwizard.servlets.tasks.GarbageCollectionTask;
 import io.dropwizard.servlets.tasks.Task;
 import io.dropwizard.servlets.tasks.TaskServlet;
@@ -37,6 +38,7 @@ public class AdminEnvironment extends ServletEnvironment {
         this.healthChecks.register("deadlocks", new ThreadDeadlockHealthCheck());
         this.tasks = new TaskServlet(metricRegistry);
         tasks.add(new GarbageCollectionTask());
+        tasks.add(new LogConfigurationTask());
         addServlet("tasks", tasks).addMapping("/tasks/*");
         handler.addLifeCycleListener(new AbstractLifeCycle.AbstractLifeCycleListener() {
             @Override

--- a/dropwizard-logging/pom.xml
+++ b/dropwizard-logging/pom.xml
@@ -23,6 +23,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-servlets</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.codahale.metrics</groupId>
             <artifactId>metrics-logback</artifactId>
             <version>${metrics3.version}</version>

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/tasks/LogConfigurationTask.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/tasks/LogConfigurationTask.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2014 Stuart Gunter
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.dropwizard.logging.tasks;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import com.google.common.collect.ImmutableMultimap;
+import io.dropwizard.servlets.tasks.Task;
+import org.slf4j.LoggerFactory;
+
+import java.io.PrintWriter;
+import java.util.List;
+
+/**
+ * <p>Sets the logging level for a number of loggers</p>
+ *
+ * <b>Parameters:</b>
+ * <table>
+ *     <tr>
+ *         <td>Name</td>
+ *         <td>Description</td>
+ *     </tr>
+ *     <tr>
+ *         <td>logger</td>
+ *         <td>One or more logger names to be configured with the specified log level.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>level</td>
+ *         <td>An optional Logback {@link Level} to configure. If not provided, the log level will be set to null.</td>
+ *     </tr>
+ * </table>
+ */
+public class LogConfigurationTask extends Task {
+
+    private final LoggerContext loggerContext;
+
+    /**
+     * Creates a new LogConfigurationTask.
+     */
+    public LogConfigurationTask() {
+        this((LoggerContext) LoggerFactory.getILoggerFactory());
+    }
+
+    /**
+     * Creates a new LogConfigurationTask with the given {@link ch.qos.logback.classic.LoggerContext} instance.
+     * <p/>
+     * <b>Use {@link LogConfigurationTask#LogConfigurationTask()} instead.</b>
+     *
+     * @param loggerContext a {@link ch.qos.logback.classic.LoggerContext} instance
+     */
+    public LogConfigurationTask(LoggerContext loggerContext) {
+        super("log-level");
+        this.loggerContext = loggerContext;
+    }
+
+    @Override
+    public void execute(ImmutableMultimap<String, String> parameters, PrintWriter output) throws Exception {
+        List<String> loggerNames = getLoggerNames(parameters);
+        Level loggerLevel = getLoggerLevel(parameters);
+
+        for (String loggerName : loggerNames) {
+            loggerContext.getLogger(loggerName).setLevel(loggerLevel);
+            output.println(String.format("Configured logging level for %s to %s", loggerName, loggerLevel));
+            output.flush();
+        }
+    }
+
+    private List<String> getLoggerNames(ImmutableMultimap<String, String> parameters) {
+        return parameters.get("logger").asList();
+    }
+
+    private Level getLoggerLevel(ImmutableMultimap<String, String> parameters) {
+        List<String> loggerLevels = parameters.get("level").asList();
+        return loggerLevels.isEmpty() ? null : Level.valueOf(loggerLevels.get(0));
+    }
+}

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/tasks/LogConfigurationTask.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/tasks/LogConfigurationTask.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 Stuart Gunter
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
-
 package io.dropwizard.logging.tasks;
 
 import ch.qos.logback.classic.Level;

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/tasks/LogConfigurationTaskTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/tasks/LogConfigurationTaskTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2014 Stuart Gunter
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.dropwizard.logging.tasks;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import com.google.common.collect.ImmutableMultimap;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LogConfigurationTaskTest {
+
+    private static final Level DEFAULT_LEVEL = Level.ALL;
+
+    private final LoggerContext loggerContext = new LoggerContext();
+    private final Logger logger1 = loggerContext.getLogger("logger.one");
+    private final Logger logger2 = loggerContext.getLogger("logger.two");
+
+    private final StringWriter stringWriter = new StringWriter();
+    private final PrintWriter output = new PrintWriter(stringWriter);
+
+    private final LogConfigurationTask task = new LogConfigurationTask(loggerContext);
+
+    @Before
+    public void setUp() throws Exception {
+        logger1.setLevel(DEFAULT_LEVEL);
+        logger2.setLevel(DEFAULT_LEVEL);
+    }
+
+    @Test
+    public void configuresSpecificLevelForALogger() throws Exception {
+        // given
+        ImmutableMultimap<String, String> parameters = ImmutableMultimap.of(
+                "logger", "logger.one",
+                "level", "debug");
+
+        // when
+        task.execute(parameters, output);
+
+        // then
+        assertThat(logger1.getLevel()).isEqualTo(Level.DEBUG);
+        assertThat(logger2.getLevel()).isEqualTo(DEFAULT_LEVEL);
+
+        assertThat(stringWriter.toString()).isEqualTo("Configured logging level for logger.one to DEBUG\n");
+    }
+
+    @Test
+    public void configuresDefaultLevelForALogger() throws Exception {
+        // given
+        ImmutableMultimap<String, String> parameters = ImmutableMultimap.of(
+                "logger", "logger.one");
+
+        // when
+        task.execute(parameters, output);
+
+        // then
+        assertThat(logger1.getLevel()).isNull();
+        assertThat(logger2.getLevel()).isEqualTo(DEFAULT_LEVEL);
+
+        assertThat(stringWriter.toString()).isEqualTo("Configured logging level for logger.one to null\n");
+    }
+
+    @Test
+    public void configuresLevelForMultipleLoggers() throws Exception {
+        // given
+        ImmutableMultimap<String, String> parameters = ImmutableMultimap.of(
+                "logger", "logger.one",
+                "logger", "logger.two",
+                "level", "INFO");
+
+        // when
+        task.execute(parameters, output);
+
+        // then
+        assertThat(logger1.getLevel()).isEqualTo(Level.INFO);
+        assertThat(logger2.getLevel()).isEqualTo(Level.INFO);
+
+        assertThat(stringWriter.toString()).isEqualTo(
+                "Configured logging level for logger.one to INFO\n" +
+                        "Configured logging level for logger.two to INFO\n");
+    }
+}

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/tasks/LogConfigurationTaskTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/tasks/LogConfigurationTaskTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 Stuart Gunter
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
-
 package io.dropwizard.logging.tasks;
 
 import ch.qos.logback.classic.Level;


### PR DESCRIPTION
Logback provides a `JmxConfigurator` for changing logging levels at runtime, but this does not currently appear to be exposed in a Dropwizard-friendly manner. I didn't want to simply use the JMX approach, as that would introduce an inconsistency in managing my DW apps (everything else is managed via config or HTTP access).

I created a `Task` implementation that essentially does the same as Logback's `JmxConfigurator` and provided this via an external library (see https://github.com/stuartgunter/dropwizard-logging-config), but feel it would be appropriate to include in the main DW library. (If there's no appetite for including this in DW, I'd be happy maintaining the library separately.)

I'm not comfortable with the way it has been included, but haven't yet come up with a nice way of doing it. I would appreciate feedback (assuming there's interest in bringing this into DW) on how it should be included at a package / module level. The summary of my concerns is:

* `Task` is defined in `dropwizard-servlets`
* `Logback` is only explicitly included in `dropwizard-logging`
* The `LogConfigurationTask` straddles both of these modules due to its dependency on both Logback and `Task`
* I don't want to create a separate Maven module just for this one class, but I don't believe it truly fits in either `dropwizard-logging` or `dropwizard-servlets`
* Would it be worth relocating `Tasks` to somewhere else (they may be used by `dropwizard-servlets` but there's nothing Servlet-specific about them - they're not all that different from named runnables with predefined method args)

Feedback would be very welcome.