### PR TITLE
Add toString for configuration objects

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/server/DefaultServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/DefaultServerFactory.java
@@ -3,6 +3,7 @@ package io.dropwizard.server;
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import io.dropwizard.jetty.ConnectorFactory;
@@ -228,5 +229,17 @@ public class DefaultServerFactory extends AbstractServerFactory {
             connectors.add(factory.build(server, metricRegistry, "application", null));
         }
         return connectors;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("applicationConnectors", applicationConnectors)
+                .add("adminConnectors", adminConnectors)
+                .add("adminMaxThreads", adminMaxThreads)
+                .add("adminMinThreads", adminMinThreads)
+                .add("applicationContextPath", applicationContextPath)
+                .add("adminContextPath", adminContextPath)
+                .toString();
     }
 }

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/DefaultLoggingFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/DefaultLoggingFactory.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -175,5 +176,14 @@ public class DefaultLoggingFactory implements LoggingFactory {
         }
 
         return root;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("level", level)
+                .add("loggers", loggers)
+                .add("appenders", appenders)
+                .toString();
     }
 }

--- a/dropwizard-metrics/src/main/java/io/dropwizard/metrics/MetricsFactory.java
+++ b/dropwizard-metrics/src/main/java/io/dropwizard/metrics/MetricsFactory.java
@@ -2,6 +2,7 @@ package io.dropwizard.metrics;
 
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import io.dropwizard.util.Duration;
@@ -90,5 +91,13 @@ public class MetricsFactory {
                 LOGGER.warn("Failed to create reporter, metrics may not be properly reported.", e);
             }
         }
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("frequency", frequency)
+                .add("reporters", reporters)
+                .toString();
     }
 }


### PR DESCRIPTION
Objects which hold configuration are serialized from json/yaml files.
Without proper ```toString()``` methods, it is impossible to log what
is the configuration of the application after it was deserialized into
the configuration class. It is especially important in regards to the
```DefaultServerFactory``` class, which holds the configuration for the
```server``` command. By adding the ```toString()``` methods, it is
possible to log during application startup what is the actual configuration
used by the app.