### PR TITLE
ConstraintViolations context determines HTTP status

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapper.java
@@ -1,19 +1,46 @@
 package io.dropwizard.jersey.validation;
 
+import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
+import javax.validation.ElementKind;
+import javax.validation.Path.Node;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
+import java.util.Set;
 
 @Provider
 public class ConstraintViolationExceptionMapper implements ExceptionMapper<ConstraintViolationException> {
-    private static final int UNPROCESSABLE_ENTITY = 422;
-
     @Override
     public Response toResponse(ConstraintViolationException exception) {
-        final ValidationErrorMessage message = new ValidationErrorMessage(exception.getConstraintViolations());
+        int status = 422;
 
-        return Response.status(UNPROCESSABLE_ENTITY)
+        // Detect where the constraint validation occurred so we can return an appropriate status
+        // code. If the constraint failed with a *Param annotation, return a bad request. If it
+        // failed validating the return value, return internal error. Else return unprocessable
+        // entity.
+        Set<ConstraintViolation<?>> violations = exception.getConstraintViolations();
+        if (violations.size() > 0) {
+            ConstraintViolation<?> violation = violations.iterator().next();
+            boolean isReturnValue = false;
+            boolean isArgument = false;
+
+            // A return value can only occur at the last path, but a parameter
+            // can occur anywhere, such as a @BeanParam that has validations.
+            for (Node node : violation.getPropertyPath()) {
+                isArgument |= node.getKind().equals(ElementKind.PARAMETER);
+                isReturnValue = node.getKind().equals(ElementKind.RETURN_VALUE);
+            }
+
+            if (isReturnValue) {
+                status = 500;
+            } else if (isArgument) {
+                status = 400;
+            }
+        }
+
+        final ValidationErrorMessage message = new ValidationErrorMessage(exception.getConstraintViolations());
+        return Response.status(status)
                        .entity(message)
                        .build();
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/BeanParameter.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/BeanParameter.java
@@ -1,0 +1,15 @@
+package io.dropwizard.jersey.validation;
+
+import org.hibernate.validator.constraints.NotEmpty;
+
+import javax.ws.rs.QueryParam;
+
+public class BeanParameter {
+    @QueryParam("name")
+    @NotEmpty
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
@@ -28,12 +28,36 @@ public class ConstraintViolationExceptionMapperTest extends JerseyTest {
     }
 
     @Test
-    public void returnsAnErrorMessage() throws Exception {
+    public void postInvalidEntityIs422() throws Exception {
         assumeThat(Locale.getDefault().getLanguage(), is("en"));
 
-        final Response response = target("/valid/").request(MediaType.APPLICATION_JSON)
+        final Response response = target("/valid/foo").request(MediaType.APPLICATION_JSON)
                 .post(Entity.entity("{}", MediaType.APPLICATION_JSON));
         assertThat(response.getStatus()).isEqualTo(422);
         assertThat(response.readEntity(String.class)).isEqualTo("{\"errors\":[\"name may not be empty (was null)\"]}");
+    }
+
+    @Test
+    public void getInvalidReturnIs500() throws Exception {
+        // return value is too long and so will fail validation
+        final Response response = target("/valid/bar")
+                .queryParam("name", "dropwizard").request().get();
+        assertThat(response.getStatus()).isEqualTo(500);
+    }
+
+    @Test
+    public void getInvalidQueryParamsIs400() throws Exception {
+        // query parameter is too short and so will fail validation
+        final Response response = target("/valid/bar")
+                .queryParam("name", "hi").request().get();
+        assertThat(response.getStatus()).isEqualTo(400);
+    }
+
+    @Test
+    public void getInvalidBeanParamsIs400() throws Exception {
+        // bean parameter is too short and so will fail validation
+        final Response response = target("/valid/zoo")
+                .request().get();
+        assertThat(response.getStatus()).isEqualTo(400);
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
@@ -1,11 +1,11 @@
 package io.dropwizard.jersey.validation;
 
 import io.dropwizard.validation.Validated;
+import org.hibernate.validator.constraints.Length;
+import org.hibernate.validator.constraints.NotEmpty;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+import javax.validation.Valid;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 
@@ -14,7 +14,21 @@ import java.io.IOException;
 @Consumes(MediaType.APPLICATION_JSON)
 public class ValidatingResource {
     @POST
+    @Path("foo")
     public String blah(@Validated ValidRepresentation representation) throws IOException {
         return representation.getName();
+    }
+
+    @GET
+    @Path("bar")
+    @Length(max = 3)
+    public String blaze(@QueryParam("name") @Length(min = 3) String name) {
+        return name;
+    }
+
+    @GET
+    @Path("zoo")
+    public String blazer(@Valid @BeanParam BeanParameter params) {
+        return params.getName();
     }
 }


### PR DESCRIPTION
Due to #842, validation opens up new opportunities and by happenstance, a new bug. Now validations can be done on resource query parameters, return values, etc, and this, in my opinion is a good thing.

The pitfall I ran into is that the current `ConstraintViolationExceptionMapper` with the new bean validation in place, does not follow the [jersey documentation], which states that:

> 500 (Internal Server Error): If the exception was thrown while validating a method return type.
>
> 400 (Bad Request): Otherwise.

This pull request attempts to fix the current behavior, which will return 422 on return values and `*Params`. The violations in `*Params` now return a 400 and a return value violation is a 500.

There is an issue with this implementation: I'm uncomfortable that the only sane implementation for checking if constraint violation was fired on a parameter is by regex. Please advise.

EDIT: I found a better way than regex from the [Jersey code]

[jersey documentation]: https://jersey.java.net/documentation/latest/bean-validation.html#d0e13792
[Jersey code]: https://github.com/jersey/jersey/blob/54e27f31205de49004331db2d714c1be9a52bb76/ext/bean-validation/src/main/java/org/glassfish/jersey/server/validation/internal/ValidationHelper.java