### PR TITLE
Updated Integration Test instructions in documentation

### DIFF
--- a/docs/source/manual/testing.rst
+++ b/docs/source/manual/testing.rst
@@ -323,11 +323,12 @@ running and stop it again when they've completed (roughly equivalent to having u
 
         @Test
         public void loginHandlerRedirectsAfterPost() {
-            Client client = new Client();
+            Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("test client");
 
-            ClientResponse response = client.resource(
-                    String.format("http://localhost:%d/login", RULE.getLocalPort()))
-                    .post(ClientResponse.class, loginForm());
+            ClientResponse response = client.target(
+                     String.format("http://localhost:%d/login", RULE.getLocalPort()))
+                    .request()
+                    .post(Entity.json(loginForm()), ClientResponse.class);
 
             assertThat(response.getStatus()).isEqualTo(302);
         }


### PR DESCRIPTION
When writing tests, I noticed Integration Tests docs are slightly out of date: not using JerseyClientBuilder nor client.target(). So I've updated them accordingly.

This is a cleaned up version of PR #859 