### PR TITLE
Add Jersey Bean Validation Support

### DIFF
--- a/dropwizard-jersey/pom.xml
+++ b/dropwizard-jersey/pom.xml
@@ -48,6 +48,17 @@
             <version>${jersey.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.jersey.ext</groupId>
+            <artifactId>jersey-bean-validation</artifactId>
+            <version>${jersey.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hibernate</groupId>
+                    <artifactId>hibernate-validator</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-jersey2</artifactId>
             <version>${metrics3.version}</version>

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -21,6 +21,7 @@ import org.glassfish.jersey.server.monitoring.ApplicationEvent;
 import org.glassfish.jersey.server.monitoring.ApplicationEventListener;
 import org.glassfish.jersey.server.monitoring.RequestEvent;
 import org.glassfish.jersey.server.monitoring.RequestEventListener;
+import org.glassfish.jersey.server.validation.ValidationFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,6 +65,7 @@ public class DropwizardResourceConfig extends ResourceConfig {
         register(OptionalMessageBodyWriter.class);
         register(OptionalParamFeature.class);
         register(new SessionFactoryProvider.Binder());
+        register(ValidationFeature.class);
     }
 
     public static DropwizardResourceConfig forTesting(MetricRegistry metricRegistry) {


### PR DESCRIPTION
See https://jersey.java.net/documentation/latest/bean-validation.html for details
about the Bean Validation support in Jersey. It enables the use of Java validation annotations like `@NotNull`, `@Min`, or `@Email` in the context of JAX-RS and Jersey.

Merging this could probably fix #625 and #633 (as both, the issue and the PR, are now outdated anyway).