### PR TITLE
Add JerseyClientConfiguration option for disabling chunked encoding.

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -873,6 +873,7 @@ See JerseyClientConfiguration_ and HttpClientConfiguration_ for more options.
       maxThreads: 128
       gzipEnabled: true
       gzipEnabledForRequests: true
+      chunkedEncodingEnabled: true
 
 
 ======================= ==================  ===================================================================================================
@@ -882,5 +883,6 @@ minThreads              1                   The minimum number of threads in the
 maxThreads              128                 The maximum number of threads in the pool used for asynchronous requests.
 gzipEnabled             true                Adds an Accept-Encoding: gzip header to all requests, and enables automatic gzip decoding of responses.
 gzipEnabledForRequests  true                Adds a Content-Encoding: gzip header to all requests, and enables automatic gzip encoding of requests.
+chunkedEncodingEnabled  true                Enables the use of chunked encoding for requests.
 ======================= ==================  ===================================================================================================
 

--- a/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
@@ -14,6 +14,8 @@ import org.apache.http.conn.DnsResolver;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.RequestEntityProcessing;
 
 import javax.validation.Validation;
 import javax.validation.Validator;
@@ -234,6 +236,9 @@ public class JerseyClientBuilder {
         for (Map.Entry<String, Object> property : this.properties.entrySet()) {
             config.property(property.getKey(), property.getValue());
         }
+
+        final RequestEntityProcessing requestEntityProcessing = configuration.isChunkedEncodingEnabled() ? RequestEntityProcessing.CHUNKED : RequestEntityProcessing.BUFFERED;
+        config.property(ClientProperties.REQUEST_ENTITY_PROCESSING, requestEntityProcessing);
 
         config.register(new DropwizardExecutorProvider(threadPool));
         config.connectorProvider(new ApacheConnectorProvider());

--- a/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientConfiguration.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientConfiguration.java
@@ -29,6 +29,8 @@ public class JerseyClientConfiguration extends HttpClientConfiguration {
 
     private boolean gzipEnabledForRequests = true;
 
+    private boolean chunkedEncodingEnabled = true;
+
     @JsonProperty
     public int getMinThreads() {
         return minThreads;
@@ -67,6 +69,16 @@ public class JerseyClientConfiguration extends HttpClientConfiguration {
     @JsonProperty
     public void setGzipEnabledForRequests(boolean enabled) {
         this.gzipEnabledForRequests = enabled;
+    }
+
+    @JsonProperty
+    public boolean isChunkedEncodingEnabled() {
+        return chunkedEncodingEnabled;
+    }
+
+    @JsonProperty
+    public void setChunkedEncodingEnabled(final boolean chunkedEncodingEnabled) {
+        this.chunkedEncodingEnabled = chunkedEncodingEnabled;
     }
 
     @JsonIgnore

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
@@ -10,6 +10,8 @@ import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import io.dropwizard.setup.Environment;
 import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.RequestEntityProcessing;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -161,6 +163,26 @@ public class JerseyClientBuilderTest {
         builder.using(configuration).using(environment).build("test");
 
         verify(lifecycleEnvironment).executorService("jersey-client-test-%d");
+    }
+
+    @Test
+    public void usesChunkedEncodingIfChunkedEncodingIsEnabled() throws Exception {
+        final JerseyClientConfiguration configuration = new JerseyClientConfiguration();
+        configuration.setChunkedEncodingEnabled(true);
+
+        final Client client = builder.using(configuration)
+                .using(executorService, objectMapper).build("test");
+        assertThat(client.getConfiguration().getProperty(ClientProperties.REQUEST_ENTITY_PROCESSING)).isEqualTo(RequestEntityProcessing.CHUNKED);
+    }
+
+    @Test
+    public void usesBufferedEncodingIfChunkedEncodingIsDisabled() throws Exception {
+        final JerseyClientConfiguration configuration = new JerseyClientConfiguration();
+        configuration.setChunkedEncodingEnabled(false);
+
+        final Client client = builder.using(configuration)
+                .using(executorService, objectMapper).build("test");
+        assertThat(client.getConfiguration().getProperty(ClientProperties.REQUEST_ENTITY_PROCESSING)).isEqualTo(RequestEntityProcessing.BUFFERED);
     }
 
     @Provider


### PR DESCRIPTION
Fixes #403
