### PR TITLE
Replaced JSON parsing error with a simple one

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapper.java
@@ -41,7 +41,7 @@ public class JsonProcessingExceptionMapper implements ExceptionMapper<JsonProces
         LOGGER.debug("Unable to process JSON", exception);
         return Response.status(Response.Status.BAD_REQUEST)
                        .entity(new ErrorMessage(Response.Status.BAD_REQUEST.getStatusCode(),
-                               message))
+                               "Unable to process JSON"))
                        .build();
     }
 }


### PR DESCRIPTION
In order to not give unnecessary information to a potential attacker.
Issue #691.
