### PR TITLE
Remove Jersey GZip Encoder

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -64,7 +64,6 @@ public class DropwizardResourceConfig extends ResourceConfig {
         register(OptionalMessageBodyWriter.class);
         register(OptionalParamFeature.class);
         register(new SessionFactoryProvider.Binder());
-        EncodingFilter.enableFor(this, GZipEncoder.class);
     }
 
     public static DropwizardResourceConfig forTesting(MetricRegistry metricRegistry) {

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/GzipDefaultVaryBehaviourTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/GzipDefaultVaryBehaviourTest.java
@@ -20,7 +20,7 @@ public class GzipDefaultVaryBehaviourTest {
 
     @ClassRule
     public static final DropwizardAppRule<TestConfiguration> RULE =
-            new DropwizardAppRule<>(TestApplication.class, resourceFilePath("test-config.yaml"));
+            new DropwizardAppRule<>(TestApplication.class, resourceFilePath("gzip-vary-test-config.yaml"));
 
     @Test
     public void testDefaultVaryHeader() {

--- a/dropwizard-testing/src/test/resources/gzip-vary-test-config.yaml
+++ b/dropwizard-testing/src/test/resources/gzip-vary-test-config.yaml
@@ -1,0 +1,16 @@
+message: "Yes, it's here"
+extra: "Something extra"
+server:
+  gzip:
+    enabled: true
+    minimumEntitySize: 0B # Always compress regardless of size
+  applicationConnectors:
+    - type: http
+      port: 0
+  adminConnectors:
+    - type: http
+      port: 0
+  requestLog:
+    appenders: []
+logging:
+  appenders: []


### PR DESCRIPTION
Resolve #774, fix #821

Jersey GZipEncoder conflicts with Jetty BiDiGzipFilter and breaks
breaks backwards compatibility of Dropwizard configuration.

It always compresses responses if a client accepts gzip encoding,
which is not the same behaviour as in BiDiGzipFilter. The latter
is configured through a YML file, has more configuration options
and could be disabled externally. As a result users can't disable
response compressing even if they want to.

Also it conflicts with Jersey LoggingFilter, which is useful
for debug purposes.