### PR TITLE
Let the Application.run(String[]) method accept String...

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/Application.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/Application.java
@@ -64,7 +64,7 @@ public abstract class Application<T extends Configuration> {
      * @param arguments the command-line arguments
      * @throws Exception if something goes wrong
      */
-    public final void run(String[] arguments) throws Exception {
+    public final void run(String... arguments) throws Exception {
         final Bootstrap<T> bootstrap = new Bootstrap<>(this);
         bootstrap.addCommand(new ServerCommand<>(this));
         bootstrap.addCommand(new CheckCommand<>(this));


### PR DESCRIPTION
This makes it easier to redirect execution from main(String... args) when calling the application programatically. Imagine

```
 // my test runner
 public static void main(String... args) {
    MyRealApplication.main("server","path-to-yaml");
    // instead of ...main(new String[]{"server","..."});
 }
```
