### PR TITLE
Remove reflection hacks for AsyncAppender

### DIFF
--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/SyslogAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/SyslogAppenderFactoryTest.java
@@ -5,6 +5,7 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.net.SyslogAppender;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
+import ch.qos.logback.classic.AsyncAppender;
 import ch.qos.logback.core.AsyncAppenderBase;
 import ch.qos.logback.core.spi.AppenderAttachableImpl;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
@@ -36,33 +37,20 @@ public class SyslogAppenderFactoryTest {
 
     @Test
     public void patternIncludesAppNameAndPid() throws Exception {
-        Appender<ILoggingEvent> wrapper = new SyslogAppenderFactory()
+        final AsyncAppender wrapper = (AsyncAppender) new SyslogAppenderFactory()
                 .build(new LoggerContext(), "MyApplication", null);
-
-        // hack to get at the SyslogAppender beneath the AsyncAppender
-        // todo: find a nicer way to do all this
-        Field delegate = AsyncAppenderBase.class.getDeclaredField("aai");
-        delegate.setAccessible(true);
-        SyslogAppender appender = (SyslogAppender) ((AppenderAttachableImpl) delegate.get(wrapper)).iteratorForAppenders().next();
-
-        assertThat(appender.getSuffixPattern())
+        assertThat(((SyslogAppender) wrapper.getAppender("syslog-appender")).getSuffixPattern())
                 .matches("^MyApplication\\[\\d+\\].+");
     }
 
     @Test
     public void stackTracePatternCanBeSet() throws Exception {
-        SyslogAppenderFactory syslogAppenderFactory = new SyslogAppenderFactory();
+        final SyslogAppenderFactory syslogAppenderFactory = new SyslogAppenderFactory();
         syslogAppenderFactory.setStackTracePrefix("--->");
-        Appender<ILoggingEvent> wrapper = syslogAppenderFactory.build(new LoggerContext(), "MyApplication", null);
-
-        // hack to get at the SyslogAppender beneath the AsyncAppender
-        // todo: find a nicer way to do all this
-        Field delegate = AsyncAppenderBase.class.getDeclaredField("aai");
-        delegate.setAccessible(true);
-        SyslogAppender appender = (SyslogAppender) ((AppenderAttachableImpl) delegate.get(wrapper)).iteratorForAppenders().next();
-
-        assertThat(appender.getStackTracePattern())
-                .isEqualTo("--->");
+        final AsyncAppender wrapper = (AsyncAppender) syslogAppenderFactory
+                .build(new LoggerContext(), "MyApplication", null);
+        assertThat(((SyslogAppender) wrapper.getAppender("syslog-appender"))
+                .getStackTracePattern()).isEqualTo("--->");
     }
 
     @Test


### PR DESCRIPTION
Now wrapper is not Dropwizard `AsyncAppender` but logback `AsyncAppender`. 
So we can use directly to access the syslog appender
