### PR TITLE
JerseyClientBuilder: Add back metrics and use provided configuration values

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/ApacheClientBuilderBase.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/ApacheClientBuilderBase.java
@@ -1,0 +1,153 @@
+package io.dropwizard.client;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.httpclient.InstrumentedHttpClientConnectionManager;
+import com.google.common.annotations.VisibleForTesting;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.util.Duration;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.DnsResolver;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.conn.SystemDefaultDnsResolver;
+
+abstract class ApacheClientBuilderBase<T extends ApacheClientBuilderBase, C extends HttpClientConfiguration> {
+
+    protected C configuration;
+    protected CredentialsProvider credentialsProvider = null;
+    protected final MetricRegistry metricRegistry;
+    protected String name;
+    protected Environment environment;
+    protected DnsResolver resolver = new SystemDefaultDnsResolver();
+    protected Registry<ConnectionSocketFactory> registry
+            = RegistryBuilder.<ConnectionSocketFactory>create()
+            .register("http", PlainConnectionSocketFactory.getSocketFactory())
+            .register("https", SSLConnectionSocketFactory.getSocketFactory())
+            .build();
+
+    public ApacheClientBuilderBase(MetricRegistry metricRegistry, C configuration) {
+        this.metricRegistry = metricRegistry;
+        using(configuration);
+    }
+
+    public ApacheClientBuilderBase(Environment environment, C configuration) {
+        this(environment.metrics(), configuration);
+        using(environment);
+    }
+
+    @SuppressWarnings("unchecked")
+    private T self() {
+        return (T)this;
+    }
+
+    /**
+     * Use the given name. This is used in the user agent.
+     *
+     * @param name a name to use in the user agent.
+     * @return {@code this}
+     */
+    public T name(String name) {
+        this.name = name;
+        return self();
+    }
+
+    /**
+     * Use the given {@link HttpClientConfiguration} instance.
+     *
+     * @param configuration a {@link HttpClientConfiguration} instance
+     * @return {@code this}
+     */
+    public T using(C configuration) {
+        this.configuration = configuration;
+        return self();
+    }
+
+    /**
+     * Use the given {@link DnsResolver} instance.
+     *
+     * @param resolver a {@link DnsResolver} instance
+     * @return {@code this}
+     */
+    public T using(DnsResolver resolver) {
+        this.resolver = resolver;
+        return self();
+    }
+
+    /**
+     * Use the given {@link CredentialsProvider} instance.
+     *
+     * @param credentialsProvider a {@link CredentialsProvider} instance
+     * @return {@code this}
+     */
+    public T using(CredentialsProvider credentialsProvider) {
+        this.credentialsProvider = credentialsProvider;
+        return self();
+    }
+
+    /**
+     * Uses the given {@link Environment}.
+     *
+     * @param environment a Dropwizard {@link Environment}
+     * @return {@code this}
+     */
+    public T using(Environment environment) {
+        this.environment = environment;
+        name(environment.getName());
+        return self();
+    }
+
+    /**
+     * Create a RequestConfig based on the HttpClientConfiguration.  It sets
+     * timeouts and cookie handling.
+     *
+     * @return a RequestConfig instance
+     */
+    protected RequestConfig createRequestConfig() {
+        final String cookiePolicy = configuration.isCookiesEnabled() ? CookieSpecs.BEST_MATCH : CookieSpecs.IGNORE_COOKIES;
+        final Integer timeout = (int) configuration.getTimeout().toMilliseconds();
+        final Integer connectionTimeout = (int) configuration.getConnectionTimeout().toMilliseconds();
+        return RequestConfig.custom()
+                .setCookieSpec(cookiePolicy)
+                .setSocketTimeout(timeout)
+                .setConnectTimeout(connectionTimeout)
+                .setStaleConnectionCheckEnabled(false)
+                .build();
+    }
+
+    /**
+     * Create a InstrumentedHttpClientConnectionManager based on the
+     * HttpClientConfiguration. It sets the maximum connections per route and
+     * the maximum total connections that the connection manager can create
+     *
+     * @param registry
+     * @param name
+     * @return a InstrumentedHttpClientConnectionManger instance
+     */
+    protected InstrumentedHttpClientConnectionManager createConnectionManager(Registry<ConnectionSocketFactory> registry,
+                                                                    String name) {
+        final Duration ttl = configuration.getTimeToLive();
+        final InstrumentedHttpClientConnectionManager manager = new InstrumentedHttpClientConnectionManager(
+                metricRegistry,
+                registry,
+                null, null,
+                resolver,
+                ttl.getQuantity(),
+                ttl.getUnit(),
+                name);
+        return configureConnectionManager(manager);
+    }
+
+    @VisibleForTesting
+    protected InstrumentedHttpClientConnectionManager configureConnectionManager(
+            InstrumentedHttpClientConnectionManager connectionManager) {
+        connectionManager.setDefaultMaxPerRoute(configuration.getMaxConnectionsPerRoute());
+        connectionManager.setMaxTotal(configuration.getMaxConnections());
+        return connectionManager;
+    }
+
+}

--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
@@ -7,27 +7,19 @@ import com.codahale.metrics.httpclient.InstrumentedHttpClientConnectionManager;
 import com.codahale.metrics.httpclient.InstrumentedHttpRequestExecutor;
 import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.setup.Environment;
-import io.dropwizard.util.Duration;
 import org.apache.http.ConnectionReuseStrategy;
 import org.apache.http.HttpResponse;
-import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.HttpRequestRetryHandler;
-import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.config.Registry;
-import org.apache.http.config.RegistryBuilder;
 import org.apache.http.config.SocketConfig;
-import org.apache.http.conn.DnsResolver;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
-import org.apache.http.conn.socket.PlainConnectionSocketFactory;
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.DefaultConnectionReuseStrategy;
 import org.apache.http.impl.NoConnectionReuseStrategy;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.DefaultConnectionKeepAliveStrategy;
 import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
-import org.apache.http.impl.conn.SystemDefaultDnsResolver;
 import org.apache.http.protocol.HttpContext;
 
 import java.io.IOException;
@@ -42,7 +34,8 @@ import java.io.IOException;
  * <li>Disables cookie management by default</li>
  * </ul>
  */
-public class HttpClientBuilder {
+public class HttpClientBuilder extends ApacheClientBuilderBase<HttpClientBuilder, HttpClientConfiguration> {
+
     private static final HttpRequestRetryHandler NO_RETRIES = new HttpRequestRetryHandler() {
         @Override
         public boolean retryRequest(IOException exception, int executionCount, HttpContext context) {
@@ -50,59 +43,15 @@ public class HttpClientBuilder {
         }
     };
 
-    private final MetricRegistry metricRegistry;
-    private String environmentName;
-    private HttpClientConfiguration configuration = new HttpClientConfiguration();
-    private DnsResolver resolver = new SystemDefaultDnsResolver();
     private HttpRequestRetryHandler httpRequestRetryHandler;
-    private Registry<ConnectionSocketFactory> registry
-            = RegistryBuilder.<ConnectionSocketFactory>create()
-            .register("http", PlainConnectionSocketFactory.getSocketFactory())
-            .register("https", SSLConnectionSocketFactory.getSocketFactory())
-            .build();
-    private CredentialsProvider credentialsProvider = null;
     private HttpClientMetricNameStrategy metricNameStrategy = HttpClientMetricNameStrategies.METHOD_ONLY;
 
     public HttpClientBuilder(MetricRegistry metricRegistry) {
-        this.metricRegistry = metricRegistry;
+        super(metricRegistry, new HttpClientConfiguration());
     }
 
     public HttpClientBuilder(Environment environment) {
-        this(environment.metrics());
-        name(environment.getName());
-    }
-
-    /**
-     * Use the given environment name. This is used in the user agent.
-     *
-     * @param environmentName an environment name to use in the user agent.
-     * @return {@code this}
-     */
-    public HttpClientBuilder name(String environmentName) {
-        this.environmentName = environmentName;
-        return this;
-    }
-
-    /**
-     * Use the given {@link HttpClientConfiguration} instance.
-     *
-     * @param configuration a {@link HttpClientConfiguration} instance
-     * @return {@code this}
-     */
-    public HttpClientBuilder using(HttpClientConfiguration configuration) {
-        this.configuration = configuration;
-        return this;
-    }
-
-    /**
-     * Use the given {@link DnsResolver} instance.
-     *
-     * @param resolver a {@link DnsResolver} instance
-     * @return {@code this}
-     */
-    public HttpClientBuilder using(DnsResolver resolver) {
-        this.resolver = resolver;
-        return this;
+        super(environment, new HttpClientConfiguration());
     }
 
     /**
@@ -124,17 +73,6 @@ public class HttpClientBuilder {
      */
     public HttpClientBuilder using(Registry<ConnectionSocketFactory> registry) {
         this.registry = registry;
-        return this;
-    }
-
-    /**
-     * Use the given {@link CredentialsProvider} instance.
-     *
-     * @param credentialsProvider a {@link CredentialsProvider} instance
-     * @return {@code this}
-     */
-    public HttpClientBuilder using(CredentialsProvider credentialsProvider) {
-        this.credentialsProvider = credentialsProvider;
         return this;
     }
 
@@ -174,9 +112,7 @@ public class HttpClientBuilder {
             final org.apache.http.impl.client.HttpClientBuilder builder,
             final InstrumentedHttpClientConnectionManager manager,
             final String name) {
-        final String cookiePolicy = configuration.isCookiesEnabled() ? CookieSpecs.BEST_MATCH : CookieSpecs.IGNORE_COOKIES;
         final Integer timeout = (int) configuration.getTimeout().toMilliseconds();
-        final Integer connectionTimeout = (int) configuration.getConnectionTimeout().toMilliseconds();
         final long keepAlive = configuration.getKeepAlive().toMilliseconds();
         final ConnectionReuseStrategy reuseStrategy = keepAlive == 0
                 ? new NoConnectionReuseStrategy()
@@ -186,12 +122,7 @@ public class HttpClientBuilder {
                 : (httpRequestRetryHandler == null ? new DefaultHttpRequestRetryHandler(configuration.getRetries(),
                 false) : httpRequestRetryHandler);
 
-        final RequestConfig requestConfig
-                = RequestConfig.custom().setCookieSpec(cookiePolicy)
-                .setSocketTimeout(timeout)
-                .setConnectTimeout(connectionTimeout)
-                .setStaleConnectionCheckEnabled(false)
-                .build();
+        final RequestConfig requestConfig = createRequestConfig();
         final SocketConfig socketConfig = SocketConfig.custom()
                 .setTcpNoDelay(true)
                 .setSoTimeout(timeout)
@@ -232,39 +163,10 @@ public class HttpClientBuilder {
      * @return the user agent string to be used by this client
      */
     protected String createUserAgent(String name) {
-        final String defaultUserAgent = environmentName == null ? name : String.format("%s (%s)", environmentName, name);
+        final String defaultUserAgent = this.name == null ? name : String.format("%s (%s)", this.name, name);
         return configuration.getUserAgent().or(defaultUserAgent);
     }
 
 
-    /**
-     * Create a InstrumentedHttpClientConnectionManager based on the
-     * HttpClientConfiguration. It sets the maximum connections per route and
-     * the maximum total connections that the connection manager can create
-     *
-     * @param registry
-     * @param name
-     * @return a InstrumentedHttpClientConnectionManger instance
-     */
-    protected InstrumentedHttpClientConnectionManager createConnectionManager(Registry<ConnectionSocketFactory> registry,
-                                                                              String name) {
-        final Duration ttl = configuration.getTimeToLive();
-        final InstrumentedHttpClientConnectionManager manager = new InstrumentedHttpClientConnectionManager(
-                metricRegistry,
-                registry,
-                null, null,
-                resolver,
-                ttl.getQuantity(),
-                ttl.getUnit(),
-                name);
-        return configureConnectionManager(manager);
-    }
 
-    @VisibleForTesting
-    protected InstrumentedHttpClientConnectionManager configureConnectionManager(
-            InstrumentedHttpClientConnectionManager connectionManager) {
-        connectionManager.setDefaultMaxPerRoute(configuration.getMaxConnectionsPerRoute());
-        connectionManager.setMaxTotal(configuration.getMaxConnections());
-        return connectionManager;
-    }
 }

--- a/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
@@ -1,7 +1,6 @@
 package io.dropwizard.client;
 
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.httpclient.HttpClientMetricNameStrategy;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -9,10 +8,9 @@ import io.dropwizard.jersey.gzip.ConfiguredGZipEncoder;
 import io.dropwizard.jersey.gzip.GZipDecoder;
 import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
 import io.dropwizard.setup.Environment;
-import org.apache.http.client.HttpRequestRetryHandler;
-import org.apache.http.config.Registry;
-import org.apache.http.conn.DnsResolver;
-import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.conn.HttpClientConnectionManager;
+import org.glassfish.jersey.apache.connector.ApacheClientProperties;
 import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
@@ -44,25 +42,22 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  * @see HttpClientBuilder
  */
-public class JerseyClientBuilder {
-    private final HttpClientBuilder builder;
+public class JerseyClientBuilder extends ApacheClientBuilderBase<JerseyClientBuilder, JerseyClientConfiguration> {
+
     private final List<Object> singletons = Lists.newArrayList();
     private final List<Class<?>> providers = Lists.newArrayList();
     private final Map<String, Object> properties = Maps.newLinkedHashMap();
 
-    private JerseyClientConfiguration configuration = new JerseyClientConfiguration();
     private Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
-    private Environment environment;
     private ObjectMapper objectMapper;
     private ExecutorService executorService;
 
     public JerseyClientBuilder(Environment environment) {
-        this.builder = new HttpClientBuilder(environment);
-        this.environment = environment;
+        super(environment, new JerseyClientConfiguration());
     }
 
     public JerseyClientBuilder(MetricRegistry metricRegistry) {
-        this.builder = new HttpClientBuilder(metricRegistry);
+        super(metricRegistry, new JerseyClientConfiguration());
     }
 
     /**
@@ -101,63 +96,6 @@ public class JerseyClientBuilder {
     }
 
     /**
-     * Uses the {@link org.apache.http.client.HttpRequestRetryHandler} for handling request retries.
-     *
-     * @param httpRequestRetryHandler a HttpRequestRetryHandler
-     * @return {@code this}
-     */
-    public JerseyClientBuilder using(HttpRequestRetryHandler httpRequestRetryHandler) {
-        builder.using(httpRequestRetryHandler);
-        return this;
-    }
-
-    /**
-     * Uses the given {@link JerseyClientConfiguration}.
-     *
-     * @param configuration a configuration object
-     * @return {@code this}
-     */
-    public JerseyClientBuilder using(JerseyClientConfiguration configuration) {
-        this.configuration = configuration;
-        builder.using(configuration);
-        return this;
-    }
-
-    /**
-     * Uses the given {@link Environment}.
-     *
-     * @param environment a Dropwizard {@link Environment}
-     * @return {@code this}
-     * @see #using(java.util.concurrent.ExecutorService, com.fasterxml.jackson.databind.ObjectMapper)
-     */
-    public JerseyClientBuilder using(Environment environment) {
-        this.environment = environment;
-        return this;
-    }
-
-    /**
-     * Use the given {@link DnsResolver} instance.
-     *
-     * @param resolver a {@link DnsResolver} instance
-     * @return {@code this}
-     */
-    public JerseyClientBuilder using(DnsResolver resolver) {
-        builder.using(resolver);
-        return this;
-    }
-
-    /**
-     * Use the given {@link Registry} instance.
-     *
-     * @param registry a {@link Registry} instance
-     * @return {@code this}
-     */
-    public JerseyClientBuilder using(Registry<ConnectionSocketFactory> registry) {
-        builder.using(registry);
-        return this;
-    }
-
-    /**
      * Use the given {@link Validator} instance.
      *
      * @param validator a {@link Validator} instance
@@ -183,17 +121,6 @@ public class JerseyClientBuilder {
     }
 
     /**
-     * Use the given {@link HttpClientMetricNameStrategy} instance.
-     *
-     * @param metricNameStrategy    a {@link HttpClientMetricNameStrategy} instance
-     * @return {@code this}
-     */
-    public JerseyClientBuilder using(HttpClientMetricNameStrategy metricNameStrategy) {
-        builder.using(metricNameStrategy);
-        return this;
-    }
-
-    /**
      * Builds the {@link Client} instance.
      *
      * @return a fully-configured {@link Client}
@@ -205,10 +132,10 @@ public class JerseyClientBuilder {
         }
 
         if (environment == null) {
-            return build(executorService, objectMapper, validator);
+            return build(name, executorService, objectMapper, validator);
         }
 
-        return build(environment.lifecycle()
+        return build(name, environment.lifecycle()
                         .executorService("jersey-client-" + name + "-%d")
                         .minThreads(configuration.getMinThreads())
                         .maxThreads(configuration.getMaxThreads())
@@ -217,10 +144,12 @@ public class JerseyClientBuilder {
                 environment.getValidator());
     }
 
-    private Client build(ExecutorService threadPool,
+    private Client build(String name,
+                         ExecutorService threadPool,
                          ObjectMapper objectMapper,
                          Validator validator) {
-        final Client client = ClientBuilder.newClient(buildConfig(threadPool, objectMapper, validator));
+
+        final Client client = ClientBuilder.newClient(buildConfig(name, threadPool, objectMapper, validator));
 
         if (configuration.isGzipEnabled()) {
             client.register(new GZipDecoder());
@@ -230,10 +159,28 @@ public class JerseyClientBuilder {
         return client;
     }
 
-    private Configuration buildConfig(final ExecutorService threadPool,
+    private Configuration buildConfig(final String name,
+                                      final ExecutorService threadPool,
                                       final ObjectMapper objectMapper,
                                       final Validator validator) {
+
+
+        final Integer timeout = (int) configuration.getTimeout().toMilliseconds();
+        final Integer connectionTimeout = (int) configuration.getConnectionTimeout().toMilliseconds();
+
+        final HttpClientConnectionManager connectionManager = createConnectionManager(registry, name);
         final ClientConfig config = new ClientConfig();
+        final RequestConfig requestConfig = createRequestConfig();
+
+        config.property(ApacheClientProperties.CONNECTION_MANAGER, connectionManager);
+        config.property(ApacheClientProperties.DISABLE_COOKIES, !configuration.isCookiesEnabled());
+        config.property(ClientProperties.CONNECT_TIMEOUT, connectionTimeout);
+        config.property(ClientProperties.READ_TIMEOUT, timeout);
+        config.property(ApacheClientProperties.REQUEST_CONFIG, requestConfig);
+
+        if (credentialsProvider != null) {
+            config.property(ApacheClientProperties.CREDENTIALS_PROVIDER, credentialsProvider);
+        }
 
         for (Object singleton : this.singletons) {
             config.register(singleton);
@@ -257,4 +204,5 @@ public class JerseyClientBuilder {
 
         return config;
     }
+
 }


### PR DESCRIPTION
This PR improves the JerseyClientBuilder with:

* Add back metrics provided by  **InstrumentedHttpClientConnectionManager**
* Respect the timeout, cookie, and credential provider configuration parameters

Additionally it:

* Adds a few tests for the configuration parameters
* Moves common code shared between **HttpClientBuilder** and **JerseyClientBuilder** into an **ApacheClientBuilderBase** class

I recommend including this in 0.8, as the existing JerseyClientBuilder is a bit broken without these enhancements.

**Note**: 

This PR does **not** include the request timing that InstrumentedHttpRequestExecutor provided.  I have submitted a metrics PR (https://github.com/dropwizard/metrics/pull/705) to add this, and will submit a dropwizard PR when that is merged.
