### PR TITLE
Make test instance constructors package-protected

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/ApacheClientBuilderBase.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/ApacheClientBuilderBase.java
@@ -36,7 +36,7 @@ abstract class ApacheClientBuilderBase<T extends ApacheClientBuilderBase, C exte
             .register("https", SSLConnectionSocketFactory.getSocketFactory())
             .build();
 
-    public ApacheClientBuilderBase(MetricRegistry metricRegistry, C configuration) {
+    protected ApacheClientBuilderBase(MetricRegistry metricRegistry, C configuration) {
         this.metricRegistry = metricRegistry;
         using(configuration);
     }

--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
@@ -39,7 +39,8 @@ public class HttpClientBuilder extends ApacheClientBuilderBase<HttpClientBuilder
         }
     };
 
-    public HttpClientBuilder(MetricRegistry metricRegistry) {
+    @VisibleForTesting
+    HttpClientBuilder(MetricRegistry metricRegistry) {
         super(metricRegistry, new HttpClientConfiguration());
     }
 

--- a/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
@@ -3,6 +3,7 @@ package io.dropwizard.client;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.httpclient.HttpClientMetricNameStrategy;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import io.dropwizard.jersey.gzip.ConfiguredGZipEncoder;
@@ -59,7 +60,8 @@ public class JerseyClientBuilder extends ApacheClientBuilderBase<JerseyClientBui
         super(environment, new JerseyClientConfiguration());
     }
 
-    public JerseyClientBuilder(MetricRegistry metricRegistry) {
+    @VisibleForTesting
+    JerseyClientBuilder(MetricRegistry metricRegistry) {
         super(metricRegistry, new JerseyClientConfiguration());
     }
 


### PR DESCRIPTION
Constructors that don't accept Environment should be package-protected because they are needed only in tests. 

In application code they confuse users.