### PR TITLE
Update JDBI Version and Remove Unnecessary Classmate Exclusion

### DIFF
--- a/dropwizard-jdbi/pom.xml
+++ b/dropwizard-jdbi/pom.xml
@@ -20,13 +20,7 @@
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi</artifactId>
-            <version>2.57</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml</groupId>
-                    <artifactId>classmate</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>2.59</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>


### PR DESCRIPTION
The version bump is straightforward.

Classmate *is* used by jdbi, but it is shaded and renamespaced. There is no declared dependency on classmate.