### PR TITLE
Add support for X.class to DropwizardClientRule

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardClientRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardClientRule.java
@@ -97,7 +97,11 @@ public class DropwizardClientRule extends ExternalResource {
             environment.healthChecks().register("dummy", new DummyHealthCheck());
 
             for (Object resource : resources) {
-                environment.jersey().register(resource);
+                if (resource instanceof Class<?>) {
+                    environment.jersey().register((Class<?>) resource);
+                } else {
+                    environment.jersey().register(resource);
+                }
             }
         }
     }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardClientRuleTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardClientRuleTest.java
@@ -12,12 +12,22 @@ import static org.junit.Assert.assertEquals;
 
 public class DropwizardClientRuleTest {
     @ClassRule
-    public static final DropwizardClientRule RULE = new DropwizardClientRule(new TestResource("foo"));
+    public static final DropwizardClientRule RULE_WITH_INSTANCE = new DropwizardClientRule(new TestResource("foo"));
+
+    @ClassRule
+    public static final DropwizardClientRule RULE_WITH_CLASS = new DropwizardClientRule(TestResource.class);
 
     @Test(timeout = 5000)
     public void shouldGetStringBodyFromDropWizard() throws IOException {
-        final URL url = new URL(RULE.baseUri() + "/test");
+        final URL url = new URL(RULE_WITH_INSTANCE.baseUri() + "/test");
         final String response = new BufferedReader(new InputStreamReader(url.openStream())).readLine();
         assertEquals("foo", response);
+    }
+
+    @Test(timeout = 5000)
+    public void shouldGetDefaultStringBodyFromDropWizard() throws IOException {
+        final URL url = new URL(RULE_WITH_CLASS.baseUri() + "/test");
+        final String response = new BufferedReader(new InputStreamReader(url.openStream())).readLine();
+        assertEquals(TestResource.DEFAULT_MESSAGE, response);
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/TestResource.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/TestResource.java
@@ -6,7 +6,13 @@ import javax.ws.rs.Path;
 @Path("/")
 public class TestResource {
 
+    public static final String DEFAULT_MESSAGE = "Default message";
+
     private final String message;
+
+    public TestResource() {
+      this(DEFAULT_MESSAGE);
+    }
 
     public TestResource(String message) {
         this.message = message;


### PR DESCRIPTION
This can be helpful in cases where non-Resources are passed in that
depend on `@Context` annotations or it's preferable for other
reasons to have Jersey manage the object lifetime.