### PR TITLE
Syntax error in docs scrubbed, and MultiPartBundle includes config interface now

### DIFF
--- a/docs/source/manual/forms.rst
+++ b/docs/source/manual/forms.rst
@@ -20,7 +20,7 @@ Then, in your application's ``initialize`` method, add a new ``MultiPartBundle``
 
     @Override
     public void initialize(Bootstrap<ExampleConfiguration> bootstrap) {
-        bootstrap.addBundle(new MultiPartBundle<ExampleConfiguration>();
+        bootstrap.addBundle(new MultiPartBundle<ExampleConfiguration>());
     }
 
 More Information

--- a/dropwizard-forms/src/main/java/io/dropwizard/forms/MultiPartBundle.java
+++ b/dropwizard-forms/src/main/java/io/dropwizard/forms/MultiPartBundle.java
@@ -1,6 +1,7 @@
 package io.dropwizard.forms;
 
-import io.dropwizard.Bundle;
+import io.dropwizard.Configuration;
+import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
@@ -8,16 +9,18 @@ import org.glassfish.jersey.media.multipart.MultiPartFeature;
 /**
  * A {@link Bundle}, which enables the processing of multi-part form data by your application.
  *
+ * @param <T>    the required configuration interface
+ * 
  * @see org.glassfish.jersey.media.multipart.MultiPartFeature
  * @see <a href="https://jersey.java.net/documentation/latest/media.html#multipart">Jersey Multipart</a>
  */
-public class MultiPartBundle implements Bundle {
+public class MultiPartBundle<T extends Configuration> implements ConfiguredBundle<T> {
     @Override
     public void initialize(Bootstrap<?> bootstrap) {
     }
 
     @Override
-    public void run(Environment environment) {
-        environment.jersey().register(MultiPartFeature.class);
+    public final void run(T configuration, Environment environment) throws Exception {
+        environment.jersey().register(new MultiPartFeature());
     }
 }

--- a/dropwizard-forms/src/test/java/io/dropwizard/forms/MultiPartBundleTest.java
+++ b/dropwizard-forms/src/test/java/io/dropwizard/forms/MultiPartBundleTest.java
@@ -23,7 +23,7 @@ public class MultiPartBundleTest {
                 getClass().getClassLoader()
         );
 
-        new MultiPartBundle<Configuration>().run(environment);
+        new MultiPartBundle<Configuration>().run(configuration, environment);
 
         assertThat(environment.jersey().getResourceConfig().getClasses()).contains(MultiPartFeature.class);
     }

--- a/dropwizard-forms/src/test/java/io/dropwizard/forms/MultiPartBundleTest.java
+++ b/dropwizard-forms/src/test/java/io/dropwizard/forms/MultiPartBundleTest.java
@@ -1,5 +1,6 @@
 package io.dropwizard.forms;
 
+import io.dropwizard.Configuration;
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.setup.Environment;
@@ -7,8 +8,10 @@ import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class MultiPartBundleTest {
+    private final Configuration configuration = mock(Configuration.class);
 
     @Test
     public void testRun() throws Exception {
@@ -20,7 +23,7 @@ public class MultiPartBundleTest {
                 getClass().getClassLoader()
         );
 
-        new MultiPartBundle().run(environment);
+        new MultiPartBundle<Configuration>().run(environment);
 
         assertThat(environment.jersey().getResourceConfig().getClasses()).contains(MultiPartFeature.class);
     }


### PR DESCRIPTION
Configuration interface is now carried into the MultiPartForm bundle and I grabbed a quick syntax error in the docs.  Everything should match up.