### PR TITLE
Update validationmethod documentation to use JsonIgnore

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -1330,6 +1330,7 @@ declarative annotations. As an emergency maneuver, add the ``@ValidationMethod``
 
 .. code-block:: java
 
+    @JsonIgnore
     @ValidationMethod(message="may not be Coda")
     public boolean isNotCoda() {
         return !("Coda".equals(name));


### PR DESCRIPTION
Added @JsonIgnore to example validation method. Whilst the application will work without this flag, it will fail during testing as additional paramters will be added to the created JSON StackOverflow: http://stackoverflow.com/questions/26551726/dropwizard-validationmethod-adding-a-json-property

To be safe, and promote unit testing, this should be included in the example documentation.