### PR TITLE
change dropwizard-forms packaging

### DIFF
--- a/dropwizard-forms/pom.xml
+++ b/dropwizard-forms/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>dropwizard-forms</artifactId>
-    <packaging>pom</packaging>
+    <packaging>jar</packaging>
     <name>Dropwizard Multipart Form Support</name>
 
     <dependencies>


### PR DESCRIPTION
Packaging needs to be changed to jar to be able to use the new bundle.