### PR TITLE
fix #953 Possible reflective cross site scripting in ConstraintViolations

### DIFF
--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryTest.java
@@ -318,7 +318,7 @@ public class ConfigurationFactoryTest {
                 assertThat(e.getMessage())
                         .endsWith(String.format(
                                 "factory-test-invalid.yml has an error:%n" +
-                                        "  * name must match \"[\\w]+[\\s]+[\\w]+([\\s][\\w]+)?\" (was Boop)%n"));
+                                        "  * name must match \"[\\w]+[\\s]+[\\w]+([\\s][\\w]+)?\"%n"));
             }
         }
     }

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationValidationExceptionTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationValidationExceptionTest.java
@@ -36,7 +36,7 @@ public class ConfigurationValidationExceptionTest {
         assertThat(e.getMessage())
                 .isEqualTo(String.format(
                         "config.yml has an error:%n" +
-                                "  * woo may not be null (was null)%n"
+                                "  * woo may not be null%n"
                 ));
     }
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProviderTest.java
@@ -235,7 +235,7 @@ public class JacksonMessageBodyProviderTest {
             failBecauseExceptionWasNotThrown(ConstraintViolationException.class);
         } catch(ConstraintViolationException e) {
             assertThat(ConstraintViolations.formatUntyped(e.getConstraintViolations()))
-                .containsOnly("text may not be null (was null)");
+                .containsOnly("text may not be null");
         }
     }
 
@@ -279,7 +279,7 @@ public class JacksonMessageBodyProviderTest {
             failBecauseExceptionWasNotThrown(ConstraintViolationException.class);
         } catch (ConstraintViolationException e) {
             assertThat(ConstraintViolations.formatUntyped(e.getConstraintViolations()))
-                    .containsOnly("id must be greater than or equal to 0 (was -1)");
+                    .containsOnly("id must be greater than or equal to 0");
         }
     }
 
@@ -440,8 +440,8 @@ public class JacksonMessageBodyProviderTest {
             failBecauseExceptionWasNotThrown(ConstraintViolationException.class);
         } catch (ConstraintViolationException e) {
             assertThat(ConstraintViolations.formatUntyped(e.getConstraintViolations()))
-                    .contains("id must be greater than or equal to 0 (was -1)",
-                            "id must be greater than or equal to 0 (was -2)");
+                    .contains("id must be greater than or equal to 0",
+                            "id must be greater than or equal to 0");
         }
     }
 
@@ -463,7 +463,7 @@ public class JacksonMessageBodyProviderTest {
             failBecauseExceptionWasNotThrown(ConstraintViolationException.class);
         } catch (ConstraintViolationException e) {
             assertThat(ConstraintViolations.formatUntyped(e.getConstraintViolations()))
-                    .contains("id must be greater than or equal to 0 (was -2)");
+                    .contains("id must be greater than or equal to 0");
         }
     }
 
@@ -485,8 +485,8 @@ public class JacksonMessageBodyProviderTest {
             failBecauseExceptionWasNotThrown(ConstraintViolationException.class);
         } catch (ConstraintViolationException e) {
             assertThat(ConstraintViolations.formatUntyped(e.getConstraintViolations()))
-                    .contains("id must be greater than or equal to 0 (was -1)",
-                            "id must be greater than or equal to 0 (was -2)");
+                    .contains("id must be greater than or equal to 0",
+                            "id must be greater than or equal to 0");
         }
     }
 
@@ -508,8 +508,8 @@ public class JacksonMessageBodyProviderTest {
             failBecauseExceptionWasNotThrown(ConstraintViolationException.class);
         } catch (ConstraintViolationException e) {
             assertThat(ConstraintViolations.formatUntyped(e.getConstraintViolations()))
-                    .containsOnly("id must be greater than or equal to 0 (was -1)",
-                            "id must be greater than or equal to 0 (was -2)");
+                    .containsOnly("id must be greater than or equal to 0",
+                            "id must be greater than or equal to 0");
         }
     }
 
@@ -531,8 +531,8 @@ public class JacksonMessageBodyProviderTest {
             failBecauseExceptionWasNotThrown(ConstraintViolationException.class);
         } catch (ConstraintViolationException e) {
             assertThat(ConstraintViolations.formatUntyped(e.getConstraintViolations()))
-                    .contains("id must be greater than or equal to 0 (was -1)",
-                            "id must be greater than or equal to 0 (was -2)");
+                    .contains("id must be greater than or equal to 0",
+                            "id must be greater than or equal to 0");
         }
     }
 
@@ -578,7 +578,7 @@ public class JacksonMessageBodyProviderTest {
             failBecauseExceptionWasNotThrown(ConstraintViolationException.class);
         } catch (ConstraintViolationException e) {
             assertThat(ConstraintViolations.formatUntyped(e.getConstraintViolations()))
-                    .containsOnly("examples may not be empty (was null)");
+                    .containsOnly("examples may not be empty");
         }
     }
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
@@ -34,6 +34,6 @@ public class ConstraintViolationExceptionMapperTest extends JerseyTest {
         final Response response = target("/valid/").request(MediaType.APPLICATION_JSON)
                 .post(Entity.entity("{}", MediaType.APPLICATION_JSON));
         assertThat(response.getStatus()).isEqualTo(422);
-        assertThat(response.readEntity(String.class)).isEqualTo("{\"errors\":[\"name may not be empty (was null)\"]}");
+        assertThat(response.readEntity(String.class)).isEqualTo("{\"errors\":[\"name may not be empty\"]}");
     }
 }

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/ConstraintViolations.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/ConstraintViolations.java
@@ -22,10 +22,7 @@ public class ConstraintViolations {
                                  Joiner.on('.').join(usefulNodes),
                                  v.getMessage()).trim();
         } else {
-            return String.format("%s %s (was %s)",
-                                 v.getPropertyPath(),
-                                 v.getMessage(),
-                                 v.getInvalidValue());
+            return String.format("%s %s", v.getPropertyPath(), v.getMessage());
         }
     }
 

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/DurationValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/DurationValidatorTest.java
@@ -19,7 +19,7 @@ public class DurationValidatorTest {
 
         @MinDuration(value = 30, unit = TimeUnit.SECONDS)
         private Duration tooSmall = Duration.milliseconds(100);
-        
+
         @DurationRange(min = 10, max = 30, unit = TimeUnit.MINUTES)
         private Duration outOfRange = Duration.minutes(60);
 
@@ -44,9 +44,9 @@ public class DurationValidatorTest {
 
             assertThat(errors)
                     .containsOnly(
-                            "outOfRange must be between 10 MINUTES and 30 MINUTES (was 60 minutes)",
-                            "tooBig must be less than or equal to 30 SECONDS (was 10 minutes)",
-                            "tooSmall must be greater than or equal to 30 SECONDS (was 100 milliseconds)");
+                            "outOfRange must be between 10 MINUTES and 30 MINUTES",
+                            "tooBig must be less than or equal to 30 SECONDS",
+                            "tooSmall must be greater than or equal to 30 SECONDS");
         }
     }
 

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/OneOfValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/OneOfValidatorTest.java
@@ -39,7 +39,7 @@ public class OneOfValidatorTest {
         example.basic = "four";
 
         assertThat(format(validator.validate(example)))
-                .containsOnly("basic must be one of [one, two, three] (was four)");
+                .containsOnly("basic must be one of [one, two, three]");
     }
 
     @Test

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/PortRangeValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/PortRangeValidatorTest.java
@@ -51,7 +51,7 @@ public class PortRangeValidatorTest {
         example.port = -1;
 
         assertThat(ConstraintViolations.format(validator.validate(example)))
-                .containsOnly("port must be between 1 and 65535 (was -1)");
+                .containsOnly("port must be between 1 and 65535");
     }
 
     @Test
@@ -59,7 +59,7 @@ public class PortRangeValidatorTest {
         example.otherPort = 8080;
 
         assertThat(ConstraintViolations.format(validator.validate(example)))
-                .containsOnly("otherPort must be between 10000 and 15000 (was 8080)");
+                .containsOnly("otherPort must be between 10000 and 15000");
     }
 
     @Test
@@ -67,6 +67,6 @@ public class PortRangeValidatorTest {
         example.otherPort = 16000;
 
         assertThat(ConstraintViolations.format(validator.validate(example)))
-                .containsOnly("otherPort must be between 10000 and 15000 (was 16000)");
+                .containsOnly("otherPort must be between 10000 and 15000");
     }
 }

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/SizeValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/SizeValidatorTest.java
@@ -18,7 +18,7 @@ public class SizeValidatorTest {
 
         @MinSize(value = 30, unit = SizeUnit.KILOBYTES)
         private Size tooSmall = Size.bytes(100);
-        
+
         @SizeRange(min = 10, max = 100, unit = SizeUnit.KILOBYTES)
         private Size outOfRange = Size.megabytes(2);
 
@@ -39,9 +39,9 @@ public class SizeValidatorTest {
     public void returnsASetOfErrorsForAnObject() throws Exception {
         if ("en".equals(Locale.getDefault().getLanguage())) {
             assertThat(ConstraintViolations.format(validator.validate(new Example())))
-                    .containsOnly("outOfRange must be between 10 KILOBYTES and 100 KILOBYTES (was 2 megabytes)",
-                                  "tooBig must be less than or equal to 30 KILOBYTES (was 2 gigabytes)",
-                                  "tooSmall must be greater than or equal to 30 KILOBYTES (was 100 bytes)");
+                    .containsOnly("outOfRange must be between 10 KILOBYTES and 100 KILOBYTES",
+                                  "tooBig must be less than or equal to 30 KILOBYTES",
+                                  "tooSmall must be greater than or equal to 30 KILOBYTES");
         }
     }
 


### PR DESCRIPTION
* ConstraintViolations should not print the invalid value as it may cause reflective-cross-site scripting issue
* Fixed all unit tests that expect the (was {invalidValue}) in the violation message.