### PR TITLE
Manage Apache HTTP and Jersey HTTP clients

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
@@ -9,6 +9,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.client.proxy.AuthConfiguration;
 import io.dropwizard.client.proxy.NonProxyListProxyRoutePlanner;
 import io.dropwizard.client.proxy.ProxyConfiguration;
+import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Duration;
 import org.apache.http.ConnectionReuseStrategy;
@@ -61,6 +62,7 @@ public class HttpClientBuilder {
 
     private final MetricRegistry metricRegistry;
     private String environmentName;
+    private Environment environment;
     private HttpClientConfiguration configuration = new HttpClientConfiguration();
     private DnsResolver resolver = new SystemDefaultDnsResolver();
     private HttpRequestRetryHandler httpRequestRetryHandler;
@@ -80,6 +82,7 @@ public class HttpClientBuilder {
     public HttpClientBuilder(Environment environment) {
         this(environment.metrics());
         name(environment.getName());
+        this.environment = environment;
     }
 
     /**
@@ -177,7 +180,21 @@ public class HttpClientBuilder {
      * @return an {@link CloseableHttpClient}
      */
     public CloseableHttpClient build(String name) {
-        return buildWithDefaultRequestConfiguration(name).getClient();
+        final CloseableHttpClient client = buildWithDefaultRequestConfiguration(name).getClient();
+        // If the environment is present, we tie the client with the server lifecycle
+        if (environment != null) {
+            environment.lifecycle().manage(new Managed() {
+                @Override
+                public void start() throws Exception {
+                }
+
+                @Override
+                public void stop() throws Exception {
+                    client.close();
+                }
+            });
+        }
+        return client;
     }
 
     /**

--- a/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
@@ -13,7 +13,9 @@ import org.apache.http.HttpStatus;
 import org.apache.http.conn.ConnectTimeoutException;
 import org.apache.http.conn.HttpHostConnectException;
 import org.assertj.core.api.AbstractLongAssert;
+import org.eclipse.jetty.util.component.LifeCycle;
 import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.JerseyClient;
 import org.junit.Before;
 import org.junit.After;
 import org.junit.ClassRule;
@@ -21,6 +23,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import javax.validation.Validation;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.ProcessingException;
@@ -54,25 +57,33 @@ public class DropwizardApacheConnectorTest {
     public ExpectedException thrown = ExpectedException.none();
 
     private final URI testUri = URI.create("http://localhost:" + APP_RULE.getLocalPort());
-    private final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
-    private Client client;
+    private JerseyClient client;
+    private Environment environment;
 
     @Before
-    public void setup() {
+    public void setup() throws Exception {
         JerseyClientConfiguration clientConfiguration = new JerseyClientConfiguration();
         clientConfiguration.setConnectionTimeout(Duration.milliseconds(SLEEP_TIME_IN_MILLIS / 2));
         clientConfiguration.setTimeout(Duration.milliseconds(DEFAULT_CONNECT_TIMEOUT_IN_MILLIS));
-        client = new JerseyClientBuilder(new MetricRegistry())
-                .using(executorService, Jackson.newObjectMapper())
+
+        environment = new Environment("test-dropwizard-apache-connector", Jackson.newObjectMapper(),
+                Validation.buildDefaultValidatorFactory().getValidator(), new MetricRegistry(),
+                getClass().getClassLoader());
+        client = (JerseyClient) new JerseyClientBuilder(environment)
                 .using(clientConfiguration)
                 .build("test");
+        for (LifeCycle lifeCycle : environment.lifecycle().getManagedObjects()) {
+            lifeCycle.start();
+        }
     }
 
     @After
     public void tearDown() throws Exception {
-        executorService.shutdown();
-        client.close();
+        for (LifeCycle lifeCycle : environment.lifecycle().getManagedObjects()) {
+            lifeCycle.stop();
+        }
+        assertThat(client.isClosed()).isTrue();
     }
 
     @Test

--- a/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
@@ -8,6 +8,10 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.client.proxy.AuthConfiguration;
 import io.dropwizard.client.proxy.ProxyConfiguration;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.lifecycle.Managed;
+import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
+import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Duration;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.http.*;
@@ -15,6 +19,7 @@ import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.HttpClient;
 import org.apache.http.client.HttpRequestRetryHandler;
 import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
@@ -43,6 +48,9 @@ import org.apache.http.protocol.HTTP;
 import org.apache.http.protocol.HttpContext;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import javax.validation.Validation;
 import java.net.ProxySelector;
 import java.net.Proxy;
 import java.net.URI;
@@ -54,6 +62,7 @@ import java.lang.reflect.Field;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -426,6 +435,31 @@ public class HttpClientBuilderTest {
         assertThat(client).isNotNull();
 
         assertThat(spyHttpClientField("defaultConfig", client.getClient())).isEqualTo(client.getDefaultRequestConfig());
+    }
+
+    @Test
+    public void managedByEnvironment() throws Exception {
+        final Environment environment = mock(Environment.class);
+        when(environment.getName()).thenReturn("test-env");
+        when(environment.metrics()).thenReturn(new MetricRegistry());
+
+        final LifecycleEnvironment lifecycle = mock(LifecycleEnvironment.class);
+        when(environment.lifecycle()).thenReturn(lifecycle);
+
+        final CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
+        HttpClientBuilder httpClientBuilder = spy(new HttpClientBuilder(environment));
+        when(httpClientBuilder.buildWithDefaultRequestConfiguration("test-apache-client"))
+                .thenReturn(new ConfiguredCloseableHttpClient(httpClient, RequestConfig.DEFAULT));
+        assertThat(httpClientBuilder.build("test-apache-client")).isSameAs(httpClient);
+
+        // Verify that we registered the managed object
+        final ArgumentCaptor<Managed> argumentCaptor = ArgumentCaptor.forClass(Managed.class);
+        verify(lifecycle).manage(argumentCaptor.capture());
+
+        // Verify that the managed object actually stops the HTTP client
+        final Managed managed = argumentCaptor.getValue();
+        managed.stop();
+        verify(httpClient).close();
     }
 
     private Object spyHttpClientBuilderField(final String fieldName, final Object obj) throws Exception {


### PR DESCRIPTION
In the [documentation](http://www.dropwizard.io/manual/client.html#apache-httpclient) we say that we create managed instances of Apache HTTP client. But in the fact, it's not true. 

To follow this contract, we should tie the lifecyle of the client to the lifecycle of the server, if the user specified the environment in the builder. The rationale is the same for Jersey HTTP client.

If the user has already created own managed object for the client  - it's not an issue, because the close method of the HTTP client is idempotent.