### PR TITLE
Update an example of using query parameters

### DIFF
--- a/dropwizard-example/src/main/java/com/example/helloworld/resources/HelloWorldResource.java
+++ b/dropwizard-example/src/main/java/com/example/helloworld/resources/HelloWorldResource.java
@@ -39,10 +39,18 @@ public class HelloWorldResource {
     public void receiveHello(@Valid Saying saying) {
         LOGGER.info("Received a saying: {}", saying);
     }
-    
+
     @GET
     @Path("/date")
-    public void receiveDate(@QueryParam("date") DateTimeParam dateTimeParam) {
-        LOGGER.info("Received a saying: {}", dateTimeParam.get());
+    @Produces(MediaType.TEXT_PLAIN)
+    public String receiveDate(@QueryParam("date") Optional<DateTimeParam> dateTimeParam) {
+        if (dateTimeParam.isPresent()) {
+            final DateTimeParam actualDateTimeParam = dateTimeParam.get();
+            LOGGER.info("Received a date: {}", actualDateTimeParam);
+            return actualDateTimeParam.get().toString();
+        } else {
+            LOGGER.warn("No received date");
+            return null;
+        }
     }
 }


### PR DESCRIPTION
~~* Use a POST, rather then GET, because GET requests should return some values, no 204 return code~~
~~* Change name of the parameter to from `date` to `value`~~
* Use `Optional` to handle an omitted parameter
* Return a passed date, so Jersey doesn't warn us about 204 error