### PR TITLE
DropwizardTestSupport: after() completes even if before() failed

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
@@ -72,8 +72,12 @@ public class DropwizardTestSupport<C extends Configuration> {
     }
 
     public void after() {
-        stopIfRequired();
-        resetConfigOverrides();
+        try {
+            stopIfRequired();
+        }
+        finally {
+            resetConfigOverrides();
+        }
     }
 
     private void stopIfRequired() {

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
@@ -74,14 +74,13 @@ public class DropwizardTestSupport<C extends Configuration> {
     public void after() {
         try {
             stopIfRequired();
-        }
-        finally {
+        } finally {
             resetConfigOverrides();
         }
     }
 
     private void stopIfRequired() {
-        if( jettyServer != null) {
+        if (jettyServer != null) {
             for (ServiceListener<C> listener : listeners) {
                 try {
                     listener.onStop(this);

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
@@ -72,19 +72,25 @@ public class DropwizardTestSupport<C extends Configuration> {
     }
 
     public void after() {
-        for (ServiceListener<C> listener : listeners) {
-            try {
-                listener.onStop(this);
-            } catch (Exception ignored) {
-            }
-        }
+        stopIfRequired();
         resetConfigOverrides();
-        try {
-            jettyServer.stop();
-        } catch (Exception e) {
-            throw propagate(e);
-        } finally {
-            jettyServer = null;
+    }
+
+    private void stopIfRequired() {
+        if( jettyServer != null) {
+            for (ServiceListener<C> listener : listeners) {
+                try {
+                    listener.onStop(this);
+                } catch (Exception ignored) {
+                }
+            }
+            try {
+                jettyServer.stop();
+            } catch (Exception e) {
+                throw propagate(e);
+            } finally {
+                jettyServer = null;
+            }
         }
     }
 


### PR DESCRIPTION
Prior to this fix, DropwizardTestSupport.after() assumed that a previous execution of before() had completed successfully. But if before() failed, then after() would fail, too -- typically, with an NPE accessing an undefined jettyServer. In which case the, JUnit report for tests using DropwizardTestSupport become muddled, showing an extra failure for each test class.