### PR TITLE
Gather all endpoints and sort before logging them

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -3,18 +3,15 @@ package io.dropwizard.jersey;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.jersey2.InstrumentedResourceMethodApplicationListener;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Joiner;
+import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
 import io.dropwizard.jersey.caching.CacheControlledResponseFeature;
 import io.dropwizard.jersey.guava.OptionalMessageBodyWriter;
 import io.dropwizard.jersey.guava.OptionalParamFeature;
 import io.dropwizard.jersey.sessions.SessionFactoryProvider;
-import org.glassfish.jersey.message.GZipEncoder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.ServerProperties;
-import org.glassfish.jersey.server.filter.EncodingFilter;
 import org.glassfish.jersey.server.model.Resource;
 import org.glassfish.jersey.server.model.ResourceMethod;
 import org.glassfish.jersey.server.monitoring.ApplicationEvent;
@@ -28,6 +25,9 @@ import org.slf4j.LoggerFactory;
 import javax.ws.rs.Path;
 import javax.ws.rs.ext.Provider;
 import java.lang.annotation.Annotation;
+import java.io.Serializable;
+import java.util.Comparator;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -110,6 +110,8 @@ public class DropwizardResourceConfig extends ResourceConfig {
 
     public String getEndpointsInfo() {
         final StringBuilder msg = new StringBuilder(1024);
+        final List<EndpointLogLine> endpointLogLines = Lists.newArrayList();
+
         msg.append("The following paths were found for the configured resources:");
         msg.append(NEWLINE).append(NEWLINE);
 
@@ -120,10 +122,15 @@ public class DropwizardResourceConfig extends ResourceConfig {
             }
         }
 
-        if (!allResources.isEmpty()) {
-            for (Class<?> klass : allResources) {
-                Joiner.on(NEWLINE).appendTo(msg, new EndpointLogger(urlPattern, klass).getEndpoints());
-                msg.append(NEWLINE);
+        for (Class<?> klass : allResources) {
+            new EndpointLogger(urlPattern, klass).populate(endpointLogLines);
+        }
+
+        if (!endpointLogLines.isEmpty()) {
+            Collections.sort(endpointLogLines, new EndpointComparator());
+
+            for (EndpointLogLine line : endpointLogLines) {
+                msg.append(line).append(NEWLINE);
             }
         } else {
             msg.append("    NONE").append(NEWLINE);
@@ -139,42 +146,41 @@ public class DropwizardResourceConfig extends ResourceConfig {
      */
     private static class EndpointLogger {
         private final String rootPath;
-        private final List<String> endpoints = Lists.newArrayList();
+        private final Class<?> klass;
 
         public EndpointLogger(String urlPattern, Class<?> klass) {
             this.rootPath = urlPattern.endsWith("/*") ? urlPattern.substring(0, urlPattern.length() - 1) : urlPattern;
-
-            populateEndpoints(rootPath, klass, false);
+            this.klass = klass;
         }
 
-        private void populateEndpoints(String basePath, Class<?> klass, boolean isLocator) {
-            populateEndpoints(basePath, klass, isLocator, Resource.from(klass));
+        public void populate(List<EndpointLogLine> endpointLogLines) {
+            populate(this.rootPath, klass, false, endpointLogLines);
         }
 
-        private void populateEndpoints(String basePath, Class<?> klass, boolean isLocator, Resource resource) {
+        private void populate(String basePath, Class<?> klass, boolean isLocator, List<EndpointLogLine> endpointLogLines) {
+            populate(basePath, klass, isLocator, Resource.from(klass), endpointLogLines);
+        }
+
+        private void populate(String basePath, Class<?> klass, boolean isLocator, Resource resource, List<EndpointLogLine> endpointLogLines) {
             if (!isLocator) {
                 basePath = normalizePath(basePath, resource.getPath());
             }
 
             for (ResourceMethod method : resource.getResourceMethods()) {
-                endpoints.add(formatEndpoint(method.getHttpMethod(), basePath, klass));
+                endpointLogLines.add(new EndpointLogLine(method.getHttpMethod(), basePath, klass));
             }
 
             for (Resource childResource : resource.getChildResources()) {
                 for (ResourceMethod method : childResource.getResourceMethods()) {
                     if (method.getType() == ResourceMethod.JaxrsType.RESOURCE_METHOD) {
                         final String path = normalizePath(basePath, childResource.getPath());
-                        endpoints.add(formatEndpoint(method.getHttpMethod(), path, klass));
+                        endpointLogLines.add(new EndpointLogLine(method.getHttpMethod(), path, klass));
                     } else if (method.getType() == ResourceMethod.JaxrsType.SUB_RESOURCE_LOCATOR) {
                         final String path = normalizePath(basePath, childResource.getPath());
-                        populateEndpoints(path, method.getInvocable().getRawResponseType(), true);
+                        populate(path, method.getInvocable().getRawResponseType(), true, endpointLogLines);
                     }
                 }
             }
-        }
-
-        private String formatEndpoint(String method, String path, Class<?> klass) {
-            return String.format("    %-7s %s (%s)", method, path, klass.getCanonicalName());
         }
 
         private String normalizePath(String basePath, String path) {
@@ -183,9 +189,34 @@ public class DropwizardResourceConfig extends ResourceConfig {
             }
             return path.startsWith("/") ? basePath + path : basePath + "/" + path;
         }
+    }
 
-        public List<String> getEndpoints() {
-            return Ordering.natural().sortedCopy(endpoints);
+    private static class EndpointLogLine {
+        private final String httpMethod;
+        private final String basePath;
+        private final Class<?> klass;
+
+        public EndpointLogLine(String httpMethod, String basePath, Class<?> klass) {
+            this.basePath = basePath;
+            this.klass = klass;
+            this.httpMethod = httpMethod;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("    %-7s %s (%s)", httpMethod, basePath, klass.getCanonicalName());
+        }
+    }
+
+    private static class EndpointComparator implements Comparator<EndpointLogLine>, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public int compare(EndpointLogLine endpointA, EndpointLogLine endpointB) {
+            return ComparisonChain.start()
+                .compare(endpointA.basePath, endpointB.basePath)
+                .compare(endpointA.httpMethod, endpointB.httpMethod)
+                .result();
         }
     }
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
@@ -3,6 +3,9 @@ package io.dropwizard.jersey;
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.dummy.DummyResource;
 import io.dropwizard.logging.LoggingFactory;
+import java.util.regex.Pattern;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.POST;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -74,11 +77,41 @@ public class DropwizardResourceConfigTest {
                 .contains("GET     /another (io.dropwizard.jersey.DropwizardResourceConfigTest.ImplementingResource)");
     }
 
+    @Test
+    public void logsEndpointsSorted() {
+        rc.register(DummyResource.class);
+        rc.register(TestResource2.class);
+        rc.register(TestResource.class);
+        rc.register(ImplementingResource.class);
+
+        assertThat(rc.getEndpointsInfo()).matches(Pattern.compile(".*"
+                + "    GET     / \\(io\\.dropwizard\\.jersey\\.dummy\\.DummyResource\\)."
+                + "    GET     /another \\(io\\.dropwizard\\.jersey\\.DropwizardResourceConfigTest\\.ImplementingResource\\)."
+                + "    GET     /async \\(io\\.dropwizard\\.jersey\\.dummy\\.DummyResource\\)."
+                + "    DELETE  /dummy \\(io\\.dropwizard\\.jersey\\.DropwizardResourceConfigTest\\.TestResource2\\)."
+                + "    GET     /dummy \\(io\\.dropwizard\\.jersey\\.DropwizardResourceConfigTest\\.TestResource\\)."
+                + "    POST    /dummy \\(io\\.dropwizard\\.jersey\\.DropwizardResourceConfigTest\\.TestResource2\\).",
+                Pattern.DOTALL));
+    }
+
 
     @Path("/dummy")
     public static class TestResource {
         @GET
         public String foo() {
+            return "bar";
+        }
+    }
+
+    @Path("/dummy")
+    public static class TestResource2 {
+        @POST
+        public String fooPost() {
+            return "bar";
+        }
+
+        @DELETE
+        public String fooDelete() {
             return "bar";
         }
     }


### PR DESCRIPTION
The list of endpoints logged when starting Dropwizard becomes hard to read when it grows larger. This will sort all endpoints before logging them.