### PR TITLE
Use dropwizard hibernate validator in jersey validations

### DIFF
--- a/dropwizard-benchmarks/src/main/java/io/dropwizard/benchmarks/jersey/ConstraintViolationBenchmark.java
+++ b/dropwizard-benchmarks/src/main/java/io/dropwizard/benchmarks/jersey/ConstraintViolationBenchmark.java
@@ -1,6 +1,7 @@
 package io.dropwizard.benchmarks.jersey;
 
 import io.dropwizard.jersey.validation.ConstraintMessage;
+import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.logging.BootstrapLogging;
 import org.hibernate.validator.constraints.NotEmpty;
 import org.openjdk.jmh.annotations.*;
@@ -9,7 +10,6 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Valid;
-import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.executable.ExecutableValidator;
 import javax.ws.rs.HeaderParam;
@@ -47,7 +47,7 @@ public class ConstraintViolationBenchmark {
 
     @Setup
     public void prepare() {
-        final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        final Validator validator = Validators.newValidator();
         final ExecutableValidator execValidator = validator.forExecutables();
 
         Set<ConstraintViolation<ConstraintViolationBenchmark.Resource>> paramViolations =

--- a/dropwizard-core/src/main/java/io/dropwizard/cli/EnvironmentCommand.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/EnvironmentCommand.java
@@ -6,8 +6,6 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import net.sourceforge.argparse4j.inf.Namespace;
 
-import javax.validation.Validation;
-
 /**
  * A command which executes with a configured {@link Environment}.
  *

--- a/dropwizard-core/src/main/java/io/dropwizard/setup/Bootstrap.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/Bootstrap.java
@@ -29,10 +29,8 @@ import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import io.dropwizard.validation.valuehandling.OptionalValidatedValueUnwrapper;
-import org.hibernate.validator.HibernateValidator;
+import io.dropwizard.jersey.validation.Validators;
 
-import javax.validation.Validation;
 import javax.validation.ValidatorFactory;
 
 /**
@@ -67,12 +65,7 @@ public class Bootstrap<T extends Configuration> {
         this.bundles = Lists.newArrayList();
         this.configuredBundles = Lists.newArrayList();
         this.commands = Lists.newArrayList();
-        this.validatorFactory = Validation
-                .byProvider(HibernateValidator.class)
-                .configure()
-                .addValidatedValueHandler(new OptionalValidatedValueUnwrapper())
-                .buildValidatorFactory();
-
+        this.validatorFactory = Validators.newValidatorFactory();
         this.metricRegistry = new MetricRegistry();
         this.configurationSourceProvider = new FileConfigurationSourceProvider();
         this.classLoader = Thread.currentThread().getContextClassLoader();

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -9,7 +9,9 @@ import com.google.common.collect.Sets;
 import io.dropwizard.jersey.caching.CacheControlledResponseFeature;
 import io.dropwizard.jersey.guava.OptionalMessageBodyWriter;
 import io.dropwizard.jersey.guava.OptionalParamFeature;
+import io.dropwizard.jersey.params.NonEmptyStringParamFeature;
 import io.dropwizard.jersey.sessions.SessionFactoryProvider;
+import io.dropwizard.jersey.validation.HibernateValidationFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.ServerProperties;
 import org.glassfish.jersey.server.model.Resource;
@@ -24,10 +26,10 @@ import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.Path;
 import javax.ws.rs.ext.Provider;
-import java.lang.annotation.Annotation;
 import java.io.Serializable;
-import java.util.Comparator;
+import java.lang.annotation.Annotation;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 
@@ -57,11 +59,14 @@ public class DropwizardResourceConfig extends ResourceConfig {
             // create a subclass to pin it to Throwable
             register(new ComponentLoggingListener(this));
         }
+
         register(new InstrumentedResourceMethodApplicationListener(metricRegistry));
         register(CacheControlledResponseFeature.class);
         register(OptionalMessageBodyWriter.class);
         register(OptionalParamFeature.class);
+        register(NonEmptyStringParamFeature.class);
         register(new SessionFactoryProvider.Binder());
+        register(HibernateValidationFeature.class);
         register(ValidationFeature.class);
     }
 

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/NonEmptyStringParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/NonEmptyStringParam.java
@@ -10,7 +10,7 @@ import com.google.common.base.Strings;
  * {@code Optional.of("")}.
  */
 public class NonEmptyStringParam extends AbstractParam<Optional<String>> {
-    protected NonEmptyStringParam(String input) {
+    public NonEmptyStringParam(String input) {
         super(input);
     }
 

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/NonEmptyStringParamFeature.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/NonEmptyStringParamFeature.java
@@ -1,0 +1,40 @@
+package io.dropwizard.jersey.params;
+
+import com.google.common.base.Optional;
+
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.ext.ParamConverter;
+import javax.ws.rs.ext.ParamConverterProvider;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+/**
+ * A class for describing how Jersey should serialize a {@link NonEmptyStringParam}. If the
+ * parameter was not detected in the response, instead of the resulting value being null, it will
+ * evaluate to {@link Optional#absent()}
+ */
+public class NonEmptyStringParamFeature implements Feature {
+    @Override
+    public boolean configure(final FeatureContext context) {
+        context.register(new ParamConverterProvider() {
+            @Override
+            public <T> ParamConverter<T> getConverter(final Class<T> rawType,
+                                                      final Type genericType,
+                                                      final Annotation[] annotations) {
+                return (rawType != NonEmptyStringParam.class) ? null : new ParamConverter<T>() {
+                    @Override
+                    public T fromString(final String value) {
+                        return rawType.cast(new NonEmptyStringParam(value));
+                    }
+
+                    @Override
+                    public String toString(final T value) {
+                        return value == null ? null : value.toString();
+                    }
+                };
+            }
+        });
+        return true;
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/HibernateValidationFeature.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/HibernateValidationFeature.java
@@ -1,0 +1,39 @@
+package io.dropwizard.jersey.validation;
+
+import org.glassfish.hk2.api.Factory;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+
+import javax.inject.Singleton;
+import javax.validation.Configuration;
+import javax.validation.Validator;
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+
+/**
+ * Register a Dropwizard configured {@link Validator} with Jersey, so that Jersey doesn't use its
+ * default, which doesn't have our configurations applied.
+ */
+public class HibernateValidationFeature implements Feature {
+    @Override
+    public boolean configure(FeatureContext context) {
+        context.register(new AbstractBinder() {
+            @Override
+            protected void configure() {
+                bindFactory(DefaultConfigurationProvider.class, Singleton.class).to(Configuration.class).in(Singleton.class);
+            }
+        });
+
+        return true;
+    }
+
+    private static class DefaultConfigurationProvider implements Factory<Configuration> {
+        @Override
+        public Configuration provide() {
+            return Validators.newConfiguration();
+        }
+
+        @Override
+        public void dispose(final Configuration configuration) {
+        }
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/NonEmptyStringParamUnwrapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/NonEmptyStringParamUnwrapper.java
@@ -1,0 +1,23 @@
+package io.dropwizard.jersey.validation;
+
+import io.dropwizard.jersey.params.NonEmptyStringParam;
+import org.hibernate.validator.spi.valuehandling.ValidatedValueUnwrapper;
+
+import java.lang.reflect.Type;
+
+/**
+ * Let's the validator know that when validating a {@link NonEmptyStringParam} to validate the
+ * underlying value. This class is needed, temporarily, while Hibernate is not able to unwrap nested
+ * classes <a href="https://hibernate.atlassian.net/browse/HV-904"/>.
+ */
+public class NonEmptyStringParamUnwrapper extends ValidatedValueUnwrapper<NonEmptyStringParam> {
+    @Override
+    public Object handleValidatedValue(final NonEmptyStringParam nonEmptyStringParam) {
+        return nonEmptyStringParam.get().orNull();
+    }
+
+    @Override
+    public Type getValidatedValueType(final Type type) {
+        return String.class;
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ParamValidatorUnwrapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ParamValidatorUnwrapper.java
@@ -1,0 +1,28 @@
+package io.dropwizard.jersey.validation;
+
+
+import com.fasterxml.classmate.ResolvedType;
+import com.fasterxml.classmate.TypeResolver;
+import io.dropwizard.jersey.params.AbstractParam;
+import org.hibernate.validator.spi.valuehandling.ValidatedValueUnwrapper;
+
+import java.lang.reflect.Type;
+
+/**
+ * Let's the validator know that when validating a class that is an {@link AbstractParam} to
+ * validate the underlying value.
+ */
+public class ParamValidatorUnwrapper extends ValidatedValueUnwrapper<AbstractParam<?>> {
+    private final TypeResolver resolver = new TypeResolver();
+
+    @Override
+    public Object handleValidatedValue(final AbstractParam<?> abstractParam) {
+        return abstractParam.get();
+    }
+
+    @Override
+    public Type getValidatedValueType(final Type type) {
+        ResolvedType resolvedType = resolver.resolve(type);
+        return resolvedType.typeParametersFor(AbstractParam.class).get(0).getErasedType();
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/Validators.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/Validators.java
@@ -1,0 +1,44 @@
+package io.dropwizard.jersey.validation;
+
+import io.dropwizard.validation.valuehandling.OptionalValidatedValueUnwrapper;
+import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.HibernateValidatorConfiguration;
+import org.hibernate.validator.spi.valuehandling.ValidatedValueUnwrapper;
+
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+/**
+ * A utility class for Hibernate.
+ */
+public class Validators {
+    private Validators() { /* singleton */ }
+
+    /**
+     * Creates a new {@link Validator} based on {@link #newValidatorFactory()}
+     */
+    public static Validator newValidator() {
+        return newValidatorFactory().getValidator();
+    }
+
+    /**
+     * Creates a new {@link ValidatorFactory} based on {@link #newConfiguration()}
+     */
+    public static ValidatorFactory newValidatorFactory() {
+        return newConfiguration().buildValidatorFactory();
+    }
+
+    /**
+     * Creates a new {@link HibernateValidatorConfiguration} with all the custom {@link
+     * ValidatedValueUnwrapper} registered.
+     */
+    public static HibernateValidatorConfiguration newConfiguration() {
+        return Validation
+                .byProvider(HibernateValidator.class)
+                .configure()
+                .addValidatedValueHandler(new OptionalValidatedValueUnwrapper())
+                .addValidatedValueHandler(new NonEmptyStringParamUnwrapper())
+                .addValidatedValueHandler(new ParamValidatorUnwrapper());
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/NonEmptyStringParamProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/NonEmptyStringParamProviderTest.java
@@ -1,0 +1,62 @@
+package io.dropwizard.jersey.params;
+
+
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.jersey.DropwizardResourceConfig;
+import io.dropwizard.logging.BootstrapLogging;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
+import org.junit.Test;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NonEmptyStringParamProviderTest extends JerseyTest {
+    static {
+        BootstrapLogging.bootstrap();
+    }
+
+    @Override
+    protected Application configure() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
+        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+                .register(NonEmptyStringParamResource.class);
+    }
+
+    @Test
+    public void shouldReturnDefaultMessageWhenNonExistent() {
+        String response = target("/non-empty/string").request().get(String.class);
+        assertThat(response).isEqualTo("Hello");
+    }
+
+    @Test
+    public void shouldReturnDefaultMessageWhenEmptyString() {
+        String response = target("/non-empty/string").queryParam("message", "").request().get(String.class);
+        assertThat(response).isEqualTo("Hello");
+    }
+
+    @Test
+    public void shouldReturnDefaultMessageWhenNull() {
+        String response = target("/non-empty/string").queryParam("message").request().get(String.class);
+        assertThat(response).isEqualTo("Hello");
+    }
+
+    @Test
+    public void shouldReturnMessageWhenSpecified() {
+        String response = target("/non-empty/string").queryParam("message", "Goodbye").request().get(String.class);
+        assertThat(response).isEqualTo("Goodbye");
+    }
+
+    @Path("/non-empty")
+    public static class NonEmptyStringParamResource {
+        @GET
+        @Path("/string")
+        public String getMessage(@QueryParam("message") NonEmptyStringParam message) {
+            return message.get().or("Hello");
+        }
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
@@ -67,7 +67,18 @@ public class ConstraintViolationExceptionMapperTest extends JerseyTest {
                 .queryParam("name", "hi").request().get();
         assertThat(cache.getStatus()).isEqualTo(400);
         assertThat(cache.readEntity(String.class)).isEqualTo(ret);
+    }
 
+    @Test
+    public void getInvalidCustomTypeIs400() throws Exception {
+        // query parameter is too short and so will fail validation
+        final Response response = target("/valid/barter")
+                .queryParam("name", "hi").request().get();
+
+        assertThat(response.getStatus()).isEqualTo(400);
+
+        String ret = "{\"errors\":[\"query param name length must be between 3 and 2147483647\"]}";
+        assertThat(response.readEntity(String.class)).isEqualTo(ret);
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ParamValidatorUnwrapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ParamValidatorUnwrapperTest.java
@@ -1,0 +1,52 @@
+package io.dropwizard.jersey.validation;
+
+import io.dropwizard.jersey.params.IntParam;
+import io.dropwizard.jersey.params.NonEmptyStringParam;
+import org.hibernate.validator.constraints.Length;
+import org.hibernate.validator.valuehandling.UnwrapValidatedValue;
+import org.junit.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+import javax.validation.constraints.Min;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ParamValidatorUnwrapperTest {
+
+    public static class Example {
+        @Min(3)
+        @UnwrapValidatedValue
+        public IntParam inter = new IntParam("4");
+
+        @Length(max = 3)
+        @UnwrapValidatedValue
+        public NonEmptyStringParam name = new NonEmptyStringParam("a");
+    }
+
+    private final Validator validator = Validators.newValidator();
+
+    @Test
+    public void succeedsWithAllGoodData() {
+        final Example example = new Example();
+        final Set<ConstraintViolation<Example>> validate = validator.validate(example);
+        assertThat(validate).isEmpty();
+    }
+
+    @Test
+    public void failsWithInvalidIntParam() {
+        final Example example = new Example();
+        example.inter = new IntParam("2");
+        final Set<ConstraintViolation<Example>> validate = validator.validate(example);
+        assertThat(validate).hasSize(1);
+    }
+
+    @Test
+    public void failsWithInvalidNonEmptyStringParam() {
+        final Example example = new Example();
+        example.name = new NonEmptyStringParam("hello");
+        final Set<ConstraintViolation<Example>> validate = validator.validate(example);
+        assertThat(validate).hasSize(1);
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
@@ -1,10 +1,12 @@
 package io.dropwizard.jersey.validation;
 
 import io.dropwizard.jersey.params.IntParam;
+import io.dropwizard.jersey.params.NonEmptyStringParam;
 import io.dropwizard.validation.Validated;
 import org.hibernate.validator.constraints.Email;
 import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.NotEmpty;
+import org.hibernate.validator.valuehandling.UnwrapValidatedValue;
 
 import javax.servlet.ServletContext;
 import javax.validation.Valid;
@@ -28,6 +30,12 @@ public class ValidatingResource {
     @Length(max = 3)
     public String blaze(@QueryParam("name") @Length(min = 3) String name) {
         return name;
+    }
+
+    @GET
+    @Path("barter")
+    public String isnt(@QueryParam("name") @Length(min = 3) @UnwrapValidatedValue NonEmptyStringParam name) {
+        return name.get().orNull();
     }
 
     @GET

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ResourceTestRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ResourceTestRule.java
@@ -9,6 +9,7 @@ import com.google.common.collect.Sets;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
+import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.logging.BootstrapLogging;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.servlet.ServletProperties;
@@ -44,7 +45,7 @@ public class ResourceTestRule implements TestRule {
         private final Set<Class<?>> providers = Sets.newHashSet();
         private final Map<String, Object> properties = Maps.newHashMap();
         private ObjectMapper mapper = Jackson.newObjectMapper();
-        private Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        private Validator validator = Validators.newValidator();
         private TestContainerFactory testContainerFactory = new InMemoryTestContainerFactory();
 
         public Builder setMapper(ObjectMapper mapper) {

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ResourceTestRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ResourceTestRule.java
@@ -10,6 +10,7 @@ import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
 import io.dropwizard.jersey.validation.Validators;
+import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
 import io.dropwizard.logging.BootstrapLogging;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.servlet.ServletProperties;
@@ -17,13 +18,12 @@ import org.glassfish.jersey.test.DeploymentContext;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.ServletDeploymentContext;
 import org.glassfish.jersey.test.inmemory.InMemoryTestContainerFactory;
-import org.glassfish.jersey.test.spi.TestContainerException;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+
 import javax.servlet.ServletConfig;
-import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Context;
@@ -152,6 +152,7 @@ public class ResourceTestRule implements TestRule {
         }
 
         private void configure(final ResourceTestRule resourceTestRule) {
+            register(new ConstraintViolationExceptionMapper());
             for (Class<?> provider : resourceTestRule.providers) {
                 register(provider);
             }


### PR DESCRIPTION
This commit enables `Optional` and `AbstractParam` parameters to be
validated in resource endpoints. This required additional code needed in
setting up the validator, so I extracted the common functionality out to a
new class `Hibernate` that should be analogous to the present `Jackson`
class.

Also this commit makes the `NonEmptyStringParam` constructor public like other
`AbstractParam`s. The second commit registers the default
`ConstraintViolationExceptionMapper` in test cases (and this can always be
overridden by the user if they have a custom exception mapper for constraint
violations)

The one area where this commit falls short is that it currently doesn't
allow a user custom hibernate configuration in the jersey validation. Thus,
request entities will be validated by the user's validator but parameters
will not (they'll still be validated by the Dropwizard configured
validator). Since I wasn't sure how best to incorporate this
functionality, I decided to leave it out of this commit.

This allows for some interesting endpoints:

```java
    @GET
    @Path("search")
    public String search(
            @QueryParam("limit")
            @DefaultValue("10")
            @UnwrapValidatedValue
            @Min(1) @Max(100)
            IntParam limit,

            @QueryParam("offset")
            @DefaultValue("0")
            @UnwrapValidatedValue
            @Min(0)
            IntParam offset) {
        // ...
    }
```

It's annotation overload (I believe `@UnwrapValidatedValue` will be
redundant in Hibernate 5.2), but it certainly does pack a lot of
functionality in the parameters.