### PR TITLE
Add CommandRunner to dropwizard-testing

### DIFF
--- a/docs/source/manual/testing.rst
+++ b/docs/source/manual/testing.rst
@@ -288,3 +288,12 @@ running and stop it again when they've completed (roughly equivalent to having u
             assertThat(response.getStatus()).isEqualTo(302);
         }
     }
+
+If you need to run a Command in your integration tests use the ``CommandRunner`` class.  You may provide a
+command to run, or you can provide the command name if it is already loaded in your Application.
+``CommandRunner`` supports the same parameters and configuration options as ``DropwizardAppRule``.
+
+.. code-block:: java
+
+    CommandRunner<TestConfiguration> runner = new CommandRunner(MyApp.class, ResourceHelpers.resourceFilePath("my-app-config.yaml"), "CommandName");
+    runner.run();

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/CommandHelper.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/CommandHelper.java
@@ -1,0 +1,74 @@
+package io.dropwizard.testing;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.cli.Command;
+import io.dropwizard.setup.Bootstrap;
+import net.sourceforge.argparse4j.inf.Namespace;
+
+import static com.google.common.base.Throwables.propagate;
+
+abstract class CommandHelper<C extends Configuration> {
+    protected final Class<? extends Application<C>> applicationClass;
+    protected final String configPath;
+    protected final ConfigOverride[] configOverrides;
+
+    protected Application<C> application;
+    protected Bootstrap<C> bootstrap;
+    protected Namespace namespace;
+
+    public CommandHelper(Class<? extends Application<C>> applicationClass,
+                         String configPath,
+                         ConfigOverride... configOverrides) {
+        this.applicationClass = applicationClass;
+        this.configPath = configPath;
+        this.configOverrides = configOverrides;
+    }
+
+    protected void applyConfigOverrides() {
+        for (ConfigOverride configOverride: configOverrides) {
+            configOverride.addToSystemProperties();
+        }
+    }
+
+    protected void resetConfigOverrides() {
+        for (ConfigOverride configOverride : configOverrides) {
+            configOverride.removeFromSystemProperties();
+        }
+    }
+
+    public Application<C> newApplication() {
+        try {
+            return applicationClass.newInstance();
+        } catch (Exception e) {
+            throw propagate(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public <A extends Application<C>> A getApplication() {
+        return (A) application;
+    }
+
+    protected Bootstrap<C> newBootStrap(Application<C> app) {
+        return new Bootstrap<C>(app);
+    }
+
+    protected Namespace newNamespace() {
+        ImmutableMap.Builder<String, Object> file = ImmutableMap.builder();
+        if (!Strings.isNullOrEmpty(configPath)) {
+            file.put("file", configPath);
+        }
+        return new Namespace(file.build());
+    }
+
+    protected void initialize() {
+        application = newApplication();
+        bootstrap = newBootStrap(application);
+        namespace = newNamespace();
+
+        application.initialize(bootstrap);
+    }
+}

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/CommandRunner.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/CommandRunner.java
@@ -39,7 +39,7 @@ public class CommandRunner<C extends Configuration> extends CommandHelper<C> {
     protected Command getCommand(String name) {
         if(bootstrap == null) throw new RuntimeException("Must be initialized before getCommand is called.");
         for(Command command : bootstrap.getCommands()) {
-            if(command.getName() == name) return command;
+            if(command.getName().equals(name)) return command;
         }
         return null;
     }

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/CommandRunner.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/CommandRunner.java
@@ -1,0 +1,66 @@
+package io.dropwizard.testing;
+
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.cli.Command;
+
+/**
+ * A test support class to initialize the application and run a command.
+ * <p>
+ * By default, the {@link Application} will be constructed using reflection to invoke the nullary
+ * constructor. If your application does not provide a public nullary constructor, you will need to
+ * override the {@link #newApplication()} method to provide your application instance(s).
+ * </p>
+ * @param <C> the configuration type
+ */
+public class CommandRunner<C extends Configuration> extends CommandHelper<C> {
+    protected final String commandName;
+
+    protected Command command;
+
+    public CommandRunner(Class<? extends Application<C>> applicationClass,
+                         String configPath,
+                         String commandName,
+                         ConfigOverride... configOverrides) {
+        super(applicationClass, configPath, configOverrides);
+        this.commandName = commandName;
+        this.command = null;
+    }
+
+    public CommandRunner(Class<? extends Application<C>> applicationClass,
+                         String configPath,
+                         Command command,
+                         ConfigOverride... configOverrides) {
+        super(applicationClass, configPath, configOverrides);
+        this.commandName = null;
+        this.command = command;
+    }
+
+    protected Command getCommand(String name) {
+        if(bootstrap == null) throw new RuntimeException("Must be initialized before getCommand is called.");
+        for(Command command : bootstrap.getCommands()) {
+            if(command.getName() == name) return command;
+        }
+        return null;
+    }
+
+    /**
+     * Initialize the application and run the specified command.
+     */
+    public void run() {
+        applyConfigOverrides();
+        initialize();
+
+        try {
+            if (command == null) {
+                if(commandName == null) throw new RuntimeException("Either the command or the commandName must be set.");
+                command = getCommand(commandName);
+            }
+            command.run(bootstrap, namespace);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        resetConfigOverrides();
+    }
+}

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/CommandRunnerTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/CommandRunnerTest.java
@@ -1,0 +1,25 @@
+package io.dropwizard.testing;
+
+import io.dropwizard.testing.DropwizardTestSupportTest.TestConfiguration;
+import org.junit.Test;
+
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class CommandRunnerTest {
+    @Test
+    public void commandIsRun() {
+        TestCommand cmd = new TestCommand();
+        new CommandRunner<>(TestApplication.class, null, cmd).run();
+        assertThat(cmd.output, is("success"));
+    }
+
+    @Test
+    public void commandIsRunByName() {
+        CommandRunner<TestConfiguration> runner = new CommandRunner<>(TestApplication.class, null, "Test");
+        runner.run();
+        TestApplication application = runner.getApplication();
+        assertThat(application.testCommand.output, is("success"));
+    }
+}

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportTest.java
@@ -3,7 +3,6 @@ package io.dropwizard.testing;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMultimap;
-import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.servlets.tasks.Task;
 import io.dropwizard.setup.Environment;
@@ -76,14 +75,6 @@ public class DropwizardTestSupportTest {
                 .post(Entity.entity("", MediaType.TEXT_PLAIN), String.class);
 
         assertThat(response, is("Hello has been said to test_user"));
-    }
-
-    public static class TestApplication extends Application<TestConfiguration> {
-        @Override
-        public void run(TestConfiguration configuration, Environment environment) throws Exception {
-            environment.jersey().register(new TestResource(configuration.getMessage()));
-            environment.admin().addTask(new HelloTask());
-        }
     }
 
     @Path("/")

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/TestApplication.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/TestApplication.java
@@ -1,0 +1,24 @@
+package io.dropwizard.testing;
+
+import io.dropwizard.Application;
+import io.dropwizard.cli.Command;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.DropwizardTestSupportTest.HelloTask;
+import io.dropwizard.testing.DropwizardTestSupportTest.TestConfiguration;
+import io.dropwizard.testing.DropwizardTestSupportTest.TestResource;
+
+public class TestApplication extends Application<TestConfiguration> {
+    public TestCommand testCommand = new TestCommand();
+
+    @Override
+    public void initialize(Bootstrap<TestConfiguration> bootstrap) {
+        bootstrap.addCommand(testCommand);
+    }
+
+    @Override
+    public void run(TestConfiguration configuration, Environment environment) throws Exception {
+        environment.jersey().register(new TestResource(configuration.getMessage()));
+        environment.admin().addTask(new HelloTask());
+    }
+}

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/TestCommand.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/TestCommand.java
@@ -1,0 +1,24 @@
+package io.dropwizard.testing;
+
+import io.dropwizard.cli.Command;
+import io.dropwizard.setup.Bootstrap;
+import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparser;
+
+public class TestCommand extends Command {
+    public String output = null;
+
+    protected TestCommand() {
+        super("Test", "A simple command for use with testing.");
+    }
+
+    @Override
+    public void configure(Subparser subparser) {
+
+    }
+
+    @Override
+    public void run(Bootstrap<?> bootstrap, Namespace namespace) throws Exception {
+        output = "success";
+    }
+}


### PR DESCRIPTION
I needed a way to run commands during integration testing.

This PR adds a CommandRunner that supports running Commands against a provided Application and configuration.  I also refactored DropwizardTestSupport so that it and CommandRunner can share code.