### PR TITLE
Make authorization optional

### DIFF
--- a/docs/source/manual/auth.rst
+++ b/docs/source/manual/auth.rst
@@ -92,7 +92,8 @@ Basic Authentication
 
 The ``AuthDynamicFeature`` with the ``BasicCredentialAuthFilter`` and ``RolesAllowedDynamicFeature``
 enables HTTP Basic authentication and authorization; requires an authenticator which
-takes instances of ``BasicCredentials``:
+takes instances of ``BasicCredentials``. If you don't use authorization, then ``RolesAllowedDynamicFeature``
+is not required.
 
 .. code-block:: java
 
@@ -117,7 +118,8 @@ OAuth2
 
 The ``AuthDynamicFeature`` with ``OAuthCredentialAuthFilter`` and ``RolesAllowedDynamicFeature``
 enables OAuth2 bearer-token authentication and authorization; requires an authenticator which
-takes instances of ``String``:
+takes instances of ``String``. If you don't use authorization, then ``RolesAllowedDynamicFeature``
+is not required.
 
 .. code-block:: java
 
@@ -174,7 +176,12 @@ For this to work properly, all chained factories must produce the same type of p
 Protecting Resources
 ====================
 
-To protect a resource, simply include the ``@RolesAllowed`` annotation with an appropriate role on your resource method.
+To protect a resource, you need to mark your resource methods with one of the following annotations:
+
+* ``@PermitAll``. All authenticated users will have access to the method.
+* ``@RolesAllowed``. Access will be granted for the users with the specified roles.
+* ``@DenyAll``. No access will be granted to anyone.
+
 If you need access to the Principal, you need to add a parameter to your method ``@Context SecurityContext context``
 
 .. code-block:: java

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthDynamicFeature.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthDynamicFeature.java
@@ -1,23 +1,41 @@
 package io.dropwizard.auth;
 
 import org.glassfish.jersey.server.model.AnnotatedMethod;
+
 import javax.annotation.security.DenyAll;
+import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
+
+import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
+
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.DynamicFeature;
 import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.FeatureContext;
 
+/**
+ * A {@link DynamicFeature} that registers the provided auth filter
+ * to resource methods annotated with the {@link RolesAllowed}, {@link PermitAll}
+ * and {@link DenyAll} annotations.
+ * <p>In conjunction with {@link RolesAllowedDynamicFeature} it enables
+ * authorization <i>AND</i> authentication of requests on the annotated methods.</p>
+ * <p>If authorization is not a concern, then {@link RolesAllowedDynamicFeature}
+ * could be omitted. But to enable authentication, the {@link PermitAll} annotation
+ * should be placed on the corresponding resource methods.</p>
+ */
 public class AuthDynamicFeature implements DynamicFeature {
-    private ContainerRequestFilter authFilter;
+
+    private final ContainerRequestFilter authFilter;
+
     public AuthDynamicFeature(ContainerRequestFilter authFilter) {
         this.authFilter = authFilter;
     }
 
     @Override
     public void configure(ResourceInfo resourceInfo, FeatureContext context) {
-        AnnotatedMethod am = new AnnotatedMethod(resourceInfo.getResourceMethod());
-        if (am.isAnnotationPresent(RolesAllowed.class) || am.isAnnotationPresent(DenyAll.class)) {
+        final AnnotatedMethod am = new AnnotatedMethod(resourceInfo.getResourceMethod());
+        if (am.isAnnotationPresent(RolesAllowed.class) || am.isAnnotationPresent(DenyAll.class) ||
+                am.isAnnotationPresent(PermitAll.class)) {
             context.register(authFilter);
         }
     }

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthFilter.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthFilter.java
@@ -27,7 +27,7 @@ public abstract class AuthFilter<C, P extends Principal> implements ContainerReq
         private String realm = "realm";
         private String prefix = "Basic";
         private Authenticator<C, P> authenticator;
-        private Authorizer<P> authorizer;
+        private Authorizer<P> authorizer = new PermitAllAuthorizer<>();
 
         /**
          * Sets the given realm
@@ -74,10 +74,10 @@ public abstract class AuthFilter<C, P extends Principal> implements ContainerReq
         }
 
         /**
-         * Builds an instance of the filter with provided an authenticator,
+         * Builds an instance of the filter with a provided authenticator,
          * an authorizer, a prefix, and a realm.
          *
-         * @return a new instance of a filter
+         * @return a new instance of the filter
          */
         public T buildAuthFilter() {
             Preconditions.checkArgument(realm != null, "Realm is not set");

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/PermitAllAuthorizer.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/PermitAllAuthorizer.java
@@ -1,0 +1,16 @@
+package io.dropwizard.auth;
+
+import java.security.Principal;
+
+/**
+ * An {@link Authorizer} that grants access for any principal in any role.
+ *
+ * @param <P> the type of the principal
+ */
+public class PermitAllAuthorizer<P extends Principal> implements Authorizer<P> {
+
+    @Override
+    public boolean authorize(P principal, String role) {
+        return true;
+    }
+}

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/basic/BasicCredentialAuthFilter.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/basic/BasicCredentialAuthFilter.java
@@ -87,7 +87,7 @@ public class BasicCredentialAuthFilter<P extends Principal> extends AuthFilter<B
 
     /**
      * Builder for {@link BasicCredentialAuthFilter}.
-     * <p>An {@link Authenticator} and an {@link Authorizer} must be provided during the building process.</p>
+     * <p>An {@link Authenticator} must be provided during the building process.</p>
      *
      * @param <P> the principal
      */

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/oauth/OAuthCredentialAuthFilter.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/oauth/OAuthCredentialAuthFilter.java
@@ -72,7 +72,7 @@ public class OAuthCredentialAuthFilter<P extends Principal> extends AuthFilter<S
 
     /**
      * Builder for {@link OAuthCredentialAuthFilter}.
-     * <p>An {@link Authenticator} and an {@link Authorizer} must be provided during the building process.</p>
+     * <p>An {@link Authenticator} must be provided during the building process.</p>
      *
      * @param <P> the type of the principal
      */

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthResource.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthResource.java
@@ -10,24 +10,23 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.SecurityContext;
-import java.security.Principal;
 
 @Path("/test/")
 @Produces(MediaType.TEXT_PLAIN)
 public class AuthResource {
+
     @RolesAllowed({"ADMIN"})
     @GET
+    @Path("admin")
     public String show(@Context SecurityContext securityContext) {
-        Principal principal = securityContext.getUserPrincipal();
-        return principal.getName();
+        return "'" + securityContext.getUserPrincipal().getName() + "' has admin privileges";
     }
 
     @PermitAll
     @GET
-    @Path("authnotrequired")
-    public String showNotRequired(@Context SecurityContext securityContext) {
-        Principal principal = securityContext.getUserPrincipal();
-        return principal == null ? "No Principal" : principal.getName();
+    @Path("profile")
+    public String showForEveryUser(@Context SecurityContext securityContext) {
+        return "'" + securityContext.getUserPrincipal().getName() + "' has user privileges";
     }
 
     @GET

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/BasicCustomAuthProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/BasicCustomAuthProviderTest.java
@@ -1,6 +1,7 @@
 package io.dropwizard.auth.basic;
 
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableList;
 import io.dropwizard.auth.*;
 import io.dropwizard.auth.util.AuthUtil;
 import io.dropwizard.jersey.DropwizardResourceConfig;
@@ -15,16 +16,10 @@ import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
 import org.glassfish.jersey.test.spi.TestContainerException;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
 import org.junit.Test;
-import javax.annotation.security.RolesAllowed;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestFilter;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.SecurityContext;
 import java.security.Principal;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,7 +27,8 @@ import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 
 public class BasicCustomAuthProviderTest extends JerseyTest {
-    final private static String VALID_ROLE = "ADMIN";
+    private final static String ADMIN_ROLE = "ADMIN";
+
     static {
         BootstrapLogging.bootstrap();
     }
@@ -54,7 +50,7 @@ public class BasicCustomAuthProviderTest extends JerseyTest {
     @Test
     public void respondsToMissingCredentialsWith401() throws Exception {
         try {
-            target("/test").request().get(String.class);
+            target("/test/admin").request().get(String.class);
             failBecauseExceptionWasNotThrown(WebApplicationException.class);
         } catch (WebApplicationException e) {
             assertThat(e.getResponse().getStatus()).isEqualTo(401);
@@ -65,23 +61,49 @@ public class BasicCustomAuthProviderTest extends JerseyTest {
 
     @Test
     public void transformsCredentialsToPrincipals() throws Exception {
-        assertThat(target("/test").request()
+        assertThat(target("/test/admin").request()
                 .header(HttpHeaders.AUTHORIZATION, "Custom Z29vZC1ndXk6c2VjcmV0")
                 .get(String.class))
-                .isEqualTo("good-guy");
+                .isEqualTo("'good-guy' has admin privileges");
     }
 
     @Test
-    public void resourceWithAuthNotRequired200() {
-        assertThat(target("/test/authnotrequired").request()
+    public void resourceWithAuthenticationWithoutAuthorizationWithCorrectCredentials200() {
+        assertThat(target("/test/profile").request()
+                .header(HttpHeaders.AUTHORIZATION, "Custom b3JkaW5hcnktZ3V5OnNlY3JldA==")
                 .get(String.class))
-                .isEqualTo("No Principal");
+                .isEqualTo("'ordinary-guy' has user privileges");
+    }
+
+    @Test
+    public void resourceWithAuthenticationWithoutAuthorizationNoCredentials401() {
+        try {
+            target("/test/profile").request().get(String.class);
+            failBecauseExceptionWasNotThrown(WebApplicationException.class);
+        } catch (WebApplicationException e) {
+            assertThat(e.getResponse().getStatus()).isEqualTo(401);
+            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
+                    .containsOnly("Custom realm=\"realm\"");
+        }
+    }
+
+    @Test
+    public void resourceWithAuthorizationPrincipalIsNotAuthorized403() {
+        try {
+            target("/test/admin").request()
+                    .header(HttpHeaders.AUTHORIZATION, "Custom b3JkaW5hcnktZ3V5OnNlY3JldA==")
+                    .get(String.class);
+            failBecauseExceptionWasNotThrown(WebApplicationException.class);
+        } catch (WebApplicationException e) {
+            assertThat(e.getResponse().getStatus()).isEqualTo(403);
+        }
     }
 
     @Test
     public void resourceWithDenyAllAndNoAuth401() {
         try {
             target("/test/denied").request().get(String.class);
+            failBecauseExceptionWasNotThrown(WebApplicationException.class);
         } catch (WebApplicationException e) {
             assertThat(e.getResponse().getStatus()).isEqualTo(401);
         }
@@ -93,6 +115,7 @@ public class BasicCustomAuthProviderTest extends JerseyTest {
             target("/test/denied").request()
                     .header(HttpHeaders.AUTHORIZATION, "Custom Z29vZC1ndXk6c2VjcmV0")
                     .get(String.class);
+            failBecauseExceptionWasNotThrown(WebApplicationException.class);
         } catch (WebApplicationException e) {
             assertThat(e.getResponse().getStatus()).isEqualTo(403);
         }
@@ -101,7 +124,7 @@ public class BasicCustomAuthProviderTest extends JerseyTest {
     @Test
     public void respondsToNonBasicCredentialsWith401() throws Exception {
         try {
-            target("/test").request()
+            target("/test/admin").request()
                     .header(HttpHeaders.AUTHORIZATION, "Derp Z29vZC1ndXk6c2VjcmV0")
                     .get(String.class);
             failBecauseExceptionWasNotThrown(WebApplicationException.class);
@@ -115,23 +138,12 @@ public class BasicCustomAuthProviderTest extends JerseyTest {
     @Test
     public void respondsToExceptionsWith500() throws Exception {
         try {
-            target("/test").request()
+            target("/test/admin").request()
                     .header(HttpHeaders.AUTHORIZATION, "Custom YmFkLWd1eTpzZWNyZXQ=")
                     .get(String.class);
-
             failBecauseExceptionWasNotThrown(WebApplicationException.class);
         } catch (WebApplicationException e) {
             assertThat(e.getResponse().getStatus()).isEqualTo(500);
-        }
-    }
-
-    @Path("/test/")
-    @Produces(MediaType.TEXT_PLAIN)
-    public static class ExampleResource {
-        @RolesAllowed({VALID_ROLE})
-        @GET
-        public String show(@Context SecurityContext context) {
-            return context.getUserPrincipal().getName();
         }
     }
 
@@ -145,11 +157,12 @@ public class BasicCustomAuthProviderTest extends JerseyTest {
         }
 
         private ContainerRequestFilter getAuthFilter() {
-            final String validUser = "good-guy";
+            final String adminUser = "good-guy";
+            final String ordinaryUser = "ordinary-guy";
 
             BasicCredentialAuthFilter.Builder<Principal> builder  = new BasicCredentialAuthFilter.Builder<>();
-            builder.setAuthorizer(AuthUtil.getTestAuthorizer(validUser, VALID_ROLE));
-            builder.setAuthenticator(AuthUtil.getTestAuthenticatorBasicCredential(validUser));
+            builder.setAuthorizer(AuthUtil.getTestAuthorizer(adminUser, ADMIN_ROLE));
+            builder.setAuthenticator(AuthUtil.getBasicAuthenticator(ImmutableList.of(adminUser, ordinaryUser)));
             builder.setPrefix("Custom");
             return builder.buildAuthFilter();
         }

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/oauth/OAuthCustomProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/oauth/OAuthCustomProviderTest.java
@@ -1,9 +1,8 @@
 package io.dropwizard.auth.oauth;
 
 import com.codahale.metrics.MetricRegistry;
-import io.dropwizard.auth.AuthDynamicFeature;
-import io.dropwizard.auth.AuthFilter;
-import io.dropwizard.auth.AuthResource;
+import com.google.common.collect.ImmutableList;
+import io.dropwizard.auth.*;
 import io.dropwizard.auth.util.AuthUtil;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.logging.BootstrapLogging;
@@ -17,6 +16,7 @@ import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
 import org.glassfish.jersey.test.spi.TestContainerException;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
 import org.junit.Test;
+
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
 
@@ -45,7 +45,7 @@ public class OAuthCustomProviderTest extends JerseyTest {
     @Test
     public void respondsToMissingCredentialsWith401() throws Exception {
         try {
-            target("/test").request().get(String.class);
+            target("/test/admin").request().get(String.class);
             failBecauseExceptionWasNotThrown(WebApplicationException.class);
         } catch (WebApplicationException e) {
             assertThat(e.getResponse().getStatus()).isEqualTo(401);
@@ -56,8 +56,10 @@ public class OAuthCustomProviderTest extends JerseyTest {
 
     @Test
     public void transformsCredentialsToPrincipals() throws Exception {
-        assertThat(target("/test").request().header(HttpHeaders.AUTHORIZATION, "Custom good-guy").get(String.class))
-                .isEqualTo("good-guy");
+        assertThat(target("/test/admin").request()
+                .header(HttpHeaders.AUTHORIZATION, "Custom good-guy")
+                .get(String.class))
+                .isEqualTo("'good-guy' has admin privileges");
     }
 
     @Test
@@ -68,16 +70,42 @@ public class OAuthCustomProviderTest extends JerseyTest {
     }
 
     @Test
-    public void resourceWithAuthNotRequired200() {
-        assertThat(target("/test/authnotrequired").request()
+    public void resourceWithAuthenticationWithoutAuthorizationWithCorrectCredentials200() {
+        assertThat(target("/test/profile").request()
+                .header(HttpHeaders.AUTHORIZATION, "custom ordinary-guy")
                 .get(String.class))
-                .isEqualTo("No Principal");
+                .isEqualTo("'ordinary-guy' has user privileges");
+    }
+
+    @Test
+    public void resourceWithAuthenticationWithoutAuthorizationNoCredentials401() {
+        try {
+            target("/test/profile").request().get(String.class);
+            failBecauseExceptionWasNotThrown(WebApplicationException.class);
+        } catch (WebApplicationException e) {
+            assertThat(e.getResponse().getStatus()).isEqualTo(401);
+            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
+                    .containsOnly("Custom realm=\"realm\"");
+        }
+    }
+
+    @Test
+    public void resourceWithAuthorizationPrincipalIsNotAuthorized403() {
+        try {
+            target("/test/admin").request()
+                    .header(HttpHeaders.AUTHORIZATION, "custom ordinary-guy")
+                    .get(String.class);
+            failBecauseExceptionWasNotThrown(WebApplicationException.class);
+        } catch (WebApplicationException e) {
+            assertThat(e.getResponse().getStatus()).isEqualTo(403);
+        }
     }
 
     @Test
     public void resourceWithDenyAllAndNoAuth401() {
         try {
             target("/test/denied").request().get(String.class);
+            failBecauseExceptionWasNotThrown(WebApplicationException.class);
         } catch (WebApplicationException e) {
             assertThat(e.getResponse().getStatus()).isEqualTo(401);
         }
@@ -89,6 +117,7 @@ public class OAuthCustomProviderTest extends JerseyTest {
             target("/test/denied").request()
                     .header(HttpHeaders.AUTHORIZATION, "Custom good-guy")
                     .get(String.class);
+            failBecauseExceptionWasNotThrown(WebApplicationException.class);
         } catch (WebApplicationException e) {
             assertThat(e.getResponse().getStatus()).isEqualTo(403);
         }
@@ -97,7 +126,7 @@ public class OAuthCustomProviderTest extends JerseyTest {
     @Test
     public void respondsToNonBasicCredentialsWith401() throws Exception {
         try {
-            target("/test").request().header(HttpHeaders.AUTHORIZATION, "Derp WHEE").get(String.class);
+            target("/test/admin").request().header(HttpHeaders.AUTHORIZATION, "Derp WHEE").get(String.class);
             failBecauseExceptionWasNotThrown(WebApplicationException.class);
         } catch (WebApplicationException e) {
             assertThat(e.getResponse().getStatus()).isEqualTo(401);
@@ -109,7 +138,7 @@ public class OAuthCustomProviderTest extends JerseyTest {
     @Test
     public void respondsToExceptionsWith500() throws Exception {
         try {
-            target("/test").request().header(HttpHeaders.AUTHORIZATION, "Custom bad-guy").get(String.class);
+            target("/test/admin").request().header(HttpHeaders.AUTHORIZATION, "Custom bad-guy").get(String.class);
             failBecauseExceptionWasNotThrown(WebApplicationException.class);
         } catch (WebApplicationException e) {
             assertThat(e.getResponse().getStatus()).isEqualTo(500);
@@ -126,11 +155,12 @@ public class OAuthCustomProviderTest extends JerseyTest {
         }
 
         private AuthFilter getAuthFilter() {
-            final String validUser = "good-guy";
+            final String adminUser = "good-guy";
+            final String ordinaryUser = "ordinary-guy";
 
             return new OAuthCredentialAuthFilter.Builder<>()
-                    .setAuthenticator(AuthUtil.getTestAuthenticator(validUser))
-                    .setAuthorizer(AuthUtil.getTestAuthorizer(validUser, "ADMIN"))
+                    .setAuthenticator(AuthUtil.getMultiplyUsersOAuthAuthenticator(ImmutableList.of(adminUser, ordinaryUser)))
+                    .setAuthorizer(AuthUtil.getTestAuthorizer(adminUser, "ADMIN"))
                     .setPrefix("Custom")
                     .buildAuthFilter();
         }

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/util/AuthUtil.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/util/AuthUtil.java
@@ -5,16 +5,16 @@ import io.dropwizard.auth.*;
 import io.dropwizard.auth.basic.BasicCredentials;
 
 import java.security.Principal;
+import java.util.List;
 
 public class AuthUtil {
 
-    public static Authenticator<BasicCredentials, Principal> getTestAuthenticatorBasicCredential(final String validUser) {
+    public static Authenticator<BasicCredentials, Principal> getBasicAuthenticator(final List<String> validUsers) {
         return new Authenticator<BasicCredentials, Principal>() {
             @Override
             public Optional<Principal> authenticate(BasicCredentials credentials) throws AuthenticationException {
-                if (validUser.equals(credentials.getUsername()) &&
-                        "secret".equals(credentials.getPassword())) {
-                    return Optional.<Principal>of(new PrincipalImpl(validUser));
+                if (validUsers.contains(credentials.getUsername()) && "secret".equals(credentials.getPassword())) {
+                    return Optional.<Principal>of(new PrincipalImpl(credentials.getUsername()));
                 }
                 if ("bad-guy".equals(credentials.getUsername())) {
                     throw new AuthenticationException("CRAP");
@@ -24,7 +24,8 @@ public class AuthUtil {
         };
     }
 
-    public static Authenticator<String, Principal> getTestAuthenticator(final String presented, final String returned) {
+    public static Authenticator<String, Principal> getSingleUserOAuthAuthenticator(final String presented,
+                                                                                   final String returned) {
         return new Authenticator<String, Principal>() {
             @Override
             public Optional<Principal> authenticate(String user) throws AuthenticationException {
@@ -39,8 +40,19 @@ public class AuthUtil {
         };
     }
 
-    public static Authenticator<String, Principal> getTestAuthenticator(final String presented) {
-        return getTestAuthenticator(presented, presented);
+    public static Authenticator<String, Principal> getMultiplyUsersOAuthAuthenticator(final List<String> validUsers) {
+        return new Authenticator<String, Principal>() {
+            @Override
+            public Optional<Principal> authenticate(String credentials) throws AuthenticationException {
+                if (validUsers.contains(credentials)) {
+                    return Optional.<Principal>of(new PrincipalImpl(credentials));
+                }
+                if (credentials.equals("bad-guy")) {
+                    throw new AuthenticationException("CRAP");
+                }
+                return Optional.absent();
+            }
+        };
     }
 
     public static Authorizer<Principal> getTestAuthorizer(final String validUser,

--- a/dropwizard-example/src/main/java/com/example/helloworld/auth/ExampleAuthorizer.java
+++ b/dropwizard-example/src/main/java/com/example/helloworld/auth/ExampleAuthorizer.java
@@ -7,6 +7,9 @@ public class ExampleAuthorizer implements Authorizer<User> {
 
     @Override
     public boolean authorize(User user, String role) {
+        if (role.equals("ADMIN") && !user.getName().startsWith("chief")) {
+            return false;
+        }
         return true;
     }
 }

--- a/dropwizard-example/src/main/java/com/example/helloworld/resources/ProtectedResource.java
+++ b/dropwizard-example/src/main/java/com/example/helloworld/resources/ProtectedResource.java
@@ -3,20 +3,27 @@ package com.example.helloworld.resources;
 import com.example.helloworld.core.User;
 import io.dropwizard.auth.Auth;
 
+import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.SecurityContext;
 
 @Path("/protected")
 @Produces(MediaType.TEXT_PLAIN)
 public class ProtectedResource {
-    @RolesAllowed("ADMIN")
+
+    @PermitAll
     @GET
     public String showSecret(@Auth User user) {
         return String.format("Hey there, %s. You know the secret! %d", user.getName(), user.getId());
+    }
+
+    @RolesAllowed("ADMIN")
+    @GET
+    @Path("admin")
+    public String showAdminSecret(@Auth User user) {
+        return String.format("Hey there, %s. It looks like you are an admin. %d", user.getName(), user.getId());
     }
 }


### PR DESCRIPTION
This change consists from two parts: fixing behavior of the`@PermitAll` annotation and making
providing an authorizer in `AuthFilterBuilder` optional.

The `@PermitAll` annotation is actually intended  for marking that a resource doesn't require authorization. Currently we treat it like the resource doesn't require authentication. 

The solution is to register an auth filter for the methods marked with the `@PermitAll` annotation. The methods will require authentication, but anyone, who was given access, can use it. This simplifies the work of users who don't care about roles and authorization. They don't need create a fiction role and register `RolesAllowedDynamicFeature`.

Because users have an option to not authorize their resource methods, it makes sense to not require a custom authorizer in `AuthFilterBuilder`. By default the filter will permit access to any principal in any role.