### PR TITLE
Use Type parameter for configuration in initialize

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/ConfiguredBundle.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/ConfiguredBundle.java
@@ -9,7 +9,7 @@ import io.dropwizard.setup.Environment;
  *
  * @param <T>    the required configuration interface
  */
-public interface ConfiguredBundle<T> {
+public interface ConfiguredBundle<T extends Configuration> {
     /**
      * Initializes the environment.
      *
@@ -24,5 +24,5 @@ public interface ConfiguredBundle<T> {
      *
      * @param bootstrap the application bootstrap
      */
-    void initialize(Bootstrap<?> bootstrap);
+    void initialize(Bootstrap<? extends T> bootstrap);
 }

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/HibernateBundle.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/HibernateBundle.java
@@ -31,7 +31,7 @@ public abstract class HibernateBundle<T extends Configuration> implements Config
     }
 
     @Override
-    public final void initialize(Bootstrap<?> bootstrap) {
+    public final void initialize(Bootstrap<? extends T> bootstrap) {
         bootstrap.getObjectMapper().registerModule(createHibernate4Module());
     }
 

--- a/dropwizard-views/src/main/java/io/dropwizard/views/ViewBundle.java
+++ b/dropwizard-views/src/main/java/io/dropwizard/views/ViewBundle.java
@@ -115,7 +115,7 @@ public class ViewBundle<T extends Configuration> implements ConfiguredBundle<T>,
     }
 
     @Override
-    public void initialize(Bootstrap<?> bootstrap) {
+    public void initialize(Bootstrap<? extends T> bootstrap) {
         // nothing doing
     }
 }


### PR DESCRIPTION
Use Type parameter for configuration in both, run and initialize so that one can for example add another ConfigurationBundle in initialize method.

See also https://github.com/dropwizard/dropwizard/pull/795

----

Example: There is a team-wide default set of bundles that is used for all webservices. They all use the same (superset) of configuration. Instead of adding all the bundles in every Application I'd like to add a single default bundle that adds all bundles I need.
```java
class DeploymentConfiguration extends Configuration {
    boolean production = true;
}

class App extends Application<DeploymentConfiguration> {
    @Override
    public void initialize(Bootstrap<DeploymentConfiguration> bootstrap) {
        bootstrap.addBundle(new DefaultBundle());
    }

    @Override
    public void run(DeploymentConfiguration configuration, Environment environment) throws Exception {
        // ..
    }
}

class DefaultBundle implements ConfiguredBundle<DeploymentConfiguration> {
    @Override
    public void run(DeploymentConfiguration configuration, Environment environment) throws Exception {
    }

    @Override
    public void initialize(Bootstrap<? extends DeploymentConfiguration> bootstrap) {
        bootstrap.addBundle(new BundleA());
        bootstrap.addBundle(new BundleB());
    }
}

class BundleA implements ConfiguredBundle<DeploymentConfiguration> {
    @Override
    public void run(DeploymentConfiguration configuration, Environment environment) throws Exception {
        environment.servlets().addServlet(
                "someservlet",
                new SomeServlet(configuration.production)); // <-- using configuration
    }

    @Override
    public void initialize(Bootstrap<? extends DeploymentConfiguration> bootstrap) {
    }
}
```
With ```Bootstrap<?>``` in the class ```DefaultBundle``` I can't add another ```ConfiguredBundle<DeploymentConfiguration>```, that produces a compile error. 