### PR TITLE
Add unit tests to SQL exception mappers in dropwizard-jdbi

### DIFF
--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/jersey/LoggingDBIExceptionMapper.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/jersey/LoggingDBIExceptionMapper.java
@@ -1,5 +1,6 @@
 package io.dropwizard.jdbi.jersey;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.jersey.errors.LoggingExceptionMapper;
 import org.skife.jdbi.v2.exceptions.DBIException;
 import org.slf4j.Logger;
@@ -13,17 +14,22 @@ import java.sql.SQLException;
  */
 @Provider
 public class LoggingDBIExceptionMapper extends LoggingExceptionMapper<DBIException> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(LoggingDBIExceptionMapper.class);
+    private static Logger logger = LoggerFactory.getLogger(LoggingDBIExceptionMapper.class);
 
     @Override
     protected void logException(long id, DBIException exception) {
         final Throwable cause = exception.getCause();
         if (cause instanceof SQLException) {
-            for (Throwable throwable : (SQLException)cause) {
-                LOGGER.error(formatLogMessage(id, throwable), throwable);
+            for (Throwable throwable : (SQLException) cause) {
+                logger.error(formatLogMessage(id, throwable), throwable);
             }
         } else {
-            LOGGER.error(formatLogMessage(id, exception), exception);
+            logger.error(formatLogMessage(id, exception), exception);
         }
+    }
+
+    @VisibleForTesting
+    static void setLogger(Logger newLogger) {
+        logger = newLogger;
     }
 }

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/jersey/LoggingSQLExceptionMapper.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/jersey/LoggingSQLExceptionMapper.java
@@ -1,5 +1,6 @@
 package io.dropwizard.jdbi.jersey;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.jersey.errors.LoggingExceptionMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,13 +13,18 @@ import java.sql.SQLException;
  */
 @Provider
 public class LoggingSQLExceptionMapper extends LoggingExceptionMapper<SQLException> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(LoggingSQLExceptionMapper.class);
+    private static Logger logger = LoggerFactory.getLogger(LoggingSQLExceptionMapper.class);
 
     @Override
     protected void logException(long id, SQLException exception) {
         final String message = formatLogMessage(id, exception);
         for (Throwable throwable : exception) {
-            LOGGER.error(message, throwable);
+            logger.error(message, throwable);
         }
+    }
+
+    @VisibleForTesting
+    static void setLogger(Logger newLogger){
+       logger = newLogger;
     }
 }

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/bundles/DBIExceptionsBundleTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/bundles/DBIExceptionsBundleTest.java
@@ -1,0 +1,24 @@
+package io.dropwizard.jdbi.bundles;
+
+import io.dropwizard.jdbi.jersey.LoggingDBIExceptionMapper;
+import io.dropwizard.jdbi.jersey.LoggingSQLExceptionMapper;
+import io.dropwizard.jersey.setup.JerseyEnvironment;
+import io.dropwizard.setup.Environment;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+public class DBIExceptionsBundleTest {
+
+    @Test
+    public void test() {
+        Environment environment = mock(Environment.class);
+        JerseyEnvironment jerseyEnvironment = mock(JerseyEnvironment.class);
+        when(environment.jersey()).thenReturn(jerseyEnvironment);
+
+        new DBIExceptionsBundle().run(environment);
+
+        verify(jerseyEnvironment, times(1)).register(isA(LoggingSQLExceptionMapper.class));
+        verify(jerseyEnvironment, times(1)).register(isA(LoggingDBIExceptionMapper.class));
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/jersey/LoggingDBIExceptionMapperTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/jersey/LoggingDBIExceptionMapperTest.java
@@ -1,0 +1,49 @@
+package io.dropwizard.jdbi.jersey;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.exceptions.DBIException;
+import org.skife.jdbi.v2.exceptions.NoResultsException;
+import org.skife.jdbi.v2.exceptions.TransactionFailedException;
+import org.slf4j.Logger;
+
+import java.sql.SQLException;
+
+import static org.mockito.Mockito.*;
+
+public class LoggingDBIExceptionMapperTest {
+
+    LoggingDBIExceptionMapper dbiExceptionMapper;
+    Logger logger;
+
+    @Before
+    public void setUp() throws Exception {
+        logger = mock(Logger.class);
+        dbiExceptionMapper = new LoggingDBIExceptionMapper();
+        LoggingDBIExceptionMapper.setLogger(logger);
+    }
+
+    @Test
+    public void testSqlExceptionIsCause() throws Exception {
+        StatementContext statementContext = mock(StatementContext.class);
+        RuntimeException runtimeException = new RuntimeException("DB is down");
+        SQLException sqlException = new SQLException("DB error", runtimeException);
+        DBIException dbiException = new NoResultsException("Unable get a result set", sqlException, statementContext);
+
+        dbiExceptionMapper.logException(9812, dbiException);
+
+        verify(logger).error("Error handling a request: 0000000000002654", sqlException);
+        verify(logger).error("Error handling a request: 0000000000002654", runtimeException);
+        verify(logger, never()).error("Error handling a request: 0000000000002654", dbiException);
+    }
+
+    @Test
+    public void testPlainDBIException() throws Exception {
+        DBIException dbiException = new TransactionFailedException("Transaction failed for unknown reason");
+
+        dbiExceptionMapper.logException(9812, dbiException);
+
+        verify(logger).error("Error handling a request: 0000000000002654", dbiException);
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/jersey/LoggingSQLExceptionMapperTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/jersey/LoggingSQLExceptionMapperTest.java
@@ -1,0 +1,26 @@
+package io.dropwizard.jdbi.jersey;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+
+import java.sql.SQLException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class LoggingSQLExceptionMapperTest {
+
+    @Test
+    public void testLogException() throws Exception {
+        Logger logger = mock(Logger.class);
+        LoggingSQLExceptionMapper sqlExceptionMapper = new LoggingSQLExceptionMapper();
+        LoggingSQLExceptionMapper.setLogger(logger);
+
+        RuntimeException runtimeException = new RuntimeException("DB is down");
+        SQLException sqlException = new SQLException("DB error", runtimeException);
+        sqlExceptionMapper.logException(4981, sqlException);
+
+        verify(logger).error("Error handling a request: 0000000000001375", sqlException);
+        verify(logger).error("Error handling a request: 0000000000001375", runtimeException);
+    }
+}


### PR DESCRIPTION
Some unit tests for JDBI exception mappers. 
They check that we log correct things when an exception from JDBI ocurrs.
