### PR TITLE
Default exception mappers are overridable

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -58,6 +58,8 @@ rootPath                            ``/``                                       
                                                                                      the JAX-RS resources will be served.
 registerDefaultExceptionMappers     true                                             Whether or not the default Jersey ExceptionMappers should be registered.
                                                                                      Set this to false if you want to register your own.
+                                                                                     Note that this option is deprecated as user defined ExceptionMappers can
+                                                                                     override the default Jersey ExceptionMappers.
 =================================== ===============================================  =============================================================================
 
 

--- a/docs/source/manual/validation.rst
+++ b/docs/source/manual/validation.rst
@@ -253,15 +253,17 @@ code and ensure that the error messages are user friendly.
 Extending
 =========
 
-While Dropwizard provides good defaults for error messages, one size may not fit all and so there
-are a series of extension points. To register your own
-``ExceptionMapper<ConstraintViolationException>`` you'll need to first set
-``registerDefaultExceptionMappers`` to false in the configuration file or in code before registering
-your exception mapper with jersey. Then, optionally, register other default exception mappers:
+While Dropwizard provides good defaults for error messages, one size may not fit all. To provide
+your own error messages, create a class implementing
+``ExceptionMapper<ConstraintViolationException>`` and register it in your
+``JerseyEnvironment``. Your custom exception mapper will override Dropwizard's.
 
-* ``LoggingExceptionMapper<Throwable>``
-* ``JsonProcessingExceptionMapper``
-* ``EarlyEofExceptionMapper``
+There are a couple methods that should help you when implementing your custom
+``ExceptionMapper<ConstraintViolationException>``.
+
+* ``ConstraintViolations.determineStatus``: determines what status code to return based on where the
+   violation occurred
+* ``ConstraintMessage.getMessage``: returns the human friendly error message for a violation
 
 If you need to validate entities outside of resource endpoints, the validator can be accessed in the
 ``Environment`` when the application is first ran.
@@ -270,9 +272,3 @@ If you need to validate entities outside of resource endpoints, the validator ca
 
     Validator validator = environment.getValidator();
     Set<ConstraintViolation> errors = validator.validate(/* instance of class */)
-
-The method used to determine what status code to return based on violations is
-``ConstraintViolations.determineStatus``
-
-The method used to determine the human friendly error message due to a constraint violation is
-``ConstraintMessage.getMessage``.

--- a/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
@@ -239,6 +239,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
 
     private Boolean startsAsRoot;
 
+    @Deprecated
     private Boolean registerDefaultExceptionMappers = Boolean.TRUE;
 
     private Duration shutdownGracePeriod = Duration.seconds(30);

--- a/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
@@ -167,7 +167,9 @@ import java.util.regex.Pattern;
  *         <td>true</td>
  *         <td>
  *            Whether or not the default Jersey ExceptionMappers should be registered.
- *            Set this to false if you want to register your own.
+ *            Set this to false if you want to register your own. Note that this option
+ *            is deprecated as user defined ExceptionMappers can override the default
+ *            Jersey ExceptionMappers.
  *         </td>
  *     </tr>
  *     <tr>

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/EarlyEofExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/EarlyEofExceptionMapper.java
@@ -4,6 +4,7 @@ import org.eclipse.jetty.io.EofException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Priority;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
@@ -16,6 +17,7 @@ import javax.ws.rs.ext.Provider;
 * only catching jetty server based errors where the client disconnects, as specified by {@link EofException}.
 */
 @Provider
+@Priority(Integer.MAX_VALUE)
 public class EarlyEofExceptionMapper implements ExceptionMapper<EofException> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EarlyEofExceptionMapper.class);

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/LoggingExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/LoggingExceptionMapper.java
@@ -3,6 +3,7 @@ package io.dropwizard.jersey.errors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Priority;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -11,6 +12,7 @@ import javax.ws.rs.ext.Provider;
 import java.util.concurrent.ThreadLocalRandom;
 
 @Provider
+@Priority(Integer.MAX_VALUE)
 public abstract class LoggingExceptionMapper<E extends Throwable> implements ExceptionMapper<E> {
     private static final Logger LOGGER = LoggerFactory.getLogger(LoggingExceptionMapper.class);
 

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapper.java
@@ -6,12 +6,14 @@ import io.dropwizard.jersey.errors.ErrorMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Priority;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
 @Provider
+@Priority(Integer.MAX_VALUE)
 public class JsonProcessingExceptionMapper implements ExceptionMapper<JsonProcessingException> {
     private static final Logger LOGGER = LoggerFactory.getLogger(JsonProcessingExceptionMapper.class);
     private final boolean showDetails;

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapper.java
@@ -6,6 +6,7 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.validation.ConstraintViolations;
 
+import javax.annotation.Priority;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 import javax.ws.rs.core.Response;
@@ -13,6 +14,7 @@ import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
 @Provider
+@Priority(Integer.MAX_VALUE)
 public class ConstraintViolationExceptionMapper implements ExceptionMapper<ConstraintViolationException> {
 
     @Override

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/OverrideDefaultExceptionMapperResourceTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/OverrideDefaultExceptionMapperResourceTest.java
@@ -1,0 +1,40 @@
+package io.dropwizard.testing.app;
+
+import io.dropwizard.testing.junit.ResourceTestRule;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import javax.validation.ConstraintViolationException;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Test to make sure that the default exception mappers registered in
+ * {@link ResourceTestRule} can be overridden
+ */
+public class OverrideDefaultExceptionMapperResourceTest {
+    @ClassRule
+    public static final ResourceTestRule resources = ResourceTestRule.builder()
+            .addResource(new PersonResource(mock(PeopleStore.class)))
+            .addProvider(new CustomMapper())
+            .build();
+
+    @Test
+    public void testThatCustomConstraintExceptionMapperIsRegistered() {
+        final Response resp = resources.client().target("/person/blah").request()
+                .post(Entity.json("{}"));
+
+        assertThat(resp.getStatus()).isEqualTo(204);
+    }
+
+    private static class CustomMapper implements ExceptionMapper<ConstraintViolationException> {
+        @Override
+        public Response toResponse(ConstraintViolationException exception) {
+            return Response.noContent().build();
+        }
+    }
+}

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/OverrideDefaultExceptionMapperTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/OverrideDefaultExceptionMapperTest.java
@@ -1,0 +1,33 @@
+package io.dropwizard.testing.app;
+
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import io.dropwizard.testing.junit.TestApplicationExceptionMappers;
+import io.dropwizard.testing.junit.TestConfiguration;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test to make sure that the default exception mappers can be overridden
+ * easily in an application.
+ */
+public class OverrideDefaultExceptionMapperTest {
+    @ClassRule
+    public static final DropwizardAppRule<TestConfiguration> RULE =
+            new DropwizardAppRule<>(TestApplicationExceptionMappers.class, resourceFilePath("test-config.yaml"));
+
+    @Test
+    public void testDefaultExceptionMappersAreOverridden() {
+        final Response clientResponse = ClientBuilder.newClient()
+                .target("http://localhost:" + RULE.getLocalPort() + "/")
+                .request().post(Entity.json(""));
+
+        assertThat(clientResponse.getStatus()).isEqualTo(204);
+    }
+}

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/TestApplicationExceptionMappers.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/TestApplicationExceptionMappers.java
@@ -1,0 +1,33 @@
+package io.dropwizard.testing.junit;
+
+import io.dropwizard.Application;
+import io.dropwizard.setup.Environment;
+import org.hibernate.validator.constraints.NotEmpty;
+
+import javax.validation.ConstraintViolationException;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+public class TestApplicationExceptionMappers extends Application<TestConfiguration> {
+    @Override
+    public void run(TestConfiguration configuration, Environment environment) throws Exception {
+        environment.jersey().register(new ExceptionMapper<ConstraintViolationException>() {
+            @Override
+            public Response toResponse(ConstraintViolationException exception) {
+                return Response.noContent().build();
+            }
+        });
+
+        environment.jersey().register(new TestResourceWithValidations());
+    }
+
+    @Path("/")
+    private static class TestResourceWithValidations {
+        @POST
+        public String endpoint(@NotEmpty String body) {
+            return body;
+        }
+    }
+}


### PR DESCRIPTION
This pull request annotates the default exception mappers with `@Priority(Integer.MAX_VALUE)`, which allows for a user to override one of the default exception mappers without having to set the configuration option `registerDefaultExceptionMappers` to `false`. Since the configuration option won't  be useful once this pull request is merged, it can be slated for removal at a later point.

As a corollary, we can add additional exception mappers (`ExceptionMapper<Foo>`) and not fear breaking applications where the user had also defined `ExceptionMapper<Foo>`