### PR TITLE
Fix #881 - Change ViewMessageBodyWriter to produce only HTML and XML.

### DIFF
--- a/dropwizard-views/src/main/java/io/dropwizard/views/ViewMessageBodyWriter.java
+++ b/dropwizard-views/src/main/java/io/dropwizard/views/ViewMessageBodyWriter.java
@@ -21,7 +21,7 @@ import java.util.ServiceLoader;
 import static com.codahale.metrics.MetricRegistry.name;
 
 @Provider
-@Produces(MediaType.WILDCARD)
+@Produces({ MediaType.TEXT_HTML, MediaType.APPLICATION_XHTML_XML })
 public class ViewMessageBodyWriter implements MessageBodyWriter<View> {
     private static final String MISSING_TEMPLATE_MSG =
             "<html>" +


### PR DESCRIPTION
Being more restrictive allows the view be serialize to both JSON and HTML.
