### PR TITLE
Empty Strings are converted into absent Optionals

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/guava/OptionalParamConverterProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/guava/OptionalParamConverterProvider.java
@@ -2,6 +2,7 @@ package io.dropwizard.jersey.guava;
 
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
+import com.google.common.base.Strings;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.jersey.internal.inject.Providers;
 import org.glassfish.jersey.internal.util.ReflectionHelper;
@@ -38,7 +39,7 @@ public class OptionalParamConverterProvider implements ParamConverterProvider {
                 return new ParamConverter<T>() {
                     @Override
                     public T fromString(final String value) {
-                        return rawType.cast(Optional.fromNullable(value));
+                        return rawType.cast(Optional.fromNullable(Strings.emptyToNull(value)));
                     }
 
                     @Override

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalCookieParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalCookieParamResourceTest.java
@@ -36,6 +36,13 @@ public class OptionalCookieParamResourceTest extends JerseyTest {
     }
 
     @Test
+    public void shouldReturnDefaultMessageWhenMessageIsBlank() {
+        String defaultMessage = "Default Message";
+        String response = target("/optional/message").request().cookie("message", "").get(String.class);
+        assertThat(response).isEqualTo(defaultMessage);
+    }
+
+    @Test
     public void shouldReturnMessageWhenMessageIsPresent() {
         String customMessage = "Custom Message";
         String response = target("/optional/message").request().cookie("message", customMessage).get(String.class);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalFormParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalFormParamResourceTest.java
@@ -41,6 +41,15 @@ public class OptionalFormParamResourceTest extends JerseyTest {
     }
 
     @Test
+    public void shouldReturnDefaultMessageWhenMyMessageBlank() throws IOException {
+        final String defaultMessage = "Default Message";
+        final Form form = new Form("message", "");
+        final Response response = target("/optional/message").request().post(Entity.form(form));
+
+        assertThat(response.readEntity(String.class)).isEqualTo(defaultMessage);
+    }
+
+    @Test
     public void shouldReturnMessageWhenMessageIsPresent() throws IOException {
         final String customMessage = "Custom Message";
         final Form form = new Form("message", customMessage);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalHeaderParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalHeaderParamResourceTest.java
@@ -36,6 +36,13 @@ public class OptionalHeaderParamResourceTest extends JerseyTest {
     }
 
     @Test
+    public void shouldReturnDefaultMessageWhenMessageIsBlank() {
+        String defaultMessage = "Default Message";
+        String response = target("/optional/message").request().header("message", "").get(String.class);
+        assertThat(response).isEqualTo(defaultMessage);
+    }
+
+    @Test
     public void shouldReturnMessageWhenMessageIsPresent() {
         String customMessage = "Custom Message";
         String response = target("/optional/message").request().header("message", customMessage).get(String.class);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalQueryParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalQueryParamResourceTest.java
@@ -43,6 +43,13 @@ public class OptionalQueryParamResourceTest extends JerseyTest {
     }
 
     @Test
+    public void shouldReturnDefaultMessageWhenMessageIsBlank() {
+        String defaultMessage = "Default Message";
+        String response = target("/optional/message").queryParam("message", "").request().get(String.class);
+        assertThat(response).isEqualTo(defaultMessage);
+    }
+
+    @Test
     public void shouldReturnDecodedMessageWhenEncodedMessageIsPresent() {
         String encodedMessage = "Custom%20Message";
         String decodedMessage = "Custom Message";


### PR DESCRIPTION
When an empty string is converted into an `Optional` for FormParam,
CookieParam, HeaderParam, or QueryParam, the optional is absent instead of
the previous behavior where the empty string would fill the optional.

Closes #983