### PR TITLE
jersey: update gzip encoder to work with Jersey 2.x

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/gzip/ConfiguredGZipEncoder.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/gzip/ConfiguredGZipEncoder.java
@@ -34,7 +34,7 @@ public class ConfiguredGZipEncoder implements WriterInterceptor, ClientRequestFi
 
     @Override
     public void filter(ClientRequestContext context) throws IOException {
-        if (context.getHeaders().getFirst(HttpHeaders.CONTENT_ENCODING) == null && this.forceEncoding) {
+        if (context.hasEntity() && context.getHeaders().getFirst(HttpHeaders.CONTENT_ENCODING) == null && this.forceEncoding) {
             context.getHeaders().add(HttpHeaders.CONTENT_ENCODING, "gzip");
         }
     }


### PR DESCRIPTION
Fix for issue #780 

Update ConfiguredGZipEncoder to work with Jersey 2.x which no longer allows setting headers via WriterInterceptor
