### PR TITLE
Migration tests

### DIFF
--- a/dropwizard-migrations/pom.xml
+++ b/dropwizard-migrations/pom.xml
@@ -50,5 +50,13 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>net.jcip</groupId>
+            <artifactId>jcip-annotations</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 </project>

--- a/dropwizard-migrations/pom.xml
+++ b/dropwizard-migrations/pom.xml
@@ -43,5 +43,12 @@
             <version>${h2.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-jdbi</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/CloseableLiquibaseTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/CloseableLiquibaseTest.java
@@ -3,12 +3,14 @@ package io.dropwizard.migrations;
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.db.ManagedPooledDataSource;
+import net.jcip.annotations.NotThreadSafe;
 import org.apache.tomcat.jdbc.pool.ConnectionPool;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@NotThreadSafe
 public class CloseableLiquibaseTest {
 
     CloseableLiquibase liquibase;

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCommandTest.java
@@ -3,6 +3,7 @@ package io.dropwizard.migrations;
 import com.google.common.collect.ImmutableMap;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.db.DatabaseConfiguration;
+import net.jcip.annotations.NotThreadSafe;
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
@@ -17,6 +18,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@NotThreadSafe
 public class DbMigrateCommandTest {
 
     private DbMigrateCommand<TestMigrateConfiguration> migrateCommand = new DbMigrateCommand<>(

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCommandTest.java
@@ -1,0 +1,116 @@
+package io.dropwizard.migrations;
+
+import com.google.common.collect.ImmutableMap;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.db.DatabaseConfiguration;
+import net.sourceforge.argparse4j.ArgumentParsers;
+import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparser;
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+
+import java.io.*;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DbMigrateCommandTest {
+
+    private DbMigrateCommand<TestMigrateConfiguration> migrateCommand = new DbMigrateCommand<>(
+            new DatabaseConfiguration<TestMigrateConfiguration>() {
+                @Override
+                public DataSourceFactory getDataSourceFactory(TestMigrateConfiguration configuration) {
+                    return configuration.getDataSource();
+                }
+            }, TestMigrateConfiguration.class);
+    private TestMigrateConfiguration conf;
+    private String databaseUrl;
+
+    private static String createTempFile() {
+        try {
+            return File.createTempFile("test-example", null).getAbsolutePath();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        databaseUrl = "jdbc:h2:" + createTempFile();
+
+        final DataSourceFactory dataSource = new DataSourceFactory();
+        dataSource.setDriverClass("org.h2.Driver");
+        dataSource.setUser("sa");
+        dataSource.setUrl(databaseUrl);
+        conf = new TestMigrateConfiguration(dataSource);
+    }
+
+    @Test
+    public void testRun() throws Exception {
+        migrateCommand.run(null, new Namespace(ImmutableMap.<String, Object>of()), conf);
+        try (Handle handle = new DBI(databaseUrl, "sa", "").open()) {
+            final List<Map<String, Object>> rows = handle.select("select * from persons");
+            assertThat(rows).hasSize(1);
+            assertThat(rows.get(0)).isEqualTo(
+                    ImmutableMap.of("id", 1, "name", "Bill Smith", "email", "bill@smith.me"));
+        }
+    }
+
+    @Test
+    public void testRunFirstTwoMigration() throws Exception {
+        migrateCommand.run(null, new Namespace(ImmutableMap.of("count", (Object) 2)), conf);
+        try (Handle handle = new DBI(databaseUrl, "sa", "").open()) {
+            assertThat(handle.select("select * from persons")).isEmpty();
+        }
+    }
+
+    @Test
+    public void testDryRun() throws Exception {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        migrateCommand.setOutputStream(new PrintStream(baos));
+        migrateCommand.run(null, new Namespace(ImmutableMap.of("dry-run", (Object) true)), conf);
+        assertThat(baos.toString("UTF-8")).startsWith(String.format(
+                "-- *********************************************************************%n" +
+                "-- Update Database Script%n" +
+                "-- *********************************************************************%n"));
+    }
+
+    @Test
+    public void testPrintHelp() throws Exception {
+        final Subparser subparser = ArgumentParsers.newArgumentParser("db")
+                .addSubparsers()
+                .addParser(migrateCommand.getName())
+                .description(migrateCommand.getDescription());
+        migrateCommand.configure(subparser);
+
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        subparser.printHelp(new PrintWriter(baos, true));
+
+        assertThat(baos.toString("UTF-8")).isEqualTo(String.format(
+                        "usage: db migrate [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
+                        "          [--schema SCHEMA] [-n] [-c COUNT] [-i CONTEXTS] [file]%n" +
+                        "%n" +
+                        "Apply all pending change sets.%n" +
+                        "%n" +
+                        "positional arguments:%n" +
+                        "  file                   application configuration file%n" +
+                        "%n" +
+                        "optional arguments:%n" +
+                        "  -h, --help             show this help message and exit%n" +
+                        "  --migrations MIGRATIONS-FILE%n" +
+                        "                         the file containing  the  Liquibase migrations for%n" +
+                        "                         the application%n" +
+                        "  --catalog CATALOG      Specify  the   database   catalog   (use  database%n" +
+                        "                         default if omitted)%n" +
+                        "  --schema SCHEMA        Specify the database schema  (use database default%n" +
+                        "                         if omitted)%n" +
+                        "  -n, --dry-run          output the DDL to stdout, don't run it%n" +
+                        "  -c COUNT, --count COUNT%n" +
+                        "                         only apply the next N change sets%n" +
+                        "  -i CONTEXTS, --include CONTEXTS%n" +
+                        "                         include change sets from the given context%n"));
+    }
+}

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/TestMigrateConfiguration.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/TestMigrateConfiguration.java
@@ -1,0 +1,17 @@
+package io.dropwizard.migrations;
+
+import io.dropwizard.Configuration;
+import io.dropwizard.db.DataSourceFactory;
+
+public class TestMigrateConfiguration extends Configuration {
+
+    private DataSourceFactory dataSource;
+
+    public TestMigrateConfiguration(DataSourceFactory dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public DataSourceFactory getDataSource() {
+        return dataSource;
+    }
+}

--- a/dropwizard-migrations/src/test/resources/migrations.xml
+++ b/dropwizard-migrations/src/test/resources/migrations.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="1" author="db_dev">
+        <createTable tableName="persons">
+            <column name="id" type="int" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="name" type="varchar(256)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2" author="db_dev">
+        <addColumn tableName="persons">
+            <column name="email" type="varchar(128)"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="3" author="db_dev">
+        <insert tableName="persons">
+            <column name="name" value="Bill Smith"/>
+            <column name="email" value="bill@smith.me"/>
+        </insert>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
It's a first attempt to write tests for the `dropwizard-migrations` module.

* First of all, this change moves [CloseableLiquibaseTest](https://github.com/dropwizard/dropwizard/blob/master/dropwizard-example/src/test/java/io/dropwizard/migrations/CloseableLiquibaseTest.java) from `dropwizard-example` to `dropwizard-migrations`. It seems to me that it was placed there for mistake. 

* It sets the test directory, Logback testing configuration and test dependencies for the module.
* It adds a test for the [DbMigrate](https://github.com/dropwizard/dropwizard/blob/master/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbMigrateCommand.java) command. The following use cases are tested:
  * Migration of pending migrations to the DB.
  * Dry-run mode (printing the pending change set to the console).
  * Migration of limited amount of changes.
  * Help page (description of the command and available arguments)
