### PR TITLE
Make auth factories flexible

### DIFF
--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/DefaultUnauthorizedHandler.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/DefaultUnauthorizedHandler.java
@@ -1,0 +1,18 @@
+package io.dropwizard.auth;
+
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+public class DefaultUnauthorizedHandler implements UnauthorizedHandler {
+    private static final String CHALLENGE_FORMAT = "%s realm=\"%s\"";
+
+    @Override
+    public Response buildResponse(String prefix, String realm) {
+        return Response.status(Response.Status.UNAUTHORIZED)
+                .header(HttpHeaders.WWW_AUTHENTICATE, String.format(CHALLENGE_FORMAT, prefix, realm))
+                .type(MediaType.TEXT_PLAIN_TYPE)
+                .entity("Credentials are required to access this resource.")
+                .build();
+    }
+}

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/UnauthorizedHandler.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/UnauthorizedHandler.java
@@ -1,0 +1,7 @@
+package io.dropwizard.auth;
+
+import javax.ws.rs.core.Response;
+
+public interface UnauthorizedHandler {
+    Response buildResponse(String prefix, String realm);
+}

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/oauth/OAuthFactory.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/oauth/OAuthFactory.java
@@ -1,9 +1,7 @@
 package io.dropwizard.auth.oauth;
 
 import com.google.common.base.Optional;
-import io.dropwizard.auth.AuthFactory;
-import io.dropwizard.auth.AuthenticationException;
-import io.dropwizard.auth.Authenticator;
+import io.dropwizard.auth.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -12,8 +10,6 @@ import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
 /**
  * A Jersey provider for OAuth2 bearer tokens.
@@ -22,12 +18,12 @@ import javax.ws.rs.core.Response;
  */
 public final class OAuthFactory<T> extends AuthFactory<String, T> {
     private static final Logger LOGGER = LoggerFactory.getLogger(OAuthFactory.class);
-    private static final String PREFIX = "Bearer";
-    private static final String CHALLENGE_FORMAT = PREFIX + " realm=\"%s\"";
 
     private final boolean required;
     private final Class<T> generatedClass;
     private final String realm;
+    private String prefix = "Bearer";
+    private UnauthorizedHandler unauthorizedHandler = new DefaultUnauthorizedHandler();
 
     @Context
     private HttpServletRequest request;
@@ -51,6 +47,16 @@ public final class OAuthFactory<T> extends AuthFactory<String, T> {
         this.generatedClass = generatedClass;
     }
 
+    public OAuthFactory<T> prefix(String prefix) {
+        this.prefix = prefix;
+        return this;
+    }
+
+    public OAuthFactory<T> responseBuilder(UnauthorizedHandler unauthorizedHandler) {
+        this.unauthorizedHandler = unauthorizedHandler;
+        return this;
+    }
+
     @Override
     public void setRequest(HttpServletRequest request) {
         this.request = request;
@@ -58,7 +64,7 @@ public final class OAuthFactory<T> extends AuthFactory<String, T> {
 
     @Override
     public AuthFactory<String, T> clone(boolean required) {
-        return new OAuthFactory<>(required, authenticator(), this.realm, this.generatedClass);
+        return new OAuthFactory<>(required, authenticator(), this.realm, this.generatedClass).prefix(prefix).responseBuilder(unauthorizedHandler);
     }
 
     @Override
@@ -69,7 +75,7 @@ public final class OAuthFactory<T> extends AuthFactory<String, T> {
                 final int space = header.indexOf(' ');
                 if (space > 0) {
                     final String method = header.substring(0, space);
-                    if (PREFIX.equalsIgnoreCase(method)) {
+                    if (prefix.equalsIgnoreCase(method)) {
                         final String credentials = header.substring(space + 1);
                         final Optional<T> result = authenticator().authenticate(credentials);
                         if (result.isPresent()) {
@@ -84,11 +90,7 @@ public final class OAuthFactory<T> extends AuthFactory<String, T> {
         }
 
         if (required) {
-            throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED)
-                    .header(HttpHeaders.WWW_AUTHENTICATE, String.format(CHALLENGE_FORMAT, realm))
-                    .type(MediaType.TEXT_PLAIN_TYPE)
-                    .entity("Credentials are required to access this resource.")
-                    .build());
+            throw new WebApplicationException(unauthorizedHandler.buildResponse(prefix, realm));
         }
 
         return null;

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/BasicCustomAuthProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/BasicCustomAuthProviderTest.java
@@ -1,0 +1,123 @@
+package io.dropwizard.auth.basic;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Optional;
+import io.dropwizard.auth.*;
+import io.dropwizard.jersey.DropwizardResourceConfig;
+import io.dropwizard.logging.LoggingFactory;
+import org.glassfish.jersey.servlet.ServletProperties;
+import org.glassfish.jersey.test.DeploymentContext;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
+import org.glassfish.jersey.test.spi.TestContainerException;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
+import org.junit.Test;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+
+public class BasicCustomAuthProviderTest extends JerseyTest {
+    static {
+        LoggingFactory.bootstrap();
+    }
+
+    @Override
+    protected TestContainerFactory getTestContainerFactory()
+            throws TestContainerException {
+        return new GrizzlyWebTestContainerFactory();
+    }
+
+    @Override
+    protected DeploymentContext configureDeployment() {
+        return ServletDeploymentContext.builder(new BasicAuthTestResourceConfig())
+                .initParam(ServletProperties.JAXRS_APPLICATION_CLASS, BasicAuthTestResourceConfig.class.getName())
+                .build();
+    }
+
+    @Test
+    public void respondsToMissingCredentialsWith401() throws Exception {
+        try {
+            target("/test").request().get(String.class);
+            failBecauseExceptionWasNotThrown(WebApplicationException.class);
+        } catch (WebApplicationException e) {
+            assertThat(e.getResponse().getStatus()).isEqualTo(401);
+            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
+                    .containsOnly("Custom realm=\"realm\"");
+        }
+    }
+
+    @Test
+    public void transformsCredentialsToPrincipals() throws Exception {
+        assertThat(target("/test").request()
+                .header(HttpHeaders.AUTHORIZATION, "Custom Z29vZC1ndXk6c2VjcmV0")
+                .get(String.class))
+                .isEqualTo("good-guy");
+    }
+
+    @Test
+    public void respondsToNonBasicCredentialsWith401() throws Exception {
+        try {
+            target("/test").request()
+                    .header(HttpHeaders.AUTHORIZATION, "Derp Z29vZC1ndXk6c2VjcmV0")
+                    .get(String.class);
+            failBecauseExceptionWasNotThrown(WebApplicationException.class);
+        } catch (WebApplicationException e) {
+            assertThat(e.getResponse().getStatus()).isEqualTo(401);
+            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
+                    .containsOnly("Custom realm=\"realm\"");
+        }
+    }
+
+    @Test
+    public void respondsToExceptionsWith500() throws Exception {
+        try {
+            target("/test").request()
+                    .header(HttpHeaders.AUTHORIZATION, "Custom YmFkLWd1eTpzZWNyZXQ=")
+                    .get(String.class);
+
+            failBecauseExceptionWasNotThrown(WebApplicationException.class);
+        } catch (WebApplicationException e) {
+            assertThat(e.getResponse().getStatus()).isEqualTo(500);
+        }
+    }
+
+    @Path("/test/")
+    @Produces(MediaType.TEXT_PLAIN)
+    public static class ExampleResource {
+        @GET
+        public String show(@Auth String principal) {
+            return principal;
+        }
+    }
+
+    public static class BasicAuthTestResourceConfig extends DropwizardResourceConfig {
+        public BasicAuthTestResourceConfig() {
+            super(true, new MetricRegistry());
+
+            final Authenticator<BasicCredentials, String> authenticator = new Authenticator<BasicCredentials, String>() {
+                @Override
+                public Optional<String> authenticate(BasicCredentials credentials) throws AuthenticationException {
+                    if ("good-guy".equals(credentials.getUsername()) &&
+                            "secret".equals(credentials.getPassword())) {
+                        return Optional.of("good-guy");
+                    }
+                    if ("bad-guy".equals(credentials.getUsername())) {
+                        throw new AuthenticationException("CRAP");
+                    }
+                    return Optional.absent();
+                }
+            };
+            register(AuthFactory.binder(new BasicAuthFactory<>(authenticator, "realm", String.class).prefix("Custom")));
+            register(AuthResource.class);
+        }
+    }
+}

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/oauth/OAuthCustomProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/oauth/OAuthCustomProviderTest.java
@@ -1,0 +1,107 @@
+package io.dropwizard.auth.oauth;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Optional;
+import io.dropwizard.auth.AuthFactory;
+import io.dropwizard.auth.AuthResource;
+import io.dropwizard.auth.AuthenticationException;
+import io.dropwizard.auth.Authenticator;
+import io.dropwizard.jersey.DropwizardResourceConfig;
+import io.dropwizard.logging.LoggingFactory;
+import org.glassfish.jersey.servlet.ServletProperties;
+import org.glassfish.jersey.test.DeploymentContext;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
+import org.glassfish.jersey.test.spi.TestContainerException;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
+import org.junit.Test;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.HttpHeaders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+public class OAuthCustomProviderTest extends JerseyTest {
+    static {
+        LoggingFactory.bootstrap();
+    }
+
+    @Override
+    protected TestContainerFactory getTestContainerFactory()
+            throws TestContainerException {
+        return new GrizzlyWebTestContainerFactory();
+    }
+
+    @Override
+    protected DeploymentContext configureDeployment() {
+        return ServletDeploymentContext.builder(new BasicAuthTestResourceConfig())
+                .initParam(ServletProperties.JAXRS_APPLICATION_CLASS, BasicAuthTestResourceConfig.class.getName())
+                .build();
+    }
+
+    @Test
+    public void respondsToMissingCredentialsWith401() throws Exception {
+        try {
+            target("/test").request().get(String.class);
+            failBecauseExceptionWasNotThrown(WebApplicationException.class);
+        } catch (WebApplicationException e) {
+            assertThat(e.getResponse().getStatus()).isEqualTo(401);
+            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
+                    .containsOnly("Custom realm=\"realm\"");
+        }
+    }
+
+    @Test
+    public void transformsCredentialsToPrincipals() throws Exception {
+        assertThat(target("/test").request().header(HttpHeaders.AUTHORIZATION, "Custom good-guy").get(String.class))
+                .isEqualTo("good-guy");
+    }
+
+    @Test
+    public void respondsToNonBasicCredentialsWith401() throws Exception {
+        try {
+            target("/test").request().header(HttpHeaders.AUTHORIZATION, "Derp WHEE").get(String.class);
+            failBecauseExceptionWasNotThrown(WebApplicationException.class);
+        } catch (WebApplicationException e) {
+            assertThat(e.getResponse().getStatus()).isEqualTo(401);
+            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
+                    .containsOnly("Custom realm=\"realm\"");
+        }
+    }
+
+    @Test
+    public void respondsToExceptionsWith500() throws Exception {
+        try {
+            target("/test").request().header(HttpHeaders.AUTHORIZATION, "Custom bad-guy").get(String.class);
+            failBecauseExceptionWasNotThrown(WebApplicationException.class);
+        } catch (WebApplicationException e) {
+            assertThat(e.getResponse().getStatus()).isEqualTo(500);
+        }
+    }
+
+    public static class BasicAuthTestResourceConfig extends DropwizardResourceConfig {
+        public BasicAuthTestResourceConfig() {
+            super(true, new MetricRegistry());
+
+            final Authenticator<String, String> authenticator = new Authenticator<String, String>() {
+                @Override
+                public Optional<String> authenticate(String credentials) throws AuthenticationException {
+                    if ("good-guy".equals(credentials)) {
+                        return Optional.of("good-guy");
+                    }
+
+                    if ("bad-guy".equals(credentials)) {
+                        throw new AuthenticationException("CRAP");
+                    }
+
+                    return Optional.absent();
+                }
+            };
+
+            register(AuthFactory.binder(new OAuthFactory<>(authenticator, "realm", String.class).prefix("Custom")));
+            register(AuthResource.class);
+        }
+    }
+}


### PR DESCRIPTION
Add prefix and responseBuilder options to Basic and OAuth factories to make them more flexible.

Close #798
