### PR TITLE
Tests with Grizzly now map exceptions properly

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ResourceTestRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ResourceTestRule.java
@@ -16,6 +16,7 @@ import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
 import io.dropwizard.logging.BootstrapLogging;
 import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.server.ServerProperties;
 import org.glassfish.jersey.servlet.ServletProperties;
 import org.glassfish.jersey.test.DeploymentContext;
 import org.glassfish.jersey.test.JerseyTest;
@@ -163,6 +164,7 @@ public class ResourceTestRule implements TestRule {
             for (Class<?> provider : resourceTestRule.providers) {
                 register(provider);
             }
+            property(ServerProperties.RESPONSE_SET_STATUS_OVER_SEND_ERROR, "true");
             for (Map.Entry<String, Object> property : resourceTestRule.properties.entrySet()) {
                 property(property.getKey(), property.getValue());
             }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ContextInjectionResource.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ContextInjectionResource.java
@@ -1,11 +1,10 @@
 package io.dropwizard.testing.app;
 
 import com.codahale.metrics.annotation.Timed;
-import io.dropwizard.testing.Person;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
@@ -18,5 +17,10 @@ public class ContextInjectionResource {
     @Timed
     public String getUriPath(@Context UriInfo uriInfo) {
         return uriInfo.getPath();
+    }
+
+    @POST
+    public String getThis() {
+        throw new RuntimeException("Can't touch this");
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestWithGrizzly.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestWithGrizzly.java
@@ -1,13 +1,14 @@
 package io.dropwizard.testing.app;
 
 import io.dropwizard.testing.junit.ResourceTestRule;
-import org.glassfish.jersey.test.grizzly.GrizzlyTestContainerFactory;
 import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -19,7 +20,8 @@ public class ResourceTestWithGrizzly {
     @ClassRule
     public static final ResourceTestRule resources = ResourceTestRule.builder()
             .addResource(new ContextInjectionResource())
-            .setTestContainerFactory(new GrizzlyTestContainerFactory())
+            .setTestContainerFactory(new GrizzlyWebTestContainerFactory())
+            .addProvider(new RuntimeExceptionMapper())
             .build();
 
     @Test
@@ -27,5 +29,23 @@ public class ResourceTestWithGrizzly {
         assertThat(resources.getJerseyTest().target("test").request()
                 .get(String.class))
                 .isEqualTo("test");
+    }
+
+    @Test
+    public void testExceptionMapper() {
+        final Response resp = resources.getJerseyTest().target("test").request()
+                .post(Entity.json(""));
+        assertThat(resp.getStatus()).isEqualTo(500);
+        assertThat(resp.readEntity(String.class)).isEqualTo("Can't touch this");
+    }
+
+    private static class RuntimeExceptionMapper implements ExceptionMapper<RuntimeException> {
+        @Override
+        public Response toResponse(RuntimeException exception) {
+            return Response.serverError()
+                    .type(MediaType.TEXT_PLAIN_TYPE)
+                    .entity(exception.getMessage())
+                    .build();
+        }
     }
 }


### PR DESCRIPTION
When using Grizzly with `ResourceTestRule`, it didn't know how to map exceptions (it would just return the generic Grizzly error page, which is not useful for testing). This pull request fixes this by turning on `RESPONSE_SET_STATUS_OVER_SEND_ERROR`

Closes #1057 (though it only mentioned protected routes)