### PR TITLE
Return back the default constructor for JodaDateTimeMapper

### DIFF
--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/JodaDateTimeMapper.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/JodaDateTimeMapper.java
@@ -24,7 +24,11 @@ public class JodaDateTimeMapper extends TypedMapper<DateTime> {
      * explicitly. Otherwise it will not be correctly represented in
      * a time zone different from the time zone of the database.
      */
-    private Optional<Calendar> calendar = Optional.absent();
+    private Optional<Calendar> calendar;
+
+    public JodaDateTimeMapper() {
+        calendar = Optional.absent();
+    }
 
     public JodaDateTimeMapper(Optional<TimeZone> timeZone) {
         calendar = timeZone.transform(new Function<TimeZone, Calendar>() {


### PR DESCRIPTION
`JodaTimeMapper` is a public class and should provide the default constructor because of:

* backwards compatibility
* users, who don't care about timezones
* consistency with `JodaTimeArgumentFactory`