### PR TITLE
Make endpoints information public

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -74,7 +74,7 @@ public class DropwizardResourceConfig extends ResourceConfig {
     public void logComponents() {
         LOGGER.debug("resources = {}", canonicalNamesByAnnotation(Path.class));
         LOGGER.debug("providers = {}", canonicalNamesByAnnotation(Provider.class));
-        LOGGER.info(logEndpoints());
+        LOGGER.info(getEndpointsInfo());
     }
 
     public String getUrlPattern() {
@@ -109,8 +109,7 @@ public class DropwizardResourceConfig extends ResourceConfig {
         return result;
     }
 
-    @VisibleForTesting
-    String logEndpoints() {
+    public String getEndpointsInfo() {
         final StringBuilder msg = new StringBuilder(1024);
         msg.append("The following paths were found for the configured resources:");
         msg.append(NEWLINE).append(NEWLINE);

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/setup/JerseyEnvironment.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/setup/JerseyEnvironment.java
@@ -107,7 +107,7 @@ public class JerseyEnvironment {
         config.setUrlPattern(urlPattern);
     }
 
-    public ResourceConfig getResourceConfig() {
+    public DropwizardResourceConfig getResourceConfig() {
         return config;
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
@@ -56,12 +56,12 @@ public class DropwizardResourceConfigTest {
     public void logsNoInterfaces() {
         rc.packages(getClass().getPackage().getName());
 
-        assertThat(rc.logEndpoints()).doesNotContain("io.dropwizard.jersey.DropwizardResourceConfigTest.ResourceInterface");
+        assertThat(rc.getEndpointsInfo()).doesNotContain("io.dropwizard.jersey.DropwizardResourceConfigTest.ResourceInterface");
     }
 
     @Test
     public void logsNoEndpointsWhenNoResourcesAreRegistered() {
-        assertThat(rc.logEndpoints()).contains("    NONE");
+        assertThat(rc.getEndpointsInfo()).contains("    NONE");
     }
 
     @Test
@@ -69,7 +69,7 @@ public class DropwizardResourceConfigTest {
         rc.register(TestResource.class);
         rc.register(ImplementingResource.class);
 
-        assertThat(rc.logEndpoints())
+        assertThat(rc.getEndpointsInfo())
                 .contains("GET     /dummy (io.dropwizard.jersey.DropwizardResourceConfigTest.TestResource)")
                 .contains("GET     /another (io.dropwizard.jersey.DropwizardResourceConfigTest.ImplementingResource)");
     }


### PR DESCRIPTION
List of endpoints is useful not only for logging but also as API for users.

This change was originally introduced in commit c0eb424, 
but has been lost after upgrading to Jersey. 

See PR #643 for reference