### PR TITLE
Tests to verify we are not leaking any validation info before authentication

### DIFF
--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/TransportObject.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/TransportObject.java
@@ -4,16 +4,21 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /** 
  *
  * Some object with a "secret" internal representation we want only authenticated 
  * people to know about.
  *
  */
+@JsonIgnoreProperties(ignoreUnknown = false)
 public class TransportObject {
     @NotNull
     @Size(min = 1)
     @Pattern(regexp="ab?b")
+    @JsonProperty
     private String givenName;
     
     public String getGivenName() {

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/TransportObject.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/TransportObject.java
@@ -1,0 +1,26 @@
+package io.dropwizard.auth;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+/** 
+ *
+ * Some object with a "secret" internal representation we want only authenticated 
+ * people to know about.
+ *
+ */
+public class TransportObject {
+    @NotNull
+    @Size(min = 1)
+    @Pattern(regexp="ab?b")
+    private String givenName;
+    
+    public String getGivenName() {
+        return givenName;
+    }
+    
+    public void setGivenName(String givenName) {
+        this.givenName = givenName;
+    }
+}

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/AuthBeforeValidateTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/AuthBeforeValidateTest.java
@@ -1,0 +1,122 @@
+package io.dropwizard.auth.basic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import io.dropwizard.auth.Auth;
+import io.dropwizard.auth.AuthFactory;
+import io.dropwizard.auth.AuthResource;
+import io.dropwizard.auth.AuthenticationException;
+import io.dropwizard.auth.Authenticator;
+import io.dropwizard.auth.TransportObject;
+import io.dropwizard.jersey.DropwizardResourceConfig;
+import io.dropwizard.logging.LoggingFactory;
+
+import org.glassfish.jersey.servlet.ServletProperties;
+import org.glassfish.jersey.test.DeploymentContext;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
+import org.glassfish.jersey.test.spi.TestContainerException;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
+import org.junit.Test;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Optional;
+
+public class AuthBeforeValidateTest extends JerseyTest {
+    static {
+        LoggingFactory.bootstrap();
+    }
+
+    @Override
+    protected TestContainerFactory getTestContainerFactory()
+            throws TestContainerException {
+        return new GrizzlyWebTestContainerFactory();
+    }
+
+    @Override
+    protected DeploymentContext configureDeployment() {
+        return ServletDeploymentContext.builder(new AuthBeforeValidateTestResourceConfig())
+                .initParam(ServletProperties.JAXRS_APPLICATION_CLASS, AuthBeforeValidateTestResourceConfig.class.getName())
+                .build();
+    }
+    
+    @Test
+    public void doNotLeakAnyValidationInfoOnFailedAuthentication() {
+        try {
+            TransportObject to = new TransportObject();
+            Entity<TransportObject> entity = Entity.entity(to, MediaType.APPLICATION_JSON_TYPE);
+            target("/greet").request()
+                .header(HttpHeaders.AUTHORIZATION, "Basic Z29vZC1ndXk6c2VjcmV0")
+                .post(entity, String.class);
+            failBecauseExceptionWasNotThrown(WebApplicationException.class);
+        } catch (WebApplicationException e) {
+            Response r = e.getResponse();
+            
+            assertThat(r.getStatus()).isEqualTo(401);
+            assertThat(r.getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
+                    .containsOnly("Basic realm=\"realm\""); 
+            assertThat(r.readEntity(String.class)).doesNotContain("may not be null");
+        }
+    }
+    
+    @Test
+    public void doNotLeakAnyValidationInfoOnMissingAuthentication() {
+        TransportObject to = new TransportObject();
+        try {
+            Entity<TransportObject> entity = Entity.entity(to, MediaType.APPLICATION_JSON_TYPE);
+            // Note that when the AUTHORIZATION header is missing on a protected resource, 
+            // we never even make it into the Authenticator instance, the client is presented
+            // with a 401 immediately.
+            target("/greet").request()
+                .post(entity, String.class);
+            failBecauseExceptionWasNotThrown(WebApplicationException.class);
+        } catch (WebApplicationException e) {
+            Response r = e.getResponse();
+            
+            assertThat(r.getStatus()).isEqualTo(401);
+            assertThat(r.getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
+                    .containsOnly("Basic realm=\"realm\""); 
+            assertThat(r.readEntity(String.class)).doesNotContain("may not be null");
+        }
+    }
+    
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/greet")
+    public static class ValidatedResource {
+        
+        @POST
+        public String greet(@Valid TransportObject validatedObject, @Auth String principal) {
+            return "hello";
+        }
+    }
+    
+    public static class AuthBeforeValidateTestResourceConfig extends DropwizardResourceConfig {
+        public AuthBeforeValidateTestResourceConfig() {
+            super(true, new MetricRegistry());
+
+            final Authenticator<BasicCredentials, String> denyAllAuthenticator = new Authenticator<BasicCredentials, String>() {
+                @Override
+                public Optional<String> authenticate(BasicCredentials credentials) throws AuthenticationException {
+                    // Deny everyone access
+                    return Optional.absent();
+                }
+            };
+            register(AuthFactory.binder(new BasicAuthFactory<>(denyAllAuthenticator, "realm", String.class)));
+            register(ValidatedResource.class);
+        }
+    }
+}

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/AuthBeforeValidateTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/AuthBeforeValidateTest.java
@@ -1,14 +1,12 @@
 package io.dropwizard.auth.basic;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 import javax.validation.Valid;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
@@ -16,11 +14,12 @@ import javax.ws.rs.core.Response;
 
 import io.dropwizard.auth.Auth;
 import io.dropwizard.auth.AuthFactory;
-import io.dropwizard.auth.AuthResource;
 import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.Authenticator;
 import io.dropwizard.auth.TransportObject;
 import io.dropwizard.jersey.DropwizardResourceConfig;
+import io.dropwizard.jersey.jackson.JsonProcessingExceptionMapper;
+import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
 import io.dropwizard.logging.LoggingFactory;
 
 import org.glassfish.jersey.servlet.ServletProperties;
@@ -54,68 +53,94 @@ public class AuthBeforeValidateTest extends JerseyTest {
     }
     
     @Test
-    public void doNotLeakAnyValidationInfoOnFailedAuthentication() {
-        try {
-            TransportObject to = new TransportObject();
-            Entity<TransportObject> entity = Entity.entity(to, MediaType.APPLICATION_JSON_TYPE);
-            target("/greet").request()
-                .header(HttpHeaders.AUTHORIZATION, "Basic Z29vZC1ndXk6c2VjcmV0")
-                .post(entity, String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            Response r = e.getResponse();
-            
-            assertThat(r.getStatus()).isEqualTo(401);
-            assertThat(r.getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
-                    .containsOnly("Basic realm=\"realm\""); 
-            assertThat(r.readEntity(String.class)).doesNotContain("may not be null");
-        }
+    public void authenticatedRequestSucceeds() throws Exception {
+        final TransportObject to = new TransportObject();
+        to.setGivenName("abba");
+        
+        final Response response = target("/test").request()
+            .header(HttpHeaders.AUTHORIZATION, "Basic Z29vZC1ndXk6c2VjcmV0")
+            .post(Entity.entity(to, MediaType.APPLICATION_JSON_TYPE));
+        
+        assertThat(response.readEntity(String.class)).isEqualTo("abba");
     }
     
     @Test
-    public void doNotLeakAnyValidationInfoOnMissingAuthentication() {
-        TransportObject to = new TransportObject();
-        try {
-            Entity<TransportObject> entity = Entity.entity(to, MediaType.APPLICATION_JSON_TYPE);
-            // Note that when the AUTHORIZATION header is missing on a protected resource, 
-            // we never even make it into the Authenticator instance, the client is presented
-            // with a 401 immediately.
-            target("/greet").request()
-                .post(entity, String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            Response r = e.getResponse();
-            
-            assertThat(r.getStatus()).isEqualTo(401);
-            assertThat(r.getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
-                    .containsOnly("Basic realm=\"realm\""); 
-            assertThat(r.readEntity(String.class)).doesNotContain("may not be null");
-        }
+    public void unauthenticatedRequestFailsWith401s() throws Exception {
+        final TransportObject to = new TransportObject();
+        to.setGivenName("abba");
+        
+        final Response response = target("/test").request()
+            .post(Entity.entity(to, MediaType.APPLICATION_JSON_TYPE));
+        
+        assertThat(response.getStatus()).isEqualTo(401);
+    }
+    
+    @Test
+    public void unauthenticatedRequestWithOptionalAuthSucceeds() throws Exception {
+        final TransportObject to = new TransportObject();
+        to.setGivenName("abba");
+        
+        final Response response = target("/test/optional").request()
+            .post(Entity.entity(to, MediaType.APPLICATION_JSON_TYPE));
+        
+        assertThat(response.readEntity(String.class)).isEqualTo("abba");
+    }
+    
+    @Test
+    public void authenticationMustHappenBeforeDeserialization() throws Exception {
+        final Response response = target("/test").request()
+            .post(Entity.entity("INVALID", MediaType.APPLICATION_JSON_TYPE));
+        
+        assertThat(response.getStatus()).isEqualTo(401);
+    }
+    
+    @Test
+    public void authenticationMustHappenBeforeValidation() throws Exception {
+        final Response response = target("/test").request()
+            .post(Entity.entity("{\"unknown\":123}", MediaType.APPLICATION_JSON_TYPE));
+        
+        assertThat(response.getStatus()).isEqualTo(401);
     }
     
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    @Path("/greet")
+    @Path("/test")
     public static class ValidatedResource {
         
         @POST
-        public String greet(@Valid TransportObject validatedObject, @Auth String principal) {
-            return "hello";
+        public String show(@Valid TransportObject validatedObject, @Auth String principal) {
+            return validatedObject.getGivenName();
         }
+        
+        @POST
+        @Path("/optional")
+        public String optionalAuth(@Valid TransportObject validatedObject, @Auth(required = false) String principle) {
+            return validatedObject.getGivenName();
+        }
+    }
+    
+  
+    public static class BasicAuthenticator implements Authenticator<BasicCredentials, String> {
+
+        @Override
+        public Optional<String> authenticate(BasicCredentials credentials) throws AuthenticationException {
+            if ("good-guy".equals(credentials.getUsername()) &&
+                "secret".equals(credentials.getPassword())) {
+                return Optional.of("good-guy");
+            }
+            return Optional.absent();
+        }
+        
     }
     
     public static class AuthBeforeValidateTestResourceConfig extends DropwizardResourceConfig {
         public AuthBeforeValidateTestResourceConfig() {
             super(true, new MetricRegistry());
 
-            final Authenticator<BasicCredentials, String> denyAllAuthenticator = new Authenticator<BasicCredentials, String>() {
-                @Override
-                public Optional<String> authenticate(BasicCredentials credentials) throws AuthenticationException {
-                    // Deny everyone access
-                    return Optional.absent();
-                }
-            };
-            register(AuthFactory.binder(new BasicAuthFactory<>(denyAllAuthenticator, "realm", String.class)));
+            final Authenticator<BasicCredentials, String> basicAuthenticator = new BasicAuthenticator();
+            register(AuthFactory.binder(new BasicAuthFactory<>(basicAuthenticator, "realm", String.class)));
+            register(new ConstraintViolationExceptionMapper());
+            register(new JsonProcessingExceptionMapper(true));
             register(ValidatedResource.class);
         }
     }


### PR DESCRIPTION
Tests to verify that issue #768 is no longer a problem in Dropwizard
8.x, presumably after the switch to Jersey 2.x.