### PR TITLE
Support for a custom name of a Hibernate bundle

### DIFF
--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryFactory.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryFactory.java
@@ -21,12 +21,21 @@ import java.util.SortedSet;
 
 public class SessionFactoryFactory {
     private static final Logger LOGGER = LoggerFactory.getLogger(SessionFactoryFactory.class);
+    private static final String DEFAULT_NAME = "hibernate";
 
     public SessionFactory build(HibernateBundle<?> bundle,
                                 Environment environment,
                                 DataSourceFactory dbConfig,
                                 List<Class<?>> entities) {
-        final ManagedDataSource dataSource = dbConfig.build(environment.metrics(), "hibernate");
+        return build(bundle, environment, dbConfig, entities, DEFAULT_NAME);
+    }
+
+    public SessionFactory build(HibernateBundle<?> bundle,
+                                Environment environment,
+                                DataSourceFactory dbConfig,
+                                List<Class<?>> entities,
+                                String name) {
+        final ManagedDataSource dataSource = dbConfig.build(environment.metrics(), name);
         return build(bundle, environment, dbConfig, dataSource, entities);
     }
 

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryManager.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryManager.java
@@ -1,5 +1,6 @@
 package io.dropwizard.hibernate;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.db.ManagedDataSource;
 import io.dropwizard.lifecycle.Managed;
 import org.hibernate.SessionFactory;
@@ -11,6 +12,11 @@ public class SessionFactoryManager implements Managed {
     public SessionFactoryManager(SessionFactory factory, ManagedDataSource dataSource) {
         this.factory = factory;
         this.dataSource = dataSource;
+    }
+
+    @VisibleForTesting
+    ManagedDataSource getDataSource() {
+        return dataSource;
     }
 
     @Override


### PR DESCRIPTION
Resolve #855

By default the name of a Hibernate bundle (actually "hibernate)" is hardcoded. This name is used for the database pool metrics and the health check associated with the bundle. This causes conflicts when
several bundles used alongside in a project.

This change adds to the HibernateBundle class a protected method which returns a bundle name. This method can be overridden by users who want to set a custom name. The new name will be used for the bundle's database pool metrics and health check.