### PR TITLE
Add facility to specify a custom MetricRegistry in Bootstrap

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/Application.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/Application.java
@@ -73,10 +73,15 @@ public abstract class Application<T extends Configuration> {
         bootstrap.addCommand(new ServerCommand<>(this));
         bootstrap.addCommand(new CheckCommand<>(this));
         initialize(bootstrap);
+        // Should by called after initialize to give an opportunity to set a custom metric registry
+        bootstrap.registerMetrics();
+
         final Cli cli = new Cli(new JarLocation(getClass()), bootstrap, System.out, System.err);
         if (!cli.run(arguments)) {
             // only exit if there's an error running the command
             System.exit(1);
         }
     }
+
+
 }


### PR DESCRIPTION
* Add a setter for the metric registry in `Bootstrap`, so users can provide own customized instance during initialization.
* Move system metrics registration into a separate method from the constructor.
* Invoke the method after `Application#initialize`, where users can customize `Bootstrap`.

Resolve #956