### PR TITLE
Replace ImmutableMap with Map interface in ViewRenderer interface

### DIFF
--- a/docs/source/manual/views.rst
+++ b/docs/source/manual/views.rst
@@ -16,7 +16,12 @@ To enable views for your :ref:`Application <man-core-application>`, add the ``Vi
 .. code-block:: java
 
     public void initialize(Bootstrap<MyConfiguration> bootstrap) {
-        bootstrap.addBundle(new ViewBundle());
+        bootstrap.addBundle(new ViewBundle<MyConfiguration>() {
+            @Override
+            public Map<String, Map<String, String>> getViewConfiguration(MyConfiguration config) {
+                return config.getViewRendererConfiguration();
+            }
+        });
     }
 
 Then, in your :ref:`resource method <man-core-resources>`, add a ``View`` class:

--- a/dropwizard-example/src/main/java/com/example/helloworld/HelloWorldApplication.java
+++ b/dropwizard-example/src/main/java/com/example/helloworld/HelloWorldApplication.java
@@ -28,6 +28,8 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
 
+import java.util.Map;
+
 public class HelloWorldApplication extends Application<HelloWorldConfiguration> {
     public static void main(String[] args) throws Exception {
         new HelloWorldApplication().run(args);
@@ -67,7 +69,7 @@ public class HelloWorldApplication extends Application<HelloWorldConfiguration> 
         bootstrap.addBundle(hibernateBundle);
         bootstrap.addBundle(new ViewBundle<HelloWorldConfiguration>() {
             @Override
-            public ImmutableMap<String, ImmutableMap<String, String>> getViewConfiguration(HelloWorldConfiguration configuration) {
+            public Map<String, Map<String, String>> getViewConfiguration(HelloWorldConfiguration configuration) {
                 return configuration.getViewRendererConfiguration();
             }
         });

--- a/dropwizard-example/src/main/java/com/example/helloworld/HelloWorldConfiguration.java
+++ b/dropwizard-example/src/main/java/com/example/helloworld/HelloWorldConfiguration.java
@@ -6,8 +6,10 @@ import com.google.common.collect.ImmutableMap;
 import io.dropwizard.Configuration;
 import io.dropwizard.db.DataSourceFactory;
 import org.hibernate.validator.constraints.NotEmpty;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import java.util.Collections;
 import java.util.Map;
 
 public class HelloWorldConfiguration extends Configuration {
@@ -22,7 +24,7 @@ public class HelloWorldConfiguration extends Configuration {
     private DataSourceFactory database = new DataSourceFactory();
     
     @NotNull
-    private ImmutableMap<String, ImmutableMap<String, String>> viewRendererConfiguration = ImmutableMap.of();
+    private Map<String, Map<String, String>> viewRendererConfiguration = Collections.emptyMap();
 
     @JsonProperty
     public String getTemplate() {
@@ -59,13 +61,13 @@ public class HelloWorldConfiguration extends Configuration {
     }
 
     @JsonProperty("viewRendererConfiguration")
-    public ImmutableMap<String, ImmutableMap<String, String>> getViewRendererConfiguration() {
+    public Map<String, Map<String, String>> getViewRendererConfiguration() {
         return viewRendererConfiguration;
     }
 
     @JsonProperty("viewRendererConfiguration")
     public void setViewRendererConfiguration(Map<String, Map<String, String>> viewRendererConfiguration) {
-        ImmutableMap.Builder<String, ImmutableMap<String, String>> builder = ImmutableMap.builder();
+        ImmutableMap.Builder<String, Map<String, String>> builder = ImmutableMap.builder();
         for (Map.Entry<String, Map<String, String>> entry : viewRendererConfiguration.entrySet()) {
             builder.put(entry.getKey(), ImmutableMap.copyOf(entry.getValue()));
         }

--- a/dropwizard-views-freemarker/src/main/java/io/dropwizard/views/freemarker/FreemarkerViewRenderer.java
+++ b/dropwizard-views-freemarker/src/main/java/io/dropwizard/views/freemarker/FreemarkerViewRenderer.java
@@ -12,6 +12,7 @@ import freemarker.template.TemplateException;
 import freemarker.template.Version;
 import io.dropwizard.views.View;
 import io.dropwizard.views.ViewRenderer;
+
 import javax.ws.rs.WebApplicationException;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -76,7 +77,7 @@ public class FreemarkerViewRenderer implements ViewRenderer {
         }
     }
 
-    public void configure(ImmutableMap<String, String> baseConfig) {
+    public void configure(Map<String, String> baseConfig) {
         this.loader.setBaseConfig(baseConfig);
     }
 

--- a/dropwizard-views-mustache/src/main/java/io/dropwizard/views/mustache/MustacheViewRenderer.java
+++ b/dropwizard-views-mustache/src/main/java/io/dropwizard/views/mustache/MustacheViewRenderer.java
@@ -7,10 +7,10 @@ import com.google.common.base.Charsets;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.dropwizard.views.View;
 import io.dropwizard.views.ViewRenderer;
+
 import javax.ws.rs.WebApplicationException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -18,6 +18,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 /**
@@ -56,7 +57,7 @@ public class MustacheViewRenderer implements ViewRenderer {
     }
 
     @Override
-    public void configure(ImmutableMap<String, String> options) {}
+    public void configure(Map<String, String> options) {}
 
     @Override
     public String getSuffix() {

--- a/dropwizard-views/src/main/java/io/dropwizard/views/ViewBundle.java
+++ b/dropwizard-views/src/main/java/io/dropwizard/views/ViewBundle.java
@@ -1,13 +1,17 @@
 package io.dropwizard.views;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import java.util.ServiceLoader;
 import io.dropwizard.Bundle;
 import io.dropwizard.Configuration;
 import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
 
 /**
  * A {@link Bundle}, which by default, enables the rendering of FreeMarker & Mustache views by your application.
@@ -66,7 +70,7 @@ import io.dropwizard.setup.Environment;
  * <p>In this template, {@code ${person.name}} calls {@code getPerson().getName()}, and the
  * {@code ?html} escapes all HTML control characters in the result. The {@code ftlvariable} comment
  * at the top indicate to Freemarker (and your IDE) that the root object is a {@code Person},
- * allowing for better typesafety in your templates.</p>
+ * allowing for better type-safety in your templates.</p>
  *
  * @see <a href="http://freemarker.sourceforge.net/docs/index.html">FreeMarker Manual</a>
  *
@@ -97,12 +101,10 @@ public abstract class ViewBundle<T extends Configuration> implements ConfiguredB
 
     @Override
     public void run(T configuration, Environment environment) throws Exception {
-        ImmutableMap<String, String> empty = ImmutableMap.of();
-        
-        ImmutableMap<String, ImmutableMap<String, String>> options = getViewConfiguration(configuration);
+        Map<String, Map<String, String>> options = getViewConfiguration(configuration);
         for(ViewRenderer viewRenderer : viewRenderers) {
-            ImmutableMap<String, String> viewOptions = options.get(viewRenderer.getSuffix());
-            viewRenderer.configure(viewOptions == null ? empty : viewOptions);
+            Map<String, String> viewOptions = options.get(viewRenderer.getSuffix());
+            viewRenderer.configure(firstNonNull(viewOptions, Collections.<String, String>emptyMap()));
         }
         environment.jersey().register(new ViewMessageBodyWriter(environment.metrics(), viewRenderers));
     }

--- a/dropwizard-views/src/main/java/io/dropwizard/views/ViewConfigurable.java
+++ b/dropwizard-views/src/main/java/io/dropwizard/views/ViewConfigurable.java
@@ -1,8 +1,9 @@
 package io.dropwizard.views;
 
-import com.google.common.collect.ImmutableMap;
 import io.dropwizard.Configuration;
 
+import java.util.Map;
+
 public interface ViewConfigurable<T extends Configuration> {
-    ImmutableMap<String, ImmutableMap<String, String>> getViewConfiguration(T configuration);
+    Map<String, Map<String, String>> getViewConfiguration(T configuration);
 }

--- a/dropwizard-views/src/main/java/io/dropwizard/views/ViewRenderer.java
+++ b/dropwizard-views/src/main/java/io/dropwizard/views/ViewRenderer.java
@@ -1,7 +1,5 @@
 package io.dropwizard.views;
 
-import com.google.common.collect.ImmutableMap;
-
 import javax.ws.rs.WebApplicationException;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -38,7 +36,7 @@ public interface ViewRenderer {
       * options for configuring the view renderer
       * @param options
      */
-    void configure(ImmutableMap<String, String> options);
+    void configure(Map<String, String> options);
 
     /**
      * @return the suffix of the template type, e.g '.ftl', '.mustache'

--- a/dropwizard-views/src/test/java/io/dropwizard/views/ViewBundleTest.java
+++ b/dropwizard-views/src/test/java/io/dropwizard/views/ViewBundleTest.java
@@ -1,15 +1,5 @@
 package io.dropwizard.views;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.lang.reflect.Field;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-
-import javax.validation.constraints.NotNull;
-import javax.ws.rs.WebApplicationException;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -21,28 +11,40 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.WebApplicationException;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class ViewBundleTest {
     private final JerseyEnvironment jerseyEnvironment = mock(JerseyEnvironment.class);
     private final Environment environment = mock(Environment.class);
     private static class MyConfiguration extends Configuration {
         @NotNull
-        private ImmutableMap<String, ImmutableMap<String, String>> viewRendererConfiguration = ImmutableMap.of();
+        private Map<String, Map<String, String>> viewRendererConfiguration = Collections.emptyMap();
 
         @JsonProperty("viewRendererConfiguration")
-        public ImmutableMap<String, ImmutableMap<String, String>> getViewRendererConfiguration() {
+        public Map<String, Map<String, String>> getViewRendererConfiguration() {
             return viewRendererConfiguration;
         }
 
         @JsonProperty("viewRendererConfiguration")
         public void setViewRendererConfiguration(Map<String, Map<String, String>> viewRendererConfiguration) {
-            ImmutableMap.Builder<String, ImmutableMap<String, String>> builder = ImmutableMap.builder();
+            ImmutableMap.Builder<String, Map<String, String>> builder = ImmutableMap.builder();
             for (Map.Entry<String, Map<String, String>> entry : viewRendererConfiguration.entrySet()) {
                 builder.put(entry.getKey(), ImmutableMap.copyOf(entry.getValue()));
             }
@@ -57,10 +59,10 @@ public class ViewBundleTest {
 
     @Test
     public void addsTheViewMessageBodyWriterToTheEnvironment() throws Exception {
-        new ViewBundle() {
+        new ViewBundle<Configuration>() {
             @Override
-            public ImmutableMap<String, Map<String, String>> getViewConfiguration(Configuration configuration) {
-                return ImmutableMap.of();
+            public Map<String, Map<String, String>> getViewConfiguration(Configuration configuration) {
+                return Collections.emptyMap();
             }
         }.run(null, environment);
 
@@ -91,7 +93,7 @@ public class ViewBundleTest {
             }
 
             @Override
-            public void configure(ImmutableMap<String, String> options) {
+            public void configure(Map<String, String> options) {
                 assertThat("should contain the testKey", Boolean.TRUE, is(options.containsKey(testKey)));
             }
 
@@ -103,7 +105,7 @@ public class ViewBundleTest {
 
         new ViewBundle<MyConfiguration>(ImmutableList.of(renderer)) {
             @Override
-            public ImmutableMap<String, ImmutableMap<String, String>> getViewConfiguration(MyConfiguration configuration) {
+            public Map<String, Map<String, String>> getViewConfiguration(MyConfiguration configuration) {
                 return configuration.getViewRendererConfiguration();
             }
         }.run(myConfiguration, environment);


### PR DESCRIPTION
The original change was using the concrete `ImmutableMap<K, V>` implementation from Google Guava instead of the generic `Map<K, V>` interface which allows the use of other map implementations.