### PR TITLE
Defer DNS resolution in GraphiteReporter

### DIFF
--- a/dropwizard-configuration/pom.xml
+++ b/dropwizard-configuration/pom.xml
@@ -30,7 +30,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.3.2</version>
         </dependency>
     </dependencies>
 

--- a/dropwizard-metrics-graphite/pom.xml
+++ b/dropwizard-metrics-graphite/pom.xml
@@ -28,5 +28,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/dropwizard-metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteReporterFactory.java
+++ b/dropwizard-metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteReporterFactory.java
@@ -6,12 +6,12 @@ import com.codahale.metrics.graphite.Graphite;
 import com.codahale.metrics.graphite.GraphiteReporter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.metrics.BaseReporterFactory;
 import org.hibernate.validator.constraints.NotEmpty;
 import org.hibernate.validator.constraints.Range;
 
 import javax.validation.constraints.NotNull;
-import java.net.InetSocketAddress;
 
 /**
  * A factory for {@link GraphiteReporter} instances.
@@ -83,12 +83,15 @@ public class GraphiteReporterFactory extends BaseReporterFactory {
 
     @Override
     public ScheduledReporter build(MetricRegistry registry) {
-        final Graphite graphite = new Graphite(new InetSocketAddress(host, port));
+        return builder(registry).build(new Graphite(host, port));
+    }
+
+    @VisibleForTesting
+    protected GraphiteReporter.Builder builder(MetricRegistry registry) {
         return GraphiteReporter.forRegistry(registry)
-                               .convertDurationsTo(getDurationUnit())
-                               .convertRatesTo(getRateUnit())
-                               .filter(getFilter())
-                               .prefixedWith(getPrefix())
-                               .build(graphite);
+                .convertDurationsTo(getDurationUnit())
+                .convertRatesTo(getRateUnit())
+                .filter(getFilter())
+                .prefixedWith(getPrefix());
     }
 }

--- a/dropwizard-metrics-graphite/src/test/java/io/dropwizard/metrics/graphite/GraphiteReporterFactoryTest.java
+++ b/dropwizard-metrics-graphite/src/test/java/io/dropwizard/metrics/graphite/GraphiteReporterFactoryTest.java
@@ -1,14 +1,49 @@
 package io.dropwizard.metrics.graphite;
 
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.graphite.Graphite;
+import com.codahale.metrics.graphite.GraphiteReporter;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class GraphiteReporterFactoryTest {
+
     @Test
     public void isDiscoverable() throws Exception {
         assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
                 .contains(GraphiteReporterFactory.class);
+    }
+
+    @Test
+    public void testNoAddressResolutionForGraphite() throws Exception {
+        final GraphiteReporter.Builder builderSpy = mock(GraphiteReporter.Builder.class);
+        new GraphiteReporterFactory() {
+            @Override
+            protected GraphiteReporter.Builder builder(MetricRegistry registry) {
+                return builderSpy;
+            }
+        }.build(new MetricRegistry());
+
+        final ArgumentCaptor<Graphite> argument = ArgumentCaptor.forClass(Graphite.class);
+        verify(builderSpy).build(argument.capture());
+
+        final Graphite graphite = argument.getValue();
+        assertThat(getField(graphite, "hostname")).isEqualTo("localhost");
+        assertThat(getField(graphite, "port")).isEqualTo(8080);
+        assertThat(getField(graphite, "address")).isNull();
+    }
+
+    private static Object getField(Graphite graphite, String name) {
+        try {
+            return FieldUtils.getDeclaredField(Graphite.class, name, true).get(graphite);
+        } catch (IllegalAccessException e) {
+            throw new IllegalStateException(e);
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -306,6 +306,11 @@
                 <version>2.1</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.3.2</version>
+            </dependency>
+            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.12</version>


### PR DESCRIPTION
`InetSockedAddres` performs DNS resolution during construction time, which is not great if the Graphite server moves to a different IP-address.

The solution is to initialize `Graphite` gateway with a hostname and port. In such configuration it will resolve an address just before connecting to the server.

Resolve #1003