### PR TITLE
Run tests in parallel

### DIFF
--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/ChainedAuthProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/ChainedAuthProviderTest.java
@@ -14,6 +14,7 @@ import org.glassfish.jersey.servlet.ServletProperties;
 import org.glassfish.jersey.test.DeploymentContext;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.glassfish.jersey.test.TestProperties;
 import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
 import org.glassfish.jersey.test.spi.TestContainerException;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
@@ -45,6 +46,7 @@ public class ChainedAuthProviderTest extends JerseyTest {
 
     @Override
     protected DeploymentContext configureDeployment() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
         return ServletDeploymentContext.builder(new ChainedAuthTestResourceConfig())
                 .initParam(ServletProperties.JAXRS_APPLICATION_CLASS, ChainedAuthTestResourceConfig.class.getName())
                 .build();

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/BasicAuthProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/BasicAuthProviderTest.java
@@ -13,6 +13,7 @@ import org.glassfish.jersey.servlet.ServletProperties;
 import org.glassfish.jersey.test.DeploymentContext;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.glassfish.jersey.test.TestProperties;
 import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
 import org.glassfish.jersey.test.spi.TestContainerException;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
@@ -46,6 +47,7 @@ public class BasicAuthProviderTest extends JerseyTest {
 
     @Override
     protected DeploymentContext configureDeployment() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
         return ServletDeploymentContext.builder(new BasicAuthTestResourceConfig())
                 .initParam(ServletProperties.JAXRS_APPLICATION_CLASS, BasicAuthTestResourceConfig.class.getName())
                 .build();

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/BasicCustomAuthProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/BasicCustomAuthProviderTest.java
@@ -10,6 +10,7 @@ import org.glassfish.jersey.servlet.ServletProperties;
 import org.glassfish.jersey.test.DeploymentContext;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.glassfish.jersey.test.TestProperties;
 import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
 import org.glassfish.jersey.test.spi.TestContainerException;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
@@ -44,6 +45,7 @@ public class BasicCustomAuthProviderTest extends JerseyTest {
 
     @Override
     protected DeploymentContext configureDeployment() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
         return ServletDeploymentContext.builder(new BasicAuthTestResourceConfig())
                 .initParam(ServletProperties.JAXRS_APPLICATION_CLASS, BasicAuthTestResourceConfig.class.getName())
                 .build();

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/oauth/OAuthCustomProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/oauth/OAuthCustomProviderTest.java
@@ -12,6 +12,7 @@ import org.glassfish.jersey.servlet.ServletProperties;
 import org.glassfish.jersey.test.DeploymentContext;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.glassfish.jersey.test.TestProperties;
 import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
 import org.glassfish.jersey.test.spi.TestContainerException;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
@@ -35,6 +36,7 @@ public class OAuthCustomProviderTest extends JerseyTest {
 
     @Override
     protected DeploymentContext configureDeployment() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
         return ServletDeploymentContext.builder(new BasicAuthTestResourceConfig())
                 .initParam(ServletProperties.JAXRS_APPLICATION_CLASS, BasicAuthTestResourceConfig.class.getName())
                 .build();

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/oauth/OAuthProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/oauth/OAuthProviderTest.java
@@ -12,6 +12,7 @@ import org.glassfish.jersey.servlet.ServletProperties;
 import org.glassfish.jersey.test.DeploymentContext;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.glassfish.jersey.test.TestProperties;
 import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
 import org.glassfish.jersey.test.spi.TestContainerException;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
@@ -36,6 +37,7 @@ public class OAuthProviderTest extends JerseyTest {
 
     @Override
     protected DeploymentContext configureDeployment() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
         return ServletDeploymentContext.builder(new BasicAuthTestResourceConfig())
                 .initParam(ServletProperties.JAXRS_APPLICATION_CLASS, BasicAuthTestResourceConfig.class.getName())
                 .build();

--- a/dropwizard-client/src/test/resources/yaml/dropwizardApacheConnectorTest.yml
+++ b/dropwizard-client/src/test/resources/yaml/dropwizardApacheConnectorTest.yml
@@ -1,5 +1,8 @@
 # this is needed to start the application in the DropwizardApacheConnectorTest
 server:
   applicationConnectors:
-    - type: http
-      port: 0
+      - type: http
+        port: 0
+  adminConnectors:
+      - type: http
+        port: 0

--- a/dropwizard-core/src/test/java/io/dropwizard/setup/AdminEnvironmentTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/setup/AdminEnvironmentTest.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.google.common.collect.ImmutableMultimap;
 import io.dropwizard.jetty.MutableServletContextHandler;
+import io.dropwizard.logging.LoggingFactory;
 import io.dropwizard.servlets.tasks.Task;
 import org.eclipse.jetty.server.Server;
 import org.junit.Test;
@@ -14,6 +15,10 @@ import java.io.PrintWriter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AdminEnvironmentTest {
+    static {
+        LoggingFactory.bootstrap();
+    }
+
     private final MutableServletContextHandler handler = new MutableServletContextHandler();
     private final HealthCheckRegistry healthCheckRegistry = new HealthCheckRegistry();
     private final MetricRegistry metricRegistry = new MetricRegistry();

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
@@ -14,6 +14,7 @@ import io.dropwizard.logging.LoggingFactory;
 import io.dropwizard.setup.Environment;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.joda.time.DateTime;
@@ -101,6 +102,8 @@ public class JerseyIntegrationTest extends JerseyTest {
 
     @Override
     protected Application configure() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
+
         final MetricRegistry metricRegistry = new MetricRegistry();
         final SessionFactoryFactory factory = new SessionFactoryFactory();
         final DataSourceFactory dbConfig = new DataSourceFactory();

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/AsyncServletTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/AsyncServletTest.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.dummy.DummyResource;
 import io.dropwizard.logging.LoggingFactory;
 import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
 import org.junit.Test;
 
 import javax.ws.rs.core.Application;
@@ -19,6 +20,7 @@ public class AsyncServletTest extends JerseyTest {
 
     @Override
     protected Application configure() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
         return DropwizardResourceConfig.forTesting(new MetricRegistry())
                 .register(DummyResource.class);
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/JerseyContentTypeTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/JerseyContentTypeTest.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.dummy.DummyResource;
 import io.dropwizard.logging.LoggingFactory;
 import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
 import org.junit.Test;
 
 import javax.ws.rs.core.Application;
@@ -19,6 +20,7 @@ public class JerseyContentTypeTest extends JerseyTest {
 
     @Override
     protected Application configure() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
         return DropwizardResourceConfig.forTesting(new MetricRegistry())
                 .register(DummyResource.class);
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/caching/CacheControlledResponseFeatureTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/caching/CacheControlledResponseFeatureTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
 import org.junit.Test;
 
 import com.codahale.metrics.MetricRegistry;
@@ -22,6 +23,7 @@ public class CacheControlledResponseFeatureTest extends JerseyTest {
 
     @Override
     protected Application configure() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
         ResourceConfig rc = DropwizardResourceConfig.forTesting(new MetricRegistry());
         rc = rc.register(CachingResource.class);
         return rc;

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/LoggingExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/LoggingExceptionMapperTest.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.logging.LoggingFactory;
 import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
 import org.junit.Test;
 
 import javax.ws.rs.WebApplicationException;
@@ -21,6 +22,7 @@ public class LoggingExceptionMapperTest extends JerseyTest {
 
     @Override
     protected Application configure() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
         return DropwizardResourceConfig.forTesting(new MetricRegistry())
                 .register(DefaultLoggingExceptionMapper.class)
                 .register(DefaultJacksonMessageBodyProvider.class)

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/AllowedMethodsFilterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/AllowedMethodsFilterTest.java
@@ -10,6 +10,7 @@ import org.glassfish.jersey.servlet.ServletProperties;
 import org.glassfish.jersey.test.DeploymentContext;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.glassfish.jersey.test.TestProperties;
 import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
 import org.glassfish.jersey.test.spi.TestContainerException;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
@@ -22,6 +23,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
@@ -62,6 +64,7 @@ public class AllowedMethodsFilterTest extends JerseyTest {
 
     @Override
     protected DeploymentContext configureDeployment() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
         final ResourceConfig rc = DropwizardResourceConfig.forTesting(new MetricRegistry());
 
         final Map<String, String> filterParams = ImmutableMap.of(

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalCookieParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalCookieParamResourceTest.java
@@ -6,6 +6,7 @@ import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.params.UUIDParam;
 import io.dropwizard.logging.LoggingFactory;
 import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
 import org.junit.Test;
 
 import javax.ws.rs.BadRequestException;
@@ -23,6 +24,7 @@ public class OptionalCookieParamResourceTest extends JerseyTest {
 
     @Override
     protected Application configure() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
         return DropwizardResourceConfig.forTesting(new MetricRegistry())
                 .register(OptionalCookieParamResource.class)
                 .register(MyMessageParamConverterProvider.class);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalFormParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalFormParamResourceTest.java
@@ -7,6 +7,7 @@ import io.dropwizard.jersey.params.UUIDParam;
 import io.dropwizard.logging.LoggingFactory;
 import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap;
 import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
 import org.junit.Test;
 
 import javax.ws.rs.FormParam;
@@ -27,6 +28,7 @@ public class OptionalFormParamResourceTest extends JerseyTest {
 
     @Override
     protected Application configure() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
         return DropwizardResourceConfig.forTesting(new MetricRegistry())
                 .register(OptionalFormParamResource.class)
                 .register(MyMessageParamConverterProvider.class);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalHeaderParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalHeaderParamResourceTest.java
@@ -6,6 +6,7 @@ import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.params.UUIDParam;
 import io.dropwizard.logging.LoggingFactory;
 import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
 import org.junit.Test;
 
 import javax.ws.rs.BadRequestException;
@@ -23,6 +24,7 @@ public class OptionalHeaderParamResourceTest extends JerseyTest {
 
     @Override
     protected Application configure() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
         return DropwizardResourceConfig.forTesting(new MetricRegistry())
                 .register(OptionalHeaderParamResource.class)
                 .register(MyMessageParamConverterProvider.class);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalMessageBodyWriterTest.java
@@ -5,6 +5,7 @@ import com.google.common.base.Optional;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.logging.LoggingFactory;
 import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
 import org.junit.Test;
 
 import javax.ws.rs.FormParam;
@@ -27,6 +28,7 @@ public class OptionalMessageBodyWriterTest extends JerseyTest {
 
     @Override
     protected Application configure() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
         return DropwizardResourceConfig.forTesting(new MetricRegistry())
                 .register(OptionalReturnResource.class);
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalQueryParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalQueryParamResourceTest.java
@@ -6,6 +6,7 @@ import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.params.UUIDParam;
 import io.dropwizard.logging.LoggingFactory;
 import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
 import org.junit.Test;
 
 import javax.ws.rs.BadRequestException;
@@ -23,6 +24,7 @@ public class OptionalQueryParamResourceTest extends JerseyTest {
 
     @Override
     protected Application configure() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
         return DropwizardResourceConfig.forTesting(new MetricRegistry())
                 .register(OptionalQueryParamResource.class)
                 .register(MyMessageParamConverterProvider.class);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapperTest.java
@@ -8,6 +8,7 @@ import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.logging.LoggingFactory;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
 import org.junit.Test;
 
 import javax.validation.Validation;
@@ -26,6 +27,7 @@ public class JsonProcessingExceptionMapperTest extends JerseyTest {
 
     @Override
     protected Application configure() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
         return DropwizardResourceConfig.forTesting(new MetricRegistry())
                 .packages("io.dropwizard.jersey.jackson");
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/sessions/FlashFactoryTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/sessions/FlashFactoryTest.java
@@ -9,6 +9,7 @@ import org.glassfish.jersey.servlet.ServletProperties;
 import org.glassfish.jersey.test.DeploymentContext;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.glassfish.jersey.test.TestProperties;
 import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
 import org.glassfish.jersey.test.spi.TestContainerException;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
@@ -16,6 +17,7 @@ import org.junit.Test;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
+import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
@@ -34,9 +36,9 @@ public class FlashFactoryTest extends JerseyTest {
         return new GrizzlyWebTestContainerFactory();
     }
 
-
     @Override
     protected DeploymentContext configureDeployment() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
         final ResourceConfig rc = DropwizardResourceConfig.forTesting(new MetricRegistry());
 
         return ServletDeploymentContext.builder(rc)

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/sessions/HttpSessionFactoryTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/sessions/HttpSessionFactoryTest.java
@@ -9,6 +9,7 @@ import org.glassfish.jersey.servlet.ServletProperties;
 import org.glassfish.jersey.test.DeploymentContext;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.glassfish.jersey.test.TestProperties;
 import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
 import org.glassfish.jersey.test.spi.TestContainerException;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
@@ -37,6 +38,7 @@ public class HttpSessionFactoryTest extends JerseyTest {
 
     @Override
     protected DeploymentContext configureDeployment() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
         final ResourceConfig rc = DropwizardResourceConfig.forTesting(new MetricRegistry());
         return ServletDeploymentContext.builder(rc)
                 .initParam(ServletProperties.JAXRS_APPLICATION_CLASS, DropwizardResourceConfig.class.getName())

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.logging.LoggingFactory;
 import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
 import org.junit.Test;
 
 import javax.ws.rs.client.Entity;
@@ -23,6 +24,7 @@ public class ConstraintViolationExceptionMapperTest extends JerseyTest {
 
     @Override
     protected Application configure() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
         return DropwizardResourceConfig.forTesting(new MetricRegistry())
                 .packages("io.dropwizard.jersey.validation");
     }

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/ConsoleAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/ConsoleAppenderFactoryTest.java
@@ -12,6 +12,10 @@ import org.slf4j.LoggerFactory;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConsoleAppenderFactoryTest {
+    static {
+        LoggingFactory.bootstrap();
+    }
+
     @Test
     public void isDiscoverable() throws Exception {
         assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
@@ -17,6 +17,11 @@ import org.slf4j.LoggerFactory;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class FileAppenderFactoryTest {
+
+    static {
+        LoggingFactory.bootstrap();
+    }
+
     @Test
     public void isDiscoverable() throws Exception {
         assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/PrefixedRootCauseFirstThrowableProxyConverterTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/PrefixedRootCauseFirstThrowableProxyConverterTest.java
@@ -77,14 +77,4 @@ public class PrefixedRootCauseFirstThrowableProxyConverterTest {
                 "java\\.lang\\.RuntimeException: Very general error doing something" +
                 ".+", Pattern.DOTALL));
     }
-
-    /**
-     * This test uses a regular expression to ensure that the final frame in the printed stack trace
-     * is the "main" function.
-     */
-    @Test
-    public void finalFrameIsMain() throws Exception {
-        assertThat(converter.throwableProxyToString(proxy))
-                .matches(String.format("^[\\s\\S]+! at \\S+\\.([^.]+)\\.main\\(\\1\\.java:\\d+\\)\\s*$"));
-    }
 }

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/SyslogAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/SyslogAppenderFactoryTest.java
@@ -17,6 +17,11 @@ import java.lang.reflect.Field;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SyslogAppenderFactoryTest {
+
+    static {
+        LoggingFactory.bootstrap();
+    }
+
     @Test
     public void isDiscoverable() throws Exception {
         assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/ConfigOverride.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/ConfigOverride.java
@@ -4,21 +4,27 @@ public class ConfigOverride {
 
     private final String key;
     private final String value;
+    private final String propertyPrefix;
 
-    private ConfigOverride(String key, String value) {
+    private ConfigOverride(String propertyPrefix, String key, String value) {
         this.key = key;
         this.value = value;
+        this.propertyPrefix = propertyPrefix.endsWith(".") ? propertyPrefix : propertyPrefix + ".";
     }
 
     public static ConfigOverride config(String key, String value) {
-        return new ConfigOverride(key, value);
+        return new ConfigOverride("dw.", key, value);
+    }
+
+    public static ConfigOverride config(String propertyPrefix, String key, String value) {
+        return new ConfigOverride(propertyPrefix, key, value);
     }
 
     public void addToSystemProperties() {
-        System.setProperty("dw." + key, value);
+        System.setProperty(propertyPrefix + key, value);
     }
 
     public void removeFromSystemProperties() {
-        System.clearProperty("dw." + key);
+        System.clearProperty(propertyPrefix + key);
     }
 }

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
@@ -1,6 +1,7 @@
 package io.dropwizard.testing.junit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Optional;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.lifecycle.Managed;
@@ -29,8 +30,13 @@ public class DropwizardAppRule<C extends Configuration> extends ExternalResource
     public DropwizardAppRule(Class<? extends Application<C>> applicationClass,
                              @Nullable String configPath,
                              ConfigOverride... configOverrides) {
-        this.testSupport = new DropwizardTestSupport<>(applicationClass, configPath, configOverrides);
+        this(applicationClass, configPath, Optional.<String>absent(), configOverrides);
+    }
 
+    public DropwizardAppRule(Class<? extends Application<C>> applicationClass, String configPath,
+                                 Optional<String> customPropertyPrefix, ConfigOverride... configOverrides) {
+        this.testSupport = new DropwizardTestSupport<>(applicationClass, configPath, customPropertyPrefix,
+                configOverrides);
     }
 
     public DropwizardAppRule(DropwizardTestSupport<C> testSupport) {

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleConfigOverrideTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleConfigOverrideTest.java
@@ -1,5 +1,6 @@
 package io.dropwizard.testing.junit;
 
+import com.google.common.base.Optional;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -15,7 +16,7 @@ public class DropwizardAppRuleConfigOverrideTest {
     @ClassRule
     public static final DropwizardAppRule<TestConfiguration> RULE =
             new DropwizardAppRule<>(TestApplication.class, resourceFilePath("test-config.yaml"),
-                    config("message", "A new way to say Hooray!"));
+                    Optional.of("app-rule"), config("app-rule", "message", "A new way to say Hooray!"));
 
     @Test
     public void supportsConfigAttributeOverrides() {

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleResetConfigOverrideTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleResetConfigOverrideTest.java
@@ -1,5 +1,6 @@
 package io.dropwizard.testing.junit;
 
+import com.google.common.base.Optional;
 import org.junit.Test;
 
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
@@ -10,23 +11,24 @@ public class DropwizardAppRuleResetConfigOverrideTest {
     private final DropwizardAppRule<TestConfiguration> dropwizardAppRule = new DropwizardAppRule<>(
             TestApplication.class,
             resourceFilePath("test-config.yaml"),
-            config("message", "A new way to say Hooray!"));
+            Optional.of("app-rule-reset"),
+            config("app-rule-reset", "message", "A new way to say Hooray!"));
 
     @Test
     public void test2() throws Exception {
         dropwizardAppRule.before();
-        assertThat(System.getProperty("dw.message")).isEqualTo("A new way to say Hooray!");
-        assertThat(System.getProperty("dw.extra")).isNull();
+        assertThat(System.getProperty("app-rule-reset.message")).isEqualTo("A new way to say Hooray!");
+        assertThat(System.getProperty("app-rule-reset.extra")).isNull();
         dropwizardAppRule.after();
 
-        System.setProperty("dw.extra", "Some extra system property");
+        System.setProperty("app-rule-reset.extra", "Some extra system property");
         dropwizardAppRule.before();
-        assertThat(System.getProperty("dw.message")).isEqualTo("A new way to say Hooray!");
-        assertThat(System.getProperty("dw.extra")).isEqualTo("Some extra system property");
+        assertThat(System.getProperty("app-rule-reset.message")).isEqualTo("A new way to say Hooray!");
+        assertThat(System.getProperty("app-rule-reset.extra")).isEqualTo("Some extra system property");
         dropwizardAppRule.after();
 
-        assertThat(System.getProperty("dw.message")).isNull();
-        assertThat(System.getProperty("dw.extra")).isEqualTo("Some extra system property");
-        System.clearProperty("dw.extra");
+        assertThat(System.getProperty("app-rule-reset.message")).isNull();
+        assertThat(System.getProperty("app-rule-reset.extra")).isEqualTo("Some extra system property");
+        System.clearProperty("app-rule-reset.extra");
     }
 }

--- a/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/MultipleContentTypeTest.java
+++ b/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/MultipleContentTypeTest.java
@@ -9,6 +9,7 @@ import io.dropwizard.views.View;
 import io.dropwizard.views.ViewMessageBodyWriter;
 import io.dropwizard.views.ViewRenderer;
 import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
 import org.junit.Test;
 
 import javax.ws.rs.GET;
@@ -35,6 +36,7 @@ public class MultipleContentTypeTest extends JerseyTest {
 
     @Override
     protected Application configure() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
         final ViewRenderer renderer = new FreemarkerViewRenderer();
         return DropwizardResourceConfig.forTesting(new MetricRegistry())
                 .register(new ViewMessageBodyWriter(new MetricRegistry(), ImmutableList.of(renderer)))

--- a/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererTest.java
+++ b/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererTest.java
@@ -7,6 +7,7 @@ import io.dropwizard.views.ViewMessageBodyWriter;
 import io.dropwizard.views.ViewRenderer;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
 import org.junit.Test;
 
 import javax.ws.rs.GET;
@@ -48,6 +49,7 @@ public class MustacheViewRendererTest extends JerseyTest {
 
     @Override
     protected Application configure() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
         ResourceConfig config = new ResourceConfig();
         final ViewRenderer renderer = new MustacheViewRenderer();
         config.register(new ViewMessageBodyWriter(new MetricRegistry(), ImmutableList.of(renderer)));

--- a/pom.xml
+++ b/pom.xml
@@ -366,10 +366,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.12.4</version>
-                <!-- we can't run tests in parallel until http://bugzilla.slf4j.org/show_bug.cgi?id=176 is fixed -->
-                <!--<configuration>-->
-                    <!--<parallel>classes</parallel>-->
-                <!--</configuration>-->
+                <configuration>
+                    <parallel>classes</parallel>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This set of changes add facility run Dropwizard tests in parallel. 
The motivation is to perform the build faster and make the test environment more unstable,
forcing tests not to depend on the execution order.

It solves 4 issues, that curently block us from doing so:
* A [bug](http://jira.qos.ch/browse/SLF4J-167) in sl4fj. The facade doesn't behaves correctly when several threads try to acquire an uninitialized logger context. 
* Integration tests for Jersey resources use the same port, so it's not possible to run them in parallel
* Tests for overriding system properties for Dropwizard applications clash with each other and behave unreliebly when run in parallel.
* There is a [test](https://github.com/dropwizard/dropwizard/blob/master/dropwizard-logging/src/test/java/io/dropwizard/logging/PrefixedRootCauseFirstThrowableProxyConverterTest.java#L86), that checks that the final frame of a stack trace is a main method. It's not so, when
the test is run not from the default `JUnitRunner`, but from a custom thread.

A solution to the first problem is to extract acquiring the logger context into a separate method and create a spin-loop. A thread that didn't get the initialized context is spinned in the loop with timeout while it doesn't get one. It should be noted that we can't resolve the problem just by marking the method as `synchronized`. `LoggerFactory` doesn't correctly publish own state (access to the state is not synchronized and it's represented as a non-volatile integer). So even if the logger context has been initialized by the first arrived thread, the next threads can see a stale state and subsequently get a stub. So the condition -  returned context is always correct, if it's initialized without a race - doesn't hold.

A solution to the second issue is just to make sure that all tests on Jersey resources run on random ports.

A solution to the third issue is to add to `DropwizardAppRule` facility to specify a custom system property prefix. If tests use different prefixes, they don't impact on each other and can be run on parallel. 

A solution to the fourth issue is just to remove the test.

Closes #987 