### PR TITLE
fixing an issue where the "name" prefix for HttpClient metrics would not...

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
@@ -88,7 +88,7 @@ public class HttpClientBuilder extends ApacheClientBuilderBase<HttpClientBuilder
                 .setSoTimeout(timeout)
                 .build();
 
-        builder.setRequestExecutor(new InstrumentedHttpRequestExecutor(metricRegistry, metricNameStrategy))
+        builder.setRequestExecutor(new InstrumentedHttpRequestExecutor(metricRegistry, metricNameStrategy, name))
                 .setConnectionManager(manager)
                 .setDefaultRequestConfig(requestConfig)
                 .setDefaultSocketConfig(socketConfig)


### PR DESCRIPTION
I noticed that the metrics for HttpClients, when named, did not include the name.  For example: org.apache.http.client.HttpClient./api/v1/services.get-requests even though I specified a name and the connection manager metrics correctly showed it.  I found a simple omission of this parameter in the HttpClientBuilder.  Now my metrics look like this: org.apache.http.client.HttpClient.PagerDuty./api/v1/services.get-requests and I am happy (PagerDuty == the name I used to build the client)