### PR TITLE
Rethrow Hibernate exceptions as Jersey exceptions

### DIFF
--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkApplicationListener.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkApplicationListener.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import javax.ws.rs.ext.Provider;
 
+import org.glassfish.jersey.server.internal.process.MappableException;
 import org.glassfish.jersey.server.model.Resource;
 import org.glassfish.jersey.server.model.ResourceMethod;
 import org.glassfish.jersey.server.monitoring.ApplicationEvent;
@@ -84,7 +85,7 @@ public class UnitOfWorkApplicationListener implements ApplicationEventListener {
                         commitTransaction();
                     } catch (Exception e) {
                         rollbackTransaction();
-                        this.<RuntimeException>rethrow(e);
+                        throw new MappableException(e);
                     }
                     finally {
                         this.session.close();
@@ -135,11 +136,6 @@ public class UnitOfWorkApplicationListener implements ApplicationEventListener {
                     txn.commit();
                 }
             }
-        }
-
-        @SuppressWarnings("unchecked")
-        private <E extends Exception> void rethrow(Exception e) throws E {
-            throw (E) e;
         }
     }
 

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/DataExceptionMapper.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/DataExceptionMapper.java
@@ -1,0 +1,26 @@
+package io.dropwizard.hibernate;
+
+import io.dropwizard.jersey.errors.ErrorMessage;
+import org.hibernate.exception.DataException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class DataExceptionMapper implements ExceptionMapper<DataException> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DataException.class);
+
+    @Override
+    public Response toResponse(DataException e) {
+        LOGGER.error("Hibernate error", e);
+        String message = e.getCause().getMessage().contains("EMAIL") ? "Wrong email" : "Wrong input";
+
+        return Response.status(Response.Status.BAD_REQUEST)
+                .entity(new ErrorMessage(Response.Status.BAD_REQUEST.getStatusCode(), message))
+                .build();
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/ErrorMessage.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/ErrorMessage.java
@@ -1,5 +1,8 @@
 package io.dropwizard.jersey.errors;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class ErrorMessage {
     private final int code;
     private final String message;
@@ -13,7 +16,9 @@ public class ErrorMessage {
         this(code, message, null);
     }
 
-    public ErrorMessage(int code, String message, String details) {
+    @JsonCreator
+    public ErrorMessage(@JsonProperty("code") int code, @JsonProperty("message") String message,
+                        @JsonProperty("details") String details) {
         this.code = code;
         this.message = message;
         this.details = details;

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/ErrorMessage.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/ErrorMessage.java
@@ -1,8 +1,10 @@
 package io.dropwizard.jersey.errors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ErrorMessage {
     private final int code;
     private final String message;

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapperTest.java
@@ -1,6 +1,7 @@
 package io.dropwizard.jersey.jackson;
 
 import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.jersey.DropwizardResourceConfig;
@@ -49,5 +50,10 @@ public class JsonProcessingExceptionMapperTest extends JerseyTest {
         Response response = target("/json/ok").request(MediaType.APPLICATION_JSON)
                 .post(Entity.entity(new UnknownRepresentation(100), MediaType.APPLICATION_JSON));
         assertThat(response.getStatus()).isEqualTo(400);
+
+        JsonNode errorMessage = response.readEntity(JsonNode.class);
+        assertThat(errorMessage.get("code").asInt()).isEqualTo(400);
+        assertThat(errorMessage.get("message").asText()).isEqualTo("Unable to process JSON");
+        assertThat(errorMessage.has("details")).isFalse();
     }
 }


### PR DESCRIPTION
If a database commit fails, it's better not to rethrow an Hibernate exception in the original form, but
wrap it as a MappableException.

This way users can map sql exceptions to web responses and derive a business value from the
database validation checks.

Resolve #949