### PR TITLE
Close Jersey ExecutorService in tests

### DIFF
--- a/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
@@ -13,6 +13,7 @@ import org.apache.http.conn.ConnectTimeoutException;
 import org.assertj.core.api.AbstractLongAssert;
 import org.glassfish.jersey.client.ClientProperties;
 import org.junit.Before;
+import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -26,6 +27,7 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import java.net.SocketTimeoutException;
 import java.net.URI;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
@@ -47,6 +49,7 @@ public class DropwizardApacheConnectorTest {
     public ExpectedException thrown = ExpectedException.none();
 
     private Client client;
+    private ExecutorService executorService = Executors.newSingleThreadExecutor();;
 
     @Before
     public void setup() {
@@ -54,9 +57,15 @@ public class DropwizardApacheConnectorTest {
         clientConfiguration.setConnectionTimeout(Duration.milliseconds(SLEEP_TIME_IN_MILLIS / 2));
         clientConfiguration.setTimeout(Duration.milliseconds(DEFAULT_CONNECT_TIMEOUT_IN_MILLIS));
         client = new JerseyClientBuilder(new MetricRegistry())
-                .using(Executors.newSingleThreadExecutor(), Jackson.newObjectMapper())
+                .using(executorService, Jackson.newObjectMapper())
                 .using(clientConfiguration)
                 .build("test");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        executorService.shutdown();
+        client.close();
     }
 
     @Test

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
@@ -24,6 +24,7 @@ import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 import org.apache.http.impl.client.SystemDefaultCredentialsProvider;
 import org.apache.http.impl.conn.SystemDefaultDnsResolver;
 import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -78,6 +79,11 @@ public class JerseyClientBuilderTest {
         when(environment.getObjectMapper()).thenReturn(objectMapper);
         when(environment.getValidator()).thenReturn(validator);
         builder.setApacheHttpClientBuilder(apacheHttpClientBuilder);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        executorService.shutdown();
     }
 
     @Test
@@ -262,13 +268,13 @@ public class JerseyClientBuilderTest {
 
            @Override
            public void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
-               
+
            }
        });
         builder.using(customHttpRoutePlanner);
         verify(apacheHttpClientBuilder).using(customHttpRoutePlanner);
     }
-    
+
     @Test
     public void usesACustomCredentialsProvider(){
         CredentialsProvider customCredentialsProvider = new SystemDefaultCredentialsProvider();


### PR DESCRIPTION
We create this executor, so our responsibility to close it.