### PR TITLE
add function to retrieve className from task and test. fixes #829

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/setup/AdminEnvironment.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/AdminEnvironment.java
@@ -15,8 +15,6 @@ import org.eclipse.jetty.util.component.LifeCycle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
-
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -30,7 +28,6 @@ public class AdminEnvironment extends ServletEnvironment {
 
     @VisibleForTesting
     final Function<Task,String> getTaskClassName = new Function<Task, String>() {
-        @Nullable
         @Override
         public String apply(final Task task) {
             // canonicalName is null for anonymous classes

--- a/dropwizard-core/src/test/java/io/dropwizard/setup/AdminEnvironmentTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/setup/AdminEnvironmentTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import javax.servlet.ServletRegistration;
 import java.io.PrintWriter;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AdminEnvironmentTest {
@@ -18,23 +19,45 @@ public class AdminEnvironmentTest {
     private final HealthCheckRegistry healthCheckRegistry = new HealthCheckRegistry();
     private final MetricRegistry metricRegistry = new MetricRegistry();
     private final AdminEnvironment env = new AdminEnvironment(handler, healthCheckRegistry, metricRegistry);
+    private final Task task = new Task("thing") {
+        @Override
+        public void execute(ImmutableMultimap<String, String> parameters, PrintWriter output) throws Exception {
+        }
+    };
 
     @Test
     public void addsATaskServlet() throws Exception {
-        final Task task = new Task("thing") {
-            @Override
-            public void execute(ImmutableMultimap<String, String> parameters, PrintWriter output) throws Exception {
-            }
-        };
         env.addTask(task);
 
         handler.setServer(new Server());
         handler.start();
 
         final ServletRegistration registration = handler.getServletHandler()
-                                                        .getServletContext()
-                                                        .getServletRegistration("tasks");
+                .getServletContext()
+                .getServletRegistration("tasks");
         assertThat(registration.getMappings())
                 .containsOnly("/tasks/*");
+    }
+
+    @Test
+    public void getsTaskClassCanonicalNameForInnerClass() {
+        assertThat(env.getTaskClassName.apply(new A())).isEqualTo(getClass().getCanonicalName() + ".A");
+    }
+
+    @Test
+    public void getsTaskClassNameForAnonymousClass() {
+        assertThat(env.getTaskClassName.apply(task)).isEqualTo(getClass().getCanonicalName() + "$1");
+    }
+
+    static class A extends Task {
+
+        protected A() {
+            super("a");
+        }
+
+        @Override
+        public void execute(ImmutableMultimap<String, String> parameters, PrintWriter output) throws Exception {
+            // nothing
+        }
     }
 }


### PR DESCRIPTION
instead of task.getClass().getCanonicalName(), task.getClass().getName is used for anonymous implementations of task.