### PR TITLE
Warning about maximum pool size and unbounded queues

### DIFF
--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
@@ -1,0 +1,46 @@
+package io.dropwizard.lifecycle.setup;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+
+import java.util.concurrent.ArrayBlockingQueue;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class ExecutorServiceBuilderTest {
+
+    private static final String WARNING = "Parameter 'maximumPoolSize' is conflicting with unbounded work queues";
+
+    private ExecutorServiceBuilder executorServiceBuilder;
+    private Logger log;
+
+    @Before
+    public void setUp() throws Exception {
+        executorServiceBuilder = new ExecutorServiceBuilder(new LifecycleEnvironment(), "test");
+        executorServiceBuilder.minThreads(4);
+        executorServiceBuilder.maxThreads(8);
+
+        log = mock(Logger.class);
+        ExecutorServiceBuilder.setLog(log);
+    }
+
+    @Test
+    public void testGiveAWarningAboutMaximumPoolSizeAndUnboundedQueue() {
+        executorServiceBuilder.build();
+
+        verify(log).warn(WARNING);
+    }
+
+    @Test
+    public void testGiveNoWarningAboutMaximumPoolSizeAndBoundedQueue() {
+        executorServiceBuilder.workQueue(new ArrayBlockingQueue<Runnable>(16));
+
+        executorServiceBuilder.build();
+
+        verify(log, never()).warn(WARNING);
+    }
+}


### PR DESCRIPTION
Fix #575
JDK ThreadPoolExecutor behaves a rather different than users can expect.

A user expects that parameter 'maximumPoolSize' controls maximum amount
of worker threads for processing tasks. When there is more tasks than
amount of worker threads then the pool grows incrementally to that size.

But actually ThreadPoolExecutor will grow the pool only if a queue is
reached it's bound. If the queue is unbounded then it won't increase
pool size beyond 'corePoolSize' limit. This seems rather awkward because
queue type shouldn't be related with speed of it's processing.

Anyway we should give a warning to users to improve their awareness
of the situation.