### PR TITLE
Add documentation and tests surrounding empty string optionals

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -448,6 +448,13 @@ is no ``name`` parameter in the query string, ``sayHello`` will be called with
 ``Optional.absent()``. (Support for Guava's ``Optional`` is a little extra sauce that Dropwizard
 adds to Jersey's existing functionality.)
 
+.. note::
+
+    If the client sends a request to ``/hello-world?name=``, ``sayHello`` will be called with
+    ``Optional.of("")``. This may seem odd at first, but this follows the standards (an application
+    may have different behavior depending on if a parameter is empty vs nonexistent). For more
+    information see :ref:`the section on parameters <man-core-resources-parameters>`
+
 Inside the ``sayHello`` method, we increment the counter, format the template using
 ``String.format(String, Object...)``, and return a new ``Saying`` instance.
 

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -452,8 +452,10 @@ adds to Jersey's existing functionality.)
 
     If the client sends a request to ``/hello-world?name=``, ``sayHello`` will be called with
     ``Optional.of("")``. This may seem odd at first, but this follows the standards (an application
-    may have different behavior depending on if a parameter is empty vs nonexistent). For more
-    information see :ref:`the section on parameters <man-core-resources-parameters>`
+    may have different behavior depending on if a parameter is empty vs nonexistent). You can swap
+    ``Optional<String>`` parameter with ``NonEmptyStringParam`` if you want ``/hello-world?name=``
+    to return "Hello, Stranger!" For more information on resource parameters see
+    :ref:`the documentation <man-core-resources-parameters>`
 
 Inside the ``sayHello`` method, we increment the counter, format the template using
 ``String.format(String, Object...)``, and return a new ``Saying`` instance.

--- a/docs/source/manual/client.rst
+++ b/docs/source/manual/client.rst
@@ -165,7 +165,7 @@ the `Jersey Client Properties`_ can be used.
 
 .. warning::
 
-    Do not try to change Jersey properties using `Jersey Client Properties` through the
+    Do not try to change Jersey properties using `Jersey Client Properties`_ through the
 
     ``withProperty(String propertyName, Object propertyValue)``
 

--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -974,28 +974,12 @@ For example:
   as an ``Integer``, returning a ``400 Bad Request`` if the value is malformed.
 * A ``@FormParam("name")``-annotated ``Set<String>`` parameter takes all the ``name`` values from a
   posted form and passes them to the method as a set of strings.
+* A ``*Param``--annotated ``NonEmptyStringParam`` will interpret empty strings as absent strings,
+  which is useful in cases where the endpoint treats empty strings and absent strings as
+  interchangeable.
 
 What's noteworthy here is that you can actually encapsulate the vast majority of your validation
 logic using specialized parameter objects. See ``AbstractParam`` for details.
-
-A good example of deriving from ``AbstractParam`` is when the application treats empty parameters as
-synonymous with nonexistent parameters, so a query string of ``?foo=`` will be interpreted as if
-``foo`` wasn't even in the query string. The following class accomplishes that goal.
-
-.. code-block:: java
-
-    public class NonEmptyString extends AbstractParam<Optional<String>> {
-        public NonEmptyString(String input) {
-            super(input);
-        }
-
-        @Override
-        protected Optional<String> parse(String input) throws Exception {
-            return Optional.fromNullable(Strings.emptyToNull(input));
-        }
-    }
-
-To use this new functionality, change the desired endpoint parameters to ``NonEmptyString``.
 
 .. _man-core-resources-request-entities:
 

--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -978,6 +978,25 @@ For example:
 What's noteworthy here is that you can actually encapsulate the vast majority of your validation
 logic using specialized parameter objects. See ``AbstractParam`` for details.
 
+A good example of deriving from ``AbstractParam`` is when the application treats empty parameters as
+synonymous with nonexistent parameters, so a query string of ``?foo=`` will be interpreted as if
+``foo`` wasn't even in the query string. The following class accomplishes that goal.
+
+.. code-block:: java
+
+    public class NonEmptyString extends AbstractParam<Optional<String>> {
+        public NonEmptyString(String input) {
+            super(input);
+        }
+
+        @Override
+        protected Optional<String> parse(String input) throws Exception {
+            return Optional.fromNullable(Strings.emptyToNull(input));
+        }
+    }
+
+To use this new functionality, change the desired endpoint parameters to ``NonEmptyString``.
+
 .. _man-core-resources-request-entities:
 
 Request Entities

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/NonEmptyStringParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/NonEmptyStringParam.java
@@ -1,0 +1,21 @@
+package io.dropwizard.jersey.params;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Strings;
+
+/**
+ * A parameter encapsulating optional string values with the condition that empty string inputs are
+ * interpreted as being absent. This class is useful when it is desired for empty parameters to be
+ * synonymous with absent parameters instead of empty parameters evaluating to
+ * {@code Optional.of("")}.
+ */
+public class NonEmptyStringParam extends AbstractParam<Optional<String>> {
+    protected NonEmptyStringParam(String input) {
+        super(input);
+    }
+
+    @Override
+    protected Optional<String> parse(String input) throws Exception {
+        return Optional.fromNullable(Strings.emptyToNull(input));
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalCookieParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalCookieParamResourceTest.java
@@ -36,6 +36,12 @@ public class OptionalCookieParamResourceTest extends JerseyTest {
     }
 
     @Test
+    public void shouldReturnMessageWhenMessageIsBlank() {
+        String response = target("/optional/message").request().cookie("message", "").get(String.class);
+        assertThat(response).isEqualTo("");
+    }
+
+    @Test
     public void shouldReturnMessageWhenMessageIsPresent() {
         String customMessage = "Custom Message";
         String response = target("/optional/message").request().cookie("message", customMessage).get(String.class);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalFormParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalFormParamResourceTest.java
@@ -41,6 +41,14 @@ public class OptionalFormParamResourceTest extends JerseyTest {
     }
 
     @Test
+    public void shouldReturnMessageWhenMessageBlank() throws IOException {
+        final Form form = new Form("message", "");
+        final Response response = target("/optional/message").request().post(Entity.form(form));
+
+        assertThat(response.readEntity(String.class)).isEqualTo("");
+    }
+
+    @Test
     public void shouldReturnMessageWhenMessageIsPresent() throws IOException {
         final String customMessage = "Custom Message";
         final Form form = new Form("message", customMessage);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalHeaderParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalHeaderParamResourceTest.java
@@ -36,6 +36,12 @@ public class OptionalHeaderParamResourceTest extends JerseyTest {
     }
 
     @Test
+    public void shouldReturnMessageWhenMessageIsBlank() {
+        String response = target("/optional/message").request().header("message", "").get(String.class);
+        assertThat(response).isEqualTo("");
+    }
+
+    @Test
     public void shouldReturnMessageWhenMessageIsPresent() {
         String customMessage = "Custom Message";
         String response = target("/optional/message").request().header("message", customMessage).get(String.class);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalQueryParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalQueryParamResourceTest.java
@@ -43,6 +43,12 @@ public class OptionalQueryParamResourceTest extends JerseyTest {
     }
 
     @Test
+    public void shouldReturnMessageWhenMessageIsBlank() {
+        String response = target("/optional/message").queryParam("message", "").request().get(String.class);
+        assertThat(response).isEqualTo("");
+    }
+
+    @Test
     public void shouldReturnDecodedMessageWhenEncodedMessageIsPresent() {
         String encodedMessage = "Custom%20Message";
         String decodedMessage = "Custom Message";

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/NonEmptyStringParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/NonEmptyStringParamTest.java
@@ -1,0 +1,26 @@
+package io.dropwizard.jersey.params;
+
+import com.google.common.base.Optional;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NonEmptyStringParamTest {
+    @Test
+    public void aBlankStringIsAnAbsentString() throws Exception {
+        final NonEmptyStringParam param = new NonEmptyStringParam("");
+        assertThat(param.get()).isEqualTo(Optional.absent());
+    }
+
+    @Test
+    public void aNullStringIsAnAbsentString() throws Exception {
+        final NonEmptyStringParam param = new NonEmptyStringParam(null);
+        assertThat(param.get()).isEqualTo(Optional.absent());
+    }
+
+    @Test
+    public void aStringWithContentIsItself() throws Exception {
+        final NonEmptyStringParam param = new NonEmptyStringParam("hello");
+        assertThat(param.get()).isEqualTo(Optional.of("hello"));
+    }
+}


### PR DESCRIPTION
Following the discussions in #986 and #983, this pull requests adds documentation and tests around empty string params, such as cases like `/hello-world?name=` where the param will evaluate to `Optional.of("")`

I decided to add in a sample implementation for those following along in the getting started, so `/hello-world?name=` will return "Hello, Stranger". The implementation derives from `AbstractParam`. Alternatively, a custom `ParamConverterProvider` could be registered but that would affect all String params for all endpoints (so I decided against that).

Also this pull request fixes a link that was missing (originally my fault :blush:)