### PR TITLE
Revert "Register default mappers in ResourceTestRule"

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ResourceTestRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ResourceTestRule.java
@@ -8,10 +8,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.DropwizardResourceConfig;
-import io.dropwizard.jersey.errors.EarlyEofExceptionMapper;
-import io.dropwizard.jersey.errors.LoggingExceptionMapper;
 import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
-import io.dropwizard.jersey.jackson.JsonProcessingExceptionMapper;
 import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
 import io.dropwizard.logging.BootstrapLogging;
@@ -156,11 +153,7 @@ public class ResourceTestRule implements TestRule {
         }
 
         private void configure(final ResourceTestRule resourceTestRule) {
-            register(new LoggingExceptionMapper<Throwable>() {
-            });
             register(new ConstraintViolationExceptionMapper());
-            register(new JsonProcessingExceptionMapper());
-            register(new EarlyEofExceptionMapper());
             for (Class<?> provider : resourceTestRule.providers) {
                 register(provider);
             }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/Person.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/Person.java
@@ -1,12 +1,10 @@
 package io.dropwizard.testing;
 
 import com.google.common.base.MoreObjects;
-import org.hibernate.validator.constraints.NotEmpty;
 
 import java.util.Objects;
 
 public class Person {
-    @NotEmpty
     private String name;
     private String email;
 

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResource.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResource.java
@@ -4,9 +4,7 @@ import com.codahale.metrics.annotation.Timed;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.testing.Person;
 
-import javax.validation.Valid;
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -32,10 +30,5 @@ public class PersonResource {
     @Path("/list")
     public ImmutableList<Person> getPersonList(@PathParam("name") String name) {
         return ImmutableList.of(getPerson(name));
-    }
-
-    @POST
-    public Person createPerson(@Valid Person person) {
-        return new Person(person.getName(), person.getEmail().trim());
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResourceTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResourceTest.java
@@ -1,15 +1,16 @@
 package io.dropwizard.testing.app;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.google.common.collect.ImmutableList;
+import io.dropwizard.jackson.Jackson;
 import io.dropwizard.testing.Person;
 import io.dropwizard.testing.junit.ResourceTestRule;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
@@ -20,9 +21,13 @@ import static org.mockito.Mockito.*;
 public class PersonResourceTest {
     private static final PeopleStore dao = mock(PeopleStore.class);
 
+    private static final ObjectMapper mapper = Jackson.newObjectMapper()
+            .registerModule(new GuavaModule());
+
     @ClassRule
     public static final ResourceTestRule resources = ResourceTestRule.builder()
             .addResource(new PersonResource(dao))
+            .setMapper(mapper)
             .build();
 
     private final Person person = new Person("blah", "blah@example.com");
@@ -46,36 +51,5 @@ public class PersonResourceTest {
         assertThat(resources.client().target("/person/blah/list").request()
                 .get(new GenericType<ImmutableList<Person>>() {}))
                 .isEqualTo(ImmutableList.of(person));
-    }
-
-    @Test
-    public void testThatJsonExceptionMapperIsRegistered() {
-        final Response resp = resources.client().target("/person/blah").request()
-                .post(Entity.json("{"));
-
-        assertThat(resp.getStatus()).isEqualTo(400);
-        assertThat(resp.readEntity(String.class))
-                .isEqualTo("{\"code\":400,\"message\":\"Unable to process JSON\"}");
-    }
-
-    @Test
-    public void testThatLoggingExceptionIsRegistered() {
-        final Response resp = resources.client().target("/person/blah").request()
-                .post(Entity.json("{\"name\": \"Coda\"}"));
-
-        assertThat(resp.getStatus()).isEqualTo(500);
-        assertThat(resp.readEntity(String.class))
-                .startsWith("{\"code\":500,\"message\":\"There was an error processing" +
-                        " your request. It has been logged");
-    }
-
-    @Test
-    public void testThatConstraintExceptionMapperIsRegistered() {
-        final Response resp = resources.client().target("/person/blah").request()
-                .post(Entity.json("{}"));
-
-        assertThat(resp.getStatus()).isEqualTo(422);
-        assertThat(resp.readEntity(String.class))
-                .isEqualTo("{\"errors\":[\"name may not be empty\"]}");
     }
 }


### PR DESCRIPTION
Reverts dropwizard/dropwizard#1125

This pull request needs to be reverted so that users that define their own exception mappers that conflict with ones that Dropwizard defines don't have their test cases fail undeterministically. I tried to make it so that overriding exception mappers can be graceful (#1144), but it is halted due to a Jersey issue. The reverted pull request didn't make it into the release notes, so those don't have to change.