### PR TITLE
move dependency commons-lang3 to dropwizard-util

### DIFF
--- a/dropwizard-configuration/pom.xml
+++ b/dropwizard-configuration/pom.xml
@@ -27,10 +27,5 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>${jackson.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.3.2</version>
-        </dependency>
     </dependencies>
 </project>

--- a/dropwizard-util/pom.xml
+++ b/dropwizard-util/pom.xml
@@ -11,6 +11,12 @@
     <artifactId>dropwizard-util</artifactId>
     <name>Dropwizard Utility Classes</name>
 
+    <properties>
+        <jsr305.version>3.0.0</jsr305.version>
+        <joda-time.version>2.5</joda-time.version>
+        <commons-lang3.version>3.3.2</commons-lang3.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -25,12 +31,17 @@
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-            <version>3.0.0</version>
+            <version>${jsr305.version}</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.5</version>
+            <version>${joda-time.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
commons-lang3 is used by dw-configuration and thus ends up in the shaded jar anyway. By moving it to util, other modules can benefit from having StringUtils, DateUtils ... on the classpath without changing the resulting artefact.
