### PR TITLE
Register auth filter when @Auth is present

### DIFF
--- a/docs/source/manual/auth.rst
+++ b/docs/source/manual/auth.rst
@@ -176,24 +176,14 @@ For this to work properly, all chained factories must produce the same type of p
 Protecting Resources
 ====================
 
-To protect a resource, you need to mark your resource methods with one of the following annotations:
+There are two ways to protect a resource.  You can mark your resource method with one of the following annotations:
 
 * ``@PermitAll``. All authenticated users will have access to the method.
 * ``@RolesAllowed``. Access will be granted for the users with the specified roles.
 * ``@DenyAll``. No access will be granted to anyone.
 
-If you need access to the Principal, you need to add a parameter to your method ``@Context SecurityContext context``
-
-.. code-block:: java
-
-    @RolesAllowed("ADMIN")
-    @GET
-    public SecretPlan getSecretPlan(@Context SecurityContext context) {
-        User userPrincipal = (User) context.getUserPrincipal();
-        return dao.findPlanForUser(user);
-    }
-
-or you can add register the following with jersey
+Alternatively, you can annotate the parameter representing your principal with ``@Auth``. Note you must register a
+jersey provider to make this work.
 
 .. code-block:: java
 
@@ -205,6 +195,19 @@ or you can add register the following with jersey
         return dao.findPlanForUser(user);
     }
 
+You can also access the Principal by adding a parameter to your method ``@Context SecurityContext context``. Note this
+will not automatically register the servlet filter which performs authentication. You will still need to add one of
+``@PermitAll``, ``@RolesAllowed``, or ``@DenyAll``. This is not the case with ``@Auth``. When that is present, the auth
+filter is automatically registered to facilitate users upgrading from older versions of Dropwizard
+
+.. code-block:: java
+
+    @RolesAllowed("ADMIN")
+    @GET
+    public SecretPlan getSecretPlan(@Context SecurityContext context) {
+        User userPrincipal = (User) context.getUserPrincipal();
+        return dao.findPlanForUser(user);
+    }
 
 If there are no provided credentials for the request, or if the credentials are invalid, the
 provider will return a scheme-appropriate ``401 Unauthorized`` response without calling your

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthDynamicFeature.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthDynamicFeature.java
@@ -12,6 +12,7 @@ import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.DynamicFeature;
 import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.FeatureContext;
+import java.lang.annotation.Annotation;
 
 /**
  * A {@link DynamicFeature} that registers the provided auth filter
@@ -34,9 +35,19 @@ public class AuthDynamicFeature implements DynamicFeature {
     @Override
     public void configure(ResourceInfo resourceInfo, FeatureContext context) {
         final AnnotatedMethod am = new AnnotatedMethod(resourceInfo.getResourceMethod());
+        final Annotation[][] parameterAnnotations = am.getParameterAnnotations();
         if (am.isAnnotationPresent(RolesAllowed.class) || am.isAnnotationPresent(DenyAll.class) ||
-                am.isAnnotationPresent(PermitAll.class)) {
+            am.isAnnotationPresent(PermitAll.class)) {
             context.register(authFilter);
+        } else {
+            for (Annotation[] annotations : parameterAnnotations) {
+                for (Annotation annotation : annotations) {
+                    if (annotation instanceof Auth) {
+                        context.register(authFilter);
+                        return;
+                    }
+                }
+            }
         }
     }
 }

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthBaseResourceConfig.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthBaseResourceConfig.java
@@ -1,0 +1,21 @@
+package io.dropwizard.auth;
+
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.jersey.DropwizardResourceConfig;
+import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
+
+import javax.ws.rs.container.ContainerRequestFilter;
+import java.security.Principal;
+
+public abstract class AuthBaseResourceConfig extends DropwizardResourceConfig {
+    public AuthBaseResourceConfig() {
+        super(true, new MetricRegistry());
+
+        register(new AuthDynamicFeature(getAuthFilter()));
+        register(new AuthValueFactoryProvider.Binder<>(Principal.class));
+        register(RolesAllowedDynamicFeature.class);
+        register(AuthResource.class);
+    }
+
+    protected abstract ContainerRequestFilter getAuthFilter();
+}

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthBaseTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthBaseTest.java
@@ -1,0 +1,172 @@
+package io.dropwizard.auth;
+
+import io.dropwizard.jersey.DropwizardResourceConfig;
+import io.dropwizard.logging.BootstrapLogging;
+import org.glassfish.jersey.servlet.ServletProperties;
+import org.glassfish.jersey.test.DeploymentContext;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.glassfish.jersey.test.TestProperties;
+import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
+import org.glassfish.jersey.test.spi.TestContainerException;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
+import org.junit.Test;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.HttpHeaders;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+public abstract class AuthBaseTest<T extends DropwizardResourceConfig> extends JerseyTest{
+    protected static final String ADMIN_ROLE = "ADMIN";
+    protected static final String ADMIN_USER = "good-guy";
+    protected static final String ORDINARY_USER = "ordinary-guy";
+    protected static final String BADGUY_USER = "bad-guy";
+    protected static final String CUSTOM_PREFIX = "Custom";
+    protected static final String BEARER_PREFIX = "Bearer";
+    protected static final String BASIC_PREFIX = "Basic";
+    protected static final String ORDINARY_USER_ENCODED_TOKEN = "b3JkaW5hcnktZ3V5OnNlY3JldA==";
+    protected static final String GOOD_USER_ENCODED_TOKEN = "Z29vZC1ndXk6c2VjcmV0";
+    protected static final String BAD_USER_ENCODED_TOKEN = "YmFkLWd1eTpzZWNyZXQ=";
+
+    static {
+        BootstrapLogging.bootstrap();
+    }
+
+    @Override
+    protected TestContainerFactory getTestContainerFactory()
+        throws TestContainerException {
+        return new GrizzlyWebTestContainerFactory();
+    }
+
+    protected abstract DropwizardResourceConfig getDropwizardResourceConfig();
+    protected abstract Class<T> getDropwizardResourceConfigClass();
+    protected abstract String getPrefix();
+    protected abstract String getOrdinaryGuyValidToken();
+    protected abstract String getGoodGuyValidToken();
+    protected abstract String getBadGuyToken();
+
+    @Override
+    protected DeploymentContext configureDeployment() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
+        return ServletDeploymentContext.builder(getDropwizardResourceConfig())
+            .initParam(ServletProperties.JAXRS_APPLICATION_CLASS, getDropwizardResourceConfigClass().getName())
+            .build();
+    }
+
+    @Test
+    public void respondsToMissingCredentialsWith401() throws Exception {
+        try {
+            target("/test/admin").request().get(String.class);
+            failBecauseExceptionWasNotThrown(WebApplicationException.class);
+        } catch (WebApplicationException e) {
+            assertThat(e.getResponse().getStatus()).isEqualTo(401);
+            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
+                .containsOnly(getPrefix() + " realm=\"realm\"");
+        }
+    }
+
+    @Test
+    public void resourceWithoutAuth200() {
+        assertThat(target("/test/noauth").request()
+            .get(String.class))
+            .isEqualTo("hello");
+    }
+
+    @Test
+    public void resourceWithAuthenticationWithoutAuthorizationWithCorrectCredentials200() {
+        assertThat(target("/test/profile").request()
+            .header(HttpHeaders.AUTHORIZATION, getPrefix() + " " + getOrdinaryGuyValidToken())
+            .get(String.class))
+            .isEqualTo("'" + ORDINARY_USER + "' has user privileges");
+    }
+
+    @Test
+    public void resourceWithAuthenticationWithoutAuthorizationNoCredentials401() {
+        try {
+            target("/test/profile").request().get(String.class);
+            failBecauseExceptionWasNotThrown(WebApplicationException.class);
+        } catch (WebApplicationException e) {
+            assertThat(e.getResponse().getStatus()).isEqualTo(401);
+            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
+                .containsOnly(getPrefix() + " realm=\"realm\"");
+        }
+    }
+
+    @Test
+    public void resourceWithAuthorizationPrincipalIsNotAuthorized403() {
+        try {
+            target("/test/admin").request()
+                .header(HttpHeaders.AUTHORIZATION, getPrefix() + " " + getOrdinaryGuyValidToken())
+                .get(String.class);
+            failBecauseExceptionWasNotThrown(WebApplicationException.class);
+        } catch (WebApplicationException e) {
+            assertThat(e.getResponse().getStatus()).isEqualTo(403);
+        }
+    }
+
+
+    @Test
+    public void resourceWithDenyAllAndNoAuth401() {
+        try {
+            target("/test/denied").request().get(String.class);
+            failBecauseExceptionWasNotThrown(WebApplicationException.class);
+        } catch (WebApplicationException e) {
+            assertThat(e.getResponse().getStatus()).isEqualTo(401);
+        }
+    }
+
+    @Test
+    public void resourceWithDenyAllAndAuth403() {
+        try {
+            target("/test/denied").request()
+                .header(HttpHeaders.AUTHORIZATION, getPrefix() + " " + getGoodGuyValidToken())
+                .get(String.class);
+            failBecauseExceptionWasNotThrown(WebApplicationException.class);
+        } catch (WebApplicationException e) {
+            assertThat(e.getResponse().getStatus()).isEqualTo(403);
+        }
+    }
+
+    @Test
+    public void transformsCredentialsToPrincipals() throws Exception {
+        assertThat(target("/test/admin").request()
+            .header(HttpHeaders.AUTHORIZATION, getPrefix() + " " + getGoodGuyValidToken())
+            .get(String.class))
+            .isEqualTo("'" + ADMIN_USER + "' has admin privileges");
+    }
+
+    @Test
+    public void transformsCredentialsToPrincipalsWhenAuthAnnotationExistsWithoutMethodAnnotation() throws Exception {
+        assertThat(target("/test/implicit-permitall").request()
+            .header(HttpHeaders.AUTHORIZATION, getPrefix() + " " + getGoodGuyValidToken())
+            .get(String.class))
+            .isEqualTo("'" + ADMIN_USER + "' has user privileges");
+    }
+
+
+    @Test
+    public void respondsToNonBasicCredentialsWith401() throws Exception {
+        try {
+            target("/test/admin").request()
+                .header(HttpHeaders.AUTHORIZATION, "Derp irrelevant")
+                .get(String.class);
+            failBecauseExceptionWasNotThrown(WebApplicationException.class);
+        } catch (WebApplicationException e) {
+            assertThat(e.getResponse().getStatus()).isEqualTo(401);
+            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
+                .containsOnly(getPrefix() + " realm=\"realm\"");
+        }
+    }
+
+    @Test
+    public void respondsToExceptionsWith500() throws Exception {
+        try {
+            target("/test/admin").request()
+                .header(HttpHeaders.AUTHORIZATION, getPrefix() + " " + getBadGuyToken())
+                .get(String.class);
+            failBecauseExceptionWasNotThrown(WebApplicationException.class);
+        } catch (WebApplicationException e) {
+            assertThat(e.getResponse().getStatus()).isEqualTo(500);
+        }
+    }
+}

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthResource.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthResource.java
@@ -10,6 +10,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.SecurityContext;
+import java.security.Principal;
 
 @Path("/test/")
 @Produces(MediaType.TEXT_PLAIN)
@@ -18,15 +19,21 @@ public class AuthResource {
     @RolesAllowed({"ADMIN"})
     @GET
     @Path("admin")
-    public String show(@Context SecurityContext securityContext) {
-        return "'" + securityContext.getUserPrincipal().getName() + "' has admin privileges";
+    public String show(@Auth Principal principal) {
+        return "'" + principal.getName() + "' has admin privileges";
     }
 
     @PermitAll
     @GET
     @Path("profile")
-    public String showForEveryUser(@Context SecurityContext securityContext) {
-        return "'" + securityContext.getUserPrincipal().getName() + "' has user privileges";
+    public String showForEveryUser(@Auth Principal principal) {
+        return "'" + principal.getName() + "' has user privileges";
+    }
+
+    @GET
+    @Path("implicit-permitall")
+    public String implicitPermitAllAuthorization(@Auth Principal principal) {
+        return "'" + principal.getName() + "' has user privileges";
     }
 
     @GET

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/BasicAuthProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/BasicAuthProviderTest.java
@@ -4,6 +4,8 @@ import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.auth.AuthDynamicFeature;
 import io.dropwizard.auth.AuthResource;
+import io.dropwizard.auth.AuthValueFactoryProvider;
+import io.dropwizard.auth.PrincipalImpl;
 import io.dropwizard.auth.util.AuthUtil;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.logging.BootstrapLogging;
@@ -129,6 +131,14 @@ public class BasicAuthProviderTest extends JerseyTest {
     }
 
     @Test
+    public void transformsCredentialsToPrincipalsWhenAuthAnnotationExistsWithoutMethodAnnotation() throws Exception {
+        assertThat(target("/test/implicit-permitall").request()
+            .header(HttpHeaders.AUTHORIZATION, "Basic Z29vZC1ndXk6c2VjcmV0")
+            .get(String.class))
+            .isEqualTo("'good-guy' has user privileges");
+    }
+
+    @Test
     public void respondsToNonBasicCredentialsWith401() throws Exception {
         try {
             target("/test/admin").request()
@@ -159,6 +169,7 @@ public class BasicAuthProviderTest extends JerseyTest {
             super(true, new MetricRegistry());
 
             register(new AuthDynamicFeature(getAuthFilter()));
+            register(new AuthValueFactoryProvider.Binder(Principal.class));
             register(RolesAllowedDynamicFeature.class);
             register(AuthResource.class);
         }

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/BasicAuthProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/BasicAuthProviderTest.java
@@ -1,187 +1,49 @@
 package io.dropwizard.auth.basic;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
-import io.dropwizard.auth.AuthDynamicFeature;
-import io.dropwizard.auth.AuthResource;
-import io.dropwizard.auth.AuthValueFactoryProvider;
-import io.dropwizard.auth.PrincipalImpl;
+import io.dropwizard.auth.*;
 import io.dropwizard.auth.util.AuthUtil;
 import io.dropwizard.jersey.DropwizardResourceConfig;
-import io.dropwizard.logging.BootstrapLogging;
-import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
-import org.glassfish.jersey.servlet.ServletProperties;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.JerseyTest;
-import org.glassfish.jersey.test.ServletDeploymentContext;
-import org.glassfish.jersey.test.TestProperties;
-import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
-import org.glassfish.jersey.test.spi.TestContainerException;
-import org.glassfish.jersey.test.spi.TestContainerFactory;
-import org.junit.Test;
-
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestFilter;
-import javax.ws.rs.core.HttpHeaders;
 import java.security.Principal;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
-
-public class BasicAuthProviderTest extends JerseyTest {
-    private final static String ADMIN_ROLE = "ADMIN";
-
-    static {
-        BootstrapLogging.bootstrap();
-    }
-
-    @Override
-    protected TestContainerFactory getTestContainerFactory()
-            throws TestContainerException {
-        return new GrizzlyWebTestContainerFactory();
-    }
-
-    @Override
-    protected DeploymentContext configureDeployment() {
-        forceSet(TestProperties.CONTAINER_PORT, "0");
-        return ServletDeploymentContext.builder(new BasicAuthTestResourceConfig())
-                .initParam(ServletProperties.JAXRS_APPLICATION_CLASS, BasicAuthTestResourceConfig.class.getName())
-                .build();
-    }
-
-    @Test
-    public void respondsToMissingCredentialsWith401() throws Exception {
-        try {
-            target("/test/admin").request().get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(401);
-            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
-                    .containsOnly("Basic realm=\"realm\"");
-        }
-    }
-
-    @Test
-    public void resourceWithoutAuth200() {
-        assertThat(target("/test/noauth").request()
-                .get(String.class))
-                .isEqualTo("hello");
-    }
-
-    @Test
-    public void resourceWithAuthenticationWithoutAuthorizationWithCorrectCredentials200() {
-        assertThat(target("/test/profile").request()
-                .header(HttpHeaders.AUTHORIZATION, "Basic b3JkaW5hcnktZ3V5OnNlY3JldA==")
-                .get(String.class))
-                .isEqualTo("'ordinary-guy' has user privileges");
-    }
-
-    @Test
-    public void resourceWithAuthenticationWithoutAuthorizationNoCredentials401() {
-        try {
-            target("/test/profile").request().get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(401);
-            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
-                    .containsOnly("Basic realm=\"realm\"");
-        }
-    }
-
-    @Test
-    public void resourceWithAuthorizationPrincipalIsNotAuthorized403() {
-        try {
-            target("/test/admin").request()
-                    .header(HttpHeaders.AUTHORIZATION, "Basic b3JkaW5hcnktZ3V5OnNlY3JldA==")
-                    .get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(403);
-        }
-    }
-
-    @Test
-    public void resourceWithDenyAllAndNoAuth401() {
-        try {
-            target("/test/denied").request().get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(401);
-        }
-    }
-
-    @Test
-    public void resourceWithDenyAllAndAuth403() {
-        try {
-            target("/test/denied").request()
-                    .header(HttpHeaders.AUTHORIZATION, "Basic Z29vZC1ndXk6c2VjcmV0")
-                    .get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(403);
-        }
-    }
-
-    @Test
-    public void transformsCredentialsToPrincipals() throws Exception {
-        assertThat(target("/test/admin").request()
-                .header(HttpHeaders.AUTHORIZATION, "Basic Z29vZC1ndXk6c2VjcmV0")
-                .get(String.class))
-                .isEqualTo("'good-guy' has admin privileges");
-    }
-
-    @Test
-    public void transformsCredentialsToPrincipalsWhenAuthAnnotationExistsWithoutMethodAnnotation() throws Exception {
-        assertThat(target("/test/implicit-permitall").request()
-            .header(HttpHeaders.AUTHORIZATION, "Basic Z29vZC1ndXk6c2VjcmV0")
-            .get(String.class))
-            .isEqualTo("'good-guy' has user privileges");
-    }
-
-    @Test
-    public void respondsToNonBasicCredentialsWith401() throws Exception {
-        try {
-            target("/test/admin").request()
-                    .header(HttpHeaders.AUTHORIZATION, "Derp Z29vZC1ndXk6c2VjcmV0")
-                    .get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(401);
-            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
-                    .containsOnly("Basic realm=\"realm\"");
-        }
-    }
-
-    @Test
-    public void respondsToExceptionsWith500() throws Exception {
-        try {
-            target("/test/admin").request()
-                    .header(HttpHeaders.AUTHORIZATION, "Basic YmFkLWd1eTpzZWNyZXQ=")
-                    .get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(500);
-        }
-    }
-
-    public static class BasicAuthTestResourceConfig extends DropwizardResourceConfig {
-        public BasicAuthTestResourceConfig() {
-            super(true, new MetricRegistry());
-
-            register(new AuthDynamicFeature(getAuthFilter()));
-            register(new AuthValueFactoryProvider.Binder(Principal.class));
-            register(RolesAllowedDynamicFeature.class);
-            register(AuthResource.class);
-        }
-
-        private ContainerRequestFilter getAuthFilter() {
-            final String adminUser = "good-guy";
-            final String ordinaryUser = "ordinary-guy";
-
+public class BasicAuthProviderTest extends AuthBaseTest<BasicAuthProviderTest.BasicAuthTestResourceConfig> {
+    public static class BasicAuthTestResourceConfig extends AuthBaseResourceConfig{
+        protected ContainerRequestFilter getAuthFilter() {
             BasicCredentialAuthFilter.Builder<Principal> builder = new BasicCredentialAuthFilter.Builder<>();
-            builder.setAuthorizer(AuthUtil.getTestAuthorizer(adminUser, ADMIN_ROLE));
-            builder.setAuthenticator(AuthUtil.getBasicAuthenticator(ImmutableList.of(adminUser, ordinaryUser)));
+            builder.setAuthorizer(AuthUtil.getTestAuthorizer(ADMIN_USER, ADMIN_ROLE));
+            builder.setAuthenticator(AuthUtil.getBasicAuthenticator(ImmutableList.of(ADMIN_USER, ORDINARY_USER)));
             return builder.buildAuthFilter();
         }
+    }
+
+    @Override
+    protected DropwizardResourceConfig getDropwizardResourceConfig() {
+        return new BasicAuthTestResourceConfig();
+    }
+
+    @Override
+    protected Class<BasicAuthTestResourceConfig> getDropwizardResourceConfigClass() {
+        return BasicAuthTestResourceConfig.class;
+    }
+
+    @Override
+    protected String getPrefix() {
+        return BASIC_PREFIX;
+    }
+
+    @Override
+    protected String getOrdinaryGuyValidToken() {
+        return ORDINARY_USER_ENCODED_TOKEN;
+    }
+
+    @Override
+    protected String getGoodGuyValidToken() {
+        return GOOD_USER_ENCODED_TOKEN;
+    }
+
+    @Override
+    protected String getBadGuyToken() {
+        return BAD_USER_ENCODED_TOKEN;
     }
 }

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/BasicCustomAuthProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/BasicCustomAuthProviderTest.java
@@ -151,6 +151,7 @@ public class BasicCustomAuthProviderTest extends JerseyTest {
         public BasicAuthTestResourceConfig() {
             super(true, new MetricRegistry());
 
+            register(new AuthValueFactoryProvider.Binder(Principal.class));
             register(new AuthDynamicFeature(getAuthFilter()));
             register(RolesAllowedDynamicFeature.class);
             register(AuthResource.class);

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/BasicCustomAuthProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/BasicCustomAuthProviderTest.java
@@ -5,167 +5,50 @@ import com.google.common.collect.ImmutableList;
 import io.dropwizard.auth.*;
 import io.dropwizard.auth.util.AuthUtil;
 import io.dropwizard.jersey.DropwizardResourceConfig;
-import io.dropwizard.logging.BootstrapLogging;
 import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
-import org.glassfish.jersey.servlet.ServletProperties;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.JerseyTest;
-import org.glassfish.jersey.test.ServletDeploymentContext;
-import org.glassfish.jersey.test.TestProperties;
-import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
-import org.glassfish.jersey.test.spi.TestContainerException;
-import org.glassfish.jersey.test.spi.TestContainerFactory;
-import org.junit.Test;
 
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestFilter;
-import javax.ws.rs.core.HttpHeaders;
 import java.security.Principal;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+public class BasicCustomAuthProviderTest extends AuthBaseTest<BasicCustomAuthProviderTest.BasicAuthTestResourceConfig> {
 
-
-public class BasicCustomAuthProviderTest extends JerseyTest {
-    private final static String ADMIN_ROLE = "ADMIN";
-
-    static {
-        BootstrapLogging.bootstrap();
-    }
-
-    @Override
-    protected TestContainerFactory getTestContainerFactory()
-            throws TestContainerException {
-        return new GrizzlyWebTestContainerFactory();
-    }
-
-    @Override
-    protected DeploymentContext configureDeployment() {
-        forceSet(TestProperties.CONTAINER_PORT, "0");
-        return ServletDeploymentContext.builder(new BasicAuthTestResourceConfig())
-                .initParam(ServletProperties.JAXRS_APPLICATION_CLASS, BasicAuthTestResourceConfig.class.getName())
-                .build();
-    }
-
-    @Test
-    public void respondsToMissingCredentialsWith401() throws Exception {
-        try {
-            target("/test/admin").request().get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(401);
-            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
-                    .containsOnly("Custom realm=\"realm\"");
-        }
-    }
-
-    @Test
-    public void transformsCredentialsToPrincipals() throws Exception {
-        assertThat(target("/test/admin").request()
-                .header(HttpHeaders.AUTHORIZATION, "Custom Z29vZC1ndXk6c2VjcmV0")
-                .get(String.class))
-                .isEqualTo("'good-guy' has admin privileges");
-    }
-
-    @Test
-    public void resourceWithAuthenticationWithoutAuthorizationWithCorrectCredentials200() {
-        assertThat(target("/test/profile").request()
-                .header(HttpHeaders.AUTHORIZATION, "Custom b3JkaW5hcnktZ3V5OnNlY3JldA==")
-                .get(String.class))
-                .isEqualTo("'ordinary-guy' has user privileges");
-    }
-
-    @Test
-    public void resourceWithAuthenticationWithoutAuthorizationNoCredentials401() {
-        try {
-            target("/test/profile").request().get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(401);
-            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
-                    .containsOnly("Custom realm=\"realm\"");
-        }
-    }
-
-    @Test
-    public void resourceWithAuthorizationPrincipalIsNotAuthorized403() {
-        try {
-            target("/test/admin").request()
-                    .header(HttpHeaders.AUTHORIZATION, "Custom b3JkaW5hcnktZ3V5OnNlY3JldA==")
-                    .get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(403);
-        }
-    }
-
-    @Test
-    public void resourceWithDenyAllAndNoAuth401() {
-        try {
-            target("/test/denied").request().get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(401);
-        }
-    }
-
-    @Test
-    public void resourceWithDenyAllAndAuth403() {
-        try {
-            target("/test/denied").request()
-                    .header(HttpHeaders.AUTHORIZATION, "Custom Z29vZC1ndXk6c2VjcmV0")
-                    .get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(403);
-        }
-    }
-
-    @Test
-    public void respondsToNonBasicCredentialsWith401() throws Exception {
-        try {
-            target("/test/admin").request()
-                    .header(HttpHeaders.AUTHORIZATION, "Derp Z29vZC1ndXk6c2VjcmV0")
-                    .get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(401);
-            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
-                    .containsOnly("Custom realm=\"realm\"");
-        }
-    }
-
-    @Test
-    public void respondsToExceptionsWith500() throws Exception {
-        try {
-            target("/test/admin").request()
-                    .header(HttpHeaders.AUTHORIZATION, "Custom YmFkLWd1eTpzZWNyZXQ=")
-                    .get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(500);
-        }
-    }
-
-    public static class BasicAuthTestResourceConfig extends DropwizardResourceConfig {
-        public BasicAuthTestResourceConfig() {
-            super(true, new MetricRegistry());
-
-            register(new AuthValueFactoryProvider.Binder(Principal.class));
-            register(new AuthDynamicFeature(getAuthFilter()));
-            register(RolesAllowedDynamicFeature.class);
-            register(AuthResource.class);
-        }
-
-        private ContainerRequestFilter getAuthFilter() {
-            final String adminUser = "good-guy";
-            final String ordinaryUser = "ordinary-guy";
-
+    public static class BasicAuthTestResourceConfig extends AuthBaseResourceConfig{
+        protected ContainerRequestFilter getAuthFilter() {
             BasicCredentialAuthFilter.Builder<Principal> builder  = new BasicCredentialAuthFilter.Builder<>();
-            builder.setAuthorizer(AuthUtil.getTestAuthorizer(adminUser, ADMIN_ROLE));
-            builder.setAuthenticator(AuthUtil.getBasicAuthenticator(ImmutableList.of(adminUser, ordinaryUser)));
-            builder.setPrefix("Custom");
+            builder.setAuthorizer(AuthUtil.getTestAuthorizer(ADMIN_USER, ADMIN_ROLE));
+            builder.setAuthenticator(AuthUtil.getBasicAuthenticator(ImmutableList.of(ADMIN_USER, ORDINARY_USER)));
+            builder.setPrefix(CUSTOM_PREFIX);
             return builder.buildAuthFilter();
         }
+    }
+
+    @Override
+    protected DropwizardResourceConfig getDropwizardResourceConfig() {
+        return new BasicAuthTestResourceConfig();
+    }
+
+    @Override
+    protected Class<BasicCustomAuthProviderTest.BasicAuthTestResourceConfig> getDropwizardResourceConfigClass() {
+        return BasicAuthTestResourceConfig.class;
+    }
+
+    @Override
+    protected String getPrefix() {
+        return CUSTOM_PREFIX;
+    }
+
+    @Override
+    protected String getOrdinaryGuyValidToken() {
+        return ORDINARY_USER_ENCODED_TOKEN;
+    }
+
+    @Override
+    protected String getGoodGuyValidToken() {
+        return GOOD_USER_ENCODED_TOKEN;
+    }
+
+    @Override
+    protected String getBadGuyToken() {
+        return BAD_USER_ENCODED_TOKEN;
     }
 }

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/chained/ChainedAuthProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/chained/ChainedAuthProviderTest.java
@@ -9,146 +9,32 @@ import io.dropwizard.auth.basic.BasicCredentials;
 import io.dropwizard.auth.oauth.OAuthCredentialAuthFilter;
 import io.dropwizard.auth.util.AuthUtil;
 import io.dropwizard.jersey.DropwizardResourceConfig;
-import io.dropwizard.logging.BootstrapLogging;
 import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
-import org.glassfish.jersey.servlet.ServletProperties;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.JerseyTest;
-import org.glassfish.jersey.test.ServletDeploymentContext;
-import org.glassfish.jersey.test.TestProperties;
-import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
-import org.glassfish.jersey.test.spi.TestContainerException;
-import org.glassfish.jersey.test.spi.TestContainerFactory;
 import org.junit.Test;
-import javax.annotation.security.RolesAllowed;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Context;
+
 import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.SecurityContext;
 import java.security.Principal;
 import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
-public class ChainedAuthProviderTest extends JerseyTest {
-    private static final String ADMIN_ROLE = "ADMIN";
-    static {
-        BootstrapLogging.bootstrap();
-    }
-
-    @Override
-    protected TestContainerFactory getTestContainerFactory()
-            throws TestContainerException {
-        return new GrizzlyWebTestContainerFactory();
-    }
-
-    @Override
-    protected DeploymentContext configureDeployment() {
-        forceSet(TestProperties.CONTAINER_PORT, "0");
-        return ServletDeploymentContext.builder(new ChainedAuthTestResourceConfig())
-                .initParam(ServletProperties.JAXRS_APPLICATION_CLASS, ChainedAuthTestResourceConfig.class.getName())
-                .build();
-    }
-
-    @Test
-    public void respondsToMissingCredentialsWith401() throws Exception {
-        try {
-            target("/test/admin").request().get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus())
-                    .isEqualTo(401);
-
-            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
-                    .containsOnly("Basic realm=\"realm\"");
-        }
-    }
-
-    @Test
-    public void transformsBasicCredentialsToPrincipals() throws Exception {
-        assertThat(target("/test/admin").request()
-                .header(HttpHeaders.AUTHORIZATION, "Basic Z29vZC1ndXk6c2VjcmV0")
-                .get(String.class))
-                .isEqualTo("'good-guy' has admin privileges");
-    }
-
-    @Test
-    public void transformsBearerCredentialsToPrincipals() throws Exception {
-        assertThat(target("/test/admin").request()
-                .header(HttpHeaders.AUTHORIZATION, "Bearer A12B3C4D")
-                .get(String.class))
-                .isEqualTo("'good-guy' has admin privileges");
-    }
-
-
-    @Test
-    public void respondsToNonBasicCredentialsWith401() throws Exception {
-        try {
-            target("/test/admin").request()
-                    .header(HttpHeaders.AUTHORIZATION, "Derp Z29vZC1ndXk6c2VjcmV0")
-                    .get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus())
-                    .isEqualTo(401);
-
-            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
-                    .containsOnly("Basic realm=\"realm\"");
-        }
-    }
-
-    @Test
-    public void respondsToExceptionsWith500() throws Exception {
-        try {
-            target("/test/admin").request()
-                    .header(HttpHeaders.AUTHORIZATION, "Basic YmFkLWd1eTpzZWNyZXQ=")
-                    .get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus())
-                    .isEqualTo(500);
-        }
-    }
-
-    @Path("/test/")
-    @Produces(MediaType.TEXT_PLAIN)
-    public static class ProtectedResource {
-        @RolesAllowed({ADMIN_ROLE})
-        @GET
-        public String show(@Context SecurityContext context) {
-            return context.getUserPrincipal().getName();
-        }
-    }
-
+public class ChainedAuthProviderTest extends AuthBaseTest<ChainedAuthProviderTest.ChainedAuthTestResourceConfig>{
+    private static final String BEARER_USER = "A12B3C4D";
     public static class ChainedAuthTestResourceConfig extends DropwizardResourceConfig {
         public ChainedAuthTestResourceConfig() {
             super(true, new MetricRegistry());
 
-            final String adminUser = "good-guy";
-            final String ordinaryUser = "ordinary-guy";
-
-            final Authorizer<Principal> authorizer = AuthUtil.getTestAuthorizer(adminUser, ADMIN_ROLE);
-
-            final Authenticator<BasicCredentials, Principal> basicAuthenticator =
-                    AuthUtil.getBasicAuthenticator(ImmutableList.of(adminUser, ordinaryUser));
-
-            final Authenticator<String, Principal> oauthAuthenticator
-                    = AuthUtil.getSingleUserOAuthAuthenticator("A12B3C4D", adminUser);
-
+            final Authorizer<Principal> authorizer = AuthUtil.getTestAuthorizer(ADMIN_USER, ADMIN_ROLE);
             final AuthFilter<BasicCredentials, Principal> basicAuthFilter = new BasicCredentialAuthFilter.Builder<>()
-                    .setAuthenticator(basicAuthenticator)
-                    .setAuthorizer(authorizer)
-                    .buildAuthFilter();
+                .setAuthenticator(AuthUtil.getBasicAuthenticator(ImmutableList.of(ADMIN_USER, ORDINARY_USER)))
+                .setAuthorizer(authorizer)
+                .buildAuthFilter();
 
             final AuthFilter<String, Principal> oAuthFilter = new OAuthCredentialAuthFilter.Builder<>()
-                    .setAuthenticator(oauthAuthenticator)
-                    .setPrefix("Bearer")
-                    .setAuthorizer(authorizer)
-                    .buildAuthFilter();
+                .setAuthenticator(AuthUtil.getSingleUserOAuthAuthenticator(BEARER_USER, ADMIN_USER))
+                .setPrefix(BEARER_PREFIX)
+                .setAuthorizer(authorizer)
+                .buildAuthFilter();
 
             register(new AuthValueFactoryProvider.Binder(Principal.class));
             register(new AuthDynamicFeature(new ChainedAuthFilter<>(buildHandlerList(basicAuthFilter, oAuthFilter ))));
@@ -164,5 +50,43 @@ public class ChainedAuthProviderTest extends JerseyTest {
             handlers.add(oAuthFilter);
             return handlers;
         }
+    }
+
+    @Test
+    public void transformsBearerCredentialsToPrincipals() throws Exception {
+        assertThat(target("/test/admin").request()
+            .header(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + " " + BEARER_USER)
+            .get(String.class))
+            .isEqualTo("'" + ADMIN_USER + "' has admin privileges");
+    }
+
+    @Override
+    protected DropwizardResourceConfig getDropwizardResourceConfig() {
+        return new ChainedAuthTestResourceConfig();
+    }
+
+    @Override
+    protected Class<ChainedAuthTestResourceConfig> getDropwizardResourceConfigClass() {
+        return ChainedAuthTestResourceConfig.class;
+    }
+
+    @Override
+    protected String getPrefix() {
+        return BASIC_PREFIX;
+    }
+
+    @Override
+    protected String getOrdinaryGuyValidToken() {
+        return ORDINARY_USER_ENCODED_TOKEN;
+    }
+
+    @Override
+    protected String getGoodGuyValidToken() {
+        return GOOD_USER_ENCODED_TOKEN;
+    }
+
+    @Override
+    protected String getBadGuyToken() {
+        return BAD_USER_ENCODED_TOKEN;
     }
 }

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/chained/ChainedAuthProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/chained/ChainedAuthProviderTest.java
@@ -150,6 +150,7 @@ public class ChainedAuthProviderTest extends JerseyTest {
                     .setAuthorizer(authorizer)
                     .buildAuthFilter();
 
+            register(new AuthValueFactoryProvider.Binder(Principal.class));
             register(new AuthDynamicFeature(new ChainedAuthFilter<>(buildHandlerList(basicAuthFilter, oAuthFilter ))));
             register(RolesAllowedDynamicFeature.class);
             register(AuthResource.class);

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/oauth/OAuthCustomProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/oauth/OAuthCustomProviderTest.java
@@ -1,171 +1,48 @@
 package io.dropwizard.auth.oauth;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.auth.*;
 import io.dropwizard.auth.util.AuthUtil;
 import io.dropwizard.jersey.DropwizardResourceConfig;
-import io.dropwizard.logging.BootstrapLogging;
-import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
-import org.glassfish.jersey.servlet.ServletProperties;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.JerseyTest;
-import org.glassfish.jersey.test.ServletDeploymentContext;
-import org.glassfish.jersey.test.TestProperties;
-import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
-import org.glassfish.jersey.test.spi.TestContainerException;
-import org.glassfish.jersey.test.spi.TestContainerFactory;
-import org.junit.Test;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.HttpHeaders;
-
-import java.security.Principal;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
-
-public class OAuthCustomProviderTest extends JerseyTest {
-    static {
-        BootstrapLogging.bootstrap();
-    }
-
-    @Override
-    protected TestContainerFactory getTestContainerFactory()
-            throws TestContainerException {
-        return new GrizzlyWebTestContainerFactory();
-    }
-
-    @Override
-    protected DeploymentContext configureDeployment() {
-        forceSet(TestProperties.CONTAINER_PORT, "0");
-        return ServletDeploymentContext.builder(new BasicAuthTestResourceConfig())
-                .initParam(ServletProperties.JAXRS_APPLICATION_CLASS, BasicAuthTestResourceConfig.class.getName())
-                .build();
-    }
-
-    @Test
-    public void respondsToMissingCredentialsWith401() throws Exception {
-        try {
-            target("/test/admin").request().get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(401);
-            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
-                    .containsOnly("Custom realm=\"realm\"");
-        }
-    }
-
-    @Test
-    public void transformsCredentialsToPrincipals() throws Exception {
-        assertThat(target("/test/admin").request()
-                .header(HttpHeaders.AUTHORIZATION, "Custom good-guy")
-                .get(String.class))
-                .isEqualTo("'good-guy' has admin privileges");
-    }
-
-    @Test
-    public void resourceWithoutAuth200() {
-        assertThat(target("/test/noauth").request()
-                .get(String.class))
-                .isEqualTo("hello");
-    }
-
-    @Test
-    public void resourceWithAuthenticationWithoutAuthorizationWithCorrectCredentials200() {
-        assertThat(target("/test/profile").request()
-                .header(HttpHeaders.AUTHORIZATION, "custom ordinary-guy")
-                .get(String.class))
-                .isEqualTo("'ordinary-guy' has user privileges");
-    }
-
-    @Test
-    public void resourceWithAuthenticationWithoutAuthorizationNoCredentials401() {
-        try {
-            target("/test/profile").request().get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(401);
-            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
-                    .containsOnly("Custom realm=\"realm\"");
-        }
-    }
-
-    @Test
-    public void resourceWithAuthorizationPrincipalIsNotAuthorized403() {
-        try {
-            target("/test/admin").request()
-                    .header(HttpHeaders.AUTHORIZATION, "custom ordinary-guy")
-                    .get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(403);
-        }
-    }
-
-    @Test
-    public void resourceWithDenyAllAndNoAuth401() {
-        try {
-            target("/test/denied").request().get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(401);
-        }
-    }
-
-    @Test
-    public void resourceWithDenyAllAndAuth403() {
-        try {
-            target("/test/denied").request()
-                    .header(HttpHeaders.AUTHORIZATION, "Custom good-guy")
-                    .get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(403);
-        }
-    }
-
-    @Test
-    public void respondsToNonBasicCredentialsWith401() throws Exception {
-        try {
-            target("/test/admin").request().header(HttpHeaders.AUTHORIZATION, "Derp WHEE").get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(401);
-            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
-                    .containsOnly("Custom realm=\"realm\"");
-        }
-    }
-
-    @Test
-    public void respondsToExceptionsWith500() throws Exception {
-        try {
-            target("/test/admin").request().header(HttpHeaders.AUTHORIZATION, "Custom bad-guy").get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(500);
-        }
-    }
-
-    public static class BasicAuthTestResourceConfig extends DropwizardResourceConfig {
-        public BasicAuthTestResourceConfig() {
-            super(true, new MetricRegistry());
-
-            register(new AuthValueFactoryProvider.Binder(Principal.class));
-            register(new AuthDynamicFeature(getAuthFilter()));
-            register(RolesAllowedDynamicFeature.class);
-            register(AuthResource.class);
-        }
-
-        private AuthFilter getAuthFilter() {
-            final String adminUser = "good-guy";
-            final String ordinaryUser = "ordinary-guy";
-
+public class OAuthCustomProviderTest extends AuthBaseTest<OAuthCustomProviderTest.BasicAuthTestResourceConfig> {
+    public static class BasicAuthTestResourceConfig extends AuthBaseResourceConfig {
+        protected AuthFilter getAuthFilter() {
             return new OAuthCredentialAuthFilter.Builder<>()
-                    .setAuthenticator(AuthUtil.getMultiplyUsersOAuthAuthenticator(ImmutableList.of(adminUser, ordinaryUser)))
-                    .setAuthorizer(AuthUtil.getTestAuthorizer(adminUser, "ADMIN"))
-                    .setPrefix("Custom")
-                    .buildAuthFilter();
+                .setAuthenticator(AuthUtil.getMultiplyUsersOAuthAuthenticator(ImmutableList.of(ADMIN_USER, ORDINARY_USER)))
+                .setAuthorizer(AuthUtil.getTestAuthorizer(ADMIN_USER, ADMIN_ROLE))
+                .setPrefix(CUSTOM_PREFIX)
+                .buildAuthFilter();
         }
+    }
+
+    @Override
+    protected DropwizardResourceConfig getDropwizardResourceConfig() {
+        return new OAuthProviderTest.BasicAuthTestResourceConfig();
+    }
+
+    @Override
+    protected Class<BasicAuthTestResourceConfig> getDropwizardResourceConfigClass() {
+        return BasicAuthTestResourceConfig.class;
+    }
+
+    @Override
+    protected String getPrefix() {
+        return CUSTOM_PREFIX;
+    }
+
+    @Override
+    protected String getOrdinaryGuyValidToken() {
+        return ORDINARY_USER;
+    }
+
+    @Override
+    protected String getGoodGuyValidToken() {
+        return ADMIN_USER;
+    }
+
+    @Override
+    protected String getBadGuyToken() {
+        return BADGUY_USER;
     }
 }

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/oauth/OAuthCustomProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/oauth/OAuthCustomProviderTest.java
@@ -20,6 +20,8 @@ import org.junit.Test;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
 
+import java.security.Principal;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
@@ -149,6 +151,7 @@ public class OAuthCustomProviderTest extends JerseyTest {
         public BasicAuthTestResourceConfig() {
             super(true, new MetricRegistry());
 
+            register(new AuthValueFactoryProvider.Binder(Principal.class));
             register(new AuthDynamicFeature(getAuthFilter()));
             register(RolesAllowedDynamicFeature.class);
             register(AuthResource.class);

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/oauth/OAuthProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/oauth/OAuthProviderTest.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableList;
 import io.dropwizard.auth.AuthDynamicFeature;
 import io.dropwizard.auth.AuthFilter;
 import io.dropwizard.auth.AuthResource;
+import io.dropwizard.auth.AuthValueFactoryProvider;
 import io.dropwizard.auth.util.AuthUtil;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.logging.BootstrapLogging;
@@ -20,6 +21,8 @@ import org.glassfish.jersey.test.spi.TestContainerFactory;
 import org.junit.Test;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
+
+import java.security.Principal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
@@ -143,6 +146,7 @@ public class OAuthProviderTest extends JerseyTest {
         public BasicAuthTestResourceConfig() {
             super(true, new MetricRegistry());
 
+            register(new AuthValueFactoryProvider.Binder(Principal.class));
             register(new AuthDynamicFeature(getAuthFilter()));
             register(RolesAllowedDynamicFeature.class);
             register(AuthResource.class);

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/oauth/OAuthProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/oauth/OAuthProviderTest.java
@@ -1,166 +1,48 @@
 package io.dropwizard.auth.oauth;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
-import io.dropwizard.auth.AuthDynamicFeature;
-import io.dropwizard.auth.AuthFilter;
-import io.dropwizard.auth.AuthResource;
-import io.dropwizard.auth.AuthValueFactoryProvider;
+import io.dropwizard.auth.*;
 import io.dropwizard.auth.util.AuthUtil;
 import io.dropwizard.jersey.DropwizardResourceConfig;
-import io.dropwizard.logging.BootstrapLogging;
-import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
-import org.glassfish.jersey.servlet.ServletProperties;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.JerseyTest;
-import org.glassfish.jersey.test.ServletDeploymentContext;
-import org.glassfish.jersey.test.TestProperties;
-import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
-import org.glassfish.jersey.test.spi.TestContainerException;
-import org.glassfish.jersey.test.spi.TestContainerFactory;
-import org.junit.Test;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.HttpHeaders;
 
-import java.security.Principal;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
-
-public class OAuthProviderTest extends JerseyTest {
-    static {
-        BootstrapLogging.bootstrap();
-    }
-
-    @Override
-    protected TestContainerFactory getTestContainerFactory()
-            throws TestContainerException {
-        return new GrizzlyWebTestContainerFactory();
-    }
-
-    @Override
-    protected DeploymentContext configureDeployment() {
-        forceSet(TestProperties.CONTAINER_PORT, "0");
-        return ServletDeploymentContext.builder(new BasicAuthTestResourceConfig())
-                .initParam(ServletProperties.JAXRS_APPLICATION_CLASS, BasicAuthTestResourceConfig.class.getName())
-                .build();
-    }
-
-    @Test
-    public void respondsToMissingCredentialsWith401() throws Exception {
-        try {
-            target("/test/admin").request().get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(401);
-            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
-                    .containsOnly("Bearer realm=\"realm\"");
-        }
-    }
-
-    @Test
-    public void transformsCredentialsToPrincipals() throws Exception {
-        assertThat(target("/test/admin").request()
-                .header(HttpHeaders.AUTHORIZATION, "Bearer good-guy")
-                .get(String.class))
-                .isEqualTo("'good-guy' has admin privileges");
-    }
-
-    @Test
-    public void resourceWithAuthenticationWithoutAuthorizationWithCorrectCredentials200() {
-        assertThat(target("/test/profile").request()
-                .header(HttpHeaders.AUTHORIZATION, "Bearer ordinary-guy")
-                .get(String.class))
-                .isEqualTo("'ordinary-guy' has user privileges");
-    }
-
-    @Test
-    public void resourceWithAuthenticationWithoutAuthorizationNoCredentials401() {
-        try {
-            target("/test/profile").request().get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(401);
-            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
-                    .containsOnly("Bearer realm=\"realm\"");
-        }
-    }
-
-    @Test
-    public void resourceWithAuthorizationPrincipalIsNotAuthorized403() {
-        try {
-            target("/test/admin").request()
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer ordinary-guy")
-                    .get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(403);
-        }
-    }
-
-    @Test
-    public void resourceWithDenyAllAndNoAuth401() {
-        try {
-            target("/test/denied").request().get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(401);
-        }
-    }
-
-    @Test
-    public void resourceWithDenyAllAndAuth403() {
-        try {
-            target("/test/denied").request()
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer good-guy")
-                    .get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(403);
-        }
-    }
-
-    @Test
-    public void respondsToNonBasicCredentialsWith401() throws Exception {
-        try {
-            target("/test/admin").request().header(HttpHeaders.AUTHORIZATION, "Derp WHEE").get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(401);
-            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
-                    .containsOnly("Bearer realm=\"realm\"");
-        }
-    }
-
-    @Test
-    public void respondsToExceptionsWith500() throws Exception {
-        try {
-            target("/test/admin").request().header(HttpHeaders.AUTHORIZATION, "Bearer bad-guy").get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(500);
-        }
-    }
-
-    public static class BasicAuthTestResourceConfig extends DropwizardResourceConfig {
-        public BasicAuthTestResourceConfig() {
-            super(true, new MetricRegistry());
-
-            register(new AuthValueFactoryProvider.Binder(Principal.class));
-            register(new AuthDynamicFeature(getAuthFilter()));
-            register(RolesAllowedDynamicFeature.class);
-            register(AuthResource.class);
-        }
-
-        private AuthFilter getAuthFilter() {
-            final String adminUser = "good-guy";
-            final String ordinaryUser = "ordinary-guy";
-
+public class OAuthProviderTest extends AuthBaseTest<OAuthProviderTest.BasicAuthTestResourceConfig>{
+    public static class BasicAuthTestResourceConfig extends AuthBaseResourceConfig{
+        protected AuthFilter getAuthFilter() {
             return new OAuthCredentialAuthFilter.Builder<>()
-                    .setAuthenticator(AuthUtil.getMultiplyUsersOAuthAuthenticator(ImmutableList.of(adminUser, ordinaryUser)))
-                    .setAuthorizer(AuthUtil.getTestAuthorizer(adminUser, "ADMIN"))
-                    .setPrefix("Bearer")
-                    .buildAuthFilter();
+                .setAuthenticator(AuthUtil.getMultiplyUsersOAuthAuthenticator(ImmutableList.of(ADMIN_USER, ORDINARY_USER)))
+                .setAuthorizer(AuthUtil.getTestAuthorizer(ADMIN_USER, ADMIN_ROLE))
+                .setPrefix(BEARER_PREFIX)
+                .buildAuthFilter();
         }
+    }
+
+    @Override
+    protected DropwizardResourceConfig getDropwizardResourceConfig() {
+        return new BasicAuthTestResourceConfig();
+    }
+
+    @Override
+    protected Class<BasicAuthTestResourceConfig> getDropwizardResourceConfigClass() {
+        return BasicAuthTestResourceConfig.class;
+    }
+
+    @Override
+    protected String getPrefix() {
+        return BEARER_PREFIX;
+    }
+
+    @Override
+    protected String getOrdinaryGuyValidToken() {
+        return "ordinary-guy";
+    }
+
+    @Override
+    protected String getGoodGuyValidToken() {
+        return "good-guy";
+    }
+
+    @Override
+    protected String getBadGuyToken() {
+        return "bad-guy";
     }
 }


### PR DESCRIPTION
* Auth alone should be enough to trigger the authentication servlet filter (https://github.com/dropwizard/dropwizard/pull/1162)
* There was a lot of duplication in auth tests, this should be more maintainable