### PR TITLE
Update Validation Documentation

### DIFF
--- a/docs/source/manual/index.rst
+++ b/docs/source/manual/index.rst
@@ -18,6 +18,7 @@ User Manual
     hibernate
     auth
     forms
+    validation
     views
     scala
     testing

--- a/docs/source/manual/validation.rst
+++ b/docs/source/manual/validation.rst
@@ -1,0 +1,254 @@
+.. _man-validation:
+
+#####################
+Dropwizard Validation
+#####################
+
+.. highlight:: text
+
+.. rubric:: Dropwizard comes with a host of validation tools out of the box to allow endpoints to return meaningful error messages when constraints are violated. `Hibernate Validator`_ is packaged with Dropwizard, so what can be done in Hibernate Validator, can be done with Dropwizard.
+
+.. _Hibernate Validator: http://hibernate.org/validator/
+
+.. _man-validation-validations:
+
+Validations
+===========
+
+Almost anything can be validated on resource endpoints. To give a quick example, the following
+endpoint doesn't allow a null or empty ``name`` query parameter.
+
+.. code-block:: java
+
+    @GET
+    public String find(@QueryParam("name") @NotEmpty String arg) {
+        // ...
+    }
+
+If a client sends an empty or nonexistant name query param, Dropwizard will respond with a ``400 Bad Request``
+code with the error: ``query param name may not be empty``.
+
+Additionally, annotations such as ``HeaderParam``, ``CookieParam``, ``FormParam``, etc, can be
+constrained with violations giving descriptive errors and 400 status codes.
+
+.. _man-validation-validations-constraining-entities:
+
+Constraining Entities
+*********************
+
+If we're accepting client-provided ``Person``, we probably want to ensure that the ``name`` field of
+the object isn't ``null`` or blank in the request. We can do this as follows:
+
+.. code-block:: java
+
+    public class Person {
+
+        @NotEmpty // ensure that name isn't null or blank
+        private final String name;
+
+        @JsonCreator
+        public Person(@JsonProperty("name") String name) {
+            this.name = name;
+        }
+
+        @JsonProperty("name")
+        public String getName() {
+            return name;
+        }
+    }
+
+Then, in our resource class, we can add the ``@Valid`` or the ``@Validated`` annotation to the
+``Person`` annotation:
+
+.. code-block:: java
+
+    @PUT
+    public Person replace(@Valid Person person) {
+        // ...
+    }
+
+If the name field is missing, Dropwizard will return a ``422 Unprocessable Entity`` response
+detailing the validation errors: ``name may not be empty``
+
+.. _man-validation-validations-optional-constraints:
+
+``Optional<T>`` Constraints
+***************************
+
+When ``Optional<T>`` is constrained, it is the type contained within the ``Optional`` that is
+constrained. If the ``Optional`` is absent, then the constraints are not applied.
+
+.. note::
+
+    Be careful when using constraints with ``*Param`` annotations with ``Optional<String>`` types as
+    there is a subtle, but important distinction between null and empty. If a client requests
+    ``bar?q=``, ``q`` will evaluate to ``Optional.of("")``. If you want ``q`` to evaluate to
+    ``Optional.absent()`` in this situation, change the type to ``NonEmptyStringParam``
+
+.. _man-validation-programming-by-contract:
+
+Programming by Contract
+=======================
+
+Validations can be performed on endpoint return values. This enables you, as the service provider,
+to make guarantees. If the constraints are violated, instead of returning faulty data, an internal
+server error is sent. This is known as "Programming by Contract"
+
+Our venerable ``Person`` needs a name and we can guarantee that it will have a name in a response if
+we mark the method with ``@Valid`` or ``@Validated``.
+
+.. code-block:: java
+
+    @PUT
+    @Valid
+    public Person replace(@Valid Person person) {
+        // Oops, we got a bug!
+        return new Person(null);
+    }
+
+In our example, the server will respond a ``500 Internal Server Error`` status and an error message:
+``name may not be empty``.
+
+.. _man-validation-annotations:
+
+Annotations
+===========
+
+In addition to the `annotations defined in Hibernate Validator`_, Dropwizard contains another set of annotations,
+which are briefly shown below.
+
+.. _annotations defined in Hibernate Validator: http://docs.jboss.org/hibernate/validator/5.1/reference/en-US/html/chapter-bean-constraints.html#section-builtin-constraints
+
+.. code-block:: java
+
+    public class Person {
+        @NotEmpty
+        private final String name;
+
+        @NotEmpty
+        @OneOf(value = {"m", "f"}, ignoreCase = true, ignoreWhitespace = true)
+        // @OneOf forces a value to value within certain values.
+        private final String gender;
+
+        @Max(10)
+        @Min(0)
+        // The integer contained, if present, can attain a min value of 0 and a max of 10.
+        private final Optional<Integer> animals;
+
+        @JsonCreator
+        public Person(@JsonProperty("name") String name) {
+            this.name = name;
+        }
+
+        @JsonProperty("name")
+        public String getName() {
+            return name;
+        }
+
+        // Method that must return true for the object to be valid
+        @ValidationMethod(message="name may not be Coda")
+        public boolean isNotCoda() {
+            return !"Coda".equals(name);
+        }
+    }
+
+The reason why Dropwizard defines ``@ValidationMethod`` is that more complex validations (for
+example, cross-field comparisons) are often hard to do using declarative annotations. Adding
+``@ValidationMethod`` to any ``boolean``-returning method which begins with ``is`` is a short and
+simple workaround:
+
+.. note::
+
+    Due to the rather daft JavaBeans conventions, when using ``@ValidationMethod``, the method must
+    begin with ``is`` (e.g., ``#isValidPortRange()``. This is a limitation of Hibernate Validator,
+    not Dropwizard.
+
+.. _man-validation-annotations-validated:
+
+``@Validated``
+**************
+
+The ``@Validated`` annotation behaves similar to ``@Valid``. The difference is that the
+``@Validated`` annotation allows for `validation groups`_ to be specifically set, instead of the
+default group. This is useful when different endpoints share the same entity but may have different
+requirements.
+
+.. _validation groups: https://docs.jboss.org/hibernate/validator/5.1/reference/en-US/html/chapter-groups.html
+
+Going back to our favorite ``Person`` class. Let's say we initially coded it such that ``name`` has
+to be non-empty, but realized that business requirements needs the max length to be no more than 5.
+Instead of blowing away our current version of our API and creating angry clients, we can accept
+both versions of the API but at different endpoints.
+
+.. code-block:: java
+
+    public interface Version1Checks { }
+
+    public interface Version2Checks { }
+
+    public class Person {
+        @NotEmpty(groups = Version1Checks.class)
+        @Length(max = 5, groups = Version2Checks.class)
+        private String name;
+
+        @JsonCreator
+        public Person(@JsonProperty("name") String name) {
+            this.name = name;
+        }
+
+        @JsonProperty
+        public String getName() {
+            return name;
+        }
+    }
+
+    @Path("/person")
+    @Produces(MediaType.APPLICATION_JSON)
+    public class PersonResource {
+        @POST
+        @Path("/v1")
+        public void createPersonV1(@Validated(Version1Checks.class) Person person) {
+        }
+
+        @POST
+        @Path("/v2")
+        public void createPersonV2(@Validated({Version1Checks.class, Version2Checks.class}) Person person) {
+        }
+    }
+
+Now, when clients hit ``/person/v1`` the ``Person`` entity will be checked by all the constraints
+that are a part of the ``Version1Checks`` group. If ``/person/v2`` is hit, then all the validations
+are performed.
+
+.. note::
+
+    Since interfaces can inherit other interfaces, ``Version2Checks`` can extend ``Version1Checks``
+    and wherever ``@Validated(Version2Checks.class)`` is used, version 1 constraints are checked
+    too.
+
+.. _man-validation-extending:
+
+Extending
+=========
+
+While Dropwizard provides good defaults for error messages, one size may not fit all and so there
+are a series of extension points. To register your own
+``ExceptionMapper<ConstraintViolationException>`` you'll need to first set
+``registerDefaultExceptionMappers`` to false in the configuration file or in code before registering
+your exception mapper with jersey. Then, optionally, register other default exception mappers:
+``LoggingExceptionMapper<Throwable>``, ``JsonProcessingExceptionMapper``,
+``EarlyEofExceptionMapper``.
+
+If you need to validate entities outside of resource endpoints, the validator can be accessed in the
+``Environment`` when the application is first ran.
+
+.. code-block:: java
+
+    Validator validator = environment.getValidator();
+    Set<ConstraintViolation> errors = validator.validate(/* instance of class */)
+
+The method used to determine what status code to return based on violations is
+``ConstraintViolations.determineStatus``
+
+The method used to determine the human friendly error message due to a constraint violation is
+``ConstraintMessage.getMessage``.

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ValidationErrorMessage.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ValidationErrorMessage.java
@@ -1,12 +1,14 @@
 package io.dropwizard.jersey.validation;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 
 public class ValidationErrorMessage {
     private final ImmutableList<String> errors;
 
-    public ValidationErrorMessage(ImmutableList<String> errors) {
+    @JsonCreator
+    public ValidationErrorMessage(@JsonProperty("errors") ImmutableList<String> errors) {
         this.errors = errors;
     }
 


### PR DESCRIPTION
A hefty chunk of documentation on validation that covers previously undocumented features and updates others. I made it into it's own page due to its length. If this is not desired (due to potentially broken links to the documentation), I can merge it back

**The documentation is currently not accurate (so it may not be a good idea to merge just yet)**: as

```java
@PUT
@Valid
public Person replace(@Valid Person person) {
    // Oops, we got a bug, a person can't have a null name
    return new Person(null);
}
```

will return a `200 OK` and not `500 Internal Server Error`. 

Let me know if there are any corrections/suggestions.