### PR TITLE
Simplify authorization

### DIFF
--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthFilter.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthFilter.java
@@ -1,12 +1,8 @@
 package io.dropwizard.auth;
 
-import com.google.common.base.Function;
-
 import javax.annotation.Priority;
 import javax.ws.rs.Priorities;
-import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
-import javax.ws.rs.core.SecurityContext;
 import java.security.Principal;
 
 @Priority(Priorities.AUTHENTICATION)
@@ -14,7 +10,7 @@ public abstract class AuthFilter<C, P extends Principal> implements ContainerReq
     protected String prefix;
     protected String realm;
     protected Authenticator<C, P> authenticator;
-    protected Function<Tuple, SecurityContext> securityContextFunction;
+    protected Authorizer<P> authorizer;
     protected UnauthorizedHandler unauthorizedHandler = new DefaultUnauthorizedHandler();
 
     protected void setPrefix(String prefix) {
@@ -29,37 +25,15 @@ public abstract class AuthFilter<C, P extends Principal> implements ContainerReq
         this.authenticator = authenticator;
     }
 
-    protected void setSecurityContextFunction(Function<Tuple, SecurityContext> securityContextFunction) {
-        this.securityContextFunction = securityContextFunction;
-    }
-
-    protected Function<Tuple, SecurityContext> getSecurityContextFunction() {
-        return securityContextFunction;
-    }
-
-    public static class Tuple {
-        private ContainerRequestContext containerRequestContext;
-        private Principal principal;
-
-        public Tuple(ContainerRequestContext containerRequestContext, Principal principal) {
-            this.containerRequestContext = containerRequestContext;
-            this.principal = principal;
-        }
-
-        public ContainerRequestContext getContainerRequestContext() {
-            return containerRequestContext;
-        }
-
-        public Principal getPrincipal() {
-            return principal;
-        }
+    protected void setAuthorizer(Authorizer<P> authorizer) {
+        this.authorizer = authorizer;
     }
 
     public abstract static class AuthFilterBuilder<C, P extends Principal, T extends AuthFilter<C, P>, A extends Authenticator<C, P>> {
         protected String realm = "realm";
         protected String prefix = "Basic";
         protected Authenticator<C, P> authenticator;
-        protected Function<Tuple, SecurityContext> securityContextFunction;
+        protected Authorizer<P> authorizer;
 
         public AuthFilterBuilder<C, P, T, A>  setRealm(String realm) {
             this.realm = realm;
@@ -71,8 +45,8 @@ public abstract class AuthFilter<C, P extends Principal> implements ContainerReq
             return this;
         }
 
-        public AuthFilterBuilder<C, P, T, A>  setSecurityContextFunction(Function<Tuple, SecurityContext> securityContextFunction) {
-            this.securityContextFunction = securityContextFunction;
+        public AuthFilterBuilder<C, P, T, A>  setAuthorizer(Authorizer<P> authorizer) {
+            this.authorizer = authorizer;
             return this;
         }
 

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/Authorizer.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/Authorizer.java
@@ -1,0 +1,20 @@
+package io.dropwizard.auth;
+
+import java.security.Principal;
+
+/**
+ * An interface for classes which authorize principal objects.
+ *
+ * @param <P> the type of principals
+ */
+public interface Authorizer<P extends Principal> {
+
+    /**
+     * Decides if access is granted for the given principal in the given role.
+     *
+     * @param principal a {@link Principal} object, representing a user
+     * @param role a user role
+     * @return {@code true}, if the access is granted, {@code false otherwise}
+     */
+    boolean authorize(P principal, String role);
+}

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/oauth/OAuthCredentialAuthFilter.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/oauth/OAuthCredentialAuthFilter.java
@@ -13,6 +13,7 @@ import javax.ws.rs.Priorities;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.SecurityContext;
 import java.io.IOException;
 import java.security.Principal;
 
@@ -23,7 +24,7 @@ public class OAuthCredentialAuthFilter<P extends Principal> extends AuthFilter<S
     }
 
     @Override
-    public void filter(ContainerRequestContext requestContext) throws IOException {
+    public void filter(final ContainerRequestContext requestContext) throws IOException {
         final String header = requestContext.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
         if (header != null) {
             try {
@@ -32,11 +33,29 @@ public class OAuthCredentialAuthFilter<P extends Principal> extends AuthFilter<S
                     final String method = header.substring(0, space);
                     if (prefix.equalsIgnoreCase(method)) {
                         final String credentials = header.substring(space + 1);
-                        final Optional<P> result = authenticator.authenticate(credentials);
-                        if (result.isPresent()) {
-                            final Principal principal = result.get();
-                            requestContext.setSecurityContext(
-                                    getSecurityContextFunction().apply(new Tuple(requestContext, principal)));
+                        final Optional<P> principal = authenticator.authenticate(credentials);
+                        if (principal.isPresent()) {
+                            requestContext.setSecurityContext(new SecurityContext() {
+                                @Override
+                                public Principal getUserPrincipal() {
+                                    return principal.get();
+                                }
+
+                                @Override
+                                public boolean isUserInRole(String role) {
+                                    return authorizer.authorize(principal.get(), role);
+                                }
+
+                                @Override
+                                public boolean isSecure() {
+                                    return requestContext.getSecurityContext().isSecure();
+                                }
+
+                                @Override
+                                public String getAuthenticationScheme() {
+                                    return SecurityContext.BASIC_AUTH;
+                                }
+                            });
                             return;
                         }
                     }
@@ -54,7 +73,7 @@ public class OAuthCredentialAuthFilter<P extends Principal> extends AuthFilter<S
             extends AuthFilterBuilder<String, APrincipal, OAuthCredentialAuthFilter<APrincipal>, AAuthenticator> {
         @Override
         public OAuthCredentialAuthFilter<APrincipal> buildAuthFilter() {
-            if (realm == null || authenticator == null || prefix == null || securityContextFunction == null) {
+            if (realm == null || authenticator == null || prefix == null || authorizer == null) {
                 throw new RuntimeException("Required auth filter parameters not set");
             }
 
@@ -62,7 +81,7 @@ public class OAuthCredentialAuthFilter<P extends Principal> extends AuthFilter<S
             oauthCredentialAuthFilter.setRealm(realm);
             oauthCredentialAuthFilter.setAuthenticator(authenticator);
             oauthCredentialAuthFilter.setPrefix(prefix);
-            oauthCredentialAuthFilter.setSecurityContextFunction(securityContextFunction);
+            oauthCredentialAuthFilter.setAuthorizer(authorizer);
             return oauthCredentialAuthFilter;
         }
     }

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/BasicAuthProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/BasicAuthProviderTest.java
@@ -2,7 +2,6 @@ package io.dropwizard.auth.basic;
 
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.auth.AuthDynamicFeature;
-import io.dropwizard.auth.AuthFilter;
 import io.dropwizard.auth.AuthResource;
 import io.dropwizard.auth.Authenticator;
 import io.dropwizard.auth.util.AuthUtil;
@@ -158,7 +157,7 @@ public class BasicAuthProviderTest extends JerseyTest {
 
             BasicCredentialAuthFilter.Builder<Principal, Authenticator<BasicCredentials, Principal>> builder
                     = new BasicCredentialAuthFilter.Builder<>();
-            builder.setSecurityContextFunction(AuthUtil.<AuthFilter.Tuple, SecurityContext>getSecurityContextProviderFunction(validUser, VALID_ROLE));
+            builder.setAuthorizer(AuthUtil.getTestAuthorizer(validUser, VALID_ROLE));
             builder.setAuthenticator(AuthUtil.<BasicCredentials, Principal>getTestAuthenticatorBasicCredential(validUser));
             return builder.buildAuthFilter();
         }

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/BasicCustomAuthProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/BasicCustomAuthProviderTest.java
@@ -149,7 +149,7 @@ public class BasicCustomAuthProviderTest extends JerseyTest {
 
             BasicCredentialAuthFilter.Builder<Principal, Authenticator<BasicCredentials, Principal>> builder
                     = new BasicCredentialAuthFilter.Builder<>();
-            builder.setSecurityContextFunction(AuthUtil.getSecurityContextProviderFunction(validUser, VALID_ROLE));
+            builder.setAuthorizer(AuthUtil.getTestAuthorizer(validUser, VALID_ROLE));
             builder.setAuthenticator(AuthUtil.getTestAuthenticatorBasicCredential(validUser));
             builder.setPrefix("Custom");
             return builder.buildAuthFilter();

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/chained/ChainedAuthProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/chained/ChainedAuthProviderTest.java
@@ -1,12 +1,8 @@
 package io.dropwizard.auth.chained;
 
 import com.codahale.metrics.MetricRegistry;
-import com.google.common.base.Function;
 import com.google.common.collect.Lists;
-import io.dropwizard.auth.AuthDynamicFeature;
-import io.dropwizard.auth.AuthFilter;
-import io.dropwizard.auth.AuthResource;
-import io.dropwizard.auth.Authenticator;
+import io.dropwizard.auth.*;
 import io.dropwizard.auth.basic.BasicCredentialAuthFilter;
 import io.dropwizard.auth.basic.BasicCredentials;
 import io.dropwizard.auth.oauth.OAuthCredentialAuthFilter;
@@ -133,8 +129,8 @@ public class ChainedAuthProviderTest extends JerseyTest {
 
             final String validUser = "good-guy";
 
-            final Function<AuthFilter.Tuple, SecurityContext> securityContextFunction =
-                    AuthUtil.getSecurityContextProviderFunction(validUser, ADMIN_ROLE);
+            final Authorizer<Principal> authorizer =
+                    AuthUtil.getTestAuthorizer(validUser, ADMIN_ROLE);
 
             final Authenticator<BasicCredentials, Principal> basicAuthenticator =
                     AuthUtil.getTestAuthenticatorBasicCredential(validUser);
@@ -145,13 +141,13 @@ public class ChainedAuthProviderTest extends JerseyTest {
             final AuthFilter<BasicCredentials, Principal> basicAuthFilter =
                     new BasicCredentialAuthFilter.Builder<>()
                     .setAuthenticator(basicAuthenticator)
-                    .setSecurityContextFunction(securityContextFunction)
+                    .setAuthorizer(authorizer)
                     .buildAuthFilter();
 
             final AuthFilter<String, Principal> oAuthFilter = new OAuthCredentialAuthFilter.Builder<>()
                     .setAuthenticator(oauthAuthenticator)
                     .setPrefix("Bearer")
-                    .setSecurityContextFunction(securityContextFunction)
+                    .setAuthorizer(authorizer)
                     .buildAuthFilter();
 
             register(new AuthDynamicFeature(new ChainedAuthFilter<>(buildHandlerList(basicAuthFilter, oAuthFilter ))));

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/oauth/OAuthCustomProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/oauth/OAuthCustomProviderTest.java
@@ -129,8 +129,8 @@ public class OAuthCustomProviderTest extends JerseyTest {
             final String validUser = "good-guy";
 
             return new OAuthCredentialAuthFilter.Builder<>()
-                    .setAuthenticator(AuthUtil.<String, SecurityContext>getTestAuthenticator(validUser))
-                    .setSecurityContextFunction(AuthUtil.getSecurityContextProviderFunction(validUser, "ADMIN"))
+                    .setAuthenticator(AuthUtil.getTestAuthenticator(validUser))
+                    .setAuthorizer(AuthUtil.getTestAuthorizer(validUser, "ADMIN"))
                     .setPrefix("Custom")
                     .buildAuthFilter();
         }

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/oauth/OAuthProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/oauth/OAuthProviderTest.java
@@ -123,9 +123,9 @@ public class OAuthProviderTest extends JerseyTest {
             final String validUser = "good-guy";
 
             return new OAuthCredentialAuthFilter.Builder<>()
-                    .setAuthenticator(AuthUtil.<String, Principal>getTestAuthenticator(validUser))
+                    .setAuthenticator(AuthUtil.getTestAuthenticator(validUser))
+                    .setAuthorizer(AuthUtil.getTestAuthorizer(validUser, "ADMIN"))
                     .setPrefix("Bearer")
-                    .setSecurityContextFunction(AuthUtil.getSecurityContextProviderFunction(validUser, "ADMIN"))
                     .buildAuthFilter();
         }
     }

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/util/AuthUtil.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/util/AuthUtil.java
@@ -1,14 +1,9 @@
 package io.dropwizard.auth.util;
 
-import com.google.common.base.Function;
 import com.google.common.base.Optional;
-import io.dropwizard.auth.AuthFilter;
-import io.dropwizard.auth.AuthenticationException;
-import io.dropwizard.auth.Authenticator;
-import io.dropwizard.auth.PrincipalImpl;
+import io.dropwizard.auth.*;
 import io.dropwizard.auth.basic.BasicCredentials;
 
-import javax.ws.rs.core.SecurityContext;
 import java.security.Principal;
 
 public class AuthUtil {
@@ -48,37 +43,14 @@ public class AuthUtil {
         return getTestAuthenticator(presented, presented);
     }
 
-    public static Function<AuthFilter.Tuple, SecurityContext> getSecurityContextProviderFunction(
-            final String validUser,
-            final String validRole
-    ) {
-        return new Function<AuthFilter.Tuple, SecurityContext>() {
+    public static Authorizer<Principal> getTestAuthorizer(final String validUser,
+                                                          final String validRole) {
+        return new Authorizer<Principal>() {
             @Override
-            public SecurityContext apply(final AuthFilter.Tuple input) {
-                return new SecurityContext() {
-
-                    @Override
-                    public Principal getUserPrincipal() {
-                        return input.getPrincipal();
-                    }
-
-                    @Override
-                    public boolean isUserInRole(String role) {
-                        return getUserPrincipal() != null
-                                && validUser.equals(getUserPrincipal().getName())
-                                && validRole.equals(role);
-                    }
-
-                    @Override
-                    public boolean isSecure() {
-                        return input.getContainerRequestContext().getSecurityContext().isSecure();
-                    }
-
-                    @Override
-                    public String getAuthenticationScheme() {
-                        return SecurityContext.BASIC_AUTH;
-                    }
-                };
+            public boolean authorize(Principal principal, String role) {
+                return principal != null
+                        && validUser.equals(principal.getName())
+                        && validRole.equals(role);
             }
         };
     }

--- a/dropwizard-example/src/main/java/com/example/helloworld/auth/ExampleAuthorizer.java
+++ b/dropwizard-example/src/main/java/com/example/helloworld/auth/ExampleAuthorizer.java
@@ -1,0 +1,12 @@
+package com.example.helloworld.auth;
+
+import com.example.helloworld.core.User;
+import io.dropwizard.auth.Authorizer;
+
+public class ExampleAuthorizer implements Authorizer<User> {
+
+    @Override
+    public boolean authorize(User user, String role) {
+        return true;
+    }
+}


### PR DESCRIPTION
The current implementation of authorization is too cumbersome and requires implementing a big amount of boilerplate code.

This changes introduce `Authorizer` interface, which is responsible for authorizing users. It's a replacement for specifying a function for creating a new secure context.

Advantage stem from the fact that users only implement business logic for authorization and nothing more. Also this type of API is similar to `Authenticator`, which makes API more consistent.