### PR TITLE
Add facility to set a custom ObjectMapper in Bootstrap

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/setup/Bootstrap.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/Bootstrap.java
@@ -41,11 +41,11 @@ import javax.validation.ValidatorFactory;
  */
 public class Bootstrap<T extends Configuration> {
     private final Application<T> application;
-    private final ObjectMapper objectMapper;
     private final List<Bundle> bundles;
     private final List<ConfiguredBundle<? super T>> configuredBundles;
     private final List<Command> commands;
 
+    private ObjectMapper objectMapper;
     private MetricRegistry metricRegistry;
     private ConfigurationSourceProvider configurationSourceProvider;
     private ClassLoader classLoader;
@@ -171,6 +171,17 @@ public class Bootstrap<T extends Configuration> {
      */
     public ObjectMapper getObjectMapper() {
         return objectMapper;
+    }
+
+    /**
+     * Sets the given {@link ObjectMapper} to the bootstrap.
+     * <p<b>WARNING:</b> The mapper should be created by {@link Jackson#newMinimalObjectMapper()}
+     * or {@link Jackson#newObjectMapper()}, otherwise it will not work with Dropwizard.</p>
+     *
+     * @param objectMapper an {@link ObjectMapper}
+     */
+    public void setObjectMapper(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
     }
 
     /**

--- a/dropwizard-core/src/test/java/io/dropwizard/setup/BootstrapTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/setup/BootstrapTest.java
@@ -3,11 +3,13 @@ package io.dropwizard.setup;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.UniformReservoir;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.configuration.DefaultConfigurationFactoryFactory;
 import io.dropwizard.configuration.FileConfigurationSourceProvider;
 
+import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.validation.NonEmptyStringParamUnwrapper;
 import io.dropwizard.jersey.validation.ParamValidatorUnwrapper;
 import io.dropwizard.validation.valuehandling.OptionalValidatedValueUnwrapper;
@@ -118,5 +120,12 @@ public class BootstrapTest {
         bootstrap.setValidatorFactory(factory);
 
         assertThat(bootstrap.getValidatorFactory()).isSameAs(factory);
+    }
+
+    @Test
+    public void canUseCustomObjectMapper() {
+        final ObjectMapper minimalObjectMapper = Jackson.newMinimalObjectMapper();
+        bootstrap.setObjectMapper(minimalObjectMapper);
+        assertThat(bootstrap.getObjectMapper()).isSameAs(minimalObjectMapper);
     }
 }

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
@@ -37,6 +37,18 @@ public class Jackson {
         return configure(mapper);
     }
 
+    /**
+     * Creates a new minimal {@link ObjectMapper} that will work with Dropwizard out of box.
+     * <p><b>NOTE:</b> Use it, if the default Dropwizard's {@link ObjectMapper}, created in
+     * {@link #newObjectMapper()}, is too aggressive for you.</p>
+     */
+    public static ObjectMapper newMinimalObjectMapper() {
+        return new ObjectMapper()
+                .registerModule(new GuavaModule())
+                .registerModule(new LogbackModule())
+                .setSubtypeResolver(new DiscoverableSubtypeResolver());
+    }
+
     private static ObjectMapper configure(ObjectMapper mapper) {
         mapper.registerModule(new GuavaModule());
         mapper.registerModule(new LogbackModule());


### PR DESCRIPTION
Some users reported, that the default Dropwizard's `ObjectMapper` is too aggresive for them. 
See #1111, #1095, #1098. So we should provide a way to set a more *ligthweight* mapper. To achieve this this change:

* Adds a factory method, that creates a minimal `ObjectMapper`, which still works with Dropwizard.
* Adds a setter in Boostrap, allowing users to provide a custom `ObjectMapper`.