### PR TITLE
Connection request timeout

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -843,23 +843,24 @@ See HttpClientConfiguration_  for more options.
       userAgent: <application name> (<client name>)
 
 
-======================= ======================================  =============================================================================
-Name                    Default                                 Description
-======================= ======================================  =============================================================================
-timeout                 500 milliseconds                        The maximum idle time for a connection, once established.
-connectionTimeout       500 milliseconds                        The maximum time to wait for a connection to open.
-timeToLive              1 hour                                  The maximum time a pooled connection can stay idle (not leased to any thread)
-                                                                before it is shut down.
-cookiesEnabled          false                                   Whether or not to enable cookies.
-maxConnections          1024                                    The maximum number of concurrent open connections.
-maxConnectionsPerRoute  1024                                    The maximum number of concurrent open connections per route.
-keepAlive               0 milliseconds                          The maximum time a connection will be kept alive before it is reconnected. If set
-                                                                to 0, connections will be immediately closed after every request/response.
-retries                 0                                       The number of times to retry failed requests. Requests are only
-                                                                retried if they throw an exception other than ``InterruptedIOException``,
-                                                                ``UnknownHostException``, ``ConnectException``, or ``SSLException``.
-userAgent               ``applicationName`` (``clientName``)    The User-Agent to send with requests.
-======================= ======================================  =============================================================================
+========================= ======================================  =============================================================================
+Name                      Default                                 Description
+========================= ======================================  =============================================================================
+timeout                   500 milliseconds                        The maximum idle time for a connection, once established.
+connectionTimeout         500 milliseconds                        The maximum time to wait for a connection to open.
+connectionRequestTimeout  500 milliseconds                        The maximum time to wait for a connection to be returned from the connection pool.
+timeToLive                1 hour                                  The maximum time a pooled connection can stay idle (not leased to any thread)
+                                                                  before it is shut down.
+cookiesEnabled            false                                   Whether or not to enable cookies.
+maxConnections            1024                                    The maximum number of concurrent open connections.
+maxConnectionsPerRoute    1024                                    The maximum number of concurrent open connections per route.
+keepAlive                 0 milliseconds                          The maximum time a connection will be kept alive before it is reconnected. If set
+                                                                  to 0, connections will be immediately closed after every request/response.
+retries                   0                                       The number of times to retry failed requests. Requests are only
+                                                                  retried if they throw an exception other than ``InterruptedIOException``,
+                                                                  ``UnknownHostException``, ``ConnectException``, or ``SSLException``.
+userAgent                 ``applicationName`` (``clientName``)    The User-Agent to send with requests.
+========================= ======================================  =============================================================================
 
 
 .. _man-configuration-clients-jersey:

--- a/dropwizard-client/src/main/java/io/dropwizard/client/ApacheClientBuilderBase.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/ApacheClientBuilderBase.java
@@ -161,10 +161,12 @@ abstract class ApacheClientBuilderBase<T extends ApacheClientBuilderBase, C exte
         final String cookiePolicy = configuration.isCookiesEnabled() ? CookieSpecs.BEST_MATCH : CookieSpecs.IGNORE_COOKIES;
         final Integer timeout = (int) configuration.getTimeout().toMilliseconds();
         final Integer connectionTimeout = (int) configuration.getConnectionTimeout().toMilliseconds();
+        final Integer connectionRequestTimeout = (int) configuration.getConnectionRequestTimeout().toMilliseconds();
         return RequestConfig.custom()
                 .setCookieSpec(cookiePolicy)
                 .setSocketTimeout(timeout)
                 .setConnectTimeout(connectionTimeout)
+                .setConnectionRequestTimeout(connectionRequestTimeout)
                 .setStaleConnectionCheckEnabled(false)
                 .build();
     }

--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientConfiguration.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientConfiguration.java
@@ -13,7 +13,7 @@ import javax.validation.constraints.NotNull;
 /**
  * The configuration class used by {@link HttpClientBuilder}.
  *
- * @see <a href="http://www.dropwizard.io/manual/client/#configuration-defaults">Http Client Configuration</a>
+ * @see <a href="http://dropwizard.io/manual/configuration.html#httpclient">Http Client Configuration</a>
  */
 public class HttpClientConfiguration {
     @NotNull
@@ -21,6 +21,9 @@ public class HttpClientConfiguration {
 
     @NotNull
     private Duration connectionTimeout = Duration.milliseconds(500);
+    
+    @NotNull
+    private Duration connectionRequestTimeout = Duration.milliseconds(500);
 
     @NotNull
     private Duration timeToLive = Duration.hours(1);
@@ -94,8 +97,18 @@ public class HttpClientConfiguration {
     public void setConnectionTimeout(Duration duration) {
         this.connectionTimeout = duration;
     }
+    
+    @JsonProperty
+    public Duration getConnectionRequestTimeout() {
+		return connectionRequestTimeout;
+	}
 
     @JsonProperty
+	public void setConnectionRequestTimeout(Duration connectionRequestTimeout) {
+		this.connectionRequestTimeout = connectionRequestTimeout;
+	}
+    
+	@JsonProperty
     public void setTimeToLive(Duration timeToLive) {
         this.timeToLive = timeToLive;
     }

--- a/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
@@ -224,6 +224,15 @@ public class HttpClientBuilderTest {
         assertThat(((RequestConfig) spyHttpClientBuilderField("defaultRequestConfig", apacheBuilder)).getConnectTimeout())
                 .isEqualTo(500);
     }
+    
+    @Test
+    public void setsTheConnectionRequestTimeout() throws Exception {
+    	configuration.setConnectionRequestTimeout(Duration.milliseconds(123));
+    	
+    	assertThat(builder.using(configuration).createClient(apacheBuilder, connectionManager, "test")).isNotNull();
+    	assertThat(((RequestConfig) spyHttpClientBuilderField("defaultRequestConfig", apacheBuilder)).getConnectionRequestTimeout())
+        		.isEqualTo(123);
+    }
 
     @Test
     public void disablesNaglesAlgorithm() throws Exception {


### PR DESCRIPTION
When number of connections per route reaches the limit (dropwizard default is 1024) a call to fetch the next connection will block. The default timeout is not set so the wait might potentially exceed the expectations. A special case is that the thread could stuck if connections are leaked somewhere instead of generating timeout exception.

This PR adds a way to set this timeout by adding an attribute to HttpClientConfiguration and support for it for both JerseyClient and HttpClient.