### PR TITLE
added setter to ExampleConfiguration class

### DIFF
--- a/docs/source/manual/jdbi.rst
+++ b/docs/source/manual/jdbi.rst
@@ -25,6 +25,11 @@ To create a :ref:`managed <man-core-managed>`, instrumented ``DBI`` instance, yo
         private DataSourceFactory database = new DataSourceFactory();
 
         @JsonProperty("database")
+        public void setDataSourceFactory(DataSourceFactory factory) {
+            this.database = factory;
+        }
+
+        @JsonProperty("database")
         public DataSourceFactory getDataSourceFactory() {
             return database;
         }


### PR DESCRIPTION
ExampleConfiguration class in JDBI example lacks setter for database json property, and it doesn't work until it's added.