### PR TITLE
Don't override the JVM timezone in a Hibernate integration test

### DIFF
--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
@@ -78,25 +78,15 @@ public class JerseyIntegrationTest extends JerseyTest {
     }
 
     private SessionFactory sessionFactory;
-    private TimeZone defaultTZ;
 
     @Override
     @After
     public void tearDown() throws Exception {
-        TimeZone.setDefault(defaultTZ);
         super.tearDown();
 
         if (sessionFactory != null) {
             sessionFactory.close();
         }
-    }
-
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
-
-        this.defaultTZ = TimeZone.getDefault();
-        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
     }
 
     @Override


### PR DESCRIPTION
HSQLDB correctly retrieves a timestamp from the DB in the JVM timezone, Jadira converts it to DateTime and then Jackson serializes it to JSON in UTC.

So all assertions in UTC will pass regardless of the JVM timezone.