### PR TITLE
Make LoggingFactory discoverable.

### DIFF
--- a/dropwizard-logging/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
+++ b/dropwizard-logging/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
@@ -1,1 +1,2 @@
 io.dropwizard.logging.AppenderFactory
+io.dropwizard.logging.LoggerFactory

--- a/dropwizard-logging/src/main/resources/META-INF/services/io.dropwizard.logging.LoggingFactory
+++ b/dropwizard-logging/src/main/resources/META-INF/services/io.dropwizard.logging.LoggingFactory
@@ -1,0 +1,1 @@
+io.dropwizard.logging.DefaultLoggingFactory


### PR DESCRIPTION
It looks like [#996](https://github.com/dropwizard/dropwizard/pull/996) omitted these changes - I'm not sure if that was deliberate. I just pulled down 0.9.0-rc1 to play around with adding a custom LoggingFactory and it wouldn't work without these changes.