### PR TITLE
User manual mentions outdated Maven Shade Plugin

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -588,7 +588,7 @@ this:
     <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>1.6</version>
+        <version>2.3</version>
         <configuration>
             <createDependencyReducedPom>true</createDependencyReducedPom>
             <filters>


### PR DESCRIPTION
Changed 1.6 in 2.3 which provides amongst others better error messages.