### PR TITLE
Width independent test

### DIFF
--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/AbstractMigrationTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/AbstractMigrationTest.java
@@ -9,6 +9,10 @@ import java.io.IOException;
 
 public class AbstractMigrationTest {
 
+    static {
+        ArgumentParsers.setTerminalWidthDetection(false);
+    }
+
     protected static Subparser createSubparser(AbstractLiquibaseCommand<?> command) {
         final Subparser subparser = ArgumentParsers.newArgumentParser("db")
                 .addSubparsers()

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCommandTest.java
@@ -5,6 +5,7 @@ import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.db.DatabaseConfiguration;
 import net.jcip.annotations.NotThreadSafe;
 import net.sourceforge.argparse4j.ArgumentParsers;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 import org.junit.Before;
@@ -69,37 +70,43 @@ public class DbMigrateCommandTest extends AbstractMigrationTest {
 
     @Test
     public void testPrintHelp() throws Exception {
-        final Subparser subparser = ArgumentParsers.newArgumentParser("db")
-                .addSubparsers()
-                .addParser(migrateCommand.getName())
-                .description(migrateCommand.getDescription());
-        migrateCommand.configure(subparser);
+        final boolean shouldWidthDetect = ArgumentParsers.getTerminalWidthDetection();
+        try {
+            ArgumentParsers.setTerminalWidthDetection(false);
+            final Subparser subparser = ArgumentParsers.newArgumentParser("db")
+                    .addSubparsers()
+                    .addParser(migrateCommand.getName())
+                    .description(migrateCommand.getDescription());
+            migrateCommand.configure(subparser);
 
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        subparser.printHelp(new PrintWriter(baos, true));
+            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            subparser.printHelp(new PrintWriter(baos, true));
 
-        assertThat(baos.toString("UTF-8")).isEqualTo(String.format(
-                        "usage: db migrate [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
-                        "          [--schema SCHEMA] [-n] [-c COUNT] [-i CONTEXTS] [file]%n" +
-                        "%n" +
-                        "Apply all pending change sets.%n" +
-                        "%n" +
-                        "positional arguments:%n" +
-                        "  file                   application configuration file%n" +
-                        "%n" +
-                        "optional arguments:%n" +
-                        "  -h, --help             show this help message and exit%n" +
-                        "  --migrations MIGRATIONS-FILE%n" +
-                        "                         the file containing  the  Liquibase migrations for%n" +
-                        "                         the application%n" +
-                        "  --catalog CATALOG      Specify  the   database   catalog   (use  database%n" +
-                        "                         default if omitted)%n" +
-                        "  --schema SCHEMA        Specify the database schema  (use database default%n" +
-                        "                         if omitted)%n" +
-                        "  -n, --dry-run          output the DDL to stdout, don't run it%n" +
-                        "  -c COUNT, --count COUNT%n" +
-                        "                         only apply the next N change sets%n" +
-                        "  -i CONTEXTS, --include CONTEXTS%n" +
-                        "                         include change sets from the given context%n"));
+            assertThat(baos.toString("UTF-8")).isEqualTo(String.format(
+                    "usage: db migrate [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
+                    "          [--schema SCHEMA] [-n] [-c COUNT] [-i CONTEXTS] [file]%n" +
+                    "%n" +
+                    "Apply all pending change sets.%n" +
+                    "%n" +
+                    "positional arguments:%n" +
+                    "  file                   application configuration file%n" +
+                    "%n" +
+                    "optional arguments:%n" +
+                    "  -h, --help             show this help message and exit%n" +
+                    "  --migrations MIGRATIONS-FILE%n" +
+                    "                         the file containing  the  Liquibase migrations for%n" +
+                    "                         the application%n" +
+                    "  --catalog CATALOG      Specify  the   database   catalog   (use  database%n" +
+                    "                         default if omitted)%n" +
+                    "  --schema SCHEMA        Specify the database schema  (use database default%n" +
+                    "                         if omitted)%n" +
+                    "  -n, --dry-run          output the DDL to stdout, don't run it%n" +
+                    "  -c COUNT, --count COUNT%n" +
+                    "                         only apply the next N change sets%n" +
+                    "  -i CONTEXTS, --include CONTEXTS%n" +
+                    "                         include change sets from the given context%n"));
+        } finally {
+            ArgumentParsers.setTerminalWidthDetection(shouldWidthDetect);
+        }
     }
 }

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCommandTest.java
@@ -5,7 +5,6 @@ import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.db.DatabaseConfiguration;
 import net.jcip.annotations.NotThreadSafe;
 import net.sourceforge.argparse4j.ArgumentParsers;
-import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 import org.junit.Before;
@@ -70,43 +69,37 @@ public class DbMigrateCommandTest extends AbstractMigrationTest {
 
     @Test
     public void testPrintHelp() throws Exception {
-        final boolean shouldWidthDetect = ArgumentParsers.getTerminalWidthDetection();
-        try {
-            ArgumentParsers.setTerminalWidthDetection(false);
-            final Subparser subparser = ArgumentParsers.newArgumentParser("db")
-                    .addSubparsers()
-                    .addParser(migrateCommand.getName())
-                    .description(migrateCommand.getDescription());
-            migrateCommand.configure(subparser);
+        final Subparser subparser = ArgumentParsers.newArgumentParser("db")
+                .addSubparsers()
+                .addParser(migrateCommand.getName())
+                .description(migrateCommand.getDescription());
+        migrateCommand.configure(subparser);
 
-            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            subparser.printHelp(new PrintWriter(baos, true));
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        subparser.printHelp(new PrintWriter(baos, true));
 
-            assertThat(baos.toString("UTF-8")).isEqualTo(String.format(
-                    "usage: db migrate [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
-                    "          [--schema SCHEMA] [-n] [-c COUNT] [-i CONTEXTS] [file]%n" +
-                    "%n" +
-                    "Apply all pending change sets.%n" +
-                    "%n" +
-                    "positional arguments:%n" +
-                    "  file                   application configuration file%n" +
-                    "%n" +
-                    "optional arguments:%n" +
-                    "  -h, --help             show this help message and exit%n" +
-                    "  --migrations MIGRATIONS-FILE%n" +
-                    "                         the file containing  the  Liquibase migrations for%n" +
-                    "                         the application%n" +
-                    "  --catalog CATALOG      Specify  the   database   catalog   (use  database%n" +
-                    "                         default if omitted)%n" +
-                    "  --schema SCHEMA        Specify the database schema  (use database default%n" +
-                    "                         if omitted)%n" +
-                    "  -n, --dry-run          output the DDL to stdout, don't run it%n" +
-                    "  -c COUNT, --count COUNT%n" +
-                    "                         only apply the next N change sets%n" +
-                    "  -i CONTEXTS, --include CONTEXTS%n" +
-                    "                         include change sets from the given context%n"));
-        } finally {
-            ArgumentParsers.setTerminalWidthDetection(shouldWidthDetect);
-        }
+        assertThat(baos.toString("UTF-8")).isEqualTo(String.format(
+                        "usage: db migrate [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
+                        "          [--schema SCHEMA] [-n] [-c COUNT] [-i CONTEXTS] [file]%n" +
+                        "%n" +
+                        "Apply all pending change sets.%n" +
+                        "%n" +
+                        "positional arguments:%n" +
+                        "  file                   application configuration file%n" +
+                        "%n" +
+                        "optional arguments:%n" +
+                        "  -h, --help             show this help message and exit%n" +
+                        "  --migrations MIGRATIONS-FILE%n" +
+                        "                         the file containing  the  Liquibase migrations for%n" +
+                        "                         the application%n" +
+                        "  --catalog CATALOG      Specify  the   database   catalog   (use  database%n" +
+                        "                         default if omitted)%n" +
+                        "  --schema SCHEMA        Specify the database schema  (use database default%n" +
+                        "                         if omitted)%n" +
+                        "  -n, --dry-run          output the DDL to stdout, don't run it%n" +
+                        "  -c COUNT, --count COUNT%n" +
+                        "                         only apply the next N change sets%n" +
+                        "  -i CONTEXTS, --include CONTEXTS%n" +
+                        "                         include change sets from the given context%n"));
     }
 }


### PR DESCRIPTION
The test for the db migrate command help is dependent upon terminal width, so it fails on my mac laptop. This change fixes the test to instruct argparse4j to not detect terminal width during the test. Unfortunately the library keeps this setting as a static class variable, rather than a setting on the parser, so the try/catch block is needed to ensure it gets reset after the test is done.
