### PR TITLE
Upgrading freemarker

### DIFF
--- a/dropwizard-views-freemarker/pom.xml
+++ b/dropwizard-views-freemarker/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
-            <version>2.3.20</version>
+            <version>2.3.21</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>

--- a/dropwizard-views-freemarker/src/main/java/io/dropwizard/views/freemarker/FreemarkerViewRenderer.java
+++ b/dropwizard-views-freemarker/src/main/java/io/dropwizard/views/freemarker/FreemarkerViewRenderer.java
@@ -5,9 +5,10 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import freemarker.template.Configuration;
-import freemarker.template.DefaultObjectWrapper;
+import freemarker.template.DefaultObjectWrapperBuilder;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
+import freemarker.template.Version;
 import io.dropwizard.views.View;
 import io.dropwizard.views.ViewRenderer;
 
@@ -22,11 +23,14 @@ import java.util.Locale;
  * A {@link ViewRenderer} which renders Freemarker ({@code .ftl}) templates.
  */
 public class FreemarkerViewRenderer implements ViewRenderer {
+
+    private static final Version FREEMARKER_VERSION = Configuration.getVersion();
+
     private static class TemplateLoader extends CacheLoader<Class<?>, Configuration> {
         @Override
         public Configuration load(Class<?> key) throws Exception {
-            final Configuration configuration = new Configuration();
-            configuration.setObjectWrapper(new DefaultObjectWrapper());
+            final Configuration configuration = new Configuration(FREEMARKER_VERSION);
+            configuration.setObjectWrapper(new DefaultObjectWrapperBuilder(FREEMARKER_VERSION).build());
             configuration.loadBuiltInEncodingMap();
             configuration.setDefaultEncoding(Charsets.UTF_8.name());
             configuration.setClassForTemplateLoading(key, "/");

--- a/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererTest.java
+++ b/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererTest.java
@@ -5,6 +5,10 @@ import com.google.common.collect.ImmutableList;
 import io.dropwizard.logging.LoggingFactory;
 import io.dropwizard.views.ViewMessageBodyWriter;
 import io.dropwizard.views.ViewRenderer;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.Test;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -14,9 +18,6 @@ import javax.ws.rs.core.MediaType;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
-import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
-import org.junit.Test;
 
 public class MustacheViewRendererTest extends JerseyTest {
     static {
@@ -78,7 +79,7 @@ public class MustacheViewRendererTest extends JerseyTest {
                     .isEqualTo(500);
 
             assertThat(e.getResponse().readEntity(String.class))
-                    .isEqualTo("<html><head><title>Missing Template</title></head><body><h1>Missing Template</h1><p>Template /woo-oo-ahh.txt.mustache not found.</p></body></html>");
+                    .isEqualTo("<html><head><title>Missing Template</title></head><body><h1>Missing Template</h1><p>Template \"/woo-oo-ahh.txt.mustache\" not found.</p></body></html>");
         }
     }
 }

--- a/dropwizard-views/src/main/java/io/dropwizard/views/ViewMessageBodyWriter.java
+++ b/dropwizard-views/src/main/java/io/dropwizard/views/ViewMessageBodyWriter.java
@@ -2,14 +2,12 @@ package io.dropwizard.views;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import com.google.common.collect.ImmutableList;
 
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.*;
 import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.Provider;
-
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -28,7 +26,7 @@ public class ViewMessageBodyWriter implements MessageBodyWriter<View> {
     private static final String MISSING_TEMPLATE_MSG =
             "<html>" +
                 "<head><title>Missing Template</title></head>" +
-                "<body><h1>Missing Template</h1><p>{0}</p></body>" +
+                "<body><h1>Missing Template</h1><p>Template \"{0}\" not found.</p></body>" +
             "</html>";
 
     @Context
@@ -80,7 +78,7 @@ public class ViewMessageBodyWriter implements MessageBodyWriter<View> {
             }
             throw new ViewRenderException("Unable to find a renderer for " + t.getTemplateName());
         } catch (FileNotFoundException e) {
-            final String msg = MessageFormat.format(MISSING_TEMPLATE_MSG, e.getMessage());
+            final String msg = MessageFormat.format(MISSING_TEMPLATE_MSG, t.getTemplateName());
             throw new WebApplicationException(Response.serverError()
                                                       .type(MediaType.TEXT_HTML_TYPE)
                                                       .entity(msg)


### PR DESCRIPTION
Exceptions are now more descriptive so we build the web error message ourselves rather than leaking internal class information.

See the final bullet point at http://freemarker.org/docs/versions_2_3_17.html#autoid_145
