### PR TITLE
add support for logback's maxFileSize attribute

### DIFF
--- a/dropwizard-example/example.yml
+++ b/dropwizard-example/example.yml
@@ -70,9 +70,10 @@ logging:
       threshold: DEBUG
       logFormat: "%-6level [%d{HH:mm:ss.SSS}] [%t] %logger{5} - %X{code} %msg %n"
       currentLogFilename: /tmp/application.log
-      archivedLogFilenamePattern: /tmp/application-%d{yyyy-MM-dd}.log
+      archivedLogFilenamePattern: /tmp/application-%d{yyyy-MM-dd}-%i.log.gz
       archivedFileCount: 7
       timeZone: UTC
+      maxFileSize: 10MB
 
 # the key needs to match the suffix of the renderer
 viewRendererConfiguration:

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
@@ -14,6 +14,7 @@ import ch.qos.logback.core.rolling.TimeBasedRollingPolicy;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.dropwizard.util.Size;
 import io.dropwizard.validation.ValidationMethod;
 
 import javax.validation.constraints.Min;
@@ -71,9 +72,10 @@ import java.util.TimeZone;
  *         <td>{@code maxFileSize}</td>
  *         <td>(unlimited)</td>
  *         <td>
- *             The maximum size of the currently active file before a rollover is triggered.  See.
- *             <a href="http://logback.qos.ch/manual/appenders.html#SizeBasedTriggeringPolicy>the Logback documentation</a>
- *             for details.
+ *             The maximum size of the currently active file before a rollover is triggered. The value can be expressed
+ *             in bytes, kilobytes, megabytes, gigabytes, and terabytes using the by appending B, K, MB, GB, or TB to the
+ *             numeric value.  Examples include 100MB, 1GB, 1TB.  Sizes can also be spelled out, such as 100 megabytes,
+ *             1 gigabyte, 1 terabyte.
  *         </td>
  *     </tr>
  *     <tr>
@@ -106,7 +108,7 @@ public class FileAppenderFactory extends AbstractAppenderFactory {
     @Min(1)
     private int archivedFileCount = 5;
 
-    private String maxFileSize;
+    private Size maxFileSize;
 
     @NotNull
     private TimeZone timeZone = TimeZone.getTimeZone("UTC");
@@ -152,12 +154,12 @@ public class FileAppenderFactory extends AbstractAppenderFactory {
     }
 
     @JsonProperty
-    public String getMaxFileSize() {
+    public Size getMaxFileSize() {
         return maxFileSize;
     }
 
     @JsonProperty
-    public void setMaxFileSize(String maxFileSize) {
+    public void setMaxFileSize(Size maxFileSize) {
         this.maxFileSize = maxFileSize;
     }
 
@@ -213,7 +215,7 @@ public class FileAppenderFactory extends AbstractAppenderFactory {
                 triggeringPolicy = new DefaultTimeBasedFileNamingAndTriggeringPolicy<>();
             } else {
                 SizeAndTimeBasedFNATP<ILoggingEvent> maxFileSizeTriggeringPolicy = new SizeAndTimeBasedFNATP<>();
-                maxFileSizeTriggeringPolicy.setMaxFileSize(maxFileSize);
+                maxFileSizeTriggeringPolicy.setMaxFileSize(String.valueOf(maxFileSize.toBytes()));
                 triggeringPolicy = maxFileSizeTriggeringPolicy;
             }
             triggeringPolicy.setContext(context);

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
@@ -73,7 +73,7 @@ import java.util.TimeZone;
  *         <td>(unlimited)</td>
  *         <td>
  *             The maximum size of the currently active file before a rollover is triggered. The value can be expressed
- *             in bytes, kilobytes, megabytes, gigabytes, and terabytes using the by appending B, K, MB, GB, or TB to the
+ *             in bytes, kilobytes, megabytes, gigabytes, and terabytesyp by appending B, K, MB, GB, or TB to the
  *             numeric value.  Examples include 100MB, 1GB, 1TB.  Sizes can also be spelled out, such as 100 megabytes,
  *             1 gigabyte, 1 terabyte.
  *         </td>

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
@@ -73,7 +73,7 @@ import java.util.TimeZone;
  *         <td>(unlimited)</td>
  *         <td>
  *             The maximum size of the currently active file before a rollover is triggered. The value can be expressed
- *             in bytes, kilobytes, megabytes, gigabytes, and terabytesyp by appending B, K, MB, GB, or TB to the
+ *             in bytes, kilobytes, megabytes, gigabytes, and terabytes by appending B, K, MB, GB, or TB to the
  *             numeric value.  Examples include 100MB, 1GB, 1TB.  Sizes can also be spelled out, such as 100 megabytes,
  *             1 gigabyte, 1 terabyte.
  *         </td>

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
@@ -9,6 +9,8 @@ import ch.qos.logback.core.FileAppender;
 import ch.qos.logback.core.rolling.RollingFileAppender;
 import ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
+import io.dropwizard.util.Size;
+import io.dropwizard.util.SizeUnit;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
 
@@ -54,12 +56,12 @@ public class FileAppenderFactoryTest {
         FileAppenderFactory fileAppenderFactory = new FileAppenderFactory();
         fileAppenderFactory.setCurrentLogFilename("logfile.log");
         fileAppenderFactory.setArchive(true);
-        fileAppenderFactory.setMaxFileSize("100MB");
+        fileAppenderFactory.setMaxFileSize(Size.kilobytes(1));
         fileAppenderFactory.setArchivedLogFilenamePattern("example-%d-%i.log.gz");
         RollingFileAppender<ILoggingEvent> appender = (RollingFileAppender<ILoggingEvent>) fileAppenderFactory.buildAppender(new LoggerContext());
 
         assertThat(appender.getTriggeringPolicy()).isInstanceOf(SizeAndTimeBasedFNATP.class);
-        assertThat(((SizeAndTimeBasedFNATP) appender.getTriggeringPolicy()).getMaxFileSize()).isEqualTo("100MB");
+        assertThat(((SizeAndTimeBasedFNATP) appender.getTriggeringPolicy()).getMaxFileSize()).isEqualTo("1024");
     }
 
     @Test

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
@@ -7,6 +7,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.FileAppender;
 import ch.qos.logback.core.rolling.RollingFileAppender;
+import ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
@@ -46,6 +47,19 @@ public class FileAppenderFactoryTest {
         fileAppenderFactory.setArchive(true);
         fileAppenderFactory.setArchivedLogFilenamePattern("example-%d.log.gz");
         assertThat(fileAppenderFactory.buildAppender(new LoggerContext())).isInstanceOf(RollingFileAppender.class);
+    }
+
+    @Test
+    public void hasMaxFileSize() throws Exception {
+        FileAppenderFactory fileAppenderFactory = new FileAppenderFactory();
+        fileAppenderFactory.setCurrentLogFilename("logfile.log");
+        fileAppenderFactory.setArchive(true);
+        fileAppenderFactory.setMaxFileSize("100MB");
+        fileAppenderFactory.setArchivedLogFilenamePattern("example-%d-%i.log.gz");
+        RollingFileAppender<ILoggingEvent> appender = (RollingFileAppender<ILoggingEvent>) fileAppenderFactory.buildAppender(new LoggerContext());
+
+        assertThat(appender.getTriggeringPolicy()).isInstanceOf(SizeAndTimeBasedFNATP.class);
+        assertThat(((SizeAndTimeBasedFNATP) appender.getTriggeringPolicy()).getMaxFileSize()).isEqualTo("100MB");
     }
 
     @Test

--- a/dropwizard-logging/src/test/resources/yaml/logging.yml
+++ b/dropwizard-logging/src/test/resources/yaml/logging.yml
@@ -9,6 +9,12 @@ appenders:
     currentLogFilename: ./logs/example.log
     archivedLogFilenamePattern: ./logs/example-%d.log.gz
     archivedFileCount: 5
+  - type: file
+    threshold: ALL
+    maxFileSize: 100MB
+    currentLogFilename: ./logs/max-file-size-example-%i.log
+    archivedLogFilenamePattern: ./logs/max-file-size-example-%d-%i.log.gz
+    archivedFileCount: 5
   - type: syslog
     host: localhost
     facility: local0

--- a/dropwizard-logging/src/test/resources/yaml/logging.yml
+++ b/dropwizard-logging/src/test/resources/yaml/logging.yml
@@ -12,7 +12,7 @@ appenders:
   - type: file
     threshold: ALL
     maxFileSize: 100MB
-    currentLogFilename: ./logs/max-file-size-example-%i.log
+    currentLogFilename: ./logs/max-file-size-example.log
     archivedLogFilenamePattern: ./logs/max-file-size-example-%d-%i.log.gz
     archivedFileCount: 5
   - type: syslog


### PR DESCRIPTION
This is a pull request to add support for logback's maxFileSize attribute.  Earlier discussed here: https://github.com/dropwizard/dropwizard/issues/997  