### PR TITLE
Add configuration section to jersey client docs

### DIFF
--- a/docs/source/manual/client.rst
+++ b/docs/source/manual/client.rst
@@ -150,3 +150,23 @@ Then, in your service's ``run`` method, create a new ``JerseyClientBuilder``:
         environment.jersey().register(new ExternalServiceResource(client));
     }
 
+Configuration
+-------------
+
+The Client that Dropwizard creates deviates from the `Jersey Client Configuration`_ defaults. The
+default, in Jersey, is for a client to never timeout reading or connecting in a request, while in
+Dropwizard, the default is 500 milliseconds. There are a couple of ways to change this behavior. The
+recommended way is to modify the :ref:`YAML configuration <man- configuration-clients-http>`.
+Alternatively, set the properties on the ``JerseyClientConfiguration``, which will take affect for all built
+clients. On a per client basis, the configuration can be changed through utilizing the ``property``
+method and, in this case, the `Jersey Client Properties`_ can be used.
+
+.. warning::
+
+    Do not try to change Jersey properties using `Jersey Client Properties`_ through the
+    ``withProperty(String propertyName, Object propertyValue`` method on the ``JerseyClientBuilder``
+    because it is meant for Apache's HttpClient and not for Jersey's, so the Jersey properties are
+    ignored.
+
+.. _Jersey Client Configuration: https://jersey.java.net/documentation/latest/appendix-properties.html#appendix-properties-client
+.. _Jersey Client Properties: https://jersey.java.net/apidocs/2.17/jersey/org/glassfish/jersey/client/ClientProperties.html


### PR DESCRIPTION
Thought I'd flesh out Jersey's Client documentation a bit more.

I welcome a second pair of eyes to make sure it is alright and makes sense.

I should note that it relies on the changes in #939 to be accurate.

Closes #960 
