### PR TITLE
Upgrading mustache

### DIFF
--- a/dropwizard-views-mustache/pom.xml
+++ b/dropwizard-views-mustache/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.github.spullara.mustache.java</groupId>
             <artifactId>compiler</artifactId>
-            <version>0.8.16</version>
+            <version>0.8.17</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>


### PR DESCRIPTION
This removed the scala extensions (now part of com.github.spullara.mustache.java:scala-extensions), and includes some internal refactoring. Nothing exciting...
