### PR TITLE
Remove assets bundle documentation that is no longer valid.

### DIFF
--- a/0.7.1/docs/_sources/manual/core.txt
+++ b/0.7.1/docs/_sources/manual/core.txt
@@ -391,27 +391,6 @@ require your application's ``Configuration`` subclass to implement a specific in
 Serving Assets
 --------------
 
-Either your application or your static assets can be served from the root path, but
-not both. The latter is useful when using Dropwizard to back a Javascript
-application. To enable it, move your application to a sub-URL.
-
-.. code-block:: yaml
-
-    server:
-      type: simple
-      applicationContextPath: /application/*  # Default value*
-
-Then use an extended ``AssetsBundle`` constructor to serve resources in the
-``assets`` folder from the root path. ``index.htm`` is served as the default
-page.
-
-.. code-block:: java
-
-    @Override
-    public void initialize(Bootstrap<HelloWorldConfiguration> bootstrap) {
-        bootstrap.addBundle(new AssetsBundle("/assets/", "/"));
-    }
-
 When an ``AssetBundle`` is added to the application, it is registered as a servlet
 using a default name of ``assets``. If the application needs to have multiple ``AssetBundle``
 instances, the extended constructor should be used to specify a unique name for the ``AssetBundle``.

--- a/0.7.1/docs/manual/core.html
+++ b/0.7.1/docs/manual/core.html
@@ -466,23 +466,6 @@ application.</p>
 require your application&#8217;s <tt class="docutils literal"><span class="pre">Configuration</span></tt> subclass to implement a specific interface.</p>
 <div class="section" id="serving-assets">
 <h3>Serving Assets</h3>
-<p>Either your application or your static assets can be served from the root path, but
-not both. The latter is useful when using Dropwizard to back a Javascript
-application. To enable it, move your application to a sub-URL.</p>
-<div class="highlight-yaml"><div class="highlight"><pre><span class="l-Scalar-Plain">server</span><span class="p-Indicator">:</span>
-  <span class="l-Scalar-Plain">type</span><span class="p-Indicator">:</span> <span class="l-Scalar-Plain">simple</span>
-  <span class="l-Scalar-Plain">applicationContextPath</span><span class="p-Indicator">:</span> <span class="l-Scalar-Plain">/application/*</span>  <span class="c1"># Default value*</span>
-</pre></div>
-</div>
-<p>Then use an extended <tt class="docutils literal"><span class="pre">AssetsBundle</span></tt> constructor to serve resources in the
-<tt class="docutils literal"><span class="pre">assets</span></tt> folder from the root path. <tt class="docutils literal"><span class="pre">index.htm</span></tt> is served as the default
-page.</p>
-<div class="highlight-java"><div class="highlight"><pre><span class="nd">@Override</span>
-<span class="kd">public</span> <span class="kt">void</span> <span class="nf">initialize</span><span class="o">(</span><span class="n">Bootstrap</span><span class="o">&lt;</span><span class="n">HelloWorldConfiguration</span><span class="o">&gt;</span> <span class="n">bootstrap</span><span class="o">)</span> <span class="o">{</span>
-    <span class="n">bootstrap</span><span class="o">.</span><span class="na">addBundle</span><span class="o">(</span><span class="k">new</span> <span class="n">AssetsBundle</span><span class="o">(</span><span class="s">&quot;/assets/&quot;</span><span class="o">,</span> <span class="s">&quot;/&quot;</span><span class="o">));</span>
-<span class="o">}</span>
-</pre></div>
-</div>
 <p>When an <tt class="docutils literal"><span class="pre">AssetBundle</span></tt> is added to the application, it is registered as a servlet
 using a default name of <tt class="docutils literal"><span class="pre">assets</span></tt>. If the application needs to have multiple <tt class="docutils literal"><span class="pre">AssetBundle</span></tt>
 instances, the extended constructor should be used to specify a unique name for the <tt class="docutils literal"><span class="pre">AssetBundle</span></tt>.</p>

--- a/_sources/manual/core.txt
+++ b/_sources/manual/core.txt
@@ -391,27 +391,6 @@ require your application's ``Configuration`` subclass to implement a specific in
 Serving Assets
 --------------
 
-Either your application or your static assets can be served from the root path, but
-not both. The latter is useful when using Dropwizard to back a Javascript
-application. To enable it, move your application to a sub-URL.
-
-.. code-block:: yaml
-
-    server:
-      type: simple
-      applicationContextPath: /application/*  # Default value*
-
-Then use an extended ``AssetsBundle`` constructor to serve resources in the
-``assets`` folder from the root path. ``index.htm`` is served as the default
-page.
-
-.. code-block:: java
-
-    @Override
-    public void initialize(Bootstrap<HelloWorldConfiguration> bootstrap) {
-        bootstrap.addBundle(new AssetsBundle("/assets/", "/"));
-    }
-
 When an ``AssetBundle`` is added to the application, it is registered as a servlet
 using a default name of ``assets``. If the application needs to have multiple ``AssetBundle``
 instances, the extended constructor should be used to specify a unique name for the ``AssetBundle``.

--- a/manual/core.html
+++ b/manual/core.html
@@ -466,23 +466,6 @@ application.</p>
 require your application&#8217;s <tt class="docutils literal"><span class="pre">Configuration</span></tt> subclass to implement a specific interface.</p>
 <div class="section" id="serving-assets">
 <h3>Serving Assets</h3>
-<p>Either your application or your static assets can be served from the root path, but
-not both. The latter is useful when using Dropwizard to back a Javascript
-application. To enable it, move your application to a sub-URL.</p>
-<div class="highlight-yaml"><div class="highlight"><pre><span class="l-Scalar-Plain">server</span><span class="p-Indicator">:</span>
-  <span class="l-Scalar-Plain">type</span><span class="p-Indicator">:</span> <span class="l-Scalar-Plain">simple</span>
-  <span class="l-Scalar-Plain">applicationContextPath</span><span class="p-Indicator">:</span> <span class="l-Scalar-Plain">/application/*</span>  <span class="c1"># Default value*</span>
-</pre></div>
-</div>
-<p>Then use an extended <tt class="docutils literal"><span class="pre">AssetsBundle</span></tt> constructor to serve resources in the
-<tt class="docutils literal"><span class="pre">assets</span></tt> folder from the root path. <tt class="docutils literal"><span class="pre">index.htm</span></tt> is served as the default
-page.</p>
-<div class="highlight-java"><div class="highlight"><pre><span class="nd">@Override</span>
-<span class="kd">public</span> <span class="kt">void</span> <span class="nf">initialize</span><span class="o">(</span><span class="n">Bootstrap</span><span class="o">&lt;</span><span class="n">HelloWorldConfiguration</span><span class="o">&gt;</span> <span class="n">bootstrap</span><span class="o">)</span> <span class="o">{</span>
-    <span class="n">bootstrap</span><span class="o">.</span><span class="na">addBundle</span><span class="o">(</span><span class="k">new</span> <span class="n">AssetsBundle</span><span class="o">(</span><span class="s">&quot;/assets/&quot;</span><span class="o">,</span> <span class="s">&quot;/&quot;</span><span class="o">));</span>
-<span class="o">}</span>
-</pre></div>
-</div>
 <p>When an <tt class="docutils literal"><span class="pre">AssetBundle</span></tt> is added to the application, it is registered as a servlet
 using a default name of <tt class="docutils literal"><span class="pre">assets</span></tt>. If the application needs to have multiple <tt class="docutils literal"><span class="pre">AssetBundle</span></tt>
 instances, the extended constructor should be used to specify a unique name for the <tt class="docutils literal"><span class="pre">AssetBundle</span></tt>.</p>


### PR DESCRIPTION
Removing this invalid documentation per the commonly reported issues:
#661, #662, #676, and bazaarvoice/dropwizard-configurable-assets-bundle#28
