### PR TITLE
Enabling UnitOfWork on implementations of interfaces

### DIFF
--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkApplicationListener.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkApplicationListener.java
@@ -172,6 +172,10 @@ public class UnitOfWorkApplicationListener implements ApplicationEventListener {
     private void registerUnitOfWorkAnnotations (ResourceMethod method) {
         UnitOfWork annotation = method.getInvocable().getDefinitionMethod().getAnnotation(UnitOfWork.class);
 
+        if (annotation == null) {
+            annotation = method.getInvocable().getHandlingMethod().getAnnotation(UnitOfWork.class);
+        }
+
         if (annotation != null) {
             this.methodMap.put(method.getInvocable().getDefinitionMethod(), annotation);
         }


### PR DESCRIPTION
* patched `UnitOfWorkApplicationListener` to detect `UnitOfWork` annotation on methods that implement a resource method defined on an interface
* caused by difference between `definitionMethod` (interface) and `handlingMethod` (implementation) for a jersey resouce
* behavior:
  * listener checks `definitionMethod` for `UnitOfWork`
  * if found, this annotation wins (as before)
  * if not found, listener now checks `handlingMethod` for `UnitOfWork`
* extended tests to cover the new behavior

Minimal example to share jersey definitions among clients and the server:
* an interface defines the jersey resources (without `UnitOfWork`)
```java
@Path("user")
public interface UserResource {
    @GET
    @Path("list")
    @Produces(MediaType.APPLICATION_JSON)
    List<User> getAllUsers();//definitionMethod
}
```

* the implementation adds the `UnitOfWork` annotation (server project, to avoid a leaked dependency).
```java
public class UserResourceImpl implements UserResource {
    @Override
    @UnitOfWork
    public List<User> getAllUsers() { //... }//handlingMethod
}
```
