### PR TITLE
Do not swallow exception cause when parsing JSON.

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapper.java
@@ -48,7 +48,7 @@ public class JsonProcessingExceptionMapper implements ExceptionMapper<JsonProces
         /*
          * Otherwise, it's those pesky users.
          */
-        LOGGER.debug("Unable to process JSON", exception);
+        LOGGER.warn("Unable to process JSON", exception);
         final ErrorMessage errorMessage = new ErrorMessage(Response.Status.BAD_REQUEST.getStatusCode(),
                 "Unable to process JSON", showDetails ? message : null);
         return Response.status(Response.Status.BAD_REQUEST)


### PR DESCRIPTION
If an error occurs processing JSON by default we just receive a message in the response indicating the dropwizard was "Unable to process JSON". This should be logged at least as a warning so a developer/sysadmin can see the cause.