### PR TITLE
use joda-time 2.8.1

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -52,6 +52,7 @@ v0.9.0
 * Upgraded to SLF4J 1.7.12
 * Upgraded to commons-lang3 3.4
 * Upgrade to tomcat-jdbc 8.0.21
+* Upgraded to joda-time 2.8.1
 
 .. _rel-0.8.1:
 

--- a/dropwizard-util/pom.xml
+++ b/dropwizard-util/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.7</version>
+            <version>2.8.1</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
It seems to be safe to upgrade from 2.7 to 2.8.1
See:
http://www.joda.org/joda-time/upgradeto281.html
http://www.joda.org/joda-time/upgradeto280.html