### PR TITLE
Ensures that unit tests always run in 'en_US' locale

### DIFF
--- a/dropwizard-jersey/pom.xml
+++ b/dropwizard-jersey/pom.xml
@@ -127,16 +127,4 @@
             <version>${jetty.version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-           <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-surefire-plugin</artifactId>
-              <configuration>
-                  <argLine>-Duser.language=en -Duser.region=US</argLine>
-              </configuration>
-           </plugin>
-        </plugins>
-    </build>
 </project>

--- a/dropwizard-jersey/pom.xml
+++ b/dropwizard-jersey/pom.xml
@@ -127,4 +127,16 @@
             <version>${jetty.version}</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+           <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                  <argLine>-Duser.language=en -Duser.region=US</argLine>
+              </configuration>
+           </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -367,6 +367,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.12.4</version>
                 <configuration>
+                    <argLine>-Duser.language=en -Duser.region=US</argLine>
                     <parallel>classes</parallel>
                 </configuration>
             </plugin>


### PR DESCRIPTION
When running Dropwizard unit tests on a pt-BR [locale] machine (by example), the validation tests fails.

```
Failed tests:  
getInvalidReturnIs500(io.dropwizard.jersey.validation.ConstraintViolationExceptionMapperTest): expected:<...laze.<return value> [length must be between 0 and] 3"]}"> but was:<...laze.<return value> [Tamanho deve estar entre 0 e] 3"]}">
  getInvalidBeanParamsIs400(io.dropwizard.jersey.validation.ConstraintViolationExceptionMapperTest): expected:<...:["blazer.arg0.name [may not be empty]"]}"> but was:<...:["blazer.arg0.name [Não pode estar vazio]"]}">
  getInvalidQueryParamsIs400(io.dropwizard.jersey.validation.ConstraintViolationExceptionMapperTest): expected:<...rrors":["blaze.arg0 [length must be between 3 and] 2147483647"]}"> but was:<...rrors":["blaze.arg0 [Tamanho deve estar entre 3 e] 2147483647"]}">
```

The cause is that the validation messages are changed to use the current machine locale. This simple pull-request adds a surefire plugin parameter to force the tests to run using `en` as language and `US` as region. So, these tests should pass even when you run them on non-`en_US` machines.