### PR TITLE
Remove javax.el 2.x dependencies

### DIFF
--- a/dropwizard-jersey/pom.xml
+++ b/dropwizard-jersey/pom.xml
@@ -56,6 +56,14 @@
                     <groupId>org.hibernate</groupId>
                     <artifactId>hibernate-validator</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.el</groupId>
+                    <artifactId>javax.el-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.web</groupId>
+                    <artifactId>javax.el</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
*Dropwizard-jersey* module has a dependency via *dropwizard-validation* on *org.glassfish.javax.el-3.0.0*, which includes API as well as an implementation of the expression language.

This also removes warnings from the *maven-shade plugin* about duplicated classes in the classpath.