### PR TITLE
Descriptive constraint violation messages

### DIFF
--- a/dropwizard-benchmarks/src/main/java/io/dropwizard/benchmarks/jersey/ConstraintViolationBenchmark.java
+++ b/dropwizard-benchmarks/src/main/java/io/dropwizard/benchmarks/jersey/ConstraintViolationBenchmark.java
@@ -1,0 +1,84 @@
+package io.dropwizard.benchmarks.jersey;
+
+import io.dropwizard.jersey.validation.ConstraintMessage;
+import org.hibernate.validator.constraints.NotEmpty;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Valid;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.executable.ExecutableValidator;
+import javax.ws.rs.HeaderParam;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.commons.lang3.reflect.MethodUtils.getAccessibleMethod;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class ConstraintViolationBenchmark {
+
+    public static class Resource {
+        public String paramFunc(@HeaderParam("cheese") @NotEmpty String secretSauce) {
+            return secretSauce;
+        }
+
+        public String objectFunc(@Valid Foo foo) {
+            return foo.toString();
+        }
+    }
+
+    public static class Foo {
+        @NotEmpty
+        private String bar;
+    }
+
+    private ConstraintViolation<ConstraintViolationBenchmark.Resource> paramViolation;
+    private ConstraintViolation<ConstraintViolationBenchmark.Resource> objViolation;
+
+    @Setup
+    public void prepare() {
+        final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        final ExecutableValidator execValidator = validator.forExecutables();
+
+        Set<ConstraintViolation<ConstraintViolationBenchmark.Resource>> paramViolations =
+            execValidator.validateParameters(
+                new Resource(),
+                getAccessibleMethod(ConstraintViolationBenchmark.Resource.class, "paramFunc", String.class),
+                new Object[]{""} // the parameter value
+            );
+        paramViolation = paramViolations.iterator().next();
+
+        Set<ConstraintViolation<ConstraintViolationBenchmark.Resource>> objViolations =
+            execValidator.validateParameters(
+                new Resource(),
+                getAccessibleMethod(ConstraintViolationBenchmark.Resource.class, "objectFunc", Foo.class),
+                new Object[]{new Foo()} // the parameter value
+            );
+        objViolation = objViolations.iterator().next();
+    }
+
+    @Benchmark
+    public String paramViolation() {
+        return ConstraintMessage.getMessage(paramViolation);
+    }
+
+    @Benchmark
+    public String objViolation() {
+        return ConstraintMessage.getMessage(objViolation);
+    }
+
+    public static void main(String[] args) throws Exception {
+        new Runner(new OptionsBuilder()
+                .include(ConstraintViolationBenchmark.class.getSimpleName())
+                .forks(1)
+                .warmupIterations(5)
+                .measurementIterations(5)
+                .build())
+                .run();
+    }
+}

--- a/dropwizard-jersey/pom.xml
+++ b/dropwizard-jersey/pom.xml
@@ -126,5 +126,9 @@
             <artifactId>jetty-continuation</artifactId>
             <version>${jetty.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ConstraintMessage.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ConstraintMessage.java
@@ -1,0 +1,113 @@
+package io.dropwizard.jersey.validation;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Iterables;
+import io.dropwizard.validation.ConstraintViolations;
+import io.dropwizard.validation.ValidationMethod;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.commons.lang3.reflect.MethodUtils;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ElementKind;
+import javax.validation.Path;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+
+public class ConstraintMessage {
+    /**
+     * Gets the human friendly location of where the violation was raised.
+     */
+    public static String getMessage(ConstraintViolation<?> v) {
+        final Optional<String> returnValueName = getMethodReturnValueName(v);
+        if (returnValueName.isPresent()) {
+            final String name = isValidationMethod(v) ?
+                    StringUtils.substringBeforeLast(returnValueName.get(), ".") : returnValueName.get();
+            return name + " " + v.getMessage();
+        } else if (isValidationMethod(v)) {
+            return ConstraintViolations.validationMethodFormatted(v);
+        } else {
+            final String name = getMemberName(v).or(v.getPropertyPath().toString());
+            return name + " " + v.getMessage();
+        }
+    }
+
+    /**
+     * Gets a method parameter (or a parameter field) name, if the violation raised in it.
+     */
+    private static Optional<String> getMemberName(ConstraintViolation<?> violation) {
+        final int size = Iterables.size(violation.getPropertyPath());
+        if (size < 2) {
+            return Optional.absent();
+        }
+
+        final Path.Node parent = Iterables.get(violation.getPropertyPath(), size - 2);
+        final Path.Node member = Iterables.getLast(violation.getPropertyPath());
+        final Class<?> resourceClass = violation.getLeafBean().getClass();
+        switch (parent.getKind()) {
+            case PARAMETER:
+                Field field = FieldUtils.getDeclaredField(resourceClass, member.getName(), true);
+                return getMemberName(field.getDeclaredAnnotations());
+            case METHOD:
+                List<Class<?>> params = parent.as(Path.MethodNode.class).getParameterTypes();
+                Class<?>[] parcs = params.toArray(new Class<?>[params.size()]);
+                Method method = MethodUtils.getAccessibleMethod(resourceClass, parent.getName(), parcs);
+
+                int paramIndex = member.as(Path.ParameterNode.class).getParameterIndex();
+                return getMemberName(method.getParameterAnnotations()[paramIndex]);
+            default:
+                return Optional.absent();
+        }
+    }
+
+    /**
+     * Gets the method return value name, if the violation is raised in it
+     */
+    private static Optional<String> getMethodReturnValueName(ConstraintViolation<?> violation) {
+        int returnValueNames = -1;
+
+        final StringBuilder result = new StringBuilder("server response");
+        for (Path.Node node : violation.getPropertyPath()) {
+            if (node.getKind().equals(ElementKind.RETURN_VALUE)) {
+                returnValueNames = 0;
+            } else if (returnValueNames >= 0) {
+                result.append(returnValueNames++ == 0 ? " " : ".").append(node);
+            }
+        }
+
+        return returnValueNames >= 0 ? Optional.of(result.toString()) : Optional.<String>absent();
+    }
+
+    /**
+     * Derives member's name and type from it's annotations
+     */
+    private static Optional<String> getMemberName(Annotation[] memberAnnotations) {
+        for (Annotation a : memberAnnotations) {
+            if (a instanceof QueryParam) {
+                return Optional.of("query param " + ((QueryParam) a).value());
+            } else if (a instanceof PathParam) {
+                return Optional.of("path param " + ((PathParam) a).value());
+            } else if (a instanceof HeaderParam) {
+                return Optional.of("header " + ((HeaderParam) a).value());
+            } else if (a instanceof CookieParam) {
+                return Optional.of("cookie " + ((CookieParam) a).value());
+            } else if (a instanceof FormParam) {
+                return Optional.of("form field " + ((FormParam) a).value());
+            } else if (a instanceof Context) {
+                return Optional.of("context");
+            } else if (a instanceof MatrixParam) {
+                return Optional.of("matrix param " + ((MatrixParam) a).value());
+            }
+        }
+
+        return Optional.absent();
+    }
+
+    private static boolean isValidationMethod(ConstraintViolation<?> v) {
+        return v.getConstraintDescriptor().getAnnotation() instanceof ValidationMethod;
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ValidationErrorMessage.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ValidationErrorMessage.java
@@ -2,16 +2,12 @@ package io.dropwizard.jersey.validation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
-import io.dropwizard.validation.ConstraintViolations;
-
-import javax.validation.ConstraintViolation;
-import java.util.Set;
 
 public class ValidationErrorMessage {
     private final ImmutableList<String> errors;
 
-    public ValidationErrorMessage(Set<ConstraintViolation<?>> errors) {
-        this.errors = ConstraintViolations.formatUntyped(errors);
+    public ValidationErrorMessage(ImmutableList<String> errors) {
+        this.errors = errors;
     }
 
     @JsonProperty

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Form;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Locale;
@@ -46,7 +47,7 @@ public class ConstraintViolationExceptionMapperTest extends JerseyTest {
                 .queryParam("name", "dropwizard").request().get();
         assertThat(response.getStatus()).isEqualTo(500);
 
-        String ret = "{\"errors\":[\"blaze.<return value> length must be between 0 and 3\"]}";
+        String ret = "{\"errors\":[\"server response length must be between 0 and 3\"]}";
         assertThat(response.readEntity(String.class)).isEqualTo(ret);
     }
 
@@ -58,7 +59,7 @@ public class ConstraintViolationExceptionMapperTest extends JerseyTest {
 
         assertThat(response.getStatus()).isEqualTo(400);
 
-        String ret = "{\"errors\":[\"blaze.arg0 length must be between 3 and 2147483647\"]}";
+        String ret = "{\"errors\":[\"query param name length must be between 3 and 2147483647\"]}";
         assertThat(response.readEntity(String.class)).isEqualTo(ret);
     }
 
@@ -69,7 +70,94 @@ public class ConstraintViolationExceptionMapperTest extends JerseyTest {
                 .request().get();
         assertThat(response.getStatus()).isEqualTo(400);
 
-        String ret = "{\"errors\":[\"blazer.arg0.name may not be empty\"]}";
+        String ret = "{\"errors\":[\"query param name may not be empty\"]}";
+        assertThat(response.readEntity(String.class)).isEqualTo(ret);
+    }
+
+    @Test
+    public void getInvalidHeaderParamsIs400() throws Exception {
+        final Response response = target("/valid/head")
+                .request().get();
+        assertThat(response.getStatus()).isEqualTo(400);
+
+        String ret = "{\"errors\":[\"header cheese may not be empty\"]}";
+        assertThat(response.readEntity(String.class)).isEqualTo(ret);
+    }
+
+    @Test
+    public void getInvalidCookieParamsIs400() throws Exception {
+        final Response response = target("/valid/cooks")
+                .request().get();
+        assertThat(response.getStatus()).isEqualTo(400);
+
+        String ret = "{\"errors\":[\"cookie user_id may not be empty\"]}";
+        assertThat(response.readEntity(String.class)).isEqualTo(ret);
+    }
+
+    @Test
+    public void getInvalidPathParamsIs400() throws Exception {
+        final Response response = target("/valid/goods/11")
+                .request().get();
+        assertThat(response.getStatus()).isEqualTo(400);
+
+        String ret = "{\"errors\":[\"path param id not a well-formed email address\"]}";
+        assertThat(response.readEntity(String.class)).isEqualTo(ret);
+    }
+
+    @Test
+    public void getInvalidFormParamsIs400() throws Exception {
+        final Response response = target("/valid/form")
+                .request().post(Entity.form(new Form()));
+        assertThat(response.getStatus()).isEqualTo(400);
+
+        String ret = "{\"errors\":[\"form field username may not be empty\"]}";
+        assertThat(response.readEntity(String.class)).isEqualTo(ret);
+    }
+
+    @Test
+    public void postInvalidMethodClassIs422() throws Exception {
+        final Response response = target("/valid/nothing")
+                .request().post(Entity.entity("{}", MediaType.APPLICATION_JSON_TYPE));
+        assertThat(response.getStatus()).isEqualTo(422);
+
+        String ret = "{\"errors\":[\"must have a false thing\"]}";
+        assertThat(response.readEntity(String.class)).isEqualTo(ret);
+    }
+
+    @Test
+    public void getInvalidNestedReturnIs500() throws Exception {
+        final Response response = target("/valid/nested").request().get();
+        assertThat(response.getStatus()).isEqualTo(500);
+
+        String ret = "{\"errors\":[\"server response representation.name may not be empty\"]}";
+        assertThat(response.readEntity(String.class)).isEqualTo(ret);
+    }
+
+    @Test
+    public void getInvalidNested2ReturnIs500() throws Exception {
+        final Response response = target("/valid/nested2").request().get();
+        assertThat(response.getStatus()).isEqualTo(500);
+
+        String ret = "{\"errors\":[\"server response example must have a false thing\"]}";
+        assertThat(response.readEntity(String.class)).isEqualTo(ret);
+    }
+
+    @Test
+    public void getInvalidContextIs400() throws Exception {
+        final Response response = target("/valid/context").request().get();
+        assertThat(response.getStatus()).isEqualTo(400);
+
+        String ret = "{\"errors\":[\"context may not be null\"]}";
+        assertThat(response.readEntity(String.class)).isEqualTo(ret);
+    }
+
+    @Test
+    public void getInvalidMatrixParamIs400() throws Exception {
+        final Response response = target("/valid/matrix")
+                .matrixParam("bob", "").request().get();
+        assertThat(response.getStatus()).isEqualTo(400);
+
+        String ret = "{\"errors\":[\"matrix param bob may not be empty\"]}";
         assertThat(response.readEntity(String.class)).isEqualTo(ret);
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/FailingExample.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/FailingExample.java
@@ -1,0 +1,10 @@
+package io.dropwizard.jersey.validation;
+
+import io.dropwizard.validation.ValidationMethod;
+
+public class FailingExample {
+    @ValidationMethod(message = "must have a false thing")
+    public boolean isFail() {
+        return false;
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
@@ -1,13 +1,16 @@
 package io.dropwizard.jersey.validation;
 
 import io.dropwizard.validation.Validated;
+import org.hibernate.validator.constraints.Email;
 import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.NotEmpty;
 
+import javax.servlet.ServletContext;
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
-import java.io.IOException;
 
 @Path("/valid/")
 @Produces(MediaType.APPLICATION_JSON)
@@ -15,7 +18,7 @@ import java.io.IOException;
 public class ValidatingResource {
     @POST
     @Path("foo")
-    public String blah(@Validated ValidRepresentation representation) throws IOException {
+    public String blah(@Validated ValidRepresentation representation) {
         return representation.getName();
     }
 
@@ -30,5 +33,66 @@ public class ValidatingResource {
     @Path("zoo")
     public String blazer(@Valid @BeanParam BeanParameter params) {
         return params.getName();
+    }
+
+    @GET
+    @Path("head")
+    public String heads(@HeaderParam("cheese") @NotEmpty String secretSauce) {
+        return secretSauce;
+    }
+
+    @GET
+    @Path("cooks")
+    public String cooks(@CookieParam("user_id") @NotEmpty String secretSauce) {
+        return secretSauce;
+    }
+
+    @GET
+    @Path("goods/{id}")
+    public String pather(@PathParam("id") @Email String is) {
+        return is;
+    }
+
+    @POST
+    @Path("form")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    public String form(@FormParam("username") @NotEmpty String secretSauce) {
+        return secretSauce;
+    }
+
+    @GET
+    @Path("nested")
+    @Valid
+    public WrappedValidRepresentation nested() {
+        WrappedValidRepresentation result = new WrappedValidRepresentation();
+        result.setRepresentation(new ValidRepresentation());
+        return result;
+    }
+
+    @GET
+    @Path("nested2")
+    @Valid
+    public WrappedFailingExample nested2() {
+        WrappedFailingExample result = new WrappedFailingExample();
+        result.setExample(new FailingExample());
+        return result;
+    }
+
+    @GET
+    @Path("context")
+    public String contextual(@Valid @Context @NotNull ServletContext con) {
+        return "A";
+    }
+
+    @GET
+    @Path("matrix")
+    public String matrixParam(@MatrixParam("bob") @NotEmpty String param) {
+        return param;
+    }
+
+    @POST
+    @Path("nothing")
+    public FailingExample valmeth(@Valid FailingExample exam) {
+        return exam;
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
@@ -1,5 +1,6 @@
 package io.dropwizard.jersey.validation;
 
+import io.dropwizard.jersey.params.IntParam;
 import io.dropwizard.validation.Validated;
 import org.hibernate.validator.constraints.Email;
 import org.hibernate.validator.constraints.Length;
@@ -39,6 +40,12 @@ public class ValidatingResource {
     @Path("head")
     public String heads(@HeaderParam("cheese") @NotEmpty String secretSauce) {
         return secretSauce;
+    }
+
+    @GET
+    @Path("headCopy")
+    public String heads(@QueryParam("cheese") @NotNull IntParam secretSauce) {
+        return secretSauce.get().toString();
     }
 
     @GET

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/WrappedFailingExample.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/WrappedFailingExample.java
@@ -1,0 +1,20 @@
+package io.dropwizard.jersey.validation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.Valid;
+
+public class WrappedFailingExample {
+    @Valid
+    private FailingExample example;
+
+    @JsonProperty
+    public FailingExample getExample() {
+        return example;
+    }
+
+    @JsonProperty
+    public void setExample(FailingExample example) {
+        this.example = example;
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/WrappedValidRepresentation.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/WrappedValidRepresentation.java
@@ -1,0 +1,20 @@
+package io.dropwizard.jersey.validation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.Valid;
+
+public class WrappedValidRepresentation {
+    @Valid
+    private ValidRepresentation representation;
+
+    @JsonProperty
+    public ValidRepresentation getRepresentation() {
+        return representation;
+    }
+
+    @JsonProperty
+    public void setRepresentation(ValidRepresentation representation) {
+        this.representation = representation;
+    }
+}

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/ConstraintViolations.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/ConstraintViolations.java
@@ -11,19 +11,23 @@ import javax.validation.Path;
 import java.util.Set;
 
 public class ConstraintViolations {
+    private static final Joiner DOT_JOINER = Joiner.on('.');
+
     private ConstraintViolations() { /* singleton */ }
 
     public static <T> String format(ConstraintViolation<T> v) {
         if (v.getConstraintDescriptor().getAnnotation() instanceof ValidationMethod) {
-            final ImmutableList<Path.Node> nodes = ImmutableList.copyOf(v.getPropertyPath());
-            final ImmutableList<Path.Node> usefulNodes = nodes.subList(0, nodes.size() - 1);
-            final String msg = v.getMessage().startsWith(".") ? "%s%s" : "%s %s";
-            return String.format(msg,
-                                 Joiner.on('.').join(usefulNodes),
-                                 v.getMessage()).trim();
+            return validationMethodFormatted(v);
         } else {
             return String.format("%s %s", v.getPropertyPath(), v.getMessage());
         }
+    }
+
+    public static <T> String validationMethodFormatted(ConstraintViolation<T> v) {
+        final ImmutableList<Path.Node> nodes = ImmutableList.copyOf(v.getPropertyPath());
+        String usefulNodes = DOT_JOINER.join(nodes.subList(0, nodes.size() - 1));
+        String msg = usefulNodes + (v.getMessage().startsWith(".") ? "" : " ") + v.getMessage();
+        return msg.trim();
     }
 
     public static <T> ImmutableList<String> format(Set<ConstraintViolation<T>> violations) {


### PR DESCRIPTION
This pull requests attempts to return user friendly error messages when constraints are violated either in the response or the request.

So instead of error messages of

```json
{"errors":["blazer.arg0.name may not be empty"]}
```
and

```json
{"errors":["blaze.<return value> length must be between 0 and 3"]}
```
more user friendly error messages are returned

```json
{"errors":["query param name may not be empty"]}
```
```json
{"errors":["server response length must be between 0 and 3"]}
```

This pull request isn't done, so don't merge (hardly any documentation and I didn't completely mull over edge cases). As it happens, I'll be off the grid for the next couple weeks, but I wanted to get some eyes on the code (hence the pull request), but if someone is extremely enthusiastic they can carry this pull request the rest of the way, else I'll pick off where I left off and incorporate any suggestions in the pull request.

The code isn't fast, concise, documented, or complete -- but it passes all the test cases I wrote for it :smile:

Opinions wanted!