### PR TITLE
Bugfix for: Ensuring that JerseyRequest scoped ClientConfig gets prop…

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardApacheConnector.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardApacheConnector.java
@@ -24,7 +24,6 @@ import org.glassfish.jersey.message.internal.OutboundMessageContext;
 import org.glassfish.jersey.message.internal.Statuses;
 
 import javax.ws.rs.ProcessingException;
-import javax.ws.rs.core.Configuration;
 import javax.ws.rs.core.Response;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -135,7 +134,7 @@ public class DropwizardApacheConnector implements Connector {
             builder.addHeader(headerName, jerseyRequest.getHeaderString(headerName));
         }
 
-        Optional<RequestConfig> requestConfig = addJerseyRequestConfig(jerseyRequest.getConfiguration());
+        Optional<RequestConfig> requestConfig = addJerseyRequestConfig(jerseyRequest);
         if (requestConfig.isPresent()) {
             builder.setConfig(requestConfig.get());
         }
@@ -143,10 +142,10 @@ public class DropwizardApacheConnector implements Connector {
         return builder.build();
     }
 
-    private Optional<RequestConfig> addJerseyRequestConfig(Configuration configuration) {
-        final Integer timeout = (Integer) configuration.getProperty(ClientProperties.READ_TIMEOUT);
-        final Integer connectTimeout = (Integer) configuration.getProperty(ClientProperties.CONNECT_TIMEOUT);
-        final Boolean followRedirects = (Boolean) configuration.getProperty(ClientProperties.FOLLOW_REDIRECTS);
+    private Optional<RequestConfig> addJerseyRequestConfig(ClientRequest clientRequest) {
+        final Integer timeout = clientRequest.resolveProperty(ClientProperties.READ_TIMEOUT, Integer.class);
+        final Integer connectTimeout = clientRequest.resolveProperty(ClientProperties.CONNECT_TIMEOUT, Integer.class);
+        final Boolean followRedirects = clientRequest.resolveProperty(ClientProperties.FOLLOW_REDIRECTS, Boolean.class);
 
         if (timeout != null || connectTimeout != null || followRedirects != null) {
             RequestConfig.Builder requestConfig = RequestConfig.copy(defaultRequestConfig);


### PR DESCRIPTION
…agated to HttpUriRequest #939

The change makes the config changes introduced via `Invocation.Builder#property(propertyName, propertyValue)` effective. We want to use this pattern because it is truely request creation scoped. In contrast the current implementation is only effective if config changes are being introduced via `WebTarget#property(propertyName, propertyValue)` which unfortunatly creates a new copy of copy of `org.glassfish.jersey.client.ClientRuntime` which effectively makes it innefective for implementing dynamic configuration (we saw OutOfMemmory errors due to that).

Original change can be founde here: https://github.com/dropwizard/dropwizard/pull/939