### PR TITLE
Use same ObjectMapper for client and server in ResourceTestRule

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ResourceTestRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ResourceTestRule.java
@@ -2,14 +2,14 @@ package io.dropwizard.testing.junit;
 
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
 import io.dropwizard.logging.LoggingFactory;
-
+import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.inmemory.InMemoryTestContainerFactory;
 import org.glassfish.jersey.test.spi.TestContainerException;
@@ -22,7 +22,6 @@ import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Application;
-
 import java.util.Map;
 import java.util.Set;
 
@@ -152,6 +151,13 @@ public class ResourceTestRule implements TestRule {
                         @Override
                         protected TestContainerFactory getTestContainerFactory() throws TestContainerException {
                             return testContainerFactory;
+                        }
+
+                        @Override
+                        protected void configureClient(final ClientConfig config) {
+                            JacksonJsonProvider jsonProvider = new JacksonJsonProvider();
+                            jsonProvider.setMapper(mapper);
+                            config.register(jsonProvider);
                         }
                     };
                     test.setUp();

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResource.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResource.java
@@ -1,6 +1,7 @@
 package io.dropwizard.testing.app;
 
 import com.codahale.metrics.annotation.Timed;
+import com.google.common.collect.ImmutableList;
 import io.dropwizard.testing.Person;
 
 import javax.ws.rs.GET;
@@ -22,5 +23,12 @@ public class PersonResource {
     @Timed
     public Person getPerson(@PathParam("name") String name) {
         return store.fetchPerson(name);
+    }
+
+    @GET
+    @Timed
+    @Path("/list")
+    public ImmutableList<Person> getPersonList(@PathParam("name") String name) {
+        return ImmutableList.of(getPerson(name));
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResourceTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResourceTest.java
@@ -1,16 +1,19 @@
 package io.dropwizard.testing.app;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.google.common.collect.ImmutableList;
+import io.dropwizard.jackson.Jackson;
 import io.dropwizard.testing.Person;
 import io.dropwizard.testing.junit.ResourceTestRule;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import javax.ws.rs.core.GenericType;
 
-import static org.mockito.Mockito.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests {@link ResourceTestRule}.
@@ -18,15 +21,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class PersonResourceTest {
     private static final PeopleStore dao = mock(PeopleStore.class);
 
+    private static final ObjectMapper mapper = Jackson.newObjectMapper()
+            .registerModule(new GuavaModule());
+
     @ClassRule
     public static final ResourceTestRule resources = ResourceTestRule.builder()
             .addResource(new PersonResource(dao))
+            .setMapper(mapper)
             .build();
 
     private final Person person = new Person("blah", "blah@example.com");
 
     @Before
     public void setup() {
+        reset(dao);
         when(dao.fetchPerson(eq("blah"))).thenReturn(person);
     }
 
@@ -36,5 +44,12 @@ public class PersonResourceTest {
                 .get(Person.class))
                 .isEqualTo(person);
         verify(dao).fetchPerson("blah");
+    }
+
+    @Test
+    public void testGetImmutableListOfPersons() {
+        assertThat(resources.client().target("/person/blah/list").request()
+                .get(new GenericType<ImmutableList<Person>>() {}))
+                .isEqualTo(ImmutableList.of(person));
     }
 }


### PR DESCRIPTION
In `ResourceTestRule` configure the client in `JerseyTest` to use the same provided `ObjectMapper` as the server to prevent serialization/deserialization issues.

See https://github.com/dropwizard/dropwizard-java8/issues/8 for details.