### PR TITLE
DefaultServerFactoryTest#testGracefulShutdown works as expected

### DIFF
--- a/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
@@ -83,7 +83,6 @@ public class DefaultServerFactoryTest {
                 .contains(DefaultServerFactory.class);
     }
 
-    @Ignore("Issue #648: Test is flaky and should be re-activated after upgrade to Jetty 9.1 or higher.")
     @Test
     public void testGracefulShutdown() throws Exception {
         ObjectMapper objectMapper = Jackson.newObjectMapper();


### PR DESCRIPTION
After upgrading to Jersey 2.11 in #706  and to Jetty 9.2.3 in #453 this test works as expected. 
I can't reproduce the issue.

``` java
    @Test
    public void testManyGracefulShutdowns() {
        int successes = 0;
        int fails = 0;
        for (int i = 0; i < 1000; i++) {
            try {
                testGracefulShutdown();
                successes++;
            } catch (Exception e) {
                e.printStackTrace();
                fails++;
            }
        }
        System.out.printf("%d successes. %d fails", successes, fails);
    }
```

```
1000 successes. 0 fails
```

As I beleive, Jersey 1.\* is to blame, because I didn't reproduce this issue with Jersey 2.11 and Jetty 9.0.7
