### PR TITLE
Add Logback appender for logging to MongoDB

### DIFF
--- a/dropwizard-logging/pom.xml
+++ b/dropwizard-logging/pom.xml
@@ -72,6 +72,11 @@
             <artifactId>jetty-util</artifactId>
             <version>${jetty.version}</version>
         </dependency>
+			<dependency>
+				<groupId>org.mongodb</groupId>
+				<artifactId>mongo-java-driver</artifactId>
+				<version>${mongodb.version}</version>
+			</dependency>        
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-configuration</artifactId>

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/MongoDBAppender.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/MongoDBAppender.java
@@ -1,5 +1,7 @@
 package io.dropwizard.logging;
 
+import io.dropwizard.util.Size;
+
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Date;
@@ -47,7 +49,7 @@ public class MongoDBAppender extends UnsynchronizedAppenderBase<ILoggingEvent>{
 
     private int socketTimeout;
 
-    private boolean slaveOk;
+    private ReadPreference readPreference;
 
     private int w;
 
@@ -57,7 +59,7 @@ public class MongoDBAppender extends UnsynchronizedAppenderBase<ILoggingEvent>{
 
     private boolean capped = false;
 
-    private long size = 10000;
+    private Size size;
 
     private long max = 10000;    
     
@@ -118,7 +120,7 @@ public class MongoDBAppender extends UnsynchronizedAppenderBase<ILoggingEvent>{
         builder.connectTimeout(connectTimeout);
         builder.socketTimeout(socketTimeout);
         builder.writeConcern(new WriteConcern(w, wtimeout, fsync, false));
-        builder.readPreference(slaveOk ? ReadPreference.secondaryPreferred() : ReadPreference.primaryPreferred());
+        builder.readPreference(this.readPreference);
 
         return builder.build();
     }
@@ -127,7 +129,7 @@ public class MongoDBAppender extends UnsynchronizedAppenderBase<ILoggingEvent>{
         if(!db.getCollectionNames().contains(collectionName)) {
             BasicDBObject dbObject = new BasicDBObject("create", collectionName);
             dbObject.put("capped", capped);
-            dbObject.put("size", size);
+            dbObject.put("size", size.toBytes());
             dbObject.put("max", max);
             CommandResult cappedResult = db.command(dbObject);
         }
@@ -178,9 +180,6 @@ public class MongoDBAppender extends UnsynchronizedAppenderBase<ILoggingEvent>{
 		this.socketTimeout = socketTimeout;
 	}
 
-	public void setSlaveOk(boolean slaveOk) {
-		this.slaveOk = slaveOk;
-	}
 
 	public void setW(int w) {
 		this.w = w;
@@ -198,12 +197,16 @@ public class MongoDBAppender extends UnsynchronizedAppenderBase<ILoggingEvent>{
 		this.capped = capped;
 	}
 
-	public void setSize(long size) {
+	public void setSize(Size size) {
 		this.size = size;
 	}
 
 	public void setMax(long max) {
 		this.max = max;
+	}
+
+	public void setReadPreference(ReadPreference readPreference) {
+		this.readPreference = readPreference;
 	}
 
 }

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/MongoDBAppender.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/MongoDBAppender.java
@@ -1,0 +1,209 @@
+package io.dropwizard.logging;
+
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.UnsynchronizedAppenderBase;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.CommandResult;
+import com.mongodb.DB;
+import com.mongodb.DBCollection;
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoClientOptions.Builder;
+import com.mongodb.MongoCredential;
+import com.mongodb.ReadPreference;
+import com.mongodb.ServerAddress;
+import com.mongodb.WriteConcern;
+
+public class MongoDBAppender extends UnsynchronizedAppenderBase<ILoggingEvent>{
+	
+    private DBCollection eventsCollection;
+    private MongoClient mongoClient;
+    
+    private String host = "localhost";
+
+    private int port = 27017;
+    
+    private String dbName = "db";
+
+    private String collectionName;
+
+    private String username;
+
+    private String password;
+
+    private int connectionsPerHost = 10;
+
+    private int threadsAllowedToBlockForConnectionMultiplier = 5;
+
+    private int maxWaitTime = 1000 * 60 * 2;
+
+    private int connectTimeout;
+
+    private int socketTimeout;
+
+    private boolean slaveOk;
+
+    private int w;
+
+    private int wtimeout;
+
+    private boolean fsync;
+
+    private boolean capped = false;
+
+    private long size = 10000;
+
+    private long max = 10000;    
+    
+    @Override
+	public void start() {
+        try {
+            connectToMongoDB();
+            super.start();
+        } catch (UnknownHostException e) {
+            addError("Error connecting to MongoDB server: " + host + ":" + port, e);
+        }
+	}
+
+	@Override
+	public void stop() {
+        if (mongoClient != null) {
+            mongoClient.close();
+        }
+        super.stop();
+	}
+
+	protected BasicDBObject toMongoDocument(ILoggingEvent event) {
+        final BasicDBObject doc = new BasicDBObject();
+        doc.append("timestamp", new Date(event.getTimeStamp()));
+        doc.append("logger", event.getLoggerName());
+        doc.append("level", event.getLevel().levelStr);
+        doc.append("thread", event.getThreadName());
+        doc.append("mdc", event.getMDCPropertyMap());
+        doc.append("message", event.getFormattedMessage());
+        return doc;
+    }
+
+	@Override
+	protected void append(ILoggingEvent eventObject) {
+		eventsCollection.insert(toMongoDocument(eventObject));		
+	}
+	
+    private void connectToMongoDB() throws UnknownHostException {
+
+        if ((username != null) && (password != null)) {
+            List<MongoCredential> credentialList = new ArrayList<>();
+            credentialList.add(MongoCredential.createMongoCRCredential(username, dbName, password.toCharArray()));
+            mongoClient = new MongoClient(new ServerAddress(host, port), credentialList, buildOptions());
+        }
+        else{
+            mongoClient = new MongoClient(new ServerAddress(host, port), buildOptions());
+        }
+        final DB db = mongoClient.getDB(dbName);
+        capIfNew(db);
+        eventsCollection = db.getCollection(collectionName);
+    }
+    
+    private MongoClientOptions buildOptions() {
+        final Builder builder = MongoClientOptions.builder();
+        builder.connectionsPerHost(connectionsPerHost);
+        builder.threadsAllowedToBlockForConnectionMultiplier(threadsAllowedToBlockForConnectionMultiplier);
+        builder.maxWaitTime(maxWaitTime);
+        builder.connectTimeout(connectTimeout);
+        builder.socketTimeout(socketTimeout);
+        builder.writeConcern(new WriteConcern(w, wtimeout, fsync, false));
+        builder.readPreference(slaveOk ? ReadPreference.secondaryPreferred() : ReadPreference.primaryPreferred());
+
+        return builder.build();
+    }
+    
+    private void capIfNew(DB db) {
+        if(!db.getCollectionNames().contains(collectionName)) {
+            BasicDBObject dbObject = new BasicDBObject("create", collectionName);
+            dbObject.put("capped", capped);
+            dbObject.put("size", size);
+            dbObject.put("max", max);
+            CommandResult cappedResult = db.command(dbObject);
+        }
+    }
+
+	public void setHost(String host) {
+		this.host = host;
+	}
+
+	public void setPort(int port) {
+		this.port = port;
+	}
+
+	public void setDbName(String dbName) {
+		this.dbName = dbName;
+	}
+
+	public void setCollectionName(String collectionName) {
+		this.collectionName = collectionName;
+	}
+
+	public void setUsername(String username) {
+		this.username = username;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+
+	public void setConnectionsPerHost(int connectionsPerHost) {
+		this.connectionsPerHost = connectionsPerHost;
+	}
+
+	public void setThreadsAllowedToBlockForConnectionMultiplier(
+			int threadsAllowedToBlockForConnectionMultiplier) {
+		this.threadsAllowedToBlockForConnectionMultiplier = threadsAllowedToBlockForConnectionMultiplier;
+	}
+
+	public void setMaxWaitTime(int maxWaitTime) {
+		this.maxWaitTime = maxWaitTime;
+	}
+
+	public void setConnectTimeout(int connectTimeout) {
+		this.connectTimeout = connectTimeout;
+	}
+
+	public void setSocketTimeout(int socketTimeout) {
+		this.socketTimeout = socketTimeout;
+	}
+
+	public void setSlaveOk(boolean slaveOk) {
+		this.slaveOk = slaveOk;
+	}
+
+	public void setW(int w) {
+		this.w = w;
+	}
+
+	public void setWtimeout(int wtimeout) {
+		this.wtimeout = wtimeout;
+	}
+
+	public void setFsync(boolean fsync) {
+		this.fsync = fsync;
+	}
+
+	public void setCapped(boolean capped) {
+		this.capped = capped;
+	}
+
+	public void setSize(long size) {
+		this.size = size;
+	}
+
+	public void setMax(long max) {
+		this.max = max;
+	}
+
+}

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/MongoDBAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/MongoDBAppenderFactory.java
@@ -1,19 +1,19 @@
 package io.dropwizard.logging;
 
-import java.util.Locale;
-import java.util.regex.Matcher;
+import io.dropwizard.util.Size;
 
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.mongodb.MongoClient;
-
 import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.net.SyslogAppender;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.Layout;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.mongodb.ReadPreference;
 
 
 /**
@@ -62,9 +62,49 @@ import ch.qos.logback.core.Layout;
  *         <td>The login password.If Auth is active.</td>
  *     </tr>
  *     <tr>
- *         <td>{@code slaveOk}</td>
- *         <td>true</td>
- *         <td>Reading from secondary is allowed when in a replication set.</td>
+ *         <td>{@code connectionsPerHost}</td>
+ *         <td>10</td>
+ *         <td>The maximum number of connections allowed per host for this Mongo instance.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code threadsAllowedToBlockForConnectionMultiplier}</td>
+ *         <td>5</td>
+ *         <td>This multiplier, multiplied with the connectionsPerHost setting, gives the maximum number of threads that may be waiting for a connection to become available from the pool.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code maxWaitTime}</td>
+ *         <td>120000</td>
+ *         <td>The maximum wait time in ms that a thread may wait for a connection to become available.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code connectTimeout}</td>
+ *         <td>1000</td>
+ *         <td>The connection timeout in milliseconds.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code socketTimeout}</td>
+ *         <td>0</td>
+ *         <td>The socket timeout in milliseconds It is used for I/O socket read and write operations Socket.setSoTimeout(int) Default is 0 and means no timeout.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code readPreference}</td>
+ *         <td>secondaryPreferred</td>
+ *         <td>Specify preferred replica set members to which a query or command can be sent.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code w}</td>
+ *         <td>0</td>
+ *         <td>Controls the acknowledgment of write operations with various options.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code wtimeout}</td>
+ *         <td>0: indefinite</td>
+ *         <td>how long to wait for slaves before failing</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code fsync}</td>
+ *         <td>false</td>
+ *         <td>If true and the server is running without journaling, blocks until the server has synced all data files to disk. If the server is running with journaling, this acts the same as the j option, blocking until write operations have been committed to the journal. Cannot be used in combination with j. In almost all cases the j flag should be used in preference to this one.</td>
  *     </tr>
  *     <tr>
  *         <td>{@code capped}</td>
@@ -78,8 +118,11 @@ import ch.qos.logback.core.Layout;
  *     </tr>
  *     <tr>
  *         <td>{@code max}</td>
- *         <td>10000</td>
- *         <td>If {@code capped} {@code max} is the maximum disk for the collection.</td>
+ *         <td>OPTIONAL</td>
+ *         <td>If {@code capped} {@code max} is the maximum disk for the collection. The value can be expressed
+ *             in bytes, kilobytes, megabytes, gigabytes, and terabytes by appending B, K, MB, GB, or TB to the
+ *             numeric value.  Examples include 100MB, 1GB, 1TB.  Sizes can also be spelled out, such as 100 megabytes,
+ *             1 gigabyte, 1 terabyte.</td>
  *     </tr>
 
  * </table>
@@ -93,6 +136,8 @@ public class MongoDBAppenderFactory extends AbstractAppenderFactory {
     private String host = "localhost";
 
 	@NotNull
+	@Min(1)
+	@Max(65535)
     private int port = 27017;
     
 	@NotNull
@@ -103,29 +148,31 @@ public class MongoDBAppenderFactory extends AbstractAppenderFactory {
 
     private String password;
     
-
+    @Min(1)
     private int connectionsPerHost = 10;
 
     private int threadsAllowedToBlockForConnectionMultiplier = 5;
-
-    private int maxWaitTime = 1000 * 60 * 2;
-
+    @Min(100)
+    private int maxWaitTime = 120000;
+    @Min(1)
     private int connectTimeout = 1000;
+    @Min(0)
+    private int socketTimeout = 0;
 
-    private int socketTimeout = 1000;
+    @NotNull
+    private String readPreference = "secondaryPreferred";
 
-    private boolean slaveOk = true;
-
+    @Min(0)
     private int w = 0;
 
-    private int wtimeout =1000;
+    private int wtimeout =0;
 
     private boolean fsync = false;
 
     private boolean capped = false;
 
-    private long size = 10000;
-
+    private Size size;
+    @Min(1)
     private long max = 10000;   
 
     @NotNull
@@ -150,7 +197,7 @@ public class MongoDBAppenderFactory extends AbstractAppenderFactory {
         appender.setPassword(password);
         appender.setPort(port);
         appender.setSize(size);
-        appender.setSlaveOk(slaveOk);
+        appender.setReadPreference(ReadPreference.valueOf(readPreference));
         appender.setSocketTimeout(socketTimeout);
         appender.setThreadsAllowedToBlockForConnectionMultiplier(threadsAllowedToBlockForConnectionMultiplier);
         appender.setUsername(username);
@@ -233,13 +280,7 @@ public class MongoDBAppenderFactory extends AbstractAppenderFactory {
 	public void setSocketTimeout(int socketTimeout) {
 		this.socketTimeout = socketTimeout;
 	}
-	@JsonProperty
-	public boolean isSlaveOk() {
-		return slaveOk;
-	}
-	public void setSlaveOk(boolean slaveOk) {
-		this.slaveOk = slaveOk;
-	}
+
 	@JsonProperty
 	public int getW() {
 		return w;
@@ -269,10 +310,10 @@ public class MongoDBAppenderFactory extends AbstractAppenderFactory {
 		this.capped = capped;
 	}
 	@JsonProperty
-	public long getSize() {
+	public Size getSize() {
 		return size;
 	}
-	public void setSize(long size) {
+	public void setSize(Size size) {
 		this.size = size;
 	}
 	@JsonProperty
@@ -288,6 +329,13 @@ public class MongoDBAppenderFactory extends AbstractAppenderFactory {
 	}
 	public void setCollectionName(String collectionName) {
 		this.collectionName = collectionName;
+	}
+	@JsonProperty
+	public String getReadPreference() {
+		return readPreference;
+	}
+	public void setReadPreference(String readPreference) {
+		this.readPreference = readPreference;
 	}
 
 }

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/MongoDBAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/MongoDBAppenderFactory.java
@@ -1,0 +1,293 @@
+package io.dropwizard.logging;
+
+import java.util.Locale;
+import java.util.regex.Matcher;
+
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.mongodb.MongoClient;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.net.SyslogAppender;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.Layout;
+
+
+/**
+ * An {@link AppenderFactory} implementation which provides an appender that writes events to a MongoDB.
+ * <p/>
+ * <b>Configuration Parameters:</b>
+ * <table>
+ *     <tr>
+ *         <td>Name</td>
+ *         <td>Default</td>
+ *         <td>Description</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code type}</td>
+ *         <td><b>REQUIRED</b></td>
+ *         <td>The appender type. Must be {@code mongodb}.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code threshold}</td>
+ *         <td>{@code ALL}</td>
+ *         <td>The lowest level of events to print to the console.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code host}</td>
+ *         <td><b>REQUIRED</b></td>
+ *         <td>IP or host name of the server running the mongo daemon.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code host}</td>
+ *         <td>27017</td>
+ *         <td>Port of the mongo daemon.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code dbName}</td>
+ *         <td><b>REQUIRED</b></td>
+ *         <td>The name of the database in the mongodb.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code username}</td>
+ *         <td><b>OPTIONAL</b></td>
+ *         <td>The login username.If Auth is active.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code password}</td>
+ *         <td><b>OPTIONAL</b></td>
+ *         <td>The login password.If Auth is active.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code slaveOk}</td>
+ *         <td>true</td>
+ *         <td>Reading from secondary is allowed when in a replication set.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code capped}</td>
+ *         <td>false</td>
+ *         <td>If the targeted collection should be capped in number of documents or disk space.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code size}</td>
+ *         <td>10000</td>
+ *         <td>If {@code capped} {@code size} is the maximum number of documents in the collection.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code max}</td>
+ *         <td>10000</td>
+ *         <td>If {@code capped} {@code max} is the maximum disk for the collection.</td>
+ *     </tr>
+
+ * </table>
+ *
+ * @see AbstractAppenderFactory
+ */
+@JsonTypeName("mongodb")
+public class MongoDBAppenderFactory extends AbstractAppenderFactory {
+	
+	@NotNull
+    private String host = "localhost";
+
+	@NotNull
+    private int port = 27017;
+    
+	@NotNull
+    private String dbName;
+
+
+    private String username;
+
+    private String password;
+    
+
+    private int connectionsPerHost = 10;
+
+    private int threadsAllowedToBlockForConnectionMultiplier = 5;
+
+    private int maxWaitTime = 1000 * 60 * 2;
+
+    private int connectTimeout = 1000;
+
+    private int socketTimeout = 1000;
+
+    private boolean slaveOk = true;
+
+    private int w = 0;
+
+    private int wtimeout =1000;
+
+    private boolean fsync = false;
+
+    private boolean capped = false;
+
+    private long size = 10000;
+
+    private long max = 10000;   
+
+    @NotNull
+    private String collectionName = "logging";
+	
+    @Override
+	public Appender<ILoggingEvent> build(LoggerContext context,
+			String applicationName, Layout<ILoggingEvent> layout) {
+        final MongoDBAppender appender = new MongoDBAppender();
+        appender.setName("mongodb-appender");
+        appender.setContext(context);
+        
+        appender.setCapped(capped);
+        appender.setCollectionName(collectionName);
+        appender.setConnectionsPerHost(connectionsPerHost);
+        appender.setConnectTimeout(connectTimeout);
+        appender.setDbName(dbName);
+        appender.setFsync(fsync);
+        appender.setHost(host);
+        appender.setMax(max);
+        appender.setMaxWaitTime(maxWaitTime);
+        appender.setPassword(password);
+        appender.setPort(port);
+        appender.setSize(size);
+        appender.setSlaveOk(slaveOk);
+        appender.setSocketTimeout(socketTimeout);
+        appender.setThreadsAllowedToBlockForConnectionMultiplier(threadsAllowedToBlockForConnectionMultiplier);
+        appender.setUsername(username);
+        appender.setW(w);
+        appender.setWtimeout(wtimeout);
+        
+        
+        addThresholdFilter(appender, threshold);
+        appender.start();
+        return wrapAsync(appender);
+	}
+	@JsonProperty
+	public String getHost() {
+		return host;
+	}
+	public void setHost(String host) {
+		this.host = host;
+	}
+	@JsonProperty
+	public int getPort() {
+		return port;
+	}
+	public void setPort(int port) {
+		this.port = port;
+	}
+	@JsonProperty
+	public String getDbName() {
+		return dbName;
+	}
+	public void setDbName(String dbName) {
+		this.dbName = dbName;
+	}
+	@JsonProperty
+	public String getUsername() {
+		return username;
+	}
+	public void setUsername(String username) {
+		this.username = username;
+	}
+	@JsonProperty
+	public String getPassword() {
+		return password;
+	}
+	public void setPassword(String password) {
+		this.password = password;
+	}
+	@JsonProperty
+	public int getConnectionsPerHost() {
+		return connectionsPerHost;
+	}
+	public void setConnectionsPerHost(int connectionsPerHost) {
+		this.connectionsPerHost = connectionsPerHost;
+	}
+	@JsonProperty
+	public int getThreadsAllowedToBlockForConnectionMultiplier() {
+		return threadsAllowedToBlockForConnectionMultiplier;
+	}
+	public void setThreadsAllowedToBlockForConnectionMultiplier(
+			int threadsAllowedToBlockForConnectionMultiplier) {
+		this.threadsAllowedToBlockForConnectionMultiplier = threadsAllowedToBlockForConnectionMultiplier;
+	}
+	@JsonProperty
+	public int getMaxWaitTime() {
+		return maxWaitTime;
+	}
+	public void setMaxWaitTime(int maxWaitTime) {
+		this.maxWaitTime = maxWaitTime;
+	}
+	@JsonProperty
+	public int getConnectTimeout() {
+		return connectTimeout;
+	}
+	public void setConnectTimeout(int connectTimeout) {
+		this.connectTimeout = connectTimeout;
+	}
+	@JsonProperty
+	public int getSocketTimeout() {
+		return socketTimeout;
+	}
+	public void setSocketTimeout(int socketTimeout) {
+		this.socketTimeout = socketTimeout;
+	}
+	@JsonProperty
+	public boolean isSlaveOk() {
+		return slaveOk;
+	}
+	public void setSlaveOk(boolean slaveOk) {
+		this.slaveOk = slaveOk;
+	}
+	@JsonProperty
+	public int getW() {
+		return w;
+	}
+	public void setW(int w) {
+		this.w = w;
+	}
+	@JsonProperty
+	public int getWtimeout() {
+		return wtimeout;
+	}
+	public void setWtimeout(int wtimeout) {
+		this.wtimeout = wtimeout;
+	}
+	@JsonProperty
+	public boolean isFsync() {
+		return fsync;
+	}
+	public void setFsync(boolean fsync) {
+		this.fsync = fsync;
+	}
+	@JsonProperty
+	public boolean isCapped() {
+		return capped;
+	}
+	public void setCapped(boolean capped) {
+		this.capped = capped;
+	}
+	@JsonProperty
+	public long getSize() {
+		return size;
+	}
+	public void setSize(long size) {
+		this.size = size;
+	}
+	@JsonProperty
+	public long getMax() {
+		return max;
+	}
+	public void setMax(long max) {
+		this.max = max;
+	}
+	@JsonProperty
+	public String getCollectionName() {
+		return collectionName;
+	}
+	public void setCollectionName(String collectionName) {
+		this.collectionName = collectionName;
+	}
+
+}

--- a/dropwizard-logging/src/main/resources/META-INF/services/io.dropwizard.logging.AppenderFactory
+++ b/dropwizard-logging/src/main/resources/META-INF/services/io.dropwizard.logging.AppenderFactory
@@ -1,3 +1,4 @@
 io.dropwizard.logging.ConsoleAppenderFactory
 io.dropwizard.logging.FileAppenderFactory
 io.dropwizard.logging.SyslogAppenderFactory
+io.dropwizard.logging.MongoDBAppenderFactory

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <h2.version>1.4.187</h2.version>
         <assertj.version>2.0.0</assertj.version>
         <mockito.version>1.10.17</mockito.version>
+        <mongodb.version>2.13.0</mongodb.version>
     </properties>
 
     <developers>


### PR DESCRIPTION
This will add a AppenderFactory for writing log messages to a runing mongoDB instance.
complete configuration example:

logging:
  level: INFO
  loggers:
    "de.havonte": DEBUG
  appenders:
    - type: mongodb
      threshold: DEBUG
      host: localhost
      port: 27017
      dbName: logs
      username: logs_user
      password: !secrect!
      collectionName: logging
      logFormat: "%d %-5level [%thread]: %msg%n"
      capped: true
      size: 100MB
      max: 1000000
      readPreference: nearest

simple configuration example:

logging:
  level: INFO
  loggers:
    "de.havonte": DEBUG
  appenders:
    - type: mongodb
      threshold: DEBUG
      host: localhost
      port: 27017
      dbName: logs
      collectionName: logging
      logFormat: "%d %-5level [%thread]: %msg%n"

Result example:

{
    "_id" : ObjectId("5552fecfe4b0cb24f4247997"),
    "timestamp" : ISODate("2015-05-13T07:35:43.852Z"),
    "logger" : "de.havonte.SomeClass",
    "level" : "ERROR",
    "thread" : "The_name_of_the_thread_where_the_logmessage_was_sent",
    "mdc" : {},
    "message" : "Look Ma' I am logging to a MongoDB"
}
