### PR TITLE
Change copyright notice to be up-to-date

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,7 +42,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Dropwizard'
-copyright = u'2010-2013, Coda Hale, Yammer Inc.'
+copyright = u'2010-2015, Coda Hale, Yammer Inc.'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
It would be way better to dynamically work out what year it is, I just don't know how to test build the docs site.

If someone knows, that would be better.

Also, should we remove Yammer from the Copyright? Maybe @ryankennedy would know.