### PR TITLE
Default exception mappers in test can be overridden

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ResourceTestRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ResourceTestRule.java
@@ -155,11 +155,6 @@ public class ResourceTestRule implements TestRule {
         }
 
         private void configure(final ResourceTestRule resourceTestRule) {
-            register(new LoggingExceptionMapper<Throwable>() {
-            });
-            register(new ConstraintViolationExceptionMapper());
-            register(new JsonProcessingExceptionMapper());
-            register(new EarlyEofExceptionMapper());
             for (Class<?> provider : resourceTestRule.providers) {
                 register(provider);
             }
@@ -170,6 +165,11 @@ public class ResourceTestRule implements TestRule {
             for (Object singleton : resourceTestRule.singletons) {
                 register(singleton);
             }
+            register(new LoggingExceptionMapper<Throwable>() {
+            });
+            register(new ConstraintViolationExceptionMapper());
+            register(new JsonProcessingExceptionMapper());
+            register(new EarlyEofExceptionMapper());
         }
     }
 

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/OverrideDefaultExceptionMapperTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/OverrideDefaultExceptionMapperTest.java
@@ -1,0 +1,42 @@
+package io.dropwizard.testing.app;
+
+import io.dropwizard.testing.junit.ResourceTestRule;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import javax.validation.ConstraintViolationException;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Test to make sure that the default exception mappers registered in
+ * {@link ResourceTestRule} can be overridden
+ */
+public class OverrideDefaultExceptionMapperTest {
+    private static final PeopleStore dao = mock(PeopleStore.class);
+
+    @ClassRule
+    public static final ResourceTestRule resources = ResourceTestRule.builder()
+            .addResource(new PersonResource(dao))
+            .addProvider(new CustomMapper())
+            .build();
+
+    private static class CustomMapper implements ExceptionMapper<ConstraintViolationException> {
+        @Override
+        public Response toResponse(ConstraintViolationException exception) {
+            return Response.noContent().build();
+        }
+    }
+
+    @Test
+    public void testThatCustomConstraintExceptionMapperIsRegistered() {
+        final Response resp = resources.client().target("/person/blah").request()
+                .post(Entity.json("{}"));
+
+        assertThat(resp.getStatus()).isEqualTo(204);
+    }
+}


### PR DESCRIPTION
#1125 registered the default exception mappers in the wrong place in the `ResourceTestRule`, such that one couldn't register their own `ExceptionMapper` with the same signature and have it be used :blush:

This pull request fixes the behavior and adds a test to ensure that the default exception mappers can be overridden in `ResourceTestRule`