### PR TITLE
Add facility to plug-in custom DB connection pools

### DIFF
--- a/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
+++ b/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
@@ -250,7 +250,7 @@ import java.util.concurrent.TimeUnit;
  *     </tr>
  * </table>
  */
-public class DataSourceFactory {
+public class DataSourceFactory implements PooledDataSourceFactory {
     @SuppressWarnings("UnusedDeclaration")
     public enum TransactionIsolation {
         NONE(Connection.TRANSACTION_NONE),
@@ -355,6 +355,7 @@ public class DataSourceFactory {
     private Duration validationInterval = Duration.seconds(30);
 
     @JsonProperty
+    @Override
     public boolean isAutoCommentsEnabled() {
         return autoCommentsEnabled;
     }
@@ -365,6 +366,7 @@ public class DataSourceFactory {
     }
 
     @JsonProperty
+    @Override
     public String getDriverClass() {
         return driverClass;
     }
@@ -405,6 +407,7 @@ public class DataSourceFactory {
     }
 
     @JsonProperty
+    @Override
     public Map<String, String> getProperties() {
         return properties;
     }
@@ -426,6 +429,11 @@ public class DataSourceFactory {
 
     @JsonProperty
     public String getValidationQuery() {
+        return validationQuery;
+    }
+
+    @Override
+    public String getHealthCheckValidationQuery() {
         return validationQuery;
     }
 
@@ -689,11 +697,24 @@ public class DataSourceFactory {
         return Optional.fromNullable(validationQueryTimeout);
     }
 
+    @Override
+    public Optional<Duration> getHealthCheckValidationTimeout() {
+        return Optional.fromNullable(validationQueryTimeout);
+    }
+
     @JsonProperty
     public void setValidationQueryTimeout(Duration validationQueryTimeout) {
         this.validationQueryTimeout = validationQueryTimeout;
     }
 
+    @Override
+    public void asSingleConnectionPool() {
+        minSize = 1;
+        maxSize = 1;
+        initialSize = 1;
+    }
+
+    @Override
     public ManagedDataSource build(MetricRegistry metricRegistry, String name) {
         final Properties properties = new Properties();
         for (Map.Entry<String, String> property : this.properties.entrySet()) {

--- a/dropwizard-db/src/main/java/io/dropwizard/db/DatabaseConfiguration.java
+++ b/dropwizard-db/src/main/java/io/dropwizard/db/DatabaseConfiguration.java
@@ -3,5 +3,5 @@ package io.dropwizard.db;
 import io.dropwizard.Configuration;
 
 public interface DatabaseConfiguration<T extends Configuration> {
-    DataSourceFactory getDataSourceFactory(T configuration);
+    PooledDataSourceFactory getDataSourceFactory(T configuration);
 }

--- a/dropwizard-db/src/main/java/io/dropwizard/db/PooledDataSourceFactory.java
+++ b/dropwizard-db/src/main/java/io/dropwizard/db/PooledDataSourceFactory.java
@@ -1,0 +1,68 @@
+package io.dropwizard.db;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Optional;
+import io.dropwizard.util.Duration;
+
+import java.util.Map;
+
+/**
+ * Interface of a factory that produces JDBC data sources
+ * backed by the connection pool.
+ */
+public interface PooledDataSourceFactory {
+
+    /**
+     * Whether ORM tools allowed to add comments to SQL queries.
+     *
+     * @return {@code true}, if allowed
+     */
+    boolean isAutoCommentsEnabled();
+
+    /**
+     * Returns the configuration properties for ORM tools.
+     *
+     * @return configuration properties as a map
+     */
+    Map<String, String> getProperties();
+
+    /**
+     * Returns the timeout for awaiting a response from the database
+     * during connection health checks.
+     *
+     * @return the timeout as {@code Duration}
+     */
+    Optional<Duration> getHealthCheckValidationTimeout();
+
+    /**
+     * Returns the SQL query, which is being used for the database
+     * connection health check.
+     *
+     * @return the SQL query as a string
+     */
+    String getHealthCheckValidationQuery();
+
+    /**
+     * Returns the Java class of the database driver.
+     *
+     * @return the JDBC driver class as a string
+     */
+    String getDriverClass();
+
+    /**
+     * Configures the pool as a single connection pool.
+     * It's useful for tools that use only one database connection,
+     * such as database migrations.
+     */
+    void asSingleConnectionPool();
+
+    /**
+     * Builds a new JDBC data source backed by the connection pool
+     * and managed by Dropwizard.
+     *
+     * @param metricRegistry the application metric registry
+     * @param name           name of the connection pool
+     * @return a new JDBC data source as {@code ManagedDataSource}
+     */
+    ManagedDataSource build(MetricRegistry metricRegistry, String name);
+}

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/HibernateBundle.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/HibernateBundle.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.datatype.hibernate4.Hibernate4Module;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.Configuration;
 import io.dropwizard.ConfiguredBundle;
-import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.db.PooledDataSourceFactory;
 import io.dropwizard.db.DatabaseConfiguration;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
@@ -52,15 +52,15 @@ public abstract class HibernateBundle<T extends Configuration> implements Config
 
     @Override
     public final void run(T configuration, Environment environment) throws Exception {
-        final DataSourceFactory dbConfig = getDataSourceFactory(configuration);
+        final PooledDataSourceFactory dbConfig = getDataSourceFactory(configuration);
         this.sessionFactory = sessionFactoryFactory.build(this, environment, dbConfig, entities, name());
         environment.jersey().register(new UnitOfWorkApplicationListener(sessionFactory));
         environment.healthChecks().register(name(),
                                             new SessionFactoryHealthCheck(
                                                     environment.getHealthCheckExecutorService(),
-                                                    dbConfig.getValidationQueryTimeout().or(Duration.seconds(5)),
+                                                    dbConfig.getHealthCheckValidationTimeout().or(Duration.seconds(5)),
                                                     sessionFactory,
-                                                    dbConfig.getValidationQuery()));
+                                                    dbConfig.getHealthCheckValidationQuery()));
     }
 
     public SessionFactory getSessionFactory() {

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryFactory.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryFactory.java
@@ -1,7 +1,7 @@
 package io.dropwizard.hibernate;
 
 import com.google.common.collect.Sets;
-import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.db.PooledDataSourceFactory;
 import io.dropwizard.db.ManagedDataSource;
 import io.dropwizard.setup.Environment;
 import org.hibernate.SessionFactory;
@@ -25,14 +25,14 @@ public class SessionFactoryFactory {
 
     public SessionFactory build(HibernateBundle<?> bundle,
                                 Environment environment,
-                                DataSourceFactory dbConfig,
+                                PooledDataSourceFactory dbConfig,
                                 List<Class<?>> entities) {
         return build(bundle, environment, dbConfig, entities, DEFAULT_NAME);
     }
 
     public SessionFactory build(HibernateBundle<?> bundle,
                                 Environment environment,
-                                DataSourceFactory dbConfig,
+                                PooledDataSourceFactory dbConfig,
                                 List<Class<?>> entities,
                                 String name) {
         final ManagedDataSource dataSource = dbConfig.build(environment.metrics(), name);
@@ -41,7 +41,7 @@ public class SessionFactoryFactory {
 
     public SessionFactory build(HibernateBundle<?> bundle,
                                 Environment environment,
-                                DataSourceFactory dbConfig,
+                                PooledDataSourceFactory dbConfig,
                                 ManagedDataSource dataSource,
                                 List<Class<?>> entities) {
         final ConnectionProvider provider = buildConnectionProvider(dataSource,
@@ -65,7 +65,7 @@ public class SessionFactoryFactory {
     }
 
     private SessionFactory buildSessionFactory(HibernateBundle<?> bundle,
-                                               DataSourceFactory dbConfig,
+                                               PooledDataSourceFactory dbConfig,
                                                ConnectionProvider connectionProvider,
                                                Map<String, String> properties,
                                                List<Class<?>> entities) {

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/AbstractLiquibaseCommand.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/AbstractLiquibaseCommand.java
@@ -3,7 +3,7 @@ package io.dropwizard.migrations;
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.Configuration;
 import io.dropwizard.cli.ConfiguredCommand;
-import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.db.PooledDataSourceFactory;
 import io.dropwizard.db.DatabaseConfiguration;
 import io.dropwizard.db.ManagedDataSource;
 import io.dropwizard.setup.Bootstrap;
@@ -54,10 +54,8 @@ public abstract class AbstractLiquibaseCommand<T extends Configuration> extends 
     @Override
     @SuppressWarnings("UseOfSystemOutOrSystemErr")
     protected void run(Bootstrap<T> bootstrap, Namespace namespace, T configuration) throws Exception {
-        final DataSourceFactory dbConfig = strategy.getDataSourceFactory(configuration);
-        dbConfig.setMaxSize(1);
-        dbConfig.setMinSize(1);
-        dbConfig.setInitialSize(1);
+        final PooledDataSourceFactory dbConfig = strategy.getDataSourceFactory(configuration);
+        dbConfig.asSingleConnectionPool();
 
         try (final CloseableLiquibase liquibase = openLiquibase(dbConfig, namespace)) {
             run(namespace, liquibase);
@@ -67,7 +65,7 @@ public abstract class AbstractLiquibaseCommand<T extends Configuration> extends 
         }
     }
 
-    private CloseableLiquibase openLiquibase(final DataSourceFactory dataSourceFactory, final Namespace namespace)
+    private CloseableLiquibase openLiquibase(final PooledDataSourceFactory dataSourceFactory, final Namespace namespace)
             throws SQLException, LiquibaseException {
         final CloseableLiquibase liquibase;
         final ManagedDataSource dataSource = dataSourceFactory.build(new MetricRegistry(), "liquibase");


### PR DESCRIPTION
Dropwizard by default is shipped with the Tomcat JDBC Connection pool. It's mostly fine, but has some disadvantages (performance, limited metrics, handling network failures). It would be great if we had facility to plug-in other DB pools into Dropwizard. For example, Brett Wooldridge's
wonderful [HikariCP](https://github.com/brettwooldridge/HikariCP) or [BoneCP](http://jolbox.com/).

Of cource, nothing stops us from implementing a factory, that creates a `ManagedDataSource`. The problem is that `dropwizard-jdb`i, `dropwizard-hibernate` and` dropwizard-migrations` modules require `DataSourceFactory` for the configuration. `DataSourceFactory` is closely tied with the Tomcat pool. So if we use an another pool, we are forced to write own factories for JDBI, Hibernate, etc...

A solution is to provide an interface that abstracts a configuration of a connection pool. Database manipulation modules will be linked with the interface, but not with `DataSourceFactory`. A custom pool factory just need to implement this interface, and it could be plug-in as a Tomcat pool
replacement.

If we writed Dropwizard from the scratch we would move the Tomcat pool to a separate module from `dropwizard-db`. But now we have many users and it would be a nightmare for them to migrate to a new implementation.

So we are forced to retain the Tomcat JDBC pool in `dropwizard-db`. New pool users should be advised to exclude it manually in the Maven configuration.