### PR TITLE
Serving static assets example

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -443,7 +443,7 @@ application. To enable it, move your application to a sub-URL.
 .. code-block:: yaml
 
     server:
-      type: simple
+      type: default
       rootPath: /application/*
 
 Then use an extended ``AssetsBundle`` constructor to serve resources in the


### PR DESCRIPTION
Changed server type from `simple` to `default`.
Having `simple` will lead to 404 errors.
I just experienced this when toying around, so maybe someone more experienced should have a closer look at this.