### PR TITLE
Tests for DbDumpCommand

### DIFF
--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbDumpCommand.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbDumpCommand.java
@@ -1,5 +1,6 @@
 package io.dropwizard.migrations;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.Configuration;
 import io.dropwizard.db.DatabaseConfiguration;
 import liquibase.CatalogAndSchema;
@@ -39,6 +40,14 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class DbDumpCommand<T extends Configuration> extends AbstractLiquibaseCommand<T> {
+
+    private PrintStream outputStream = System.out;
+
+    @VisibleForTesting
+    void setOutputStream(PrintStream outputStream) {
+        this.outputStream = outputStream;
+    }
+
     public DbDumpCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass) {
         super("dump",
               "Generate a dump of the existing database state.",
@@ -152,31 +161,31 @@ public class DbDumpCommand<T extends Configuration> extends AbstractLiquibaseCom
     public void run(Namespace namespace, Liquibase liquibase) throws Exception {
         final Set<Class<? extends DatabaseObject>> compareTypes = new HashSet<>();
 
-        if (namespace.getBoolean("columns")) {
+        if (isTrue(namespace.getBoolean("columns"))) {
             compareTypes.add(Column.class);
         }
-        if (namespace.getBoolean("data")) {
+        if (isTrue(namespace.getBoolean("data"))) {
             compareTypes.add(Data.class);
         }
-        if (namespace.getBoolean("foreign-keys")) {
+        if (isTrue(namespace.getBoolean("foreign-keys"))) {
             compareTypes.add(ForeignKey.class);
         }
-        if (namespace.getBoolean("indexes")) {
+        if (isTrue(namespace.getBoolean("indexes"))) {
             compareTypes.add(Index.class);
         }
-        if (namespace.getBoolean("primary-keys")) {
+        if (isTrue(namespace.getBoolean("primary-keys"))) {
             compareTypes.add(PrimaryKey.class);
         }
-        if (namespace.getBoolean("sequences")) {
+        if (isTrue(namespace.getBoolean("sequences"))) {
             compareTypes.add(Sequence.class);
         }
-        if (namespace.getBoolean("tables")) {
+        if (isTrue(namespace.getBoolean("tables"))) {
             compareTypes.add(Table.class);
         }
-        if (namespace.getBoolean("unique-constraints")) {
+        if (isTrue(namespace.getBoolean("unique-constraints"))) {
             compareTypes.add(UniqueConstraint.class);
         }
-        if (namespace.getBoolean("views")) {
+        if (isTrue(namespace.getBoolean("views"))) {
             compareTypes.add(View.class);
         }
 
@@ -189,7 +198,7 @@ public class DbDumpCommand<T extends Configuration> extends AbstractLiquibaseCom
                 generateChangeLog(database, database.getDefaultSchema(), diffToChangeLog, file, compareTypes);
             }
         } else {
-            generateChangeLog(database, database.getDefaultSchema(), diffToChangeLog, System.out, compareTypes);
+            generateChangeLog(database, database.getDefaultSchema(), diffToChangeLog, outputStream, compareTypes);
         }
     }
 
@@ -211,5 +220,9 @@ public class DbDumpCommand<T extends Configuration> extends AbstractLiquibaseCom
         } catch (InvalidExampleException e) {
             throw new UnexpectedLiquibaseException(e);
         }
+    }
+
+    private static boolean isTrue(Boolean nullableCondition) {
+        return nullableCondition != null && nullableCondition;
     }
 }

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbDumpCommand.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbDumpCommand.java
@@ -68,7 +68,7 @@ public class DbDumpCommand<T extends Configuration> extends AbstractLiquibaseCom
         columns.addArgument("--columns")
                .action(Arguments.storeTrue())
                .dest("columns")
-               .help("Check for added, removed, or modified tables (default)");
+               .help("Check for added, removed, or modified columns (default)");
         columns.addArgument("--ignore-columns")
                .action(Arguments.storeFalse())
                .dest("columns")
@@ -132,7 +132,7 @@ public class DbDumpCommand<T extends Configuration> extends AbstractLiquibaseCom
         sequences.addArgument("--ignore-sequences")
                  .action(Arguments.storeFalse())
                  .dest("sequences")
-                 .help("Ignore foreign keys");
+                 .help("Ignore sequences");
 
         final ArgumentGroup data = subparser.addArgumentGroup("Data");
         data.addArgument("--data")

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDumpCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDumpCommandTest.java
@@ -1,0 +1,234 @@
+package io.dropwizard.migrations;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
+import com.google.common.io.Files;
+import com.google.common.io.Resources;
+import net.jcip.annotations.NotThreadSafe;
+import net.sourceforge.argparse4j.inf.Namespace;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.*;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@NotThreadSafe
+public class DbDumpCommandTest extends AbstractMigrationTest {
+
+    private static DocumentBuilder xmlParser;
+    private static List<String> attributeNames;
+
+    private final DbDumpCommand<TestMigrationConfiguration> dumpCommand =
+            new DbDumpCommand<>(new TestMigrationDatabaseConfiguration(), TestMigrationConfiguration.class);
+    private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    private TestMigrationConfiguration existedDbConf;
+
+    @BeforeClass
+    public static void initXmlParser() throws Exception {
+        xmlParser = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        attributeNames = ImmutableList.of("columns", "foreign-keys", "indexes", "primary-keys", "sequences",
+                "tables", "unique-constraints", "views");
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        final String existedDbPath = new File(Resources.getResource("test-db.mv.db").toURI()).getAbsolutePath();
+        final String existedDbUrl = "jdbc:h2:" + StringUtils.removeEnd(existedDbPath, ".mv.db");
+        existedDbConf = createConfiguration(existedDbUrl);
+        dumpCommand.setOutputStream(new PrintStream(baos));
+    }
+
+    @Test
+    public void testDumpSchema() throws Exception {
+        final Map<String, Object> attributes = Maps.newHashMap();
+        for (String name : attributeNames) {
+            attributes.put(name, true);
+        }
+        dumpCommand.run(null, new Namespace(attributes), existedDbConf);
+
+        final Element changeSet = getFirstElement(toXmlDocument(baos).getDocumentElement(), "changeSet");
+        assertCreateTable(changeSet);
+    }
+
+    @Test
+    public void testDumpSchemaAndData() throws Exception {
+        final Map<String, Object> attributes = Maps.newHashMap();
+        for (String name : Iterables.concat(attributeNames, ImmutableList.of("data"))) {
+            attributes.put(name, true);
+        }
+        dumpCommand.run(null, new Namespace(attributes), existedDbConf);
+
+        final NodeList changeSets = toXmlDocument(baos).getDocumentElement().getElementsByTagName("changeSet");
+        assertCreateTable((Element) changeSets.item(0));
+        assertInsertData((Element) changeSets.item(1));
+    }
+
+    @Test
+    public void testDumpOnlyData() throws Exception {
+        dumpCommand.run(null, new Namespace(ImmutableMap.of("data", (Object) true)), existedDbConf);
+
+        final Element changeSet = getFirstElement(toXmlDocument(baos).getDocumentElement(), "changeSet");
+        assertInsertData(changeSet);
+    }
+
+    @Test
+    public void testWriteToFile() throws Exception {
+        final File file = File.createTempFile("migration", ".xml");
+        final Map<String, Object> attributes = ImmutableMap.of("output", (Object) file.getAbsolutePath());
+        dumpCommand.run(null, new Namespace(attributes), existedDbConf);
+        // Check that file is exist, and has some XML content (no reason to make a full-blown XML assertion)
+        assertThat(Files.toString(file, Charsets.UTF_8)).startsWith("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>");
+    }
+
+    @Test
+    public void testHelpPage() throws Exception {
+        createSubparser(dumpCommand).printHelp(new PrintWriter(baos, true));
+        assertThat(baos.toString("UTF-8")).isEqualTo(String.format(
+                "usage: db dump [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
+                        "          [--schema SCHEMA] [-o OUTPUT] [--tables] [--ignore-tables]%n" +
+                        "          [--columns] [--ignore-columns] [--views] [--ignore-views]%n" +
+                        "          [--primary-keys] [--ignore-primary-keys] [--unique-constraints]%n" +
+                        "          [--ignore-unique-constraints] [--indexes] [--ignore-indexes]%n" +
+                        "          [--foreign-keys] [--ignore-foreign-keys] [--sequences]%n" +
+                        "          [--ignore-sequences] [--data] [--ignore-data] [file]%n" +
+                        "%n" +
+                        "Generate a dump of the existing database state.%n" +
+                        "%n" +
+                        "positional arguments:%n" +
+                        "  file                   application configuration file%n" +
+                        "%n" +
+                        "optional arguments:%n" +
+                        "  -h, --help             show this help message and exit%n" +
+                        "  --migrations MIGRATIONS-FILE%n" +
+                        "                         the file containing  the  Liquibase migrations for%n" +
+                        "                         the application%n" +
+                        "  --catalog CATALOG      Specify  the   database   catalog   (use  database%n" +
+                        "                         default if omitted)%n" +
+                        "  --schema SCHEMA        Specify the database schema  (use database default%n" +
+                        "                         if omitted)%n" +
+                        "  -o OUTPUT, --output OUTPUT%n" +
+                        "                         Write output to <file> instead of stdout%n" +
+                        "%n" +
+                        "Tables:%n" +
+                        "  --tables               Check for added or removed tables (default)%n" +
+                        "  --ignore-tables        Ignore tables%n" +
+                        "%n" +
+                        "Columns:%n" +
+                        "  --columns              Check for  added,  removed,  or  modified  columns%n" +
+                        "                         (default)%n" +
+                        "  --ignore-columns       Ignore columns%n" +
+                        "%n" +
+                        "Views:%n" +
+                        "  --views                Check  for  added,  removed,   or  modified  views%n" +
+                        "                         (default)%n" +
+                        "  --ignore-views         Ignore views%n" +
+                        "%n" +
+                        "Primary Keys:%n" +
+                        "  --primary-keys         Check for changed primary keys (default)%n" +
+                        "  --ignore-primary-keys  Ignore primary keys%n" +
+                        "%n" +
+                        "Unique Constraints:%n" +
+                        "  --unique-constraints   Check for changed unique constraints (default)%n" +
+                        "  --ignore-unique-constraints%n" +
+                        "                         Ignore unique constraints%n" +
+                        "%n" +
+                        "Indexes:%n" +
+                        "  --indexes              Check for changed indexes (default)%n" +
+                        "  --ignore-indexes       Ignore indexes%n" +
+                        "%n" +
+                        "Foreign Keys:%n" +
+                        "  --foreign-keys         Check for changed foreign keys (default)%n" +
+                        "  --ignore-foreign-keys  Ignore foreign keys%n" +
+                        "%n" +
+                        "Sequences:%n" +
+                        "  --sequences            Check for changed sequences (default)%n" +
+                        "  --ignore-sequences     Ignore sequences%n" +
+                        "%n" +
+                        "Data:%n" +
+                        "  --data                 Check for changed data%n" +
+                        "  --ignore-data          Ignore data (default)%n"));
+    }
+
+
+    private static Document toXmlDocument(ByteArrayOutputStream baos) throws SAXException, IOException {
+        return xmlParser.parse(new ByteArrayInputStream(baos.toByteArray()));
+    }
+
+    /**
+     * Assert correctness of a change set with creation of a table
+     *
+     * @param changeSet actual XML element
+     */
+    private static void assertCreateTable(Element changeSet) {
+        final Element createTable = getFirstElement(changeSet, "createTable");
+
+        assertThat(createTable.getAttribute("catalogName")).isEqualTo("TEST-DB");
+        assertThat(createTable.getAttribute("schemaName")).isEqualTo("PUBLIC");
+        assertThat(createTable.getAttribute("tableName")).isEqualTo("PERSONS");
+
+        final NodeList columns = createTable.getElementsByTagName("column");
+
+        final Element idColumn = (Element) columns.item(0);
+        assertThat(idColumn.getAttribute("autoIncrement")).isEqualTo("true");
+        assertThat(idColumn.getAttribute("name")).isEqualTo("ID");
+        assertThat(idColumn.getAttribute("type")).isEqualTo("INT(10)");
+        final Element idColumnConstraints = getFirstElement(idColumn, "constraints");
+        assertThat(idColumnConstraints.getAttribute("primaryKey")).isEqualTo("true");
+        assertThat(idColumnConstraints.getAttribute("primaryKeyName")).isEqualTo("PK_PERSONS");
+
+        final Element nameColumn = (Element) columns.item(1);
+        assertThat(nameColumn.getAttribute("name")).isEqualTo("NAME");
+        assertThat(nameColumn.getAttribute("type")).isEqualTo("VARCHAR(256)");
+        final Element nameColumnConstraints = getFirstElement(nameColumn, "constraints");
+        assertThat(nameColumnConstraints.getAttribute("nullable")).isEqualTo("false");
+
+        final Element emailColumn = (Element) columns.item(2);
+        assertThat(emailColumn.getAttribute("name")).isEqualTo("EMAIL");
+        assertThat(emailColumn.getAttribute("type")).isEqualTo("VARCHAR(128)");
+    }
+
+    /**
+     * Assert a correctness of a change set with insertion data into a table
+     *
+     * @param changeSet actual XML element
+     */
+    private static void assertInsertData(Element changeSet) {
+        final Element insert = getFirstElement(changeSet, "insert");
+
+        assertThat(insert.getAttribute("catalogName")).isEqualTo("TEST-DB");
+        assertThat(insert.getAttribute("schemaName")).isEqualTo("PUBLIC");
+        assertThat(insert.getAttribute("tableName")).isEqualTo("PERSONS");
+
+        final NodeList columns = insert.getElementsByTagName("column");
+
+        final Element idColumn = (Element) columns.item(0);
+        assertThat(idColumn.getAttribute("name")).isEqualTo("ID");
+        assertThat(idColumn.getAttribute("valueNumeric")).isEqualTo("1");
+
+        final Element nameColumn = (Element) columns.item(1);
+        assertThat(nameColumn.getAttribute("name")).isEqualTo("NAME");
+        assertThat(nameColumn.getAttribute("value")).isEqualTo("Bill Smith");
+
+        final Element emailColumn = (Element) columns.item(2);
+        assertThat(emailColumn.getAttribute("name")).isEqualTo("EMAIL");
+        assertThat(emailColumn.getAttribute("value")).isEqualTo("bill@smith.me");
+    }
+
+    private static Element getFirstElement(Element root, String tagName) {
+        return (Element) root.getElementsByTagName(tagName).item(0);
+    }
+}


### PR DESCRIPTION
This pull requests consists from 2 changes:
* Fix descriptions of some parameters in `DbDumpCommand`
* Add tests for `DbDumpCommand`

This suite checks 4 cases:

* Dump the existed database schema to an XML change set
* Dump the schema and data to an XML change set
* Dump only data
* Print a correct help page

For checking correctness of a change set, it uses a DOM XML parser, rather than regular expressions or string manipulations. The reason for this is that the resulted XML text is not a constant and depends on environment and time of a run. To overcome this, we use the XML parser, because it provides ability to make an intelligent  assertions. In the end, it makes tests more stable and easy to maintain.