### PR TITLE
Exclude slf4j-api from metrics-httpclient

### DIFF
--- a/dropwizard-client/pom.xml
+++ b/dropwizard-client/pom.xml
@@ -31,6 +31,10 @@
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
Not sure why this wasn't picked up by the enforcer.
metrics-httpclient relies on slf4j-api 1.7.7, not 1.7.10