### PR TITLE
Size now implements Comparable

### DIFF
--- a/dropwizard-util/src/main/java/io/dropwizard/util/Size.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Size.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public class Size {
+public class Size implements Comparable<Size> {
     private static final Pattern SIZE_PATTERN = Pattern.compile("(\\d+)\\s*(\\S+)");
 
     private static final Map<String, SizeUnit> SUFFIXES = new ImmutableMap.Builder<String, SizeUnit>()
@@ -128,5 +128,28 @@ public class Size {
             units = units.substring(0, units.length() - 1);
         }
         return Long.toString(count) + ' ' + units;
+    }
+
+    @Override
+    public int compareTo(Size other) {
+        if (count == 0 && other.count == 0) {
+            return 0;
+        }
+
+        // this is negative, other is non-negative
+        if (count < 0 && other.count >= 0) {
+            return -1;
+        }
+
+        // this is non-negative, other is negative
+        if (count >= 0 && other.count < 0) {
+            return 1;
+        }
+
+        if (unit == other.unit) {
+            return Long.compare(count, other.count);
+        }
+
+        return Long.compare(toBytes(), other.toBytes());
     }
 }

--- a/dropwizard-util/src/test/java/io/dropwizard/util/SizeTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/SizeTest.java
@@ -148,4 +148,343 @@ public class SizeTest {
         assertThat(Size.gigabytes(3).getUnit())
                 .isEqualTo(SizeUnit.GIGABYTES);
     }
+
+    @Test
+    public void isComparable() throws Exception {
+        // both zero
+        assertThat(Size.bytes(0).compareTo(Size.bytes(0))).isEqualTo(0);
+        assertThat(Size.bytes(0).compareTo(Size.kilobytes(0))).isEqualTo(0);
+        assertThat(Size.bytes(0).compareTo(Size.megabytes(0))).isEqualTo(0);
+        assertThat(Size.bytes(0).compareTo(Size.gigabytes(0))).isEqualTo(0);
+        assertThat(Size.bytes(0).compareTo(Size.terabytes(0))).isEqualTo(0);
+
+        assertThat(Size.kilobytes(0).compareTo(Size.bytes(0))).isEqualTo(0);
+        assertThat(Size.kilobytes(0).compareTo(Size.kilobytes(0))).isEqualTo(0);
+        assertThat(Size.kilobytes(0).compareTo(Size.megabytes(0))).isEqualTo(0);
+        assertThat(Size.kilobytes(0).compareTo(Size.gigabytes(0))).isEqualTo(0);
+        assertThat(Size.kilobytes(0).compareTo(Size.terabytes(0))).isEqualTo(0);
+
+        assertThat(Size.megabytes(0).compareTo(Size.bytes(0))).isEqualTo(0);
+        assertThat(Size.megabytes(0).compareTo(Size.kilobytes(0))).isEqualTo(0);
+        assertThat(Size.megabytes(0).compareTo(Size.megabytes(0))).isEqualTo(0);
+        assertThat(Size.megabytes(0).compareTo(Size.gigabytes(0))).isEqualTo(0);
+        assertThat(Size.megabytes(0).compareTo(Size.terabytes(0))).isEqualTo(0);
+
+        assertThat(Size.gigabytes(0).compareTo(Size.bytes(0))).isEqualTo(0);
+        assertThat(Size.gigabytes(0).compareTo(Size.kilobytes(0))).isEqualTo(0);
+        assertThat(Size.gigabytes(0).compareTo(Size.megabytes(0))).isEqualTo(0);
+        assertThat(Size.gigabytes(0).compareTo(Size.gigabytes(0))).isEqualTo(0);
+        assertThat(Size.gigabytes(0).compareTo(Size.terabytes(0))).isEqualTo(0);
+
+        assertThat(Size.terabytes(0).compareTo(Size.bytes(0))).isEqualTo(0);
+        assertThat(Size.terabytes(0).compareTo(Size.kilobytes(0))).isEqualTo(0);
+        assertThat(Size.terabytes(0).compareTo(Size.megabytes(0))).isEqualTo(0);
+        assertThat(Size.terabytes(0).compareTo(Size.gigabytes(0))).isEqualTo(0);
+        assertThat(Size.terabytes(0).compareTo(Size.terabytes(0))).isEqualTo(0);
+
+        // one zero, one negative
+        assertThat(Size.bytes(0)).isGreaterThan(Size.bytes(-1));
+        assertThat(Size.bytes(0)).isGreaterThan(Size.kilobytes(-1));
+        assertThat(Size.bytes(0)).isGreaterThan(Size.megabytes(-1));
+        assertThat(Size.bytes(0)).isGreaterThan(Size.gigabytes(-1));
+        assertThat(Size.bytes(0)).isGreaterThan(Size.terabytes(-1));
+
+        assertThat(Size.kilobytes(0)).isGreaterThan(Size.bytes(-1));
+        assertThat(Size.kilobytes(0)).isGreaterThan(Size.kilobytes(-1));
+        assertThat(Size.kilobytes(0)).isGreaterThan(Size.megabytes(-1));
+        assertThat(Size.kilobytes(0)).isGreaterThan(Size.gigabytes(-1));
+        assertThat(Size.kilobytes(0)).isGreaterThan(Size.terabytes(-1));
+
+        assertThat(Size.megabytes(0)).isGreaterThan(Size.bytes(-1));
+        assertThat(Size.megabytes(0)).isGreaterThan(Size.kilobytes(-1));
+        assertThat(Size.megabytes(0)).isGreaterThan(Size.megabytes(-1));
+        assertThat(Size.megabytes(0)).isGreaterThan(Size.gigabytes(-1));
+        assertThat(Size.megabytes(0)).isGreaterThan(Size.terabytes(-1));
+
+        assertThat(Size.gigabytes(0)).isGreaterThan(Size.bytes(-1));
+        assertThat(Size.gigabytes(0)).isGreaterThan(Size.kilobytes(-1));
+        assertThat(Size.gigabytes(0)).isGreaterThan(Size.megabytes(-1));
+        assertThat(Size.gigabytes(0)).isGreaterThan(Size.gigabytes(-1));
+        assertThat(Size.gigabytes(0)).isGreaterThan(Size.terabytes(-1));
+
+        assertThat(Size.terabytes(0)).isGreaterThan(Size.bytes(-1));
+        assertThat(Size.terabytes(0)).isGreaterThan(Size.kilobytes(-1));
+        assertThat(Size.terabytes(0)).isGreaterThan(Size.megabytes(-1));
+        assertThat(Size.terabytes(0)).isGreaterThan(Size.gigabytes(-1));
+        assertThat(Size.terabytes(0)).isGreaterThan(Size.terabytes(-1));
+
+        assertThat(Size.bytes(-1)).isLessThan(Size.bytes(0));
+        assertThat(Size.bytes(-1)).isLessThan(Size.kilobytes(0));
+        assertThat(Size.bytes(-1)).isLessThan(Size.megabytes(0));
+        assertThat(Size.bytes(-1)).isLessThan(Size.gigabytes(0));
+        assertThat(Size.bytes(-1)).isLessThan(Size.terabytes(0));
+
+        assertThat(Size.kilobytes(-1)).isLessThan(Size.bytes(0));
+        assertThat(Size.kilobytes(-1)).isLessThan(Size.kilobytes(0));
+        assertThat(Size.kilobytes(-1)).isLessThan(Size.megabytes(0));
+        assertThat(Size.kilobytes(-1)).isLessThan(Size.gigabytes(0));
+        assertThat(Size.kilobytes(-1)).isLessThan(Size.terabytes(0));
+
+        assertThat(Size.megabytes(-1)).isLessThan(Size.bytes(0));
+        assertThat(Size.megabytes(-1)).isLessThan(Size.kilobytes(0));
+        assertThat(Size.megabytes(-1)).isLessThan(Size.megabytes(0));
+        assertThat(Size.megabytes(-1)).isLessThan(Size.gigabytes(0));
+        assertThat(Size.megabytes(-1)).isLessThan(Size.terabytes(0));
+
+        assertThat(Size.gigabytes(-1)).isLessThan(Size.bytes(0));
+        assertThat(Size.gigabytes(-1)).isLessThan(Size.kilobytes(0));
+        assertThat(Size.gigabytes(-1)).isLessThan(Size.megabytes(0));
+        assertThat(Size.gigabytes(-1)).isLessThan(Size.gigabytes(0));
+        assertThat(Size.gigabytes(-1)).isLessThan(Size.terabytes(0));
+
+        assertThat(Size.terabytes(-1)).isLessThan(Size.bytes(0));
+        assertThat(Size.terabytes(-1)).isLessThan(Size.kilobytes(0));
+        assertThat(Size.terabytes(-1)).isLessThan(Size.megabytes(0));
+        assertThat(Size.terabytes(-1)).isLessThan(Size.gigabytes(0));
+        assertThat(Size.terabytes(-1)).isLessThan(Size.terabytes(0));
+
+        // one zero, one positive
+        assertThat(Size.bytes(0)).isLessThan(Size.bytes(1));
+        assertThat(Size.bytes(0)).isLessThan(Size.kilobytes(1));
+        assertThat(Size.bytes(0)).isLessThan(Size.megabytes(1));
+        assertThat(Size.bytes(0)).isLessThan(Size.gigabytes(1));
+        assertThat(Size.bytes(0)).isLessThan(Size.terabytes(1));
+
+        assertThat(Size.kilobytes(0)).isLessThan(Size.bytes(1));
+        assertThat(Size.kilobytes(0)).isLessThan(Size.kilobytes(1));
+        assertThat(Size.kilobytes(0)).isLessThan(Size.megabytes(1));
+        assertThat(Size.kilobytes(0)).isLessThan(Size.gigabytes(1));
+        assertThat(Size.kilobytes(0)).isLessThan(Size.terabytes(1));
+
+        assertThat(Size.megabytes(0)).isLessThan(Size.bytes(1));
+        assertThat(Size.megabytes(0)).isLessThan(Size.kilobytes(1));
+        assertThat(Size.megabytes(0)).isLessThan(Size.megabytes(1));
+        assertThat(Size.megabytes(0)).isLessThan(Size.gigabytes(1));
+        assertThat(Size.megabytes(0)).isLessThan(Size.terabytes(1));
+
+        assertThat(Size.gigabytes(0)).isLessThan(Size.bytes(1));
+        assertThat(Size.gigabytes(0)).isLessThan(Size.kilobytes(1));
+        assertThat(Size.gigabytes(0)).isLessThan(Size.megabytes(1));
+        assertThat(Size.gigabytes(0)).isLessThan(Size.gigabytes(1));
+        assertThat(Size.gigabytes(0)).isLessThan(Size.terabytes(1));
+
+        assertThat(Size.terabytes(0)).isLessThan(Size.bytes(1));
+        assertThat(Size.terabytes(0)).isLessThan(Size.kilobytes(1));
+        assertThat(Size.terabytes(0)).isLessThan(Size.megabytes(1));
+        assertThat(Size.terabytes(0)).isLessThan(Size.gigabytes(1));
+        assertThat(Size.terabytes(0)).isLessThan(Size.terabytes(1));
+
+        assertThat(Size.bytes(1)).isGreaterThan(Size.bytes(0));
+        assertThat(Size.bytes(1)).isGreaterThan(Size.kilobytes(0));
+        assertThat(Size.bytes(1)).isGreaterThan(Size.megabytes(0));
+        assertThat(Size.bytes(1)).isGreaterThan(Size.gigabytes(0));
+        assertThat(Size.bytes(1)).isGreaterThan(Size.terabytes(0));
+
+        assertThat(Size.kilobytes(1)).isGreaterThan(Size.bytes(0));
+        assertThat(Size.kilobytes(1)).isGreaterThan(Size.kilobytes(0));
+        assertThat(Size.kilobytes(1)).isGreaterThan(Size.megabytes(0));
+        assertThat(Size.kilobytes(1)).isGreaterThan(Size.gigabytes(0));
+        assertThat(Size.kilobytes(1)).isGreaterThan(Size.terabytes(0));
+
+        assertThat(Size.megabytes(1)).isGreaterThan(Size.bytes(0));
+        assertThat(Size.megabytes(1)).isGreaterThan(Size.kilobytes(0));
+        assertThat(Size.megabytes(1)).isGreaterThan(Size.megabytes(0));
+        assertThat(Size.megabytes(1)).isGreaterThan(Size.gigabytes(0));
+        assertThat(Size.megabytes(1)).isGreaterThan(Size.terabytes(0));
+
+        assertThat(Size.gigabytes(1)).isGreaterThan(Size.bytes(0));
+        assertThat(Size.gigabytes(1)).isGreaterThan(Size.kilobytes(0));
+        assertThat(Size.gigabytes(1)).isGreaterThan(Size.megabytes(0));
+        assertThat(Size.gigabytes(1)).isGreaterThan(Size.gigabytes(0));
+        assertThat(Size.gigabytes(1)).isGreaterThan(Size.terabytes(0));
+
+        assertThat(Size.terabytes(1)).isGreaterThan(Size.bytes(0));
+        assertThat(Size.terabytes(1)).isGreaterThan(Size.kilobytes(0));
+        assertThat(Size.terabytes(1)).isGreaterThan(Size.megabytes(0));
+        assertThat(Size.terabytes(1)).isGreaterThan(Size.gigabytes(0));
+        assertThat(Size.terabytes(1)).isGreaterThan(Size.terabytes(0));
+
+        // both negative
+        assertThat(Size.bytes(-2)).isLessThan(Size.bytes(-1));
+        assertThat(Size.bytes(-2)).isGreaterThan(Size.kilobytes(-1));
+        assertThat(Size.bytes(-2)).isGreaterThan(Size.megabytes(-1));
+        assertThat(Size.bytes(-2)).isGreaterThan(Size.gigabytes(-1));
+        assertThat(Size.bytes(-2)).isGreaterThan(Size.terabytes(-1));
+
+        assertThat(Size.kilobytes(-2)).isLessThan(Size.bytes(-1));
+        assertThat(Size.kilobytes(-2)).isLessThan(Size.kilobytes(-1));
+        assertThat(Size.kilobytes(-2)).isGreaterThan(Size.megabytes(-1));
+        assertThat(Size.kilobytes(-2)).isGreaterThan(Size.gigabytes(-1));
+        assertThat(Size.kilobytes(-2)).isGreaterThan(Size.terabytes(-1));
+
+        assertThat(Size.megabytes(-2)).isLessThan(Size.bytes(-1));
+        assertThat(Size.megabytes(-2)).isLessThan(Size.kilobytes(-1));
+        assertThat(Size.megabytes(-2)).isLessThan(Size.megabytes(-1));
+        assertThat(Size.megabytes(-2)).isGreaterThan(Size.gigabytes(-1));
+        assertThat(Size.megabytes(-2)).isGreaterThan(Size.terabytes(-1));
+
+        assertThat(Size.gigabytes(-2)).isLessThan(Size.bytes(-1));
+        assertThat(Size.gigabytes(-2)).isLessThan(Size.kilobytes(-1));
+        assertThat(Size.gigabytes(-2)).isLessThan(Size.megabytes(-1));
+        assertThat(Size.gigabytes(-2)).isLessThan(Size.gigabytes(-1));
+        assertThat(Size.gigabytes(-2)).isGreaterThan(Size.terabytes(-1));
+
+        assertThat(Size.terabytes(-2)).isLessThan(Size.bytes(-1));
+        assertThat(Size.terabytes(-2)).isLessThan(Size.kilobytes(-1));
+        assertThat(Size.terabytes(-2)).isLessThan(Size.megabytes(-1));
+        assertThat(Size.terabytes(-2)).isLessThan(Size.gigabytes(-1));
+        assertThat(Size.terabytes(-2)).isLessThan(Size.terabytes(-1));
+
+        assertThat(Size.bytes(-1)).isGreaterThan(Size.bytes(-2));
+        assertThat(Size.bytes(-1)).isGreaterThan(Size.kilobytes(-2));
+        assertThat(Size.bytes(-1)).isGreaterThan(Size.megabytes(-2));
+        assertThat(Size.bytes(-1)).isGreaterThan(Size.gigabytes(-2));
+        assertThat(Size.bytes(-1)).isGreaterThan(Size.terabytes(-2));
+
+        assertThat(Size.kilobytes(-1)).isLessThan(Size.bytes(-2));
+        assertThat(Size.kilobytes(-1)).isGreaterThan(Size.kilobytes(-2));
+        assertThat(Size.kilobytes(-1)).isGreaterThan(Size.megabytes(-2));
+        assertThat(Size.kilobytes(-1)).isGreaterThan(Size.gigabytes(-2));
+        assertThat(Size.kilobytes(-1)).isGreaterThan(Size.terabytes(-2));
+
+        assertThat(Size.megabytes(-1)).isLessThan(Size.bytes(-2));
+        assertThat(Size.megabytes(-1)).isLessThan(Size.kilobytes(-2));
+        assertThat(Size.megabytes(-1)).isGreaterThan(Size.megabytes(-2));
+        assertThat(Size.megabytes(-1)).isGreaterThan(Size.gigabytes(-2));
+        assertThat(Size.megabytes(-1)).isGreaterThan(Size.terabytes(-2));
+
+        assertThat(Size.gigabytes(-1)).isLessThan(Size.bytes(-2));
+        assertThat(Size.gigabytes(-1)).isLessThan(Size.kilobytes(-2));
+        assertThat(Size.gigabytes(-1)).isLessThan(Size.megabytes(-2));
+        assertThat(Size.gigabytes(-1)).isGreaterThan(Size.gigabytes(-2));
+        assertThat(Size.gigabytes(-1)).isGreaterThan(Size.terabytes(-2));
+
+        assertThat(Size.terabytes(-1)).isLessThan(Size.bytes(-2));
+        assertThat(Size.terabytes(-1)).isLessThan(Size.kilobytes(-2));
+        assertThat(Size.terabytes(-1)).isLessThan(Size.megabytes(-2));
+        assertThat(Size.terabytes(-1)).isLessThan(Size.gigabytes(-2));
+        assertThat(Size.terabytes(-1)).isGreaterThan(Size.terabytes(-2));
+
+        // both positive
+        assertThat(Size.bytes(1)).isLessThan(Size.bytes((2)));
+        assertThat(Size.bytes(1)).isLessThan(Size.kilobytes((2)));
+        assertThat(Size.bytes(1)).isLessThan(Size.megabytes((2)));
+        assertThat(Size.bytes(1)).isLessThan(Size.gigabytes((2)));
+        assertThat(Size.bytes(1)).isLessThan(Size.terabytes((2)));
+
+        assertThat(Size.kilobytes(1)).isGreaterThan(Size.bytes((2)));
+        assertThat(Size.kilobytes(1)).isLessThan(Size.kilobytes((2)));
+        assertThat(Size.kilobytes(1)).isLessThan(Size.megabytes((2)));
+        assertThat(Size.kilobytes(1)).isLessThan(Size.gigabytes((2)));
+        assertThat(Size.kilobytes(1)).isLessThan(Size.terabytes((2)));
+
+        assertThat(Size.megabytes(1)).isGreaterThan(Size.bytes((2)));
+        assertThat(Size.megabytes(1)).isGreaterThan(Size.kilobytes((2)));
+        assertThat(Size.megabytes(1)).isLessThan(Size.megabytes((2)));
+        assertThat(Size.megabytes(1)).isLessThan(Size.gigabytes((2)));
+        assertThat(Size.megabytes(1)).isLessThan(Size.terabytes((2)));
+
+        assertThat(Size.gigabytes(1)).isGreaterThan(Size.bytes((2)));
+        assertThat(Size.gigabytes(1)).isGreaterThan(Size.kilobytes((2)));
+        assertThat(Size.gigabytes(1)).isGreaterThan(Size.megabytes((2)));
+        assertThat(Size.gigabytes(1)).isLessThan(Size.gigabytes((2)));
+        assertThat(Size.gigabytes(1)).isLessThan(Size.terabytes((2)));
+
+        assertThat(Size.terabytes(1)).isGreaterThan(Size.bytes((2)));
+        assertThat(Size.terabytes(1)).isGreaterThan(Size.kilobytes((2)));
+        assertThat(Size.terabytes(1)).isGreaterThan(Size.megabytes((2)));
+        assertThat(Size.terabytes(1)).isGreaterThan(Size.gigabytes((2)));
+        assertThat(Size.terabytes(1)).isLessThan(Size.terabytes((2)));
+
+        assertThat(Size.bytes(2)).isGreaterThan(Size.bytes((1)));
+        assertThat(Size.bytes(2)).isLessThan(Size.kilobytes((1)));
+        assertThat(Size.bytes(2)).isLessThan(Size.megabytes((1)));
+        assertThat(Size.bytes(2)).isLessThan(Size.gigabytes((1)));
+        assertThat(Size.bytes(2)).isLessThan(Size.terabytes((1)));
+
+        assertThat(Size.kilobytes(2)).isGreaterThan(Size.bytes((1)));
+        assertThat(Size.kilobytes(2)).isGreaterThan(Size.kilobytes((1)));
+        assertThat(Size.kilobytes(2)).isLessThan(Size.megabytes((1)));
+        assertThat(Size.kilobytes(2)).isLessThan(Size.gigabytes((1)));
+        assertThat(Size.kilobytes(2)).isLessThan(Size.terabytes((1)));
+
+        assertThat(Size.megabytes(2)).isGreaterThan(Size.bytes((1)));
+        assertThat(Size.megabytes(2)).isGreaterThan(Size.kilobytes((1)));
+        assertThat(Size.megabytes(2)).isGreaterThan(Size.megabytes((1)));
+        assertThat(Size.megabytes(2)).isLessThan(Size.gigabytes((1)));
+        assertThat(Size.megabytes(2)).isLessThan(Size.terabytes((1)));
+
+        assertThat(Size.gigabytes(2)).isGreaterThan(Size.bytes((1)));
+        assertThat(Size.gigabytes(2)).isGreaterThan(Size.kilobytes((1)));
+        assertThat(Size.gigabytes(2)).isGreaterThan(Size.megabytes((1)));
+        assertThat(Size.gigabytes(2)).isGreaterThan(Size.gigabytes((1)));
+        assertThat(Size.gigabytes(2)).isLessThan(Size.terabytes((1)));
+
+        assertThat(Size.terabytes(2)).isGreaterThan(Size.bytes((1)));
+        assertThat(Size.terabytes(2)).isGreaterThan(Size.kilobytes((1)));
+        assertThat(Size.terabytes(2)).isGreaterThan(Size.megabytes((1)));
+        assertThat(Size.terabytes(2)).isGreaterThan(Size.gigabytes((1)));
+        assertThat(Size.terabytes(2)).isGreaterThan(Size.terabytes((1)));
+
+        // one negative, one positive
+        assertThat(Size.bytes(-1)).isLessThan(Size.bytes(1));
+        assertThat(Size.bytes(-1)).isLessThan(Size.kilobytes(1));
+        assertThat(Size.bytes(-1)).isLessThan(Size.megabytes(1));
+        assertThat(Size.bytes(-1)).isLessThan(Size.gigabytes(1));
+        assertThat(Size.bytes(-1)).isLessThan(Size.terabytes(1));
+
+        assertThat(Size.kilobytes(-1)).isLessThan(Size.bytes(1));
+        assertThat(Size.kilobytes(-1)).isLessThan(Size.kilobytes(1));
+        assertThat(Size.kilobytes(-1)).isLessThan(Size.megabytes(1));
+        assertThat(Size.kilobytes(-1)).isLessThan(Size.gigabytes(1));
+        assertThat(Size.kilobytes(-1)).isLessThan(Size.terabytes(1));
+
+        assertThat(Size.megabytes(-1)).isLessThan(Size.bytes(1));
+        assertThat(Size.megabytes(-1)).isLessThan(Size.kilobytes(1));
+        assertThat(Size.megabytes(-1)).isLessThan(Size.megabytes(1));
+        assertThat(Size.megabytes(-1)).isLessThan(Size.gigabytes(1));
+        assertThat(Size.megabytes(-1)).isLessThan(Size.terabytes(1));
+
+        assertThat(Size.gigabytes(-1)).isLessThan(Size.bytes(1));
+        assertThat(Size.gigabytes(-1)).isLessThan(Size.kilobytes(1));
+        assertThat(Size.gigabytes(-1)).isLessThan(Size.megabytes(1));
+        assertThat(Size.gigabytes(-1)).isLessThan(Size.gigabytes(1));
+        assertThat(Size.gigabytes(-1)).isLessThan(Size.terabytes(1));
+
+        assertThat(Size.terabytes(-1)).isLessThan(Size.bytes(1));
+        assertThat(Size.terabytes(-1)).isLessThan(Size.kilobytes(1));
+        assertThat(Size.terabytes(-1)).isLessThan(Size.megabytes(1));
+        assertThat(Size.terabytes(-1)).isLessThan(Size.gigabytes(1));
+        assertThat(Size.terabytes(-1)).isLessThan(Size.terabytes(1));
+
+        assertThat(Size.bytes(1)).isGreaterThan(Size.bytes(-1));
+        assertThat(Size.bytes(1)).isGreaterThan(Size.kilobytes(-1));
+        assertThat(Size.bytes(1)).isGreaterThan(Size.megabytes(-1));
+        assertThat(Size.bytes(1)).isGreaterThan(Size.gigabytes(-1));
+        assertThat(Size.bytes(1)).isGreaterThan(Size.terabytes(-1));
+
+        assertThat(Size.kilobytes(1)).isGreaterThan(Size.bytes(-1));
+        assertThat(Size.kilobytes(1)).isGreaterThan(Size.kilobytes(-1));
+        assertThat(Size.kilobytes(1)).isGreaterThan(Size.megabytes(-1));
+        assertThat(Size.kilobytes(1)).isGreaterThan(Size.gigabytes(-1));
+        assertThat(Size.kilobytes(1)).isGreaterThan(Size.terabytes(-1));
+
+        assertThat(Size.megabytes(1)).isGreaterThan(Size.bytes(-1));
+        assertThat(Size.megabytes(1)).isGreaterThan(Size.kilobytes(-1));
+        assertThat(Size.megabytes(1)).isGreaterThan(Size.megabytes(-1));
+        assertThat(Size.megabytes(1)).isGreaterThan(Size.gigabytes(-1));
+        assertThat(Size.megabytes(1)).isGreaterThan(Size.terabytes(-1));
+
+        assertThat(Size.gigabytes(1)).isGreaterThan(Size.bytes(-1));
+        assertThat(Size.gigabytes(1)).isGreaterThan(Size.kilobytes(-1));
+        assertThat(Size.gigabytes(1)).isGreaterThan(Size.megabytes(-1));
+        assertThat(Size.gigabytes(1)).isGreaterThan(Size.gigabytes(-1));
+        assertThat(Size.gigabytes(1)).isGreaterThan(Size.terabytes(-1));
+
+        assertThat(Size.terabytes(1)).isGreaterThan(Size.bytes(-1));
+        assertThat(Size.terabytes(1)).isGreaterThan(Size.kilobytes(-1));
+        assertThat(Size.terabytes(1)).isGreaterThan(Size.megabytes(-1));
+        assertThat(Size.terabytes(1)).isGreaterThan(Size.gigabytes(-1));
+        assertThat(Size.terabytes(1)).isGreaterThan(Size.terabytes(-1));
+    }
 }


### PR DESCRIPTION
This will be especially handy for Groovy, where it will allow comparisons such as `sizeA > sizeB` rather than `sizeA.toBytes() > sizeB.toBytes()`.
