### PR TITLE
Add support for setting a custom DB pool connection validator

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -988,6 +988,9 @@ evictionInterval                5 seconds                The amount of time to s
 
 validationInterval              30 seconds               To avoid excess validation, only run validation once every
                                                          interval.
+
+validatorClassName              none                     Name of a class of a custom validator implementation, which
+                                                         will be used for validating connections.
 ============================    =====================    ===============================================================
 
 .. _man-configuration-polymorphic:

--- a/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
+++ b/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
@@ -248,6 +248,14 @@ import java.util.concurrent.TimeUnit;
  *             To avoid excess validation, only run validation once every interval.
  *         </td>
  *     </tr>
+ *     <tr>
+ *         <td>{@code validatorClassName}</td>
+ *         <td>(none)</td>
+ *         <td>
+ *             Name of a class of a custom {@link org.apache.tomcat.jdbc.pool.Validator}
+ *             implementation, which will be used for validating connections.
+ *         </td>
+ *     </tr>
  * </table>
  */
 public class DataSourceFactory implements PooledDataSourceFactory {
@@ -353,6 +361,8 @@ public class DataSourceFactory implements PooledDataSourceFactory {
     @NotNull
     @MinDuration(1)
     private Duration validationInterval = Duration.seconds(30);
+
+    private Optional<String> validatorClassName = Optional.absent();
 
     @JsonProperty
     @Override
@@ -697,6 +707,16 @@ public class DataSourceFactory implements PooledDataSourceFactory {
         return Optional.fromNullable(validationQueryTimeout);
     }
 
+    @JsonProperty
+    public Optional<String> getValidatorClassName() {
+        return validatorClassName;
+    }
+
+    @JsonProperty
+    public void setValidatorClassName(Optional<String> validatorClassName) {
+        this.validatorClassName = validatorClassName;
+    }
+
     @Override
     public Optional<Duration> getHealthCheckValidationTimeout() {
         return Optional.fromNullable(validationQueryTimeout);
@@ -760,6 +780,9 @@ public class DataSourceFactory implements PooledDataSourceFactory {
 
         if (getValidationQueryTimeout().isPresent()) {
             poolConfig.setValidationQueryTimeout((int) validationQueryTimeout.toSeconds());
+        }
+        if (validatorClassName.isPresent()) {
+            poolConfig.setValidatorClassName(validatorClassName.get());
         }
 
         return new ManagedPooledDataSource(poolConfig, metricRegistry);

--- a/dropwizard-db/src/test/java/io/dropwizard/db/CustomConnectionValidator.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/CustomConnectionValidator.java
@@ -1,0 +1,17 @@
+package io.dropwizard.db;
+
+import org.apache.tomcat.jdbc.pool.Validator;
+
+import java.sql.Connection;
+
+public class CustomConnectionValidator implements Validator {
+
+    // It's used only once, so static access should be fine
+    static volatile boolean loaded;
+
+    @Override
+    public boolean validate(Connection connection, int validateAction) {
+        loaded = true;
+        return true;
+    }
+}

--- a/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceConfigurationTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceConfigurationTest.java
@@ -50,6 +50,7 @@ public class DataSourceConfigurationTest {
         assertThat(ds.getCheckConnectionOnConnect()).isEqualTo(false);
         assertThat(ds.getCheckConnectionOnReturn()).isEqualTo(true);
         assertThat(ds.getValidationQueryTimeout()).isEqualTo(Optional.of(Duration.seconds(3)));
+        assertThat(ds.getValidatorClassName()).isEqualTo(Optional.of("io.dropwizard.db.CustomConnectionValidator"));
     }
 
     @Test

--- a/dropwizard-db/src/test/resources/yaml/full_db_pool.yml
+++ b/dropwizard-db/src/test/resources/yaml/full_db_pool.yml
@@ -39,3 +39,5 @@ checkConnectionWhileIdle: false
 checkConnectionOnBorrow: true
 checkConnectionOnConnect: false
 checkConnectionOnReturn: true
+
+validatorClassName: io.dropwizard.db.CustomConnectionValidator


### PR DESCRIPTION
Some users want to specify a custom validation logic for database connections. 
Tomcat JDBC Pool provides this facility and we can support it in the YAML configuration.

Close #1089