### PR TITLE
Use a custom mustache resolver then a custom factory

### DIFF
--- a/dropwizard-views-mustache/src/main/java/io/dropwizard/views/mustache/MustacheViewRenderer.java
+++ b/dropwizard-views-mustache/src/main/java/io/dropwizard/views/mustache/MustacheViewRenderer.java
@@ -1,5 +1,6 @@
 package io.dropwizard.views.mustache;
 
+import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheException;
 import com.github.mustachejava.MustacheFactory;
@@ -32,7 +33,7 @@ public class MustacheViewRenderer implements ViewRenderer {
                                      .build(new CacheLoader<Class<? extends View>, MustacheFactory>() {
                                          @Override
                                          public MustacheFactory load(Class<? extends View> key) throws Exception {
-                                             return new PerClassMustacheFactory(key);
+                                             return new DefaultMustacheFactory(new PerClassMustacheResolver(key));
                                          }
                                      });
     }

--- a/dropwizard-views-mustache/src/main/java/io/dropwizard/views/mustache/PerClassMustacheResolver.java
+++ b/dropwizard-views-mustache/src/main/java/io/dropwizard/views/mustache/PerClassMustacheResolver.java
@@ -1,7 +1,6 @@
 package io.dropwizard.views.mustache;
 
-import com.github.mustachejava.DefaultMustacheFactory;
-import com.github.mustachejava.MustacheException;
+import com.github.mustachejava.MustacheResolver;
 import com.google.common.base.Charsets;
 import io.dropwizard.views.View;
 
@@ -11,12 +10,13 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 
 /**
- * A class-specific Mustache factory which caches the parsed/compiled templates.
+ * @{link MustacheResolver} implementation that resolves mustache
+ * files from the classpath relatively from a provided class.
  */
-class PerClassMustacheFactory extends DefaultMustacheFactory {
+class PerClassMustacheResolver implements MustacheResolver {
     private final Class<? extends View> klass;
 
-    PerClassMustacheFactory(Class<? extends View> klass) {
+    PerClassMustacheResolver(Class<? extends View> klass) {
         this.klass = klass;
     }
 
@@ -24,7 +24,7 @@ class PerClassMustacheFactory extends DefaultMustacheFactory {
     public Reader getReader(String resourceName) {
         final InputStream is = klass.getResourceAsStream(resourceName);
         if (is == null) {
-            throw new MustacheException("Template " + resourceName + " not found");
+            return null;
         }
         return new BufferedReader(new InputStreamReader(is, Charsets.UTF_8));
     }


### PR DESCRIPTION
A more canonical way to provide a custom resource loader is through delegation, rather then inheritance.

There is the `MustacheResolver` interface, that gives ability to provide own strategy of loading resources and pass it to the `DefaultMustacheFactory` class in the constructor.

Also this removes throwing `MustacheException`, because internally Mustache already handles the case when a returned reader is null and throws a `MustacheNotFoundException` with the same semantic.