### PR TITLE
Print error messages (if any) when initializing loggers

### DIFF
--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/LoggingFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/LoggingFactory.java
@@ -8,6 +8,7 @@ import ch.qos.logback.classic.jmx.JMXConfigurator;
 import ch.qos.logback.classic.jul.LevelChangePropagator;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.ConsoleAppender;
+import ch.qos.logback.core.util.StatusPrinter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.logback.InstrumentedAppender;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -21,12 +22,12 @@ import org.slf4j.bridge.SLF4JBridgeHandler;
 import javax.management.*;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import java.io.PrintStream;
 import java.lang.management.ManagementFactory;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 
-import static ch.qos.logback.core.util.StatusPrinter.printIfErrorsOccured;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class LoggingFactory {
@@ -78,13 +79,17 @@ public class LoggingFactory {
     @JsonIgnore
     private final LoggerContext loggerContext;
 
+    @JsonIgnore
+    private final PrintStream configurationErrorsStream;
+
     public LoggingFactory() {
-        this((LoggerContext) LoggerFactory.getILoggerFactory());
+        this((LoggerContext) LoggerFactory.getILoggerFactory(), System.err);
     }
 
     @VisibleForTesting
-    LoggingFactory(LoggerContext loggerContext) {
+    LoggingFactory(LoggerContext loggerContext, PrintStream configurationErrorsStream) {
         this.loggerContext = checkNotNull(loggerContext);
+        this.configurationErrorsStream = checkNotNull(configurationErrorsStream);
     }
 
     @JsonProperty
@@ -126,7 +131,12 @@ public class LoggingFactory {
             root.addAppender(output.build(loggerContext, name, null));
         }
 
-        printIfErrorsOccured(loggerContext);
+        StatusPrinter.setPrintStream(configurationErrorsStream);
+        try {
+            StatusPrinter.printIfErrorsOccured(loggerContext);
+        }finally {
+            StatusPrinter.setPrintStream(System.out);
+        }
 
         final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
         try {

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/LoggingFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/LoggingFactory.java
@@ -123,16 +123,16 @@ public class LoggingFactory {
         final Logger root = configureLevels();
 
         for (AppenderFactory output : appenders) {
-            root.addAppender(output.build(root.getLoggerContext(), name, null));
+            root.addAppender(output.build(loggerContext, name, null));
         }
 
-        printIfErrorsOccured(root.getLoggerContext());
+        printIfErrorsOccured(loggerContext);
 
         final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
         try {
             final ObjectName objectName = new ObjectName("io.dropwizard:type=Logging");
             if (!server.isRegistered(objectName)) {
-                server.registerMBean(new JMXConfigurator(root.getLoggerContext(),
+                server.registerMBean(new JMXConfigurator(loggerContext,
                                                          server,
                                                          objectName),
                                      objectName);
@@ -151,20 +151,20 @@ public class LoggingFactory {
 
     private void configureInstrumentation(Logger root, MetricRegistry metricRegistry) {
         final InstrumentedAppender appender = new InstrumentedAppender(metricRegistry);
-        appender.setContext(root.getLoggerContext());
+        appender.setContext(loggerContext);
         appender.start();
         root.addAppender(appender);
     }
 
     private Logger configureLevels() {
         final Logger root = loggerContext.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
-        root.getLoggerContext().reset();
+        loggerContext.reset();
 
         final LevelChangePropagator propagator = new LevelChangePropagator();
-        propagator.setContext(root.getLoggerContext());
+        propagator.setContext(loggerContext);
         propagator.setResetJUL(true);
 
-        root.getLoggerContext().addListener(propagator);
+        loggerContext.addListener(propagator);
 
         root.setLevel(level);
 

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/LoggingFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/LoggingFactory.java
@@ -77,10 +77,10 @@ public class LoggingFactory {
     );
 
     @JsonIgnore
-    private final LoggerContext loggerContext;
+    final LoggerContext loggerContext;
 
     @JsonIgnore
-    private final PrintStream configurationErrorsStream;
+    final PrintStream configurationErrorsStream;
 
     public LoggingFactory() {
         this((LoggerContext) LoggerFactory.getILoggerFactory(), System.err);

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/LoggingFactoryPrintErrorMessagesTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/LoggingFactoryPrintErrorMessagesTest.java
@@ -1,0 +1,93 @@
+package io.dropwizard.logging;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.core.util.StatusPrinter;
+import com.codahale.metrics.MetricRegistry;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LoggingFactoryPrintErrorMessagesTest {
+
+    @Rule
+    public final TemporaryFolder tempDir = new TemporaryFolder();
+
+    File folderWithoutWritePermission;
+    File folderWithWritePermission;
+
+    LoggingFactory factory;
+    LoggerContext loggerContext;
+
+    @Before
+    public void setUp() throws Exception {
+        folderWithoutWritePermission = tempDir.newFolder("folder-without-write-permission");
+        folderWithoutWritePermission.setWritable(false);
+
+        folderWithWritePermission = tempDir.newFolder("folder-with-write-permission");
+
+        loggerContext = new LoggerContext();
+        factory = new LoggingFactory(loggerContext);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        loggerContext.stop();
+    }
+
+    private void configureLoggingFactoryWithFileAppender(File file){
+        factory.setAppenders(singletonList(newFileAppenderFactory(file)));
+    }
+
+    private AppenderFactory newFileAppenderFactory(File file){
+        FileAppenderFactory fileAppenderFactory = new FileAppenderFactory();
+
+        fileAppenderFactory.setCurrentLogFilename(file.toString() + File.separator + "my-log-file.log");
+        fileAppenderFactory.setArchive(false);
+
+        return fileAppenderFactory;
+    }
+
+    private String configureAndCaptureSystemOut() throws UnsupportedEncodingException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        try {
+            StatusPrinter.setPrintStream(new PrintStream(out));
+            factory.configure(new MetricRegistry(), "logger-test");
+        }finally {
+            StatusPrinter.setPrintStream(System.out);
+        }
+
+        return out.toString(StandardCharsets.UTF_8.name());
+    }
+
+    @Test
+    public void testWhenFileAppenderDoesNotHaveWritePermissionToFolder_PrintsErrorMessageToConsole() throws Exception {
+        File file = folderWithoutWritePermission;
+
+        configureLoggingFactoryWithFileAppender(file);
+
+        assertThat(file.canWrite()).isFalse();
+        assertThat(configureAndCaptureSystemOut()).contains(file.toString());
+    }
+
+    @Test
+    public void testWhenSettingUpLoggingWithValidConfiguration_NoErrorMessageIsPrintedToConsole() throws Exception {
+        File file = folderWithWritePermission;
+
+        configureLoggingFactoryWithFileAppender(file);
+
+        assertThat(file.canWrite()).isTrue();
+        assertThat(configureAndCaptureSystemOut()).isEmpty();
+    }
+}

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/LoggingFactoryPrintErrorMessagesTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/LoggingFactoryPrintErrorMessagesTest.java
@@ -27,7 +27,6 @@ public class LoggingFactoryPrintErrorMessagesTest {
     File folderWithWritePermission;
 
     LoggingFactory factory;
-    LoggerContext loggerContext;
 
     @Before
     public void setUp() throws Exception {
@@ -36,20 +35,19 @@ public class LoggingFactoryPrintErrorMessagesTest {
 
         folderWithWritePermission = tempDir.newFolder("folder-with-write-permission");
 
-        loggerContext = new LoggerContext();
-        factory = new LoggingFactory(loggerContext);
+        factory = new LoggingFactory(new LoggerContext());
     }
 
     @After
     public void tearDown() throws Exception {
-        loggerContext.stop();
+        factory.stop();
     }
 
-    private void configureLoggingFactoryWithFileAppender(File file){
+    private void configureLoggingFactoryWithFileAppender(File file) {
         factory.setAppenders(singletonList(newFileAppenderFactory(file)));
     }
 
-    private AppenderFactory newFileAppenderFactory(File file){
+    private AppenderFactory newFileAppenderFactory(File file) {
         FileAppenderFactory fileAppenderFactory = new FileAppenderFactory();
 
         fileAppenderFactory.setCurrentLogFilename(file.toString() + File.separator + "my-log-file.log");

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/LoggingFactoryPrintErrorMessagesTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/LoggingFactoryPrintErrorMessagesTest.java
@@ -25,19 +25,11 @@ public class LoggingFactoryPrintErrorMessagesTest {
     @Rule
     public final TemporaryFolder tempDir = new TemporaryFolder();
 
-    File folderWithoutWritePermission;
-    File folderWithWritePermission;
-
     LoggingFactory factory;
     ByteArrayOutputStream output;
 
     @Before
     public void setUp() throws Exception {
-        folderWithoutWritePermission = tempDir.newFolder("folder-without-write-permission");
-        folderWithoutWritePermission.setWritable(false);
-
-        folderWithWritePermission = tempDir.newFolder("folder-with-write-permission");
-
         output = new ByteArrayOutputStream();
         factory = new LoggingFactory(new LoggerContext(), new PrintStream(output));
     }
@@ -82,21 +74,22 @@ public class LoggingFactoryPrintErrorMessagesTest {
 
     @Test
     public void testWhenFileAppenderDoesNotHaveWritePermissionToFolder_PrintsErrorMessageToConsole() throws Exception {
-        File file = folderWithoutWritePermission;
+        File folderWithoutWritePermission = tempDir.newFolder("folder-without-write-permission");
+        folderWithoutWritePermission.setWritable(false);
 
-        configureLoggingFactoryWithFileAppender(file);
+        configureLoggingFactoryWithFileAppender(folderWithoutWritePermission);
 
-        assertThat(file.canWrite()).isFalse();
-        assertThat(configureAndGetOutputWrittenToErrorStream()).contains(file.toString());
+        assertThat(folderWithoutWritePermission.canWrite()).isFalse();
+        assertThat(configureAndGetOutputWrittenToErrorStream()).contains(folderWithoutWritePermission.toString());
     }
 
     @Test
     public void testWhenSettingUpLoggingWithValidConfiguration_NoErrorMessageIsPrintedToConsole() throws Exception {
-        File file = folderWithWritePermission;
+        File folderWithWritePermission = tempDir.newFolder("folder-with-write-permission");
 
-        configureLoggingFactoryWithFileAppender(file);
+        configureLoggingFactoryWithFileAppender(folderWithWritePermission);
 
-        assertThat(file.canWrite()).isTrue();
+        assertThat(folderWithWritePermission.canWrite()).isTrue();
         assertThat(configureAndGetOutputWrittenToErrorStream()).isEmpty();
     }
 

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/LoggingFactoryPrintErrorMessagesTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/LoggingFactoryPrintErrorMessagesTest.java
@@ -8,6 +8,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -63,6 +64,20 @@ public class LoggingFactoryPrintErrorMessagesTest {
         factory.configure(new MetricRegistry(), "logger-test");
 
         return output.toString(StandardCharsets.UTF_8.name());
+    }
+
+    @Test
+    public void testWhenUsingDefaultConstructor_SystemErrIsSet() throws Exception {
+        PrintStream configurationErrorsStream = new LoggingFactory().configurationErrorsStream;
+
+        assertThat(configurationErrorsStream).isSameAs(System.err);
+    }
+
+    @Test
+    public void testWhenUsingDefaultConstructor_StaticILoggerFactoryIsSet() throws Exception {
+        LoggerContext loggerContext = new LoggingFactory().loggerContext;
+
+        assertThat(loggerContext).isSameAs(LoggerFactory.getILoggerFactory());
     }
 
     @Test


### PR DESCRIPTION
A couple of days ago, I spent a ridiculous amount of time tracking down a relatively stupid issue. 

Turned out that I had messed up write permission in my log directly. So the file appender
couldn't write to my configured log directory.

My own fault, I know. But I got no warning when I started up the application. 

So, I'm proposing a change :)

In `LoggingFactory#configure`, after the appenders are set up, logback's `StatusPrinter#printIfErrorsOccured` is called. If any errors has occurred, those are printed to `System.out`. 

I'm not sure if printing to `System.out` is smart, perhaps we should print to `System.err` instead? Printing to `System.out` could interfere with output from other commands.

Example of an error message:
```
10:51:26,122 |-ERROR in ch.qos.logback.core.FileAppender[file-appender] - openFile(/var/folders/p7/81qg63wn2p14k0kgpk5_wz8m0000gn/T/junit888714839740087763/folder-without-write-permission/my-log-file.log,true) call failed. java.io.FileNotFoundException: /var/folders/p7/81qg63wn2p14k0kgpk5_wz8m0000gn/T/junit888714839740087763/folder-without-write-permission/my-log-file.log (Permission denied)
	at java.io.FileNotFoundException: /var/folders/p7/81qg63wn2p14k0kgpk5_wz8m0000gn/T/junit888714839740087763/folder-without-write-permission/my-log-file.log (Permission denied)
	at 	at java.io.FileOutputStream.open(Native Method)
	at 	at java.io.FileOutputStream.<init>(FileOutputStream.java:221)
	at 	at ch.qos.logback.core.recovery.ResilientFileOutputStream.<init>(ResilientFileOutputStream.java:28)
	at 	at ch.qos.logback.core.FileAppender.openFile(FileAppender.java:150)
	at 	at ch.qos.logback.core.FileAppender.start(FileAppender.java:108)
	at 	at io.dropwizard.logging.FileAppenderFactory.build(FileAppenderFactory.java:168)
	at 	at io.dropwizard.logging.LoggingFactory.configure(LoggingFactory.java:126)
	at 	at io.dropwizard.logging.LoggingFactoryPrintErrorMessagesTest.configureAndCaptureSystemOut(LoggingFactoryPrintErrorMessagesTest.java:66)
	at 	at io.dropwizard.logging.LoggingFactoryPrintErrorMessagesTest.testWhenFileAppenderDoesNotHaveWritePermissionToFolder_PrintsErrorMessageToConsole(LoggingFactoryPrintErrorMessagesTest.java:79)
	at 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at 	at java.lang.reflect.Method.invoke(Method.java:606)
	[...]
```