### PR TITLE
First stab on dropwizard-benchmarks

### DIFF
--- a/dropwizard-benchmarks/pom.xml
+++ b/dropwizard-benchmarks/pom.xml
@@ -26,6 +26,12 @@
             <artifactId>jmh-generator-annprocess</artifactId>
             <version>${jmh.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-util</artifactId>
+            <version>${parent.version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/dropwizard-benchmarks/pom.xml
+++ b/dropwizard-benchmarks/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>dropwizard-parent</artifactId>
@@ -7,7 +8,24 @@
         <version>0.9.0-SNAPSHOT</version>
     </parent>
 
+    <properties>
+        <jmh.version>1.8</jmh.version>
+    </properties>
+
     <artifactId>dropwizard-benchmarks</artifactId>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/dropwizard-benchmarks/src/io/dropwizard/benchmarks/util/DurationBenchmark.java
+++ b/dropwizard-benchmarks/src/io/dropwizard/benchmarks/util/DurationBenchmark.java
@@ -1,0 +1,34 @@
+package io.dropwizard.benchmarks.util;
+
+import io.dropwizard.util.Duration;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class DurationBenchmark {
+
+    /**
+     * Don't trust the IDE, it's advisedly non-final to avoid constant folding
+     */
+    private String duration = "12h";
+
+    @Benchmark
+    public Duration parseDuration() {
+        return Duration.parse(duration);
+    }
+
+    public static void main(String[] args) throws Exception {
+        new Runner(new OptionsBuilder()
+                .include(DurationBenchmark.class.getSimpleName())
+                .forks(1)
+                .warmupIterations(5)
+                .measurementIterations(5)
+                .build())
+                .run();
+    }
+}

--- a/dropwizard-benchmarks/src/io/dropwizard/benchmarks/util/SizeBenchmark.java
+++ b/dropwizard-benchmarks/src/io/dropwizard/benchmarks/util/SizeBenchmark.java
@@ -1,0 +1,34 @@
+package io.dropwizard.benchmarks.util;
+
+import io.dropwizard.util.Size;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class SizeBenchmark {
+
+    /**
+     * Don't trust the IDE, it's advisedly non-final to avoid constant folding
+     */
+    private String size = "256KiB";
+
+    @Benchmark
+    public Size parseSize() {
+        return Size.parse(size);
+    }
+
+    public static void main(String[] args) throws Exception {
+        new Runner(new OptionsBuilder()
+                .include(SizeBenchmark.class.getSimpleName())
+                .forks(1)
+                .warmupIterations(5)
+                .measurementIterations(5)
+                .build())
+                .run();
+    }
+}


### PR DESCRIPTION
Add benchmarks for [Duration](https://github.com/dropwizard/dropwizard/blob/master/dropwizard-util/src/main/java/io/dropwizard/util/Duration.java) and [Size](https://github.com/dropwizard/dropwizard/blob/master/dropwizard-util/src/main/java/io/dropwizard/util/Size.java)

The benchmarks measure an average time to parse a string to Duration and Size representations.