### PR TITLE
Make LoggingFactory threadsafe for parallel running tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -361,7 +361,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.12.4</version>
-                <!-- we can't run tests in parallel until http://bugzilla.slf4j.org/show_bug.cgi?id=176 is fixed -->
+                <!-- not all modules support parallel tests for now -->
+                <!-- parallel tests had been disabled due to http://jira.qos.ch/browse/SLF4J-167 -->
+                <!-- now a workaround is in place in io.dropwizard.logging.LoggingFactory -->
                 <!--<configuration>-->
                     <!--<parallel>classes</parallel>-->
                 <!--</configuration>-->


### PR DESCRIPTION
Running parallel unit tests in my personal project with the current Dropwizard release leads to errors in class initialization probably due to http://jira.qos.ch/browse/SLF4J-167

The change below allows me to run the unit tests in my personal project in parallel by making the log initialization `synchronized`. The change below also avoids a second initialization as this might lead to log messages getting lost.

Activating parallel tests in all dropwizard modules will lead to test failures in some modules, therefore I left it disabled in the parent pom.xml. 