### PR TITLE
Instead of IOException which has to be handled by the developer, an unch...

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/FixtureHelpers.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/FixtureHelpers.java
@@ -18,9 +18,9 @@ public class FixtureHelpers {
      *
      * @param filename    the filename of the fixture file
      * @return the contents of {@code src/test/resources/{filename}}
-     * @throws IOException if {@code filename} doesn't exist or can't be opened
+     * @throws IllegalStateException if {@code filename} doesn't exist or can't be opened
      */
-    public static String fixture(String filename) throws IOException {
+    public static String fixture(String filename) {
         return fixture(filename, Charsets.UTF_8);
     }
 
@@ -31,9 +31,13 @@ public class FixtureHelpers {
      * @param filename    the filename of the fixture file
      * @param charset     the character set of {@code filename}
      * @return the contents of {@code src/test/resources/{filename}}
-     * @throws IOException if {@code filename} doesn't exist or can't be opened
+     * @throws IllegalStateException if {@code filename} doesn't exist or can't be opened
      */
-    private static String fixture(String filename, Charset charset) throws IOException {
-        return Resources.toString(Resources.getResource(filename), charset).trim();
+    private static String fixture(String filename, Charset charset) {
+        try {
+            return Resources.toString(Resources.getResource(filename), charset).trim();
+        } catch (IllegalArgumentException | IOException e) {
+            throw new IllegalStateException(e);
+        }
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/FixtureHelpersTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/FixtureHelpersTest.java
@@ -1,14 +1,25 @@
 package io.dropwizard.testing;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class FixtureHelpersTest {
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
     @Test
-    public void readsTheFileAsAString() throws Exception {
-        assertThat(fixture("fixtures/fixture.txt"))
-                .isEqualTo("YAY FOR ME");
+    public void readsTheFileAsAString() {
+        assertThat(fixture("fixtures/fixture.txt")).isEqualTo("YAY FOR ME");
+    }
+
+    @Test
+    public void throwsIllegalStateExceptionWhenFileDoesNotExist() {
+        thrown.expect(IllegalStateException.class);
+        fixture("this-does-not-exist.foo");
     }
 }


### PR DESCRIPTION
...ecked exception is sufficient and makes it easier to statically create fixtures used in more than one test case.

Also, the existing documentation was wrong, when the resource does not exist, fixture() threw an IllegalArgumentException (Preconditions.checkArgument) not an IOException as stated in the javadoc.

This fixes #723.
