### PR TITLE
Updating the BaseReporterFactory to optionally support regex

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -630,6 +630,7 @@ durationUnit           milliseconds   The unit to report durations as. Overrides
 rateUnit               seconds        The unit to report rates as. Overrides per-metric rate units.
 excludes               (none)         Metrics to exclude from reports, by name. When defined, matching metrics will not be reported.
 includes               (all)          Metrics to include in reports, by name. When defined, only these metrics will be reported.
+useRegexFilters        false          Indicates whether the values of the 'includes' and 'excludes' fields should be treated as regular expressions or not.
 frequency              (none)         The frequency to report metrics. Overrides the default.
 ====================== =============  ===========
 

--- a/dropwizard-metrics/src/main/java/io/dropwizard/metrics/BaseReporterFactory.java
+++ b/dropwizard-metrics/src/main/java/io/dropwizard/metrics/BaseReporterFactory.java
@@ -11,6 +11,7 @@ import io.dropwizard.util.Duration;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
 /**
  * A base {@link ReporterFactory} for configuring metric reporters.
@@ -47,6 +48,12 @@ import java.util.concurrent.TimeUnit;
  *         reported. See {@link #getFilter()}.</td>
  *     </tr>
  *     <tr>
+ *         <td>useRegexFilters</td>
+ *         <td>false</td>
+ *         <td>Indicates whether the values of the 'includes' and 'excludes' fields should be
+ *         treated as regular expressions or not.</td>
+ *     </tr>
+ *     <tr>
  *         <td>frequency</td>
  *         <td>1 second</td>
  *         <td>The frequency to report metrics. Overrides the {@link
@@ -55,6 +62,13 @@ import java.util.concurrent.TimeUnit;
  * </table>
  */
 public abstract class BaseReporterFactory implements ReporterFactory {
+
+    private static final DefaultStringMatchingStrategy DEFAULT_STRING_MATCHING_STRATEGY =
+            new DefaultStringMatchingStrategy();
+
+    private static final RegexStringMatchingStrategy REGEX_STRING_MATCHING_STRATEGY =
+            new RegexStringMatchingStrategy();
+
     @NotNull
     private TimeUnit durationUnit = TimeUnit.MILLISECONDS;
 
@@ -70,6 +84,8 @@ public abstract class BaseReporterFactory implements ReporterFactory {
     @NotNull
     @Valid
     private Optional<Duration> frequency = Optional.absent();
+
+    private boolean useRegexFilters = false;
 
     public TimeUnit getDurationUnit() {
         return durationUnit;
@@ -120,6 +136,16 @@ public abstract class BaseReporterFactory implements ReporterFactory {
         this.frequency = frequency;
     }
 
+    @JsonProperty
+    public boolean getUseRegexFilters() {
+        return useRegexFilters;
+    }
+
+    @JsonProperty
+    public void setUseRegexFilters(boolean useRegexFilters) {
+        this.useRegexFilters = useRegexFilters;
+    }
+
     /**
      * Gets a {@link MetricFilter} that specifically includes and excludes configured metrics.
      * <p/>
@@ -139,6 +165,9 @@ public abstract class BaseReporterFactory implements ReporterFactory {
      * @see #getExcludes()
      */
     public MetricFilter getFilter() {
+        final StringMatchingStrategy stringMatchingStrategy = getUseRegexFilters() ?
+                REGEX_STRING_MATCHING_STRATEGY : DEFAULT_STRING_MATCHING_STRATEGY;
+
         return new MetricFilter() {
             @Override
             public boolean matches(final String name, final Metric metric) {
@@ -146,18 +175,44 @@ public abstract class BaseReporterFactory implements ReporterFactory {
                 boolean useExcl = !getExcludes().isEmpty();
 
                 if (useIncl && useExcl) {
-                    return getIncludes().contains(name) || !getExcludes().contains(name);
+                    return stringMatchingStrategy.containsMatch(getIncludes(), name) ||
+                            !stringMatchingStrategy.containsMatch(getExcludes(), name);
                 }
                 else if (useIncl && !useExcl) {
-                    return getIncludes().contains(name);
+                    return stringMatchingStrategy.containsMatch(getIncludes(), name);
                 }
                 else if (!useIncl && useExcl) {
-                    return !getExcludes().contains(name);
+                    return !stringMatchingStrategy.containsMatch(getExcludes(), name);
                 }
                 else {
                     return true;
                 }
             }
         };
+    }
+
+    private interface StringMatchingStrategy {
+        boolean containsMatch(ImmutableSet<String> matchExpressions, String metricName);
+    }
+
+    private static class DefaultStringMatchingStrategy implements StringMatchingStrategy {
+        @Override
+        public boolean containsMatch(ImmutableSet<String> matchExpressions, String metricName) {
+            return matchExpressions.contains(metricName);
+        }
+    }
+
+    private static class RegexStringMatchingStrategy implements StringMatchingStrategy {
+        @Override
+        public boolean containsMatch(ImmutableSet<String> matchExpressions, String metricName) {
+            for (String regexExpression : matchExpressions) {
+                if (Pattern.matches(regexExpression, metricName)) {
+                    // just need to match on a single value - return as soon as we do
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/dropwizard-metrics/src/main/java/io/dropwizard/metrics/BaseReporterFactory.java
+++ b/dropwizard-metrics/src/main/java/io/dropwizard/metrics/BaseReporterFactory.java
@@ -5,6 +5,9 @@ import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.ScheduledReporter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableSet;
 import io.dropwizard.util.Duration;
 
@@ -203,10 +206,23 @@ public abstract class BaseReporterFactory implements ReporterFactory {
     }
 
     private static class RegexStringMatchingStrategy implements StringMatchingStrategy {
+        private final LoadingCache<String, Pattern> patternCache;
+
+        private RegexStringMatchingStrategy() {
+            patternCache = CacheBuilder.newBuilder()
+                    .expireAfterWrite(1, TimeUnit.HOURS)
+                    .build(new CacheLoader<String, Pattern>() {
+                        @Override
+                        public Pattern load(String regex) throws Exception {
+                            return Pattern.compile(regex);
+                        }
+                    });
+        }
+
         @Override
         public boolean containsMatch(ImmutableSet<String> matchExpressions, String metricName) {
             for (String regexExpression : matchExpressions) {
-                if (Pattern.matches(regexExpression, metricName)) {
+                if (patternCache.getUnchecked(regexExpression).matcher(metricName).matches()) {
                     // just need to match on a single value - return as soon as we do
                     return true;
                 }

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/BaseReporterFactoryTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/BaseReporterFactoryTest.java
@@ -103,7 +103,7 @@ public class BaseReporterFactoryTest {
     private final Metric metric = mock(Metric.class);
 
     @Test
-    public void matches() {
+    public void testDefaultMatching() {
         factory.setIncludes(includes);
         factory.setExcludes(excludes);
 
@@ -111,6 +111,12 @@ public class BaseReporterFactoryTest {
         assertThat(factory.getFilter().matches(name, metric))
                 .overridingErrorMessage(msg + ": expected 'matches(%s)=%s' for default matcher", name, expectedDefaultResult)
                 .isEqualTo(expectedDefaultResult);
+    }
+
+    @Test
+    public void testRegexMatching() {
+        factory.setIncludes(includes);
+        factory.setExcludes(excludes);
 
         factory.setUseRegexFilters(true);
         assertThat(factory.getFilter().matches(name, metric))

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/BaseReporterFactoryTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/BaseReporterFactoryTest.java
@@ -18,8 +18,8 @@ import static org.mockito.Mockito.mock;
 public class BaseReporterFactoryTest {
 
 
-    private static final ImmutableSet<String> INCLUDES = ImmutableSet.of("inc", "both");
-    private static final ImmutableSet<String> EXCLUDES = ImmutableSet.of("both", "exc");
+    private static final ImmutableSet<String> INCLUDES = ImmutableSet.of("inc", "both", "inc.+");
+    private static final ImmutableSet<String> EXCLUDES = ImmutableSet.of("both", "exc", "exc.+");
     private static final ImmutableSet<String> EMPTY = ImmutableSet.of();
 
 
@@ -31,38 +31,46 @@ public class BaseReporterFactoryTest {
                  * case1: If include list is empty and exclude list is empty, everything should be
                  * included.
                  */
-                new Object[]{EMPTY, EMPTY, "inc", true, "case1"},
-                new Object[]{EMPTY, EMPTY, "both", true, "case1"},
-                new Object[]{EMPTY, EMPTY, "exc", true, "case1"},
-                new Object[]{EMPTY, EMPTY, "any", true, "case1"},
+                new Object[]{EMPTY, EMPTY, "inc", true, true, "case1"},
+                new Object[]{EMPTY, EMPTY, "both", true, true, "case1"},
+                new Object[]{EMPTY, EMPTY, "exc", true, true, "case1"},
+                new Object[]{EMPTY, EMPTY, "any", true, true, "case1"},
+                new Object[]{EMPTY, EMPTY, "incWithSuffix", true, true, "case1"},
+                new Object[]{EMPTY, EMPTY, "excWithSuffix", true, true, "case1"},
 
                 /**
                  * case2: If include list is NOT empty and exclude list is empty, only the ones
                  * specified in the include list should be included.
                  */
-                new Object[]{INCLUDES, EMPTY, "inc", true, "case2"},
-                new Object[]{INCLUDES, EMPTY, "both", true, "case2"},
-                new Object[]{INCLUDES, EMPTY, "exc", false, "case2"},
-                new Object[]{INCLUDES, EMPTY, "any", false, "case2"},
+                new Object[]{INCLUDES, EMPTY, "inc", true, true, "case2"},
+                new Object[]{INCLUDES, EMPTY, "both", true, true, "case2"},
+                new Object[]{INCLUDES, EMPTY, "exc", false, false, "case2"},
+                new Object[]{INCLUDES, EMPTY, "any", false, false, "case2"},
+                new Object[]{INCLUDES, EMPTY, "incWithSuffix", false, true, "case2"},
+                new Object[]{INCLUDES, EMPTY, "excWithSuffix", false, false, "case2"},
 
                 /**
                  * case3: If include list is empty and exclude list is NOT empty, everything should be
                  * included except the ones in the exclude list.
                  */
-                new Object[]{EMPTY, EXCLUDES, "inc", true, "case3"},
-                new Object[]{EMPTY, EXCLUDES, "both", false, "case3"},
-                new Object[]{EMPTY, EXCLUDES, "exc", false, "case3"},
-                new Object[]{EMPTY, EXCLUDES, "any", true, "case3"},
+                new Object[]{EMPTY, EXCLUDES, "inc", true, true, "case3"},
+                new Object[]{EMPTY, EXCLUDES, "both", false, false, "case3"},
+                new Object[]{EMPTY, EXCLUDES, "exc", false, false, "case3"},
+                new Object[]{EMPTY, EXCLUDES, "any", true, true, "case3"},
+                new Object[]{EMPTY, EXCLUDES, "incWithSuffix", true, true, "case3"},
+                new Object[]{EMPTY, EXCLUDES, "excWithSuffix", true, false, "case3"},
 
                 /**
                  * case4: If include list is NOT empty and exclude list is NOT empty, everything
                  * should be included except the
                  * ones that are not in the include list AND are in the exclude list
                  */
-                new Object[]{INCLUDES, EXCLUDES, "inc", true, "case4"},
-                new Object[]{INCLUDES, EXCLUDES, "both", true, "case4"},
-                new Object[]{INCLUDES, EXCLUDES, "exc", false, "case4"},
-                new Object[]{INCLUDES, EXCLUDES, "any", true, "case4"}
+                new Object[]{INCLUDES, EXCLUDES, "inc", true, true, "case4"},
+                new Object[]{INCLUDES, EXCLUDES, "both", true, true, "case4"},
+                new Object[]{INCLUDES, EXCLUDES, "exc", false, false, "case4"},
+                new Object[]{INCLUDES, EXCLUDES, "any", true, true, "case4"},
+                new Object[]{INCLUDES, EXCLUDES, "incWithSuffix", true, true, "case4"},
+                new Object[]{INCLUDES, EXCLUDES, "excWithSuffix", true, false, "case4"}
         );
     }
 
@@ -84,9 +92,12 @@ public class BaseReporterFactoryTest {
     public String name;
 
     @Parameterized.Parameter(3)
-    public boolean expected;
+    public boolean expectedDefaultResult;
 
     @Parameterized.Parameter(4)
+    public boolean expectedRegexResult;
+
+    @Parameterized.Parameter(5)
     public String msg;
 
     private final Metric metric = mock(Metric.class);
@@ -96,9 +107,15 @@ public class BaseReporterFactoryTest {
         factory.setIncludes(includes);
         factory.setExcludes(excludes);
 
+        factory.setUseRegexFilters(false);
         assertThat(factory.getFilter().matches(name, metric))
-                .overridingErrorMessage(msg + ": expected 'matches(%s)=%s'", name, expected)
-                .isEqualTo(expected);
+                .overridingErrorMessage(msg + ": expected 'matches(%s)=%s' for default matcher", name, expectedDefaultResult)
+                .isEqualTo(expectedDefaultResult);
+
+        factory.setUseRegexFilters(true);
+        assertThat(factory.getFilter().matches(name, metric))
+                .overridingErrorMessage(msg + ": expected 'matches(%s)=%s' for regex matcher", name, expectedRegexResult)
+                .isEqualTo(expectedRegexResult);
     }
 
 }


### PR DESCRIPTION
Updating the BaseReporterFactory to optionally support regex in its includes/excludes fields. This implementation makes a few assumptions:

- By default any existing implementations or configurations that use the BaseReporterFactory should not have their behavior changed
- The user should be able to toggle on regular expressions by changing data, without modifications to the code
- The code should be easily extended to support still-more complicated matching functionality (potentially by making the StringMatchingStrategy public and adding it as a parameter to the getFilter() call)

These assumptions influenced my design decisions.

Please let me know what you think!