### PR TITLE
[Documentation] Specify boolean false parameter in EnvironmentVariableSubstitutor constructor

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -233,7 +233,7 @@ value of environment variables using a ``SubstitutingSourceProvider`` and ``Envi
             // Enable variable substitution with environment variables
             bootstrap.setConfigurationSourceProvider(
                     new SubstitutingSourceProvider(bootstrap.getConfigurationSourceProvider(),
-                                                       new EnvironmentVariableSubstitutor()
+                                                       new EnvironmentVariableSubstitutor(false)
                     )
             );
 


### PR DESCRIPTION
In order for the app startup not to fail if an env var defined in the yaml config file cannot be found I had to add a boolean false parameter to the EnvironmentVariableSubstitutor constructor