### PR TITLE
Made names consistent in configuration examples

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -140,7 +140,7 @@ Your main ``Configuration`` subclass can then include this as a member field:
 
 .. code-block:: java
 
-    public class ExampleApplicationConfiguration extends Configuration {
+    public class ExampleConfiguration extends Configuration {
         @Valid
         @NotNull
         private MessageQueueFactory messageQueue = new MessageQueueFactory();


### PR DESCRIPTION
See next code block, where config class is named `ExampleConfiguration`. Chose the shorter variant. 
