### PR TITLE
 Real type is not always set properly in Java

### DIFF
--- a/dropwizard-core/src/test/java/issue804/BaseApplication.java
+++ b/dropwizard-core/src/test/java/issue804/BaseApplication.java
@@ -1,0 +1,12 @@
+package issue804;
+
+import io.dropwizard.Application;
+import io.dropwizard.setup.Bootstrap;
+
+public abstract class BaseApplication<R extends BaseConfiguration> extends Application<R> {
+
+    @Override
+    public void initialize(Bootstrap<R> bootstrap) {
+        bootstrap.addBundle(new MigrationsBundleClone() {});
+    }
+}

--- a/dropwizard-core/src/test/java/issue804/BaseConfiguration.java
+++ b/dropwizard-core/src/test/java/issue804/BaseConfiguration.java
@@ -1,0 +1,7 @@
+package issue804;
+
+import io.dropwizard.Configuration;
+
+public abstract class BaseConfiguration extends Configuration {
+
+}

--- a/dropwizard-core/src/test/java/issue804/Issue804TestProblem.java
+++ b/dropwizard-core/src/test/java/issue804/Issue804TestProblem.java
@@ -1,0 +1,13 @@
+package issue804;
+
+import io.dropwizard.setup.Bootstrap;
+import org.junit.Test;
+
+public class Issue804TestProblem {
+    @Test
+    public void testOnProvidedExtendedConfigurationClassShouldReturnExtendedClass() throws Exception {
+        BaseApplication<SampleConfiguration> application = new SampleApplication();
+
+        application.initialize(new Bootstrap<>(application));
+    }
+}

--- a/dropwizard-core/src/test/java/issue804/MigrationsBundleClone.java
+++ b/dropwizard-core/src/test/java/issue804/MigrationsBundleClone.java
@@ -14,8 +14,8 @@ public abstract class MigrationsBundleClone<T extends Configuration> implements 
 
     @Override
     public final void initialize(Bootstrap<?> bootstrap) {
-        Assert.assertEquals(SampleApplication.class, this.getClass());
-        final Class<T> klass = Generics.getTypeParameter(getClass(), Configuration.class);
+        Assert.assertEquals(SampleApplication.class, bootstrap.getApplication().getClass());
+        final Class<T> klass = Generics.getTypeParameter(bootstrap.getApplication().getClass(), Configuration.class);
         Assert.assertEquals(SampleConfiguration.class, klass);
     }
 

--- a/dropwizard-core/src/test/java/issue804/MigrationsBundleClone.java
+++ b/dropwizard-core/src/test/java/issue804/MigrationsBundleClone.java
@@ -1,0 +1,27 @@
+package issue804;
+
+import io.dropwizard.Bundle;
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.util.Generics;
+import org.junit.Assert;
+
+/**
+ * I just cloned MigrationsBundle. I couldn't find any other way to get the configuration class...
+ */
+public abstract class MigrationsBundleClone<T extends Configuration> implements Bundle {
+
+    @Override
+    public final void initialize(Bootstrap<?> bootstrap) {
+        Assert.assertEquals(SampleApplication.class, this.getClass());
+        final Class<T> klass = Generics.getTypeParameter(getClass(), Configuration.class);
+        Assert.assertEquals(SampleConfiguration.class, klass);
+    }
+
+    @Override
+    public final void run(Environment environment) {
+        // nothing doing
+    }
+}
+

--- a/dropwizard-core/src/test/java/issue804/SampleApplication.java
+++ b/dropwizard-core/src/test/java/issue804/SampleApplication.java
@@ -1,0 +1,11 @@
+package issue804;
+
+import io.dropwizard.setup.Environment;
+
+public class SampleApplication extends BaseApplication<SampleConfiguration> {
+
+    @Override
+    public void run(SampleConfiguration configuration, Environment environment) throws Exception {
+
+    }
+}

--- a/dropwizard-core/src/test/java/issue804/SampleConfiguration.java
+++ b/dropwizard-core/src/test/java/issue804/SampleConfiguration.java
@@ -1,0 +1,4 @@
+package issue804;
+
+public class SampleConfiguration extends BaseConfiguration {
+}

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/MigrationsBundle.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/MigrationsBundle.java
@@ -10,7 +10,8 @@ import io.dropwizard.util.Generics;
 public abstract class MigrationsBundle<T extends Configuration> implements Bundle, DatabaseConfiguration<T> {
     @Override
     public final void initialize(Bootstrap<?> bootstrap) {
-        final Class<T> klass = Generics.getTypeParameter(getClass(), Configuration.class);
+        final Class<T> klass = Generics
+            .getTypeParameter(bootstrap.getApplication().getClass(), Configuration.class);
         bootstrap.addCommand(new DbCommand<>(this, klass));
     }
 


### PR DESCRIPTION
Not every time a real type of a class is set using getClass method. It is better to rely on getting class from a field than getting from this reference. Sometimes real class type is held in this$0 synthetic field.