### PR TITLE
Extract constraint status for public use

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapper.java
@@ -1,46 +1,18 @@
 package io.dropwizard.jersey.validation;
 
-import javax.validation.ConstraintViolation;
+import io.dropwizard.validation.ConstraintViolations;
+
 import javax.validation.ConstraintViolationException;
-import javax.validation.ElementKind;
-import javax.validation.Path.Node;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
-import java.util.Set;
 
 @Provider
 public class ConstraintViolationExceptionMapper implements ExceptionMapper<ConstraintViolationException> {
     @Override
     public Response toResponse(ConstraintViolationException exception) {
-        int status = 422;
-
-        // Detect where the constraint validation occurred so we can return an appropriate status
-        // code. If the constraint failed with a *Param annotation, return a bad request. If it
-        // failed validating the return value, return internal error. Else return unprocessable
-        // entity.
-        Set<ConstraintViolation<?>> violations = exception.getConstraintViolations();
-        if (violations.size() > 0) {
-            ConstraintViolation<?> violation = violations.iterator().next();
-            boolean isReturnValue = false;
-            boolean isArgument = false;
-
-            // A return value can only occur at the last path, but a parameter
-            // can occur anywhere, such as a @BeanParam that has validations.
-            for (Node node : violation.getPropertyPath()) {
-                isArgument |= node.getKind().equals(ElementKind.PARAMETER);
-                isReturnValue = node.getKind().equals(ElementKind.RETURN_VALUE);
-            }
-
-            if (isReturnValue) {
-                status = 500;
-            } else if (isArgument) {
-                status = 400;
-            }
-        }
-
         final ValidationErrorMessage message = new ValidationErrorMessage(exception.getConstraintViolations());
-        return Response.status(status)
+        return Response.status(ConstraintViolations.determineStatus(exception))
                        .entity(message)
                        .build();
     }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapper.java
@@ -2,17 +2,19 @@ package io.dropwizard.jersey.validation;
 
 import io.dropwizard.validation.ConstraintViolations;
 
+import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
+import java.util.Set;
 
 @Provider
 public class ConstraintViolationExceptionMapper implements ExceptionMapper<ConstraintViolationException> {
     @Override
     public Response toResponse(ConstraintViolationException exception) {
         final ValidationErrorMessage message = new ValidationErrorMessage(exception.getConstraintViolations());
-        return Response.status(ConstraintViolations.determineStatus(exception))
+        return Response.status(ConstraintViolations.determineStatus(exception.getConstraintViolations()))
                        .entity(message)
                        .build();
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
@@ -43,6 +43,9 @@ public class ConstraintViolationExceptionMapperTest extends JerseyTest {
         final Response response = target("/valid/bar")
                 .queryParam("name", "dropwizard").request().get();
         assertThat(response.getStatus()).isEqualTo(500);
+
+        String ret = "{\"errors\":[\"blaze.<return value> length must be between 0 and 3\"]}";
+        assertThat(response.readEntity(String.class)).isEqualTo(ret);
     }
 
     @Test
@@ -50,7 +53,11 @@ public class ConstraintViolationExceptionMapperTest extends JerseyTest {
         // query parameter is too short and so will fail validation
         final Response response = target("/valid/bar")
                 .queryParam("name", "hi").request().get();
+
         assertThat(response.getStatus()).isEqualTo(400);
+
+        String ret = "{\"errors\":[\"blaze.arg0 length must be between 3 and 2147483647\"]}";
+        assertThat(response.readEntity(String.class)).isEqualTo(ret);
     }
 
     @Test
@@ -59,5 +66,8 @@ public class ConstraintViolationExceptionMapperTest extends JerseyTest {
         final Response response = target("/valid/zoo")
                 .request().get();
         assertThat(response.getStatus()).isEqualTo(400);
+
+        String ret = "{\"errors\":[\"blazer.arg0.name may not be empty\"]}";
+        assertThat(response.readEntity(String.class)).isEqualTo(ret);
     }
 }

--- a/dropwizard-validation/pom.xml
+++ b/dropwizard-validation/pom.xml
@@ -27,5 +27,10 @@
             <artifactId>javax.el</artifactId>
             <version>3.0.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/ConstraintViolations.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/ConstraintViolations.java
@@ -7,8 +7,6 @@ import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
 
 import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
-import javax.validation.ElementKind;
 import javax.validation.Path;
 import java.util.Set;
 
@@ -52,31 +50,25 @@ public class ConstraintViolations {
         return builder.build();
     }
 
-    public static int determineStatus(ConstraintViolationException exception) {
+    public static <T extends ConstraintViolation<?>> int determineStatus(Set<T> violations) {
         // Detect where the constraint validation occurred so we can return an appropriate status
         // code. If the constraint failed with a *Param annotation, return a bad request. If it
         // failed validating the return value, return internal error. Else return unprocessable
         // entity.
-        Set<ConstraintViolation<?>> violations = exception.getConstraintViolations();
         if (violations.size() > 0) {
             ConstraintViolation<?> violation = violations.iterator().next();
-            boolean isReturnValue = false;
-            boolean isArgument = false;
-
-            // A return value can only occur at the last path, but a parameter
-            // can occur anywhere, such as a @BeanParam that has validations.
             for (Path.Node node : violation.getPropertyPath()) {
-                isArgument |= node.getKind().equals(ElementKind.PARAMETER);
-                isReturnValue = node.getKind().equals(ElementKind.RETURN_VALUE);
-            }
-
-            if (isReturnValue) {
-                return 500;
-            } else if (isArgument) {
-                return 400;
+                switch (node.getKind()) {
+                    case RETURN_VALUE:
+                        return 500;
+                    case PARAMETER:
+                        return 400;
+                }
             }
         }
 
+        // When Jackson deserializes and validates POST, PUT, etc and constraint violations occur,
+        // they occur from the entity's properties and not as parameter from the resource endpoint.
         return 422;
     }
 }

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/ConstraintViolations.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/ConstraintViolations.java
@@ -7,6 +7,8 @@ import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
 
 import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.ElementKind;
 import javax.validation.Path;
 import java.util.Set;
 
@@ -48,5 +50,33 @@ public class ConstraintViolations {
             builder.add(violation);
         }
         return builder.build();
+    }
+
+    public static int determineStatus(ConstraintViolationException exception) {
+        // Detect where the constraint validation occurred so we can return an appropriate status
+        // code. If the constraint failed with a *Param annotation, return a bad request. If it
+        // failed validating the return value, return internal error. Else return unprocessable
+        // entity.
+        Set<ConstraintViolation<?>> violations = exception.getConstraintViolations();
+        if (violations.size() > 0) {
+            ConstraintViolation<?> violation = violations.iterator().next();
+            boolean isReturnValue = false;
+            boolean isArgument = false;
+
+            // A return value can only occur at the last path, but a parameter
+            // can occur anywhere, such as a @BeanParam that has validations.
+            for (Path.Node node : violation.getPropertyPath()) {
+                isArgument |= node.getKind().equals(ElementKind.PARAMETER);
+                isReturnValue = node.getKind().equals(ElementKind.RETURN_VALUE);
+            }
+
+            if (isReturnValue) {
+                return 500;
+            } else if (isArgument) {
+                return 400;
+            }
+        }
+
+        return 422;
     }
 }

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/ConstraintPerson.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/ConstraintPerson.java
@@ -1,0 +1,19 @@
+package io.dropwizard.validation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.hibernate.validator.constraints.NotEmpty;
+
+public class ConstraintPerson {
+    @NotEmpty
+    private String name;
+
+    @JsonProperty
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/ConstraintViolationsTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/ConstraintViolationsTest.java
@@ -1,0 +1,94 @@
+package io.dropwizard.validation;
+
+import org.junit.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Valid;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.executable.ExecutableValidator;
+import java.util.Set;
+
+import static org.apache.commons.lang3.reflect.MethodUtils.getAccessibleMethod;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings({"UnusedDeclaration"})
+public class ConstraintViolationsTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+    private final ExecutableValidator execValidator = validator.forExecutables();
+
+    @Max(3)
+    public Integer theIntTest(@Min(2) Integer x) {
+        return x + 1;
+    }
+
+    @Valid
+    public ConstraintPerson thePersonTest(@Valid ConstraintPerson person) {
+        person.setName(null);
+        return person;
+    }
+
+    @Test
+    public void invalidIntReturnIs500() {
+        Set<ConstraintViolation<ConstraintViolationsTest>> violations =
+                execValidator.validateReturnValue(
+                        this,
+                        getAccessibleMethod(getClass(), "theIntTest", Integer.class),
+                        4 // the return value
+                );
+
+        assertThat(violations).hasSize(1);
+        assertThat(ConstraintViolations.determineStatus(violations)).isEqualTo(500);
+    }
+
+    @Test
+    public void invalidIntParameterIs400() {
+        Set<ConstraintViolation<ConstraintViolationsTest>> violations =
+                execValidator.validateParameters(
+                        this,
+                        getAccessibleMethod(getClass(), "theIntTest", Integer.class),
+                        new Object[]{1} // the parameter value
+                );
+
+        assertThat(violations).hasSize(1);
+        assertThat(ConstraintViolations.determineStatus(violations)).isEqualTo(400);
+    }
+
+    @Test
+    public void invalidPersonReturnIs500() {
+        Set<ConstraintViolation<ConstraintViolationsTest>> violations =
+                execValidator.validateReturnValue(
+                        this,
+                        getAccessibleMethod(getClass(), "thePersonTest", ConstraintPerson.class),
+                        new ConstraintPerson() // return value has null name
+                );
+
+        assertThat(violations).hasSize(1);
+        assertThat(ConstraintViolations.determineStatus(violations)).isEqualTo(500);
+    }
+
+    @Test
+    public void invalidPersonParamIs400() {
+        Set<ConstraintViolation<ConstraintViolationsTest>> violations =
+                execValidator.validateParameters(
+                        this,
+                        getAccessibleMethod(getClass(), "thePersonTest", ConstraintPerson.class),
+                        new Object[]{new ConstraintPerson()} // the parameter value
+                );
+
+        assertThat(violations).hasSize(1);
+        assertThat(ConstraintViolations.determineStatus(violations)).isEqualTo(400);
+    }
+
+    @Test
+    public void invalidPersonRepresentationIs422() {
+        Set<ConstraintViolation<ConstraintPerson>> violations =
+                validator.validate(new ConstraintPerson());
+
+        assertThat(violations).hasSize(1);
+        assertThat(ConstraintViolations.determineStatus(violations)).isEqualTo(422);
+    }
+}


### PR DESCRIPTION
Useful for those who want to derive their own `ExceptionMapper<ConstraintViolationException>` (for instance, an exception mapper that returns JSON containing constraint violations)