### PR TITLE
Improve AuthFactoryProvider

### DIFF
--- a/docs/source/manual/auth.rst
+++ b/docs/source/manual/auth.rst
@@ -132,7 +132,7 @@ takes instances of ``String``:
                 .buildAuthFilter()));
         environment.jersey().register(RolesAllowedDynamicFeature.class);
         //If you want to use @Auth to inject a custom Principal type into your resource
-        environment.jersey().register(new AuthValueFactoryProvider.Binder(User.class));
+        environment.jersey().register(new AuthValueFactoryProvider.Binder<>(User.class));
     }
 
 .. _man-auth-chained:
@@ -163,7 +163,7 @@ The ``ChainedAuthFilter`` enables usage of various authentication factories at t
         environment.jersey().register(new AuthDynamicFeature(new ChainedAuthFilter(handlers)));
         environment.jersey().register(RolesAllowedDynamicFeature.class);
         //If you want to use @Auth to inject a custom Principal type into your resource
-        environment.jersey().register(new AuthValueFactoryProvider.Binder(User.class));
+        environment.jersey().register(new AuthValueFactoryProvider.Binder<>(User.class));
     }
 
 For this to work properly, all chained factories must produce the same type of principal, here ``User``.
@@ -190,7 +190,7 @@ or you can add register the following with jersey
 
 .. code-block:: java
 
-    environment.jersey().register(new AuthValueFactoryProvider.Binder(User.class));
+    environment.jersey().register(new AuthValueFactoryProvider.Binder<>(User.class));
 
     @RolesAllowed("ADMIN")
     @GET

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthValueFactoryProvider.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthValueFactoryProvider.java
@@ -10,49 +10,69 @@ import org.glassfish.jersey.server.internal.inject.MultivaluedParameterExtractor
 import org.glassfish.jersey.server.internal.inject.ParamInjectionResolver;
 import org.glassfish.jersey.server.model.Parameter;
 import org.glassfish.jersey.server.spi.internal.ValueFactoryProvider;
-import org.jvnet.hk2.annotations.Contract;
+
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.security.Principal;
 
+/**
+ * Value factory provider supporting {@link Principal} injection
+ * by the {@link Auth} annotation.
+ *
+ * @param <T> the type of the principal
+ */
 @Singleton
-public class AuthValueFactoryProvider<T> extends AbstractValueFactoryProvider {
-    private Class<?> clazz;
+public class AuthValueFactoryProvider<T extends Principal> extends AbstractValueFactoryProvider {
+
     /**
-     * {@link Auth} annotation value factory provider injection constructor.
+     * Class of the provided {@link Principal}
+     */
+    private final Class<T> principalClass;
+
+    /**
+     * {@link Principal} value factory provider injection constructor.
      *
-     * @param mpep
-     *            multivalued parameter extractor provider.
-     * @param injector
-     *            injector instance.
+     * @param mpep                   multivalued parameter extractor provider
+     * @param injector               injector instance
+     * @param principalClassProvider provider of the principal class
      */
     @Inject
-    public AuthValueFactoryProvider(MultivaluedParameterExtractorProvider mpep, ServiceLocator injector) {
+    public AuthValueFactoryProvider(MultivaluedParameterExtractorProvider mpep,
+                                    ServiceLocator injector, PrincipalClassProvider<T> principalClassProvider) {
         super(mpep, injector, Parameter.Source.UNKNOWN);
-        PrincipalClassProvider service = injector.getService(PrincipalClassProvider.class);
-        clazz = service.getClazz();
+        this.principalClass = principalClassProvider.clazz;
     }
 
     /**
-     * Return a factory for the provided parameter. We only expect objects of type {@link T} being annotated with
-     * {@link Auth} annotation
+     * Return a factory for the provided parameter. We only expect objects of
+     * the type {@link T} being annotated with {@link Auth} annotation.
      *
-     * @param parameter
-     *            Parameter that was annotated for being injected
-     * @return {@link AuthValueFactory} if parameter matched type
+     * @param parameter parameter that was annotated for being injected
+     * @return the factory if parameter matched type
      */
     @Override
     public AbstractContainerRequestValueFactory<?> createValueFactory(Parameter parameter) {
-        Class<?> classType = parameter.getRawType();
-
-        if (classType == null || (!classType.equals(clazz))) {
+        if (!principalClass.equals(parameter.getRawType())) {
             return null;
         }
+        return new AbstractContainerRequestValueFactory<Principal>() {
 
-        return new AuthValueFactory<T>();
+            /**
+             * @return {@link Principal} stored on the request, or {@code null} if no object was found.
+             */
+            public Principal provide() {
+                final Principal principal = getContainerRequest().getSecurityContext().getUserPrincipal();
+                if (principal == null) {
+                    throw new IllegalStateException("Cannot inject a custom principal into unauthenticated request");
+                }
+                return principal;
+            }
+        };
     }
 
     @Singleton
-    static final class AuthInjectionResolver extends ParamInjectionResolver<Auth> {
+    private static class AuthInjectionResolver extends ParamInjectionResolver<Auth> {
+
         /**
          * Create new {@link Auth} annotation injection resolver.
          */
@@ -61,43 +81,35 @@ public class AuthValueFactoryProvider<T> extends AbstractValueFactoryProvider {
         }
     }
 
-    @Contract
-    public interface PrincipalClassProvider {
-        Class<?> getClazz();
-    }
+    @Singleton
+    private static class PrincipalClassProvider<T extends Principal> {
 
-    private static final class AuthValueFactory<T> extends AbstractContainerRequestValueFactory {
-        /**
-         * @return {@link T} stored on the request, or NULL if no object was found.
-         */
-        public T provide() {
-            @SuppressWarnings("unchecked")
-            T principal = (T) getContainerRequest().getSecurityContext().getUserPrincipal();
-            if (principal == null) {
-                throw new RuntimeException("Cannot inject Custom principal into unauthenticated request");
-            }
-            return principal;
+        private final Class<T> clazz;
+
+        public PrincipalClassProvider(Class<T> clazz) {
+            this.clazz = clazz;
         }
     }
 
-    public static class Binder<T> extends AbstractBinder {
-        private final Class<T> clazz;
-        public Binder(Class<T> clazz) {
-            this.clazz = clazz;
+    /**
+     * Injection binder for {@link AuthValueFactoryProvider} and {@link AuthInjectionResolver}.
+     *
+     * @param <T> the type of the principal
+     */
+    public static class Binder<T extends Principal> extends AbstractBinder {
+
+        private final Class<T> principalClass;
+
+        public Binder(Class<T> principalClass) {
+            this.principalClass = principalClass;
         }
 
         @Override
         protected void configure() {
-            bind(new PrincipalClassProvider() {
-                @Override
-                public Class<?> getClazz() {
-                    return clazz;
-                }
-            }).to(PrincipalClassProvider.class);
+            bind(new PrincipalClassProvider<>(principalClass)).to(PrincipalClassProvider.class);
             bind(AuthValueFactoryProvider.class).to(ValueFactoryProvider.class).in(Singleton.class);
-            TypeLiteral<InjectionResolver<Auth>> typeLiteral
-                    = new TypeLiteral<InjectionResolver<Auth>>() { };
-            bind(AuthInjectionResolver.class).to(typeLiteral).in(Singleton.class);
+            bind(AuthInjectionResolver.class).to(new TypeLiteral<InjectionResolver<Auth>>() {
+            }).in(Singleton.class);
         }
     }
 }

--- a/dropwizard-example/src/main/java/com/example/helloworld/HelloWorldApplication.java
+++ b/dropwizard-example/src/main/java/com/example/helloworld/HelloWorldApplication.java
@@ -87,7 +87,7 @@ public class HelloWorldApplication extends Application<HelloWorldConfiguration> 
                 .setAuthorizer(new ExampleAuthorizer())
                 .setRealm("SUPER SECRET STUFF")
                 .buildAuthFilter()));
-        environment.jersey().register(new AuthValueFactoryProvider.Binder(User.class));
+        environment.jersey().register(new AuthValueFactoryProvider.Binder<>(User.class));
         environment.jersey().register(RolesAllowedDynamicFeature.class);
         environment.jersey().register(new HelloWorldResource(template));
         environment.jersey().register(new ViewResource());

--- a/dropwizard-example/src/test/java/com/example/helloworld/resources/ProtectedResourceTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/resources/ProtectedResourceTest.java
@@ -56,7 +56,7 @@ public class ProtectedResourceTest {
     public static final ResourceTestRule resources = ResourceTestRule.builder()
             .addProvider(RolesAllowedDynamicFeature.class)
             .addProvider(new AuthDynamicFeature(BASIC_AUTH_HANDLER))
-            .addProvider(new AuthValueFactoryProvider.Binder(User.class))
+            .addProvider(new AuthValueFactoryProvider.Binder<>(User.class))
             .setTestContainerFactory(new GrizzlyWebTestContainerFactory())
             .addProvider(ProtectedResource.class)
             .build();


### PR DESCRIPTION
* Make sure users pass the type inherited from `Principal`.
* Remove unchecked cast warnings.
* Remove unnecessary static class `AuthValueFactory`, which could be replaced by an anonymous class.
* Make `PrincipalClassProvider` a holder class, rather then an interface. Doing so, we don't create a new anonymous class in `Binder`.
* Documentation and style improvements.