### PR TITLE
Improvements of IntegrationTest in the example application

### DIFF
--- a/dropwizard-example/src/main/java/com/example/helloworld/core/Person.java
+++ b/dropwizard-example/src/main/java/com/example/helloworld/core/Person.java
@@ -29,6 +29,14 @@ public class Person {
     @Column(name = "jobTitle", nullable = false)
     private String jobTitle;
 
+    public Person() {
+    }
+
+    public Person(String fullName, String jobTitle) {
+        this.fullName = fullName;
+        this.jobTitle = jobTitle;
+    }
+
     public long getId() {
         return id;
     }

--- a/dropwizard-example/src/test/java/com/example/helloworld/IntegrationTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/IntegrationTest.java
@@ -1,33 +1,76 @@
 package com.example.helloworld;
 
+import com.example.helloworld.core.Person;
 import com.example.helloworld.core.Saying;
 import com.google.common.base.Optional;
+import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.*;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import java.io.File;
+import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-
 public class IntegrationTest {
+
+    private static final String TMP_FILE = createTempFile();
+    private static final String CONFIG_PATH = ResourceHelpers.resourceFilePath("test-example.yml");
 
     @ClassRule
     public static final DropwizardAppRule<HelloWorldConfiguration> RULE = new DropwizardAppRule<>(
-            HelloWorldApplication.class, ResourceHelpers.resourceFilePath("test-example.yml"));
+            HelloWorldApplication.class, CONFIG_PATH,
+            ConfigOverride.config("database.url", "jdbc:h2:" + TMP_FILE));
+
+    private Client client;
+
+    @BeforeClass
+    public static void migrateDb() throws Exception {
+        RULE.getApplication().run("db", "migrate", CONFIG_PATH);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        client = ClientBuilder.newClient();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        client.close();
+    }
+
+    private static String createTempFile() {
+        try {
+            return File.createTempFile("test-example", null).getAbsolutePath();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
 
     @Test
     public void testHelloWorld() throws Exception {
         final Optional<String> name = Optional.fromNullable("Dr. IntegrationTest");
-        final Client client = ClientBuilder.newClient();
         final Saying saying = client.target("http://localhost:" + RULE.getLocalPort() + "/hello-world")
                 .queryParam("name", name.get())
                 .request()
                 .get(Saying.class);
         assertThat(saying.getContent()).isEqualTo(RULE.getConfiguration().buildTemplate().render(name));
-        client.close();
+    }
+
+    @Test
+    public void testPostPerson() throws Exception {
+        final Person person = new Person("Dr. IntegrationTest", "Chief Wizard");
+        final Person newPerson = client.target("http://localhost:" + RULE.getLocalPort() + "/people")
+                .request()
+                .post(Entity.entity(person, MediaType.APPLICATION_JSON_TYPE))
+                .readEntity(Person.class);
+        assertThat(newPerson.getId()).isNotNull();
+        assertThat(newPerson.getFullName()).isEqualTo(person.getFullName());
+        assertThat(newPerson.getJobTitle()).isEqualTo(person.getJobTitle());
     }
 }

--- a/dropwizard-example/src/test/java/com/example/helloworld/IntegrationTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/IntegrationTest.java
@@ -2,32 +2,32 @@ package com.example.helloworld;
 
 import com.example.helloworld.core.Saying;
 import com.google.common.base.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
-
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.WebTarget;
-
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class IntegrationTest {
-	@ClassRule
-	public static final DropwizardAppRule<HelloWorldConfiguration> RULE =
-		new DropwizardAppRule<HelloWorldConfiguration>(HelloWorldApplication.class, "example.yml");
-	
-	@Test
-	public void testHelloWorld() throws Exception {
-		Client client = ClientBuilder.newClient();
-		WebTarget target = client.target("http://localhost:" + RULE.getLocalPort() + "/hello-world");
-		
-		final Optional<String> NAME = Optional.fromNullable("Dr. IntegrationTest");
-		
-		Saying saying = target.queryParam("name", NAME.get()).request().get(Saying.class);
-		
-		assertThat(saying.getContent()).isEqualTo(RULE.getConfiguration().buildTemplate().render(NAME));
-	}
+
+    @ClassRule
+    public static final DropwizardAppRule<HelloWorldConfiguration> RULE = new DropwizardAppRule<>(
+            HelloWorldApplication.class, ResourceHelpers.resourceFilePath("test-example.yml"));
+
+    @Test
+    public void testHelloWorld() throws Exception {
+        final Optional<String> name = Optional.fromNullable("Dr. IntegrationTest");
+        final Client client = ClientBuilder.newClient();
+        final Saying saying = client.target("http://localhost:" + RULE.getLocalPort() + "/hello-world")
+                .queryParam("name", name.get())
+                .request()
+                .get(Saying.class);
+        assertThat(saying.getContent()).isEqualTo(RULE.getConfiguration().buildTemplate().render(name));
+        client.close();
+    }
 }

--- a/dropwizard-example/src/test/resources/test-example.yml
+++ b/dropwizard-example/src/test/resources/test-example.yml
@@ -1,0 +1,16 @@
+template: Hello, %s!
+defaultName: Stranger
+
+database:
+  driverClass: org.h2.Driver
+  user: sa
+  password: sa
+  url: jdbc:h2:./target/test-example
+
+server:
+  applicationConnectors:
+    - type: http
+      port: 0
+  adminConnectors:
+    - type: http
+      port: 0


### PR DESCRIPTION
* The test can be executed from an IDE
* Use a test, not a real configuration
* Dynamically assign application and admin ports
* Close an HTTP client in the test
* Replace tabs to spaces
* Add an integration test for work with a database  
* Create a temporary folder
* Override the DW database config
* Migrate the DB schema
* Test that database-related resource is working

