### PR TITLE
Register default mappers in ResourceTestRule

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ResourceTestRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ResourceTestRule.java
@@ -8,7 +8,10 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.DropwizardResourceConfig;
+import io.dropwizard.jersey.errors.EarlyEofExceptionMapper;
+import io.dropwizard.jersey.errors.LoggingExceptionMapper;
 import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
+import io.dropwizard.jersey.jackson.JsonProcessingExceptionMapper;
 import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
 import io.dropwizard.logging.BootstrapLogging;
@@ -152,7 +155,11 @@ public class ResourceTestRule implements TestRule {
         }
 
         private void configure(final ResourceTestRule resourceTestRule) {
+            register(new LoggingExceptionMapper<Throwable>() {
+            });
             register(new ConstraintViolationExceptionMapper());
+            register(new JsonProcessingExceptionMapper());
+            register(new EarlyEofExceptionMapper());
             for (Class<?> provider : resourceTestRule.providers) {
                 register(provider);
             }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/Person.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/Person.java
@@ -1,10 +1,12 @@
 package io.dropwizard.testing;
 
 import com.google.common.base.MoreObjects;
+import org.hibernate.validator.constraints.NotEmpty;
 
 import java.util.Objects;
 
 public class Person {
+    @NotEmpty
     private String name;
     private String email;
 

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResource.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResource.java
@@ -4,7 +4,9 @@ import com.codahale.metrics.annotation.Timed;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.testing.Person;
 
+import javax.validation.Valid;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -30,5 +32,10 @@ public class PersonResource {
     @Path("/list")
     public ImmutableList<Person> getPersonList(@PathParam("name") String name) {
         return ImmutableList.of(getPerson(name));
+    }
+
+    @POST
+    public Person createPerson(@Valid Person person) {
+        return new Person(person.getName(), person.getEmail().trim());
     }
 }


### PR DESCRIPTION
The default exception mappers are not registered in `ResourceTestRule`, which may be an annoyance to users, as they would have know what the defaults are and know to re-register them if their tests relied on functionality the exception mappers provided. This pull requests fixes this situation by registering them out of the box.

The only users who would be negatively affected by this pull request are those that turn off `registerDefaultExceptionMappers` in the configuration and choose not to define new mappers to replace them. Those that override default exception mappers in the application will still override them in `ResourceTestRule` as usual.

Closes #808