### PR TITLE
Fix NPE when resources have the @Path annotation just on method level

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -45,7 +45,6 @@ public class DropwizardResourceConfig extends ResourceConfig {
         this(true, null);
     }
 
-    @SuppressWarnings("unchecked")
     public DropwizardResourceConfig(boolean testOnly, MetricRegistry metricRegistry) {
         super();
 
@@ -184,6 +183,9 @@ public class DropwizardResourceConfig extends ResourceConfig {
         }
 
         private String normalizePath(String basePath, String path) {
+            if (path == null) {
+                return basePath;
+            }
             if (basePath.endsWith("/")) {
                 return path.startsWith("/") ? basePath + path.substring(1) : basePath + path;
             }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
@@ -57,6 +57,21 @@ public class DropwizardResourceConfigTest {
     }
 
     @Test
+    public void combinesAlRegisteredClassesPathOnMethodLevel() {
+        rc.register(new TestResource());
+        rc.register(new ResourcePathOnMethodLevel());
+
+        assertThat(rc.allClasses()).contains(
+                TestResource.class,
+                ResourcePathOnMethodLevel.class
+        );
+
+        assertThat(rc.getEndpointsInfo())
+                .contains("GET     /bar (io.dropwizard.jersey.DropwizardResourceConfigTest.ResourcePathOnMethodLevel)")
+                .contains("GET     /dummy (io.dropwizard.jersey.DropwizardResourceConfigTest.TestResource)");
+    }
+
+    @Test
     public void logsNoInterfaces() {
         rc.packages(getClass().getPackage().getName());
 
@@ -123,6 +138,13 @@ public class DropwizardResourceConfigTest {
     public static interface ResourceInterface {
         @GET
         public String bar();
+    }
+
+    public static class ResourcePathOnMethodLevel {
+        @GET @Path("/bar")
+        public String bar() {
+            return "";
+        }
     }
 
     public static class ImplementingResource implements ResourceInterface {


### PR DESCRIPTION
Referring this https://github.com/dropwizard/dropwizard/issues/1066 and consequently this: https://github.com/federecio/dropwizard-swagger/issues/52

This pull request fixes this referred NPE. Basically, what I've found is that resources without @Path annotation on class level the method `org.glassfish.jersey.server.model.Resource#getPath` returns null, so, causing the issue in `EndpointLogger#normalizePath`. I've just wrote a defensive code to avoid this NPE.