### PR TITLE
Fix Coveralls integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
   - oraclejdk7
   - oraclejdk8
 after_success:
-- mvn cobertura:cobertura coveralls:cobertura
+- mvn cobertura:cobertura coveralls:report
 - if [[ "$TRAVIS_PULL_REQUEST" = "false" ]]; then mvn deploy --settings maven_deploy_settings.xml; else echo 'Pull request, skipping deploy.'; fi
 
 # encrypted CI_DEPLOY_USERNAME and CI_DEPLOY_PASSWORD

--- a/pom.xml
+++ b/pom.xml
@@ -483,6 +483,12 @@
                         <format>xml</format>
                     </formats>
                     <aggregate>true</aggregate>
+                    <instrumentation>
+                        <excludes>
+                            <exclude>io/dropwizard/benchmarks/**/*.class</exclude>
+                            <exclude>org/openjdk/jmh/**/*.class</exclude>
+                        </excludes>
+                    </instrumentation>
                 </configuration>
                 <dependencies>
                     <dependency>


### PR DESCRIPTION
Coveralls-plugin 3.x changed the plugin goal.  Now it's just `coveralls:report`.

See [this](https://github.com/trautonen/coveralls-maven-plugin/commit/355b2e73715bdde4375bb151aeeddaf446b0779c).