### PR TITLE
Log context paths in `SimpleServerFactory` during startup

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/server/SimpleServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/SimpleServerFactory.java
@@ -12,6 +12,8 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.thread.ThreadPool;
 import org.hibernate.validator.constraints.NotEmpty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -52,6 +54,9 @@ import javax.validation.constraints.NotNull;
  */
 @JsonTypeName("simple")
 public class SimpleServerFactory extends AbstractServerFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SimpleServerFactory.class);
+
     @Valid
     @NotNull
     private ConnectorFactory connector = HttpConnectorFactory.application();
@@ -98,6 +103,7 @@ public class SimpleServerFactory extends AbstractServerFactory {
         final ThreadPool threadPool = createThreadPool(environment.metrics());
         final Server server = buildServer(environment.lifecycle(), threadPool);
 
+        LOGGER.info("Registering jersey handler with root path prefix: {}", applicationContextPath);
         environment.getApplicationContext().setContextPath(applicationContextPath);
         final Handler applicationHandler = createAppServlet(server,
                                                             environment.jersey(),
@@ -107,6 +113,7 @@ public class SimpleServerFactory extends AbstractServerFactory {
                                                             environment.getJerseyServletContainer(),
                                                             environment.metrics());
 
+        LOGGER.info("Registering admin handler with root path prefix: {}", adminContextPath);
         environment.getAdminContext().setContextPath(adminContextPath);
         final Handler adminHandler = createAdminServlet(server,
                                                         environment.getAdminContext(),


### PR DESCRIPTION
Add logging of application and admin context paths during server startup. `DefaultServerFactory` already does [that](https://github.com/dropwizard/dropwizard/blob/master/dropwizard-core/src/main/java/io/dropwizard/server/DefaultServerFactory.java#L160).

It should help to avoid confusion for users who use this configuration for the first time and expect that application resources are served from the root path.

Resolve #1058