### PR TITLE
Fixed connection leak in CloseableLiquibase

### DIFF
--- a/dropwizard-example/src/test/java/io/dropwizard/migrations/CloseableLiquibaseTest.java
+++ b/dropwizard-example/src/test/java/io/dropwizard/migrations/CloseableLiquibaseTest.java
@@ -1,0 +1,38 @@
+package io.dropwizard.migrations;
+
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.db.ManagedPooledDataSource;
+import org.apache.tomcat.jdbc.pool.ConnectionPool;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CloseableLiquibaseTest {
+
+    CloseableLiquibase liquibase;
+    ManagedPooledDataSource dataSource;
+
+    @Before
+    public void setUp() throws Exception {
+        DataSourceFactory factory = new DataSourceFactory();
+
+        factory.setDriverClass(org.h2.Driver.class.getName());
+        factory.setUrl("jdbc:h2:mem:DbTest-" + System.currentTimeMillis());
+        factory.setUser("DbTest");
+
+        dataSource = (ManagedPooledDataSource) factory.build(new MetricRegistry(), "DbTest");
+        liquibase = new CloseableLiquibase(dataSource);
+    }
+
+    @Test
+    public void testWhenClosingAllConnectionsInPoolIsReleased() throws Exception {
+        ConnectionPool pool = dataSource.getPool();
+        liquibase.close();
+
+        assertThat(pool.getActive()).isZero();
+        assertThat(pool.getIdle()).isZero();
+        assertThat(pool.isClosed()).isTrue();
+    }
+}

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibase.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibase.java
@@ -6,14 +6,10 @@ import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.LiquibaseException;
 import liquibase.resource.ClassLoaderResourceAccessor;
 import liquibase.resource.FileSystemResourceAccessor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.sql.SQLException;
 
 public class CloseableLiquibase extends Liquibase implements AutoCloseable {
-    private static final Logger LOGGER = LoggerFactory.getLogger("liquibase");
-
     private static final String DEFAULT_MIGRATIONS_FILE = "migrations.xml";
     private final ManagedDataSource dataSource;
 
@@ -35,10 +31,8 @@ public class CloseableLiquibase extends Liquibase implements AutoCloseable {
     public void close() throws Exception {
         try {
             database.close();
-        } catch (LiquibaseException e){
-            LOGGER.warn("Failed to close liquibase", e);
+        } finally {
+            dataSource.stop();
         }
-
-        dataSource.stop();
     }
 }

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibase.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibase.java
@@ -6,10 +6,14 @@ import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.LiquibaseException;
 import liquibase.resource.ClassLoaderResourceAccessor;
 import liquibase.resource.FileSystemResourceAccessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.SQLException;
 
 public class CloseableLiquibase extends Liquibase implements AutoCloseable {
+    private static final Logger LOGGER = LoggerFactory.getLogger("liquibase");
+
     private static final String DEFAULT_MIGRATIONS_FILE = "migrations.xml";
     private final ManagedDataSource dataSource;
 
@@ -29,6 +33,12 @@ public class CloseableLiquibase extends Liquibase implements AutoCloseable {
 
     @Override
     public void close() throws Exception {
+        try {
+            database.close();
+        } catch (LiquibaseException e){
+            LOGGER.warn("Failed to close liquibase", e);
+        }
+
         dataSource.stop();
     }
 }


### PR DESCRIPTION
When creating an instance of `CloseableLiquibase`, a jdbc connection is fetched from the supplied datasource. This connection is never closed in `CloseableLiquibase#close`, which results in a connection leak. 

I'm not sure if catching `LiquibaseException` is the "right" thing to do, let me know if I should just propagate the exception.