### PR TITLE
Fix logback error, which ultimately quiets the noise on startup

### DIFF
--- a/dropwizard-example/example.yml
+++ b/dropwizard-example/example.yml
@@ -66,6 +66,13 @@ logging:
 
   appenders:
     - type: console
+    - type: file
+      threshold: DEBUG
+      logFormat: "%-6level [%d{HH:mm:ss.SSS}] [%t] %logger{5} - %X{code} %msg %n"
+      currentLogFilename: /tmp/application.log
+      archivedLogFilenamePattern: /tmp/application-%d{yyyy-MM-dd}.log
+      archivedFileCount: 7
+      timeZone: UTC
 
 # the key needs to match the suffix of the renderer
 viewRendererConfiguration:

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
@@ -166,7 +166,6 @@ public class FileAppenderFactory extends AbstractAppenderFactory {
         layoutEncoder.setLayout(layout == null ? buildLayout(context, timeZone) : layout);
         appender.setEncoder(layoutEncoder);
 
-        appender.setFile(currentLogFilename);
         appender.setPrudent(false);
         addThresholdFilter(appender, threshold);
         appender.stop();
@@ -178,6 +177,7 @@ public class FileAppenderFactory extends AbstractAppenderFactory {
     protected FileAppender<ILoggingEvent> buildAppender(LoggerContext context) {
         if (archive) {
             final RollingFileAppender<ILoggingEvent> appender = new RollingFileAppender<>();
+            appender.setFile(currentLogFilename);
             final DefaultTimeBasedFileNamingAndTriggeringPolicy<ILoggingEvent> triggeringPolicy =
                     new DefaultTimeBasedFileNamingAndTriggeringPolicy<>();
             triggeringPolicy.setContext(context);
@@ -197,6 +197,9 @@ public class FileAppenderFactory extends AbstractAppenderFactory {
             rollingPolicy.start();
             return appender;
         }
-        return new FileAppender<>();
+
+        final FileAppender<ILoggingEvent> appender = new FileAppender<>();
+        appender.setFile(currentLogFilename);
+        return appender;
     }
 }


### PR DESCRIPTION
The example doesn't have a file appender which does archiving, so it wasn't triggering the issue. I've added that.

http://logback.qos.ch/codes.html
## The File property must be set before any rolling policy or triggering policy.
The File property, if present, must be placed before any rolling policy or triggering policy. Thus, in a configuration file, the File property, if present, must be declared declared before any rolling policy or triggering policy declarations.



