### PR TITLE
Ensuring that JerseyRequest scoped ClientConfig gets propagated to HttpUriRequest

### DIFF
--- a/dropwizard-client/pom.xml
+++ b/dropwizard-client/pom.xml
@@ -52,5 +52,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-testing</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/dropwizard-client/src/main/java/io/dropwizard/client/ConfiguredCloseableHttpClient.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/ConfiguredCloseableHttpClient.java
@@ -1,0 +1,22 @@
+package io.dropwizard.client;
+
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.CloseableHttpClient;
+
+/* package */ class ConfiguredCloseableHttpClient {
+    private final CloseableHttpClient closeableHttpClient;
+    private final RequestConfig defaultRequestConfig;
+
+    /* package */ ConfiguredCloseableHttpClient(CloseableHttpClient closeableHttpClient, RequestConfig defaultRequestConfig) {
+        this.closeableHttpClient = closeableHttpClient;
+        this.defaultRequestConfig = defaultRequestConfig;
+    }
+
+    public RequestConfig getDefaultRequestConfig() {
+        return defaultRequestConfig;
+    }
+
+    public CloseableHttpClient getClient() {
+        return closeableHttpClient;
+    }
+}

--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
@@ -170,6 +170,15 @@ public class HttpClientBuilder {
      * @return an {@link CloseableHttpClient}
      */
     public CloseableHttpClient build(String name) {
+        return buildWithDefaultRequestConfiguration(name).getClient();
+    }
+
+    /**
+     * For internal use only, used in {@link io.dropwizard.client.JerseyClientBuilder} to create an instance of {@link io.dropwizard.client.DropwizardApacheConnector}
+     * @param name
+     * @return an {@link io.dropwizard.client.ConfiguredCloseableHttpClient}
+     */
+    ConfiguredCloseableHttpClient buildWithDefaultRequestConfiguration(String name) {
         final InstrumentedHttpClientConnectionManager manager = createConnectionManager(registry, name);
         return createClient(org.apache.http.impl.client.HttpClientBuilder.create(), manager, name);
     }
@@ -184,7 +193,7 @@ public class HttpClientBuilder {
      * @return the configured {@link CloseableHttpClient}
      */
     @VisibleForTesting
-    protected CloseableHttpClient createClient(
+    protected ConfiguredCloseableHttpClient createClient(
             final org.apache.http.impl.client.HttpClientBuilder builder,
             final InstrumentedHttpClientConnectionManager manager,
             final String name) {
@@ -241,7 +250,7 @@ public class HttpClientBuilder {
             builder.setRoutePlanner(routePlanner);
         }
 
-        return builder.build();
+        return new ConfiguredCloseableHttpClient(builder.build(), requestConfig);
     }
 
     /**

--- a/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
@@ -16,7 +16,6 @@ import org.apache.http.config.Registry;
 import org.apache.http.conn.DnsResolver;
 import org.apache.http.conn.routing.HttpRoutePlanner;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
-import org.apache.http.impl.client.CloseableHttpClient;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.spi.Connector;
 import org.glassfish.jersey.client.spi.ConnectorProvider;
@@ -271,13 +270,14 @@ public class JerseyClientBuilder {
         }
 
         return build(name, environment.lifecycle()
-                .executorService("jersey-client-" + name + "-%d")
-                .minThreads(configuration.getMinThreads())
-                .maxThreads(configuration.getMaxThreads())
-                .workQueue(new ArrayBlockingQueue<Runnable>(configuration.getWorkQueueSize()))
-                .build(),
+                        .executorService("jersey-client-" + name + "-%d")
+                        .minThreads(configuration.getMinThreads())
+                        .maxThreads(configuration.getMaxThreads())
+                        .workQueue(new ArrayBlockingQueue<Runnable>(configuration.getWorkQueueSize()))
+                        .build(),
                 environment.getObjectMapper(),
-                environment.getValidator());
+                environment.getValidator()
+        );
     }
 
     private Client build(String name, ExecutorService threadPool,
@@ -314,11 +314,15 @@ public class JerseyClientBuilder {
 
         config.register(new DropwizardExecutorProvider(threadPool));
         if (connectorProvider == null) {
-            final CloseableHttpClient apacheHttpClient = apacheHttpClientBuilder.build(name);
+            final ConfiguredCloseableHttpClient apacheHttpClient =
+                    apacheHttpClientBuilder.buildWithDefaultRequestConfiguration(name);
             connectorProvider = new ConnectorProvider() {
                 @Override
                 public Connector getConnector(Client client, Configuration runtimeConfig) {
-                    return new DropwizardApacheConnector(apacheHttpClient, configuration.isChunkedEncodingEnabled());
+                    return new DropwizardApacheConnector(
+                            apacheHttpClient.getClient(),
+                            apacheHttpClient.getDefaultRequestConfig(),
+                            configuration.isChunkedEncodingEnabled());
                 }
             };
         }

--- a/dropwizard-client/src/test/java/io/dropwizard/client/ConfiguredCloseableHttpClientTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/ConfiguredCloseableHttpClientTest.java
@@ -1,0 +1,35 @@
+package io.dropwizard.client;
+
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConfiguredCloseableHttpClientTest {
+    public ConfiguredCloseableHttpClient configuredClient;
+    @Mock
+    private CloseableHttpClient closeableHttpClientMock;
+    @Mock
+    private RequestConfig defaultRequestConfigMock;
+
+    @Before
+    public void setUp() {
+        configuredClient = new ConfiguredCloseableHttpClient(closeableHttpClientMock, defaultRequestConfigMock);
+    }
+
+    @Test
+    public void getDefaultRequestConfig_returns_config_provided_at_construction() {
+        assertThat(configuredClient.getDefaultRequestConfig()).isEqualTo(defaultRequestConfigMock);
+    }
+
+    @Test
+    public void getClient_returns_config_provided_at_construction() {
+        assertThat(configuredClient.getClient()).isEqualTo(closeableHttpClientMock);
+    }
+}

--- a/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
@@ -1,0 +1,178 @@
+package io.dropwizard.client;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.io.Resources;
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import io.dropwizard.util.Duration;
+import org.apache.http.HttpStatus;
+import org.apache.http.conn.ConnectTimeoutException;
+import org.assertj.core.api.AbstractLongAssert;
+import org.glassfish.jersey.client.ClientProperties;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+import java.net.SocketTimeoutException;
+import java.net.URI;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.any;
+
+public class DropwizardApacheConnectorTest {
+    private static final int SLEEP_TIME_IN_MILLIS = 500;
+    private static final int DEFAULT_CONNECT_TIMEOUT_IN_MILLIS = 200;
+    private static final int ERROR_MARGIN_IN_MILLIS = 300;
+    private static final int INCREASE_IN_MILLIS = 100;
+    private static final String NON_ROUTABLE_IP_ADDRESS = "10.255.255.1"; 
+    public static final URI URI_THAT_TIMESOUT_ON_CONNECTION_ATTEMPT = URI.create("http://" + NON_ROUTABLE_IP_ADDRESS);
+    @ClassRule
+    public static DropwizardAppRule<Configuration> APP_RULE =
+            new DropwizardAppRule<>(TestApplication.class, Resources.getResource("yaml/dropwizardApacheConnectorTest.yml").getPath());
+    public final URI testUri = URI.create("http://localhost:" + APP_RULE.getLocalPort());
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private Client client;
+
+    @Before
+    public void setup() {
+        JerseyClientConfiguration clientConfiguration = new JerseyClientConfiguration();
+        clientConfiguration.setConnectionTimeout(Duration.milliseconds(SLEEP_TIME_IN_MILLIS / 2));
+        clientConfiguration.setTimeout(Duration.milliseconds(DEFAULT_CONNECT_TIMEOUT_IN_MILLIS));
+        client = new JerseyClientBuilder(new MetricRegistry())
+                .using(Executors.newSingleThreadExecutor(), Jackson.newObjectMapper())
+                .using(clientConfiguration)
+                .build("test");
+    }
+
+    @Test
+    public void when_no_read_timeout_override_then_client_request_times_out() {
+        thrown.expect(ProcessingException.class);
+        thrown.expectCause(any(SocketTimeoutException.class));
+
+        client.target(testUri + "/long_running")
+                .request()
+                .get();
+    }
+
+    @Test
+    public void when_read_timeout_override_created_then_client_requests_completes_successfully() {
+        client.target(testUri + "/long_running")
+                .property(ClientProperties.READ_TIMEOUT, SLEEP_TIME_IN_MILLIS * 2)
+                .request()
+                .get();
+    }
+
+    /**
+     *
+     * In first assertion we prove, that a request takes no longer than:
+     * request_time < set_connect_timeout + error_margin (1)
+     *
+     * in the second we show that if we set connect_timeout to set_connect_timeout + error margin + increase
+     * then
+     *
+     * request_time' > set_connect_timeout + error margin + increase (2)
+     *
+     * Now, (1) and (2) can hold at the same time iff then connect_timeout update was successful.
+     */
+    @Test
+    public void connect_timeout_override_changes_how_long_it_takes_for_a_connection_to_timeout() {
+        // before override
+        assertThatGetConnectonTimeoutForTarget(
+                client.target(URI_THAT_TIMESOUT_ON_CONNECTION_ATTEMPT)
+        ).isLessThan(DEFAULT_CONNECT_TIMEOUT_IN_MILLIS + ERROR_MARGIN_IN_MILLIS);
+
+        // after override
+        assertThatGetConnectonTimeoutForTarget(
+                client.target(URI_THAT_TIMESOUT_ON_CONNECTION_ATTEMPT)
+                        .property(ClientProperties.CONNECT_TIMEOUT, DEFAULT_CONNECT_TIMEOUT_IN_MILLIS + INCREASE_IN_MILLIS + ERROR_MARGIN_IN_MILLIS)
+        ).isGreaterThan(DEFAULT_CONNECT_TIMEOUT_IN_MILLIS + INCREASE_IN_MILLIS + ERROR_MARGIN_IN_MILLIS);
+    }
+
+    @Test
+    public void when_no_override_then_redirected_request_successfully_redirected() {
+        assertThat(
+                client.target(testUri + "/redirect")
+                        .request()
+                        .get(String.class)
+        ).isEqualTo("redirected");
+    }
+
+    @Test
+    public void when_configuration_overridden_to_disallow_redirects_temporary_redirect_status_returned() {
+        assertThat(
+                client.target(testUri + "/redirect")
+                        .property(ClientProperties.FOLLOW_REDIRECTS, false)
+                        .request()
+                        .get(Response.class)
+                        .getStatus()
+        ).isEqualTo(HttpStatus.SC_TEMPORARY_REDIRECT);
+    }
+
+    @Path("/")
+    public static class TestResource {
+
+        @GET
+        @Path("/long_running")
+        public String getWithSleep() throws InterruptedException {
+            TimeUnit.MILLISECONDS.sleep(SLEEP_TIME_IN_MILLIS);
+            return "success";
+        }
+
+        @GET
+        @Path("redirect")
+        public Response getWithRedirect() {
+            return Response.temporaryRedirect(URI.create("/redirected")).build();
+        }
+
+        @GET
+        @Path("redirected")
+        public String redirectedGet() {
+            return "redirected";
+        }
+
+    }
+
+    public static class TestApplication extends Application<Configuration> {
+        public static void main(String[] args) throws Exception {
+            new TestApplication().run(args);
+        }
+
+        @Override
+        public void run(Configuration configuration, Environment environment) throws Exception {
+            environment.jersey().register(TestResource.class);
+        }
+    }
+
+    private static AbstractLongAssert<?> assertThatGetConnectonTimeoutForTarget(WebTarget webTarget) {
+        final long startTime = System.nanoTime();
+        try {
+            webTarget
+                    .request()
+                    .get(Response.class);
+        } catch (ProcessingException e) {
+            final long endTime = System.nanoTime();
+            assertThat(e).isNotNull();
+            //noinspection ConstantConditions
+            assertThat(e.getCause()).isNotNull();
+            assertThat(e.getCause()).isInstanceOf(ConnectTimeoutException.class);
+            return assertThat((endTime - startTime)/1000000);
+        }
+        throw new AssertionError("ProcessingException expected but not thrown");
+    }
+
+}

--- a/dropwizard-client/src/test/resources/yaml/dropwizardApacheConnectorTest.yml
+++ b/dropwizard-client/src/test/resources/yaml/dropwizardApacheConnectorTest.yml
@@ -1,0 +1,5 @@
+# this is needed to start the application in the DropwizardApacheConnectorTest
+server:
+  applicationConnectors:
+    - type: http
+      port: 0


### PR DESCRIPTION
**Motivation**

JerseyClient and the ApacheHttpClient are statically configured at creation time. Dropwizard configuration builders ensure those configs are in sync. However, `WebTarget` objects can have the configuration overridden per generated request. This information will be added to the `JerseyRequest`. Unfortunately, the current implementation of the `DropwizardApacheConnector` does not propagate this onto the `RequestConfig` in the created `HttpUriRequest`.

In DW 0.7.1 this was working thanks to this code: http://grepcode.com/file/repo1.maven.org/maven2/com.sun.jersey.contribs/jersey-apache-client4/1.18.1/com/sun/jersey/client/apache4/ApacheHttpClient4Handler.java#241

This is currently blocking the migration of https://github.com/yammer/tenacity project to DW 0.8.0, as we need this functionality to sync Hystrix timeouts with those of the HttpClient.

**Solution**

The solution is to update the `DropwizardApacheConnector` to check the `JerseyRequest#getConfiguration` for properties (present only if overridden) that should be propagated to the `HttpUriRequest` specific `RequestConfig` instance.

I didn't want to loose the default values for not overridden properties, so I wrapped the `CloseableHttpClient` in a delegating class that exposes the default `RequestConfig` to use as basis.
