### PR TITLE
Allow passing explicit Configuration via `DropwizardTestSupport`, `DropwizardAppRule` (for #1130)

### DIFF
--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationFactory.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationFactory.java
@@ -59,11 +59,18 @@ public class ConfigurationFactory<T> {
                                 ObjectMapper objectMapper,
                                 String propertyPrefix) {
         this.klass = klass;
-        this.propertyPrefix = propertyPrefix.endsWith(".") ? propertyPrefix : propertyPrefix + '.';
-        this.mapper = objectMapper.copy();
-        mapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        this.propertyPrefix = (propertyPrefix == null || propertyPrefix.endsWith("."))
+                ? propertyPrefix : (propertyPrefix + '.');
+        // Sub-classes may choose to omit data-binding; if so, null ObjectMapper passed:
+        if (objectMapper == null) { // sub-class has no need for mapper
+            mapper = null;
+            yamlFactory = null;
+        } else {
+            mapper = objectMapper.copy()
+                    .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+            yamlFactory = new YAMLFactory();
+        }
         this.validator = validator;
-        this.yamlFactory = new YAMLFactory();
     }
 
     /**
@@ -128,7 +135,7 @@ public class ConfigurationFactory<T> {
         }
     }
 
-    private T build(JsonNode node, String path) throws IOException, ConfigurationException {
+    protected T build(JsonNode node, String path) throws IOException, ConfigurationException {
         for (Map.Entry<Object, Object> pref : System.getProperties().entrySet()) {
             final String prefName = (String) pref.getKey();
             if (prefName.startsWith(propertyPrefix)) {
@@ -173,7 +180,7 @@ public class ConfigurationFactory<T> {
         }
     }
 
-    private void addOverride(JsonNode root, String name, String value) {
+    protected void addOverride(JsonNode root, String name, String value) {
         JsonNode node = root;
         final Iterable<String> split = Splitter.on('.').trimResults().split(name);
         final String[] parts = Iterables.toArray(split, String.class);
@@ -246,9 +253,11 @@ public class ConfigurationFactory<T> {
     }
 
     private void validate(String path, T config) throws ConfigurationValidationException {
-        final Set<ConstraintViolation<T>> violations = validator.validate(config);
-        if (!violations.isEmpty()) {
-            throw new ConfigurationValidationException(path, violations);
+        if (validator != null) {
+            final Set<ConstraintViolation<T>> violations = validator.validate(config);
+            if (!violations.isEmpty()) {
+                throw new ConfigurationValidationException(path, violations);
+            }
         }
     }
 }

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
@@ -83,7 +83,7 @@ public class DropwizardTestSupport<C extends Configuration> {
      * @since 0.9
      *
      * @param applicationClass Type of Application to create
-     * @param config Pre-constructed configuration object caller provides; will not
+     * @param configuration Pre-constructed configuration object caller provides; will not
      *   be manipulated in any way, no overriding
      */
     public DropwizardTestSupport(Class<? extends Application<C>> applicationClass,
@@ -93,7 +93,7 @@ public class DropwizardTestSupport<C extends Configuration> {
         }
         this.applicationClass = applicationClass;
         configPath = "";
-        configOverrides = Collections.emptySet();
+        configOverrides = ImmutableSet.of();
         customPropertyPrefix = Optional.absent();
         this.configuration = configuration;
         explicitConfig = true;
@@ -190,10 +190,10 @@ public class DropwizardTestSupport<C extends Configuration> {
                     @Override
                     public ConfigurationFactory<C> create(Class<C> klass, Validator validator,
                                                           ObjectMapper objectMapper, String propertyPrefix) {
-                        return new POJOConfigurationFactory<C>(configuration);
+                        return new POJOConfigurationFactory<>(configuration);
                     }
                 });
-            } else  if (customPropertyPrefix.isPresent()) {
+            } else if (customPropertyPrefix.isPresent()) {
                 bootstrap.setConfigurationFactoryFactory(new ConfigurationFactoryFactory<C>() {
                     @Override
                     public ConfigurationFactory<C> create(Class<C> klass, Validator validator,

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/POJOConfigurationFactory.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/POJOConfigurationFactory.java
@@ -1,0 +1,41 @@
+package io.dropwizard.testing;
+
+import java.io.File;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.dropwizard.Configuration;
+import io.dropwizard.configuration.ConfigurationFactory;
+import io.dropwizard.configuration.ConfigurationSourceProvider;
+
+public class POJOConfigurationFactory<C extends Configuration>
+    extends ConfigurationFactory<C>
+{
+    protected final C configuration;
+
+    @SuppressWarnings("unchecked")
+    public POJOConfigurationFactory(C cfg) {
+        super((Class<C>) cfg.getClass(), null, null, null);
+        configuration = cfg;
+    }
+
+    @Override
+    public C build(ConfigurationSourceProvider provider, String path) {
+        return configuration;
+    }
+
+    @Override
+    public C build(File file) {
+        return configuration;
+    }
+
+    @Override
+    public C build() {
+        return configuration;
+    }
+
+    @Override
+    protected C build(JsonNode node, String path) {
+        return configuration;
+    }
+}

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/POJOConfigurationFactory.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/POJOConfigurationFactory.java
@@ -9,8 +9,7 @@ import io.dropwizard.configuration.ConfigurationFactory;
 import io.dropwizard.configuration.ConfigurationSourceProvider;
 
 public class POJOConfigurationFactory<C extends Configuration>
-    extends ConfigurationFactory<C>
-{
+    extends ConfigurationFactory<C> {
     protected final C configuration;
 
     @SuppressWarnings("unchecked")

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
@@ -27,6 +27,10 @@ public class DropwizardAppRule<C extends Configuration> extends ExternalResource
 
     private final DropwizardTestSupport<C> testSupport;
 
+    public DropwizardAppRule(Class<? extends Application<C>> applicationClass) {
+        this(applicationClass, (String) null);
+    }
+
     public DropwizardAppRule(Class<? extends Application<C>> applicationClass,
                              @Nullable String configPath,
                              ConfigOverride... configOverrides) {
@@ -35,8 +39,19 @@ public class DropwizardAppRule<C extends Configuration> extends ExternalResource
 
     public DropwizardAppRule(Class<? extends Application<C>> applicationClass, String configPath,
                                  Optional<String> customPropertyPrefix, ConfigOverride... configOverrides) {
-        this.testSupport = new DropwizardTestSupport<>(applicationClass, configPath, customPropertyPrefix,
-                configOverrides);
+        this(new DropwizardTestSupport<>(applicationClass, configPath, customPropertyPrefix,
+                configOverrides));
+    }
+
+    /**
+     * Alternate constructor that allows specifying exact Configuration object to
+     * use, instead of reading a resource and binding it as Configuration object.
+     *
+     * @since 0.9
+     */
+    public DropwizardAppRule(Class<? extends Application<C>> applicationClass,
+            C configuration) {
+        this(new DropwizardTestSupport<>(applicationClass, configuration));
     }
 
     public DropwizardAppRule(DropwizardTestSupport<C> testSupport) {
@@ -45,15 +60,15 @@ public class DropwizardAppRule<C extends Configuration> extends ExternalResource
 
     public DropwizardAppRule<C> addListener(final ServiceListener<C> listener) {
         this.testSupport.addListener(new DropwizardTestSupport.ServiceListener<C>() {
-
+            @Override
             public void onRun(C configuration, Environment environment, DropwizardTestSupport<C> rule) throws Exception {
                 listener.onRun(configuration, environment, DropwizardAppRule.this);
             }
 
+            @Override
             public void onStop(DropwizardTestSupport<C> rule) throws Exception {
                 listener.onStop(DropwizardAppRule.this);
             }
-
         });
         return this;
     }
@@ -73,7 +88,6 @@ public class DropwizardAppRule<C extends Configuration> extends ExternalResource
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     protected void after() {
         testSupport.after();
     }

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardClientRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardClientRule.java
@@ -56,7 +56,7 @@ public class DropwizardClientRule extends ExternalResource {
     private final DropwizardTestSupport<Configuration> testSupport;
 
     public DropwizardClientRule(Object... resources) {
-        testSupport = new DropwizardTestSupport<Configuration>(null, null) {
+        testSupport = new DropwizardTestSupport<Configuration>(FakeApplication.class, "") {
             @Override
             public Application<Configuration> newApplication() {
                 return new FakeApplication();

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleTest.java
@@ -1,13 +1,12 @@
 package io.dropwizard.testing.junit;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMultimap;
+
 import io.dropwizard.Application;
-import io.dropwizard.Configuration;
 import io.dropwizard.servlets.tasks.Task;
 import io.dropwizard.setup.Environment;
-import org.hibernate.validator.constraints.NotEmpty;
+
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -16,6 +15,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
+
 import java.io.PrintWriter;
 
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
@@ -88,20 +88,6 @@ public class DropwizardAppRuleTest {
         @Path("test")
         @GET
         public String test() {
-            return message;
-        }
-    }
-
-    public static class TestConfiguration extends Configuration {
-        @NotEmpty
-        @JsonProperty
-        private String message;
-
-        @NotEmpty
-        @JsonProperty
-        private String extra;
-
-        public String getMessage() {
             return message;
         }
     }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleWithExplicitTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleWithExplicitTest.java
@@ -1,7 +1,6 @@
 package io.dropwizard.testing.junit;
 
 import io.dropwizard.Application;
-import io.dropwizard.jetty.ConnectorFactory;
 import io.dropwizard.jetty.HttpConnectorFactory;
 import io.dropwizard.server.DefaultServerFactory;
 import io.dropwizard.setup.Environment;

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleWithExplicitTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleWithExplicitTest.java
@@ -1,0 +1,72 @@
+package io.dropwizard.testing.junit;
+
+import io.dropwizard.Application;
+import io.dropwizard.jetty.ConnectorFactory;
+import io.dropwizard.jetty.HttpConnectorFactory;
+import io.dropwizard.server.DefaultServerFactory;
+import io.dropwizard.setup.Environment;
+
+import java.util.Map;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+public class DropwizardAppRuleWithExplicitTest {
+
+    @Test
+    public void bogusTest() { }
+
+    @ClassRule
+    public static final DropwizardAppRule<TestConfiguration> RULE;
+    static {
+        // Bit complicated, as we want to avoid using the default http port (8080)
+        // as there is another test that uses it already. So force bogus value of
+        // 0, similar to what `test-config.yaml` defines.
+        TestConfiguration config = new TestConfiguration("stuff!", "extra");
+        DefaultServerFactory sf = (DefaultServerFactory) config.getServerFactory();
+        ((HttpConnectorFactory) sf.getApplicationConnectors().get(0)).setPort(0);
+        ((HttpConnectorFactory) sf.getAdminConnectors().get(0)).setPort(0);
+        RULE = new DropwizardAppRule<TestConfiguration>(TestApplication.class, config);
+    }
+
+    Client client = ClientBuilder.newClient();
+
+    @Test
+    public void runWithExplicitConfig() {
+        Map<?,?> response = client.target("http://localhost:" + RULE.getLocalPort() + "/test")
+                .request()
+                .get(Map.class);
+        Assert.assertEquals(ImmutableMap.of("message", "stuff!"), response);
+    }
+
+    public static class TestApplication extends Application<TestConfiguration> {
+        @Override
+        public void run(TestConfiguration configuration, Environment environment) throws Exception {
+            environment.jersey().register(new TestResource(configuration.getMessage()));
+        }
+    }
+
+    @Path("test")
+    @Produces(MediaType.APPLICATION_JSON)
+    public static class TestResource {
+        private final String message;
+
+        public TestResource(String m) { message = m; }
+
+        @GET
+        public Response get() {
+            return Response.ok(ImmutableMap.of("message", message)).build();
+        }
+    }
+}

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleWithoutConfigTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleWithoutConfigTest.java
@@ -19,13 +19,13 @@ import org.junit.Test;
 public class DropwizardAppRuleWithoutConfigTest {
 
     @ClassRule
-    public static final DropwizardAppRule<Configuration> RULE = new DropwizardAppRule<>(TestApplication.class, null);
+    public static final DropwizardAppRule<Configuration> RULE = new DropwizardAppRule<>(TestApplication.class);
 
     Client client = ClientBuilder.newClient();
 
     @Test
     public void runWithoutConfigFile() {
-        Map response = client.target("http://localhost:" + RULE.getLocalPort() + "/test")
+        Map<?,?> response = client.target("http://localhost:" + RULE.getLocalPort() + "/test")
                 .request()
                 .get(Map.class);
         Assert.assertEquals(ImmutableMap.of("color", "orange"), response);

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/TestConfiguration.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/TestConfiguration.java
@@ -14,6 +14,13 @@ public class TestConfiguration extends Configuration {
     @NotEmpty
     private String extra;
 
+    public TestConfiguration() { }
+
+    public TestConfiguration(String message, String extra) {
+        this.message = message;
+        this.extra = extra;
+    }
+
     public String getMessage() {
         return message;
     }


### PR DESCRIPTION
PR adds an alternate way to construct test scaffolding, by passing pre-constructed `Configuration` instead of relying on a YAML resource. This is useful for tests where configuration is programmatically set. Other minor access changes needed to support this functionality.
