### PR TITLE
Add logging (on TRACE) for failed validation of Jackson data.

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProvider.java
@@ -31,7 +31,7 @@ import java.util.*;
  * {@link JsonIgnoreType}.)
  */
 public class JacksonMessageBodyProvider extends JacksonJaxbJsonProvider {
-    private static final Logger LOGGER = LoggerFactory.getLogger(JsonProcessingExceptionMapper.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(JacksonMessageBodyProvider.class);
     /**
      * The default group array used in case any of the validate methods is called without a group.
      */

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProvider.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
 import io.dropwizard.validation.ConstraintViolations;
 import io.dropwizard.validation.Validated;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
@@ -29,6 +31,7 @@ import java.util.*;
  * {@link JsonIgnoreType}.)
  */
 public class JacksonMessageBodyProvider extends JacksonJaxbJsonProvider {
+    private static final Logger LOGGER = LoggerFactory.getLogger(JsonProcessingExceptionMapper.class);
     /**
      * The default group array used in case any of the validate methods is called without a group.
      */
@@ -92,8 +95,11 @@ public class JacksonMessageBodyProvider extends JacksonJaxbJsonProvider {
             }
 
             if (violations != null && !violations.isEmpty()) {
+                Set<ConstraintViolation<?>> constraintViolations = ConstraintViolations.copyOf(violations);
+                LOGGER.trace("Validation failed: {}; original data was {}",
+                        ConstraintViolations.formatUntyped(constraintViolations), value);
                 throw new ConstraintViolationException("The request entity had the following errors:",
-                        ConstraintViolations.copyOf(violations));
+                        constraintViolations);
             }
         }
 


### PR DESCRIPTION
As discussed on https://groups.google.com/forum/#!topic/dropwizard-user/FQd_Y4ihb7I, I have prepared a little patch that will print the failed validation alongside the object that was validated, on TRACE only.