### PR TITLE
Prevent ConcurrentModificationException during stopping logger context

### DIFF
--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/DefaultLoggingFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/DefaultLoggingFactory.java
@@ -29,7 +29,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonTypeName("default")
 public class DefaultLoggingFactory implements LoggingFactory {
     private static final ReentrantLock MBEAN_REGISTRATION_LOCK = new ReentrantLock();
-    private static final ReentrantLock CONFIGURE_LOGGING_LEVEL_LOCK = new ReentrantLock();
+    private static final ReentrantLock CHANGE_LOGGER_CONTEXT_LOCK = new ReentrantLock();
 
     @NotNull
     private Level level = Level.INFO;
@@ -102,12 +102,12 @@ public class DefaultLoggingFactory implements LoggingFactory {
     public void configure(MetricRegistry metricRegistry, String name) {
         LoggingUtil.hijackJDKLogging();
 
-        CONFIGURE_LOGGING_LEVEL_LOCK.lock();
+        CHANGE_LOGGER_CONTEXT_LOCK.lock();
         final Logger root;
         try {
             root = configureLevels();
         } finally {
-            CONFIGURE_LOGGING_LEVEL_LOCK.unlock();
+            CHANGE_LOGGER_CONTEXT_LOCK.unlock();
         }
 
         for (AppenderFactory output : appenders) {
@@ -142,7 +142,13 @@ public class DefaultLoggingFactory implements LoggingFactory {
     }
 
     public void stop() {
-        loggerContext.stop();
+        // Should acquire the lock to avoid concurrent listener changes
+        CHANGE_LOGGER_CONTEXT_LOCK.lock();
+        try {
+            loggerContext.stop();
+        } finally {
+            CHANGE_LOGGER_CONTEXT_LOCK.unlock();
+        }
     }
 
     private void configureInstrumentation(Logger root, MetricRegistry metricRegistry) {


### PR DESCRIPTION
We should acquire the lock when we stop the context, because other threads could change it in the `configure` in the same time, which leads to `ConcurrentModificationException`.
I've seen this exception in Travis several times and had to restart builds.

````
io.dropwizard.testing.app.GzipDefaultVaryBehaviourTest  Time elapsed: 0.001 sec  <<< ERROR!
java.util.ConcurrentModificationException
	at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:901)
	at java.util.ArrayList$Itr.next(ArrayList.java:851)
	at ch.qos.logback.classic.LoggerContext.fireOnStop(LoggerContext.java:323)
	at ch.qos.logback.classic.LoggerContext.stop(LoggerContext.java:337)
	at io.dropwizard.logging.DefaultLoggingFactory.stop(DefaultLoggingFactory.java:145)
	at io.dropwizard.cli.ConfiguredCommand.cleanup(ConfiguredCommand.java:91)
	at io.dropwizard.cli.ServerCommand$LifeCycleListener.lifeCycleStopped(ServerCommand.java:55)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.setStopped(AbstractLifeCycle.java:206)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:90)
	at io.dropwizard.testing.DropwizardTestSupport.stopIfRequired(DropwizardTestSupport.java:102)
	at io.dropwizard.testing.DropwizardTestSupport.after(DropwizardTestSupport.java:87)
	at io.dropwizard.testing.junit.DropwizardAppRule.after(DropwizardAppRule.java:78)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:50)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
````