### PR TITLE
Configure Jersey client thread pool with a bounded queue

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -879,6 +879,7 @@ See JerseyClientConfiguration_ and HttpClientConfiguration_ for more options.
     jerseyClient:
       minThreads: 1
       maxThreads: 128
+      workQueueSize: 8
       gzipEnabled: true
       gzipEnabledForRequests: true
       chunkedEncodingEnabled: true
@@ -889,6 +890,8 @@ Name                    Default             Description
 ======================= ==================  ===================================================================================================
 minThreads              1                   The minimum number of threads in the pool used for asynchronous requests.
 maxThreads              128                 The maximum number of threads in the pool used for asynchronous requests.
+workQueueSize           8                   The size of the work queue of the pool used for asynchronous requests.
+                                            Additional threads will be spawn only if the queue is reached its maximum size.
 gzipEnabled             true                Adds an Accept-Encoding: gzip header to all requests, and enables automatic gzip decoding of responses.
 gzipEnabledForRequests  true                Adds a Content-Encoding: gzip header to all requests, and enables automatic gzip encoding of requests.
 chunkedEncodingEnabled  true                Enables the use of chunked encoding for requests.

--- a/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
@@ -27,6 +27,7 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Configuration;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -272,6 +273,7 @@ public class JerseyClientBuilder {
                 .executorService("jersey-client-" + name + "-%d")
                 .minThreads(configuration.getMinThreads())
                 .maxThreads(configuration.getMaxThreads())
+                .workQueue(new ArrayBlockingQueue<Runnable>(configuration.getWorkQueueSize()))
                 .build(),
                 environment.getObjectMapper(),
                 environment.getValidator());

--- a/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientConfiguration.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientConfiguration.java
@@ -25,6 +25,10 @@ public class JerseyClientConfiguration extends HttpClientConfiguration {
     @Max(16 * 1024)
     private int maxThreads = 128;
 
+    @Min(1)
+    @Max(16 * 1024)
+    private int workQueueSize = 8;
+
     private boolean gzipEnabled = true;
 
     private boolean gzipEnabledForRequests = true;
@@ -79,6 +83,16 @@ public class JerseyClientConfiguration extends HttpClientConfiguration {
     @JsonProperty
     public void setChunkedEncodingEnabled(final boolean chunkedEncodingEnabled) {
         this.chunkedEncodingEnabled = chunkedEncodingEnabled;
+    }
+
+    @JsonProperty
+    public int getWorkQueueSize() {
+        return workQueueSize;
+    }
+
+    @JsonProperty
+    public void setWorkQueueSize(int workQueueSize) {
+        this.workQueueSize = workQueueSize;
     }
 
     @JsonIgnore

--- a/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientConfiguration.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientConfiguration.java
@@ -12,7 +12,7 @@ import javax.validation.constraints.Min;
  * {@link HttpClientConfiguration}.
  *
  * @see HttpClientConfiguration
- * @see <a href="http://www.dropwizard.io/manual/client/#man-client-jersey-config">Jersey Client Configuration</a>
+ * @see <a href="http://dropwizard.io/manual/configuration.html#jerseyclient">Jersey Client Configuration</a>
  */
 public class JerseyClientConfiguration extends HttpClientConfiguration {
     @Min(1)

--- a/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientConfiguration.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientConfiguration.java
@@ -7,8 +7,6 @@ import io.dropwizard.validation.ValidationMethod;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 
-// TODO: 5/15/13 <coda> -- write tests for JerseyClientConfiguration
-
 /**
  * The configuration class used by {@link JerseyClientBuilder}. Extends
  * {@link HttpClientConfiguration}.

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientConfigurationTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientConfigurationTest.java
@@ -1,0 +1,28 @@
+package io.dropwizard.client;
+
+import com.google.common.io.Resources;
+import io.dropwizard.configuration.ConfigurationFactory;
+import io.dropwizard.jackson.Jackson;
+import org.junit.Test;
+
+import javax.validation.Validation;
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JerseyClientConfigurationTest {
+
+    @Test
+    public void testBasicJerseyClient() throws Exception {
+        final JerseyClientConfiguration configuration = new ConfigurationFactory<>(JerseyClientConfiguration.class,
+                Validation.buildDefaultValidatorFactory().getValidator(), Jackson.newObjectMapper(), "dw")
+                .build(new File(Resources.getResource("yaml/jersey-client.yml").toURI()));
+
+        assertThat(configuration.getMinThreads()).isEqualTo(8);
+        assertThat(configuration.getMaxThreads()).isEqualTo(64);
+        assertThat(configuration.getWorkQueueSize()).isEqualTo(16);
+        assertThat(configuration.isGzipEnabled()).isFalse();
+        assertThat(configuration.isGzipEnabledForRequests()).isFalse();
+        assertThat(configuration.isChunkedEncodingEnabled()).isFalse();
+    }
+}

--- a/dropwizard-client/src/test/resources/yaml/jersey-client.yml
+++ b/dropwizard-client/src/test/resources/yaml/jersey-client.yml
@@ -1,0 +1,6 @@
+minThreads: 8
+maxThreads: 64
+gzipEnabled: false
+workQueueSize: 16
+gzipEnabledForRequests: false
+chunkedEncodingEnabled : false


### PR DESCRIPTION
In relation to #834 

Jersey's async thread pool is configured with 2 parameters: *minThreads* and *maxThreads*. 
The problem is that the pool will not grow up than *minThread* because its work queue is 
unbounded. It's a property of JDK *ThreadPoolExecutor*.

A solution to this problem is to set a bounded queue as the work queue and provide facility 
to users to set the queue size.

By default queue size is set to 8. It's a middle ground between creating too many threads 
and waiting too much time in the queue without spawning new threads.