### PR TITLE
Use configuration class from Application object

### DIFF
--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/MigrationsBundle.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/MigrationsBundle.java
@@ -10,7 +10,7 @@ import io.dropwizard.util.Generics;
 public abstract class MigrationsBundle<T extends Configuration> implements Bundle, DatabaseConfiguration<T> {
     @Override
     public final void initialize(Bootstrap<?> bootstrap) {
-        final Class<T> klass = Generics.getTypeParameter(getClass(), Configuration.class);
+        final Class<T> klass = (Class<T>)bootstrap.getApplication().getConfigurationClass();
         bootstrap.addCommand(new DbCommand<>(this, klass));
     }
 


### PR DESCRIPTION
In some case, configuration class retrieved by MigrationsBundle is invalid (in my case, when MigrationsBundle is constructed from an abstract Application class where configuration is still a Generic Type).

This fix the issue by retrieving the configuration class from Application object.