### PR TITLE
Facility to specify a database timezone

### DIFF
--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/JodaDateTimeArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/JodaDateTimeArgumentFactory.java
@@ -1,14 +1,48 @@
 package io.dropwizard.jdbi.args;
 
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
 import org.joda.time.DateTime;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.Argument;
 import org.skife.jdbi.v2.tweak.ArgumentFactory;
 
+import javax.annotation.Nullable;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
 /**
  * An {@link ArgumentFactory} for Joda {@link DateTime} arguments.
  */
 public class JodaDateTimeArgumentFactory implements ArgumentFactory<DateTime> {
+
+    /**
+     * <p>{@link Calendar} for representing a database time zone.<p>
+     * It's needed when an argument is not represented in a database
+     * as {@code TIMESTAMP WITH TIME ZONE}. In this case for correct
+     * representing of a timestamp an explicit cast to the database
+     * time zone is needed at the JDBC driver level.
+     */
+    private final Optional<Calendar> calendar;
+
+    public JodaDateTimeArgumentFactory() {
+        calendar = Optional.absent();
+    }
+
+    /**
+     * Create an argument factory with a custom time zone offset
+     *
+     * @param timeZone a time zone representing an offset
+     */
+    public JodaDateTimeArgumentFactory(Optional<TimeZone> timeZone) {
+        calendar = timeZone.transform(new Function<TimeZone, Calendar>() {
+            @Override
+            public Calendar apply(TimeZone tz) {
+                return new GregorianCalendar(tz);
+            }
+        });
+    }
 
     @Override
     public boolean accepts(final Class<?> expectedType,
@@ -21,6 +55,6 @@ public class JodaDateTimeArgumentFactory implements ArgumentFactory<DateTime> {
     public Argument build(final Class<?> expectedType,
                           final DateTime value,
                           final StatementContext ctx) {
-        return new JodaDateTimeArgument(value);
+        return new JodaDateTimeArgument(value, calendar);
     }
 }

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/JodaDateTimeMapper.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/JodaDateTimeMapper.java
@@ -1,20 +1,59 @@
 package io.dropwizard.jdbi.args;
 
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
 import org.joda.time.DateTime;
 import org.skife.jdbi.v2.util.TypedMapper;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
 
 /**
  * A {@link TypedMapper} to map Joda {@link DateTime} objects.
  */
 public class JodaDateTimeMapper extends TypedMapper<DateTime> {
 
+    /**
+     * <p>{@link Calendar} for representing a database time zone.<p>
+     * If a field is not represented in a database as
+     * {@code TIMESTAMP WITH TIME ZONE}, we need to set its time zone
+     * explicitly. Otherwise it will not be correctly represented in
+     * a time zone different from the time zone of the database.
+     */
+    private Optional<Calendar> calendar = Optional.absent();
+
+    public JodaDateTimeMapper(Optional<TimeZone> timeZone) {
+        calendar = timeZone.transform(new Function<TimeZone, Calendar>() {
+            @Override
+            public Calendar apply(TimeZone tz) {
+                return new GregorianCalendar(tz);
+            }
+        });
+    }
+
+    /**
+     * Make a clone of a calendar.
+     * <p>Despite the fact that {@link Calendar} is used only for
+     * representing a time zone, some JDBC drivers actually use it
+     * for time calculations,</p>
+     * <p>Also {@link Calendar} is not immutable, which makes it
+     * thread-unsafe. Therefore we need to make a copy to avoid
+     * state mutation problems.</p>
+     *
+     * @return a clone of calendar, representing a database time zone
+     */
+    private Calendar cloneCalendar() {
+        return (Calendar) calendar.get().clone();
+    }
+
     @Override
     protected DateTime extractByName(final ResultSet r, final String name) throws SQLException {
-        final Timestamp timestamp = r.getTimestamp(name);
+        final Timestamp timestamp = calendar.isPresent() ? r.getTimestamp(name, cloneCalendar()) :
+                r.getTimestamp(name);
         if (timestamp == null) {
             return null;
         }
@@ -23,7 +62,8 @@ public class JodaDateTimeMapper extends TypedMapper<DateTime> {
 
     @Override
     protected DateTime extractByIndex(final ResultSet r, final int index) throws SQLException {
-        final Timestamp timestamp = r.getTimestamp(index);
+        final Timestamp timestamp = calendar.isPresent() ? r.getTimestamp(index, cloneCalendar()) :
+                r.getTimestamp(index);
         if (timestamp == null) {
             return null;
         }

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/DBIClient.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/DBIClient.java
@@ -1,0 +1,74 @@
+package io.dropwizard.jdbi.timestamps;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Optional;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jdbi.DBIFactory;
+import io.dropwizard.setup.Environment;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.rules.ExternalResource;
+import org.skife.jdbi.v2.DBI;
+
+import javax.validation.Validation;
+import java.util.List;
+import java.util.TimeZone;
+
+/**
+ * Configured JDBI client for the database
+ */
+public class DBIClient extends ExternalResource {
+
+    private final TimeZone dbTimeZone;
+
+    private DBI dbi;
+    private List<LifeCycle> managedObjects;
+
+    public DBIClient(TimeZone dbTimeZone) {
+        this.dbTimeZone = dbTimeZone;
+    }
+
+    public DBI getDbi() {
+        return dbi;
+    }
+
+    @Override
+    protected void before() throws Throwable {
+        final Environment environment = new Environment("test", Jackson.newObjectMapper(),
+                Validation.buildDefaultValidatorFactory().getValidator(), new MetricRegistry(),
+                getClass().getClassLoader());
+
+        final DataSourceFactory dataSourceFactory = new DataSourceFactory();
+        dataSourceFactory.setDriverClass("org.h2.Driver");
+        dataSourceFactory.setUrl("jdbc:h2:tcp://localhost/fldb");
+        dataSourceFactory.setUser("sa");
+        dataSourceFactory.setPassword("");
+
+        // Set the time zone of the database
+        final DBIFactory dbiFactory = new DBIFactory() {
+            @Override
+            protected Optional<TimeZone> databaseTimeZone() {
+                return Optional.of(dbTimeZone);
+            }
+        };
+        dbi = dbiFactory.build(environment, dataSourceFactory, "test-jdbi-time-zones");
+
+        // Start the DB pool
+        managedObjects = environment.lifecycle().getManagedObjects();
+        for (LifeCycle managedObject : managedObjects) {
+            managedObject.start();
+        }
+    }
+
+    @Override
+    protected void after() {
+        // Shutdown the DB pool
+        try {
+            for (LifeCycle managedObject : managedObjects) {
+                managedObject.stop();
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/DatabaseInTimeZone.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/DatabaseInTimeZone.java
@@ -1,0 +1,65 @@
+package io.dropwizard.jdbi.timestamps;
+
+import org.h2.tools.Server;
+import org.junit.rules.ExternalResource;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Run an instance of the H2 database in an another time zone
+ */
+public class DatabaseInTimeZone extends ExternalResource {
+
+    private final TemporaryFolder temporaryFolder;
+    private final TimeZone timeZone;
+
+    private Process process;
+
+    public DatabaseInTimeZone(TemporaryFolder temporaryFolder, TimeZone timeZone) {
+        this.temporaryFolder = temporaryFolder;
+        this.timeZone = timeZone;
+    }
+
+    @Override
+    protected void before() throws Throwable {
+        String java = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
+        File h2jar = new File(Server.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+        String vmArguments = "-Duser.timezone=" + timeZone.getID();
+
+        ProcessBuilder pb = new ProcessBuilder(java, vmArguments, "-cp", h2jar.getAbsolutePath(), Server.class.getName(),
+                "-tcp", "-baseDir", temporaryFolder.newFolder().getAbsolutePath());
+        process = pb.start();
+    }
+
+    @Override
+    protected void after() {
+        try {
+            // Graceful shutdown of the database
+            Server.shutdownTcpServer("tcp://localhost:9092", "", true, false);
+            boolean exited = waitFor(process, 1, TimeUnit.SECONDS);
+            if (!exited) {
+                process.destroy();
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable shutdown DB", e);
+        }
+    }
+
+    private static boolean waitFor(Process process, long timeout, TimeUnit unit) throws InterruptedException {
+        long startTime = System.nanoTime();
+        while (true) {
+            try {
+                process.exitValue();
+                return true;
+            } catch (IllegalThreadStateException ex) {
+                Thread.sleep(100);
+            }
+            if (System.nanoTime() - startTime > unit.toNanos(timeout)) {
+                return false;
+            }
+        }
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/DateTimeSqlTimestampTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/DateTimeSqlTimestampTest.java
@@ -1,0 +1,116 @@
+package io.dropwizard.jdbi.timestamps;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+
+import java.util.Random;
+import java.util.TimeZone;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for handling translation between DateTime to SQL TIMESTAMP
+ * in a different time zone
+ */
+public class DateTimeSqlTimestampTest {
+
+    private static final DateTimeFormatter ISO_FMT = ISODateTimeFormat.dateTimeNoMillis();
+
+    private static TimeZone timeZone = getRandomTimeZone();
+    private static TemporaryFolder temporaryFolder = new TemporaryFolder();
+    private static DatabaseInTimeZone databaseInTimeZone = new DatabaseInTimeZone(temporaryFolder, timeZone);
+    private static DBIClient DBIClient = new DBIClient(timeZone);
+
+    private Handle handle;
+    private FlightDao flightDao;
+    private DateTimeZone dbTimeZone = DateTimeZone.forTimeZone(timeZone);
+
+    @ClassRule
+    public static TestRule chain = RuleChain.outerRule(temporaryFolder)
+            .around(databaseInTimeZone)
+            .around(DBIClient);
+
+    private static TimeZone getRandomTimeZone() {
+        String[] ids = TimeZone.getAvailableIDs();
+        return TimeZone.getTimeZone(ids[new Random().nextInt(ids.length)]);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        handle = DBIClient.getDbi().open();
+        handle.execute("CREATE TABLE flights (" +
+                "  flight_id         VARCHAR(5)  PRIMARY KEY," +
+                "  departure_airport VARCHAR(3)  NOT NULL," +
+                "  arrival_airport   VARCHAR(3)  NOT NULL," +
+                "  departure_time    TIMESTAMP   NOT NULL," +
+                "  arrival_time      TIMESTAMP   NOT NULL" +
+                ")");
+        flightDao = handle.attach(FlightDao.class);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        handle.execute("DROP TABLE flights");
+        handle.close();
+    }
+
+    @Test
+    public void testInsertTimestamp() {
+        final DateTime departureTime = ISO_FMT.parseDateTime("2015-04-01T06:00:00-05:00");
+        final DateTime arrivalTime = ISO_FMT.parseDateTime("2015-04-01T21:00:00+02:00");
+        final int result = flightDao.insert("C1671", "ORD", "DUS", departureTime, arrivalTime);
+        assertThat(result).isGreaterThan(0);
+
+        final Integer serverDepartureHour = (Integer) handle.select(
+                "SELECT EXTRACT(HOUR FROM departure_time) departure_hour " +
+                        "FROM flights WHERE flight_id=?", "C1671").get(0).get("departure_hour");
+        final Integer serverArrivalHour = (Integer) handle.select(
+                "SELECT EXTRACT(HOUR FROM arrival_time) arrival_hour " +
+                        "FROM flights WHERE flight_id=?", "C1671").get(0).get("arrival_hour");
+
+        assertThat(serverDepartureHour).isEqualTo(departureTime.withZone(dbTimeZone).getHourOfDay());
+        assertThat(serverArrivalHour).isEqualTo(arrivalTime.withZone(dbTimeZone).getHourOfDay());
+    }
+
+    @Test
+    public void testReadTimestamp() {
+        int result = handle.insert(
+                "INSERT INTO flights(flight_id, departure_airport, arrival_airport, departure_time, arrival_time) " +
+                        "VALUES ('C1671','ORD','DUS','2015-04-01T06:00:00-05:00','2015-04-01T21:00:00+02:00')");
+        assertThat(result).isGreaterThan(0);
+
+        final DateTime departureTime = flightDao.getDepartureTime("C1671");
+        final DateTime arrivalTime = flightDao.getArrivalTime("C1671");
+
+        assertThat(departureTime).isEqualTo(ISO_FMT.parseDateTime("2015-04-01T06:00:00-05:00"));
+        assertThat(arrivalTime).isEqualTo(ISO_FMT.parseDateTime("2015-04-01T21:00:00+02:00"));
+    }
+
+    public interface FlightDao {
+
+        @SqlUpdate("INSERT INTO flights(flight_id, departure_airport, arrival_airport,departure_time, arrival_time) " +
+                "VALUES (:flight_id, :departure_airport, :arrival_airport, :departure_time, :arrival_time)")
+        int insert(@Bind("flight_id") String flightId, @Bind("departure_airport") String departureAirport,
+                   @Bind("arrival_airport") String arrivalAirport,
+                   @Bind("departure_time") DateTime departureTime, @Bind("arrival_time") DateTime arrivalTime);
+
+        @SqlQuery("SELECT arrival_time FROM flights WHERE flight_id=:flight_id")
+        DateTime getArrivalTime(@Bind("flight_id") String flightId);
+
+        @SqlQuery("SELECT departure_time FROM flights WHERE flight_id=:flight_id")
+        DateTime getDepartureTime(@Bind("flight_id") String flightId);
+    }
+}

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/LifecycleEnvironment.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/LifecycleEnvironment.java
@@ -26,6 +26,10 @@ public class LifecycleEnvironment {
         this.lifecycleListeners = Lists.newArrayList();
     }
 
+    public List<LifeCycle> getManagedObjects() {
+        return managedObjects;
+    }
+
     /**
      * Adds the given {@link Managed} instance to the set of objects managed by the server's
      * lifecycle. When the server starts, {@code managed} will be started. When the server stops,


### PR DESCRIPTION
Provide facility to specify the database time zone during converting Joda-Time `DateTime`
values from/to `SQL TIMESTAMP`.

It's crucial for cases when the database operates in a different timezone then the client and it doesn't handle timestamps as SQL `TIMESTAMP WITH TIME ZONE`

Resolve #968