### PR TITLE
Improve View Template Error Message

### DIFF
--- a/docs/source/manual/views.rst
+++ b/docs/source/manual/views.rst
@@ -117,3 +117,12 @@ For more information on how to use FreeMarker, see the `FreeMarker`_ documentati
 For more information on how to use Mustache, see the `Mustache`_ and `Mustache.java`_ documentation.
 
  .. _Mustache.java: https://github.com/spullara/mustache.java
+
+.. _man-views-template-errors:
+
+Template Errors
+===============
+
+If there is an error with the template (eg. the template file is not found or there is a compilation
+error with the template), the user will receive a ``500 Internal Sever Error`` with a generic HTML
+message. The exact error will logged under debug mode.

--- a/dropwizard-views-freemarker/src/main/java/io/dropwizard/views/freemarker/FreemarkerViewRenderer.java
+++ b/dropwizard-views-freemarker/src/main/java/io/dropwizard/views/freemarker/FreemarkerViewRenderer.java
@@ -13,7 +13,6 @@ import freemarker.template.Version;
 import io.dropwizard.views.View;
 import io.dropwizard.views.ViewRenderer;
 
-import javax.ws.rs.WebApplicationException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -73,7 +72,7 @@ public class FreemarkerViewRenderer implements ViewRenderer {
             final Template template = configuration.getTemplate(view.getTemplateName(), locale, charset.name());
             template.process(view, new OutputStreamWriter(output, template.getEncoding()));
         } catch (TemplateException e) {
-            throw new WebApplicationException(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/ErrorView.java
+++ b/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/ErrorView.java
@@ -1,0 +1,9 @@
+package io.dropwizard.views.freemarker;
+
+import io.dropwizard.views.View;
+
+public class ErrorView extends View {
+    protected ErrorView() {
+        super("/example-error.ftl");
+    }
+}

--- a/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/FreemarkerViewRendererTest.java
+++ b/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/FreemarkerViewRendererTest.java
@@ -44,6 +44,12 @@ public class FreemarkerViewRendererTest extends JerseyTest {
         public BadView showBad() {
             return new BadView();
         }
+
+        @GET
+        @Path("/error")
+        public ErrorView showError() {
+            return new ErrorView();
+        }
     }
 
     @Override
@@ -83,7 +89,21 @@ public class FreemarkerViewRendererTest extends JerseyTest {
                     .isEqualTo(500);
 
             assertThat(e.getResponse().readEntity(String.class))
-                .isEqualTo("<html><head><title>Missing Template</title></head><body><h1>Missing Template</h1><p>Template \"/woo-oo-ahh.txt.ftl\" not found.</p></body></html>");
+                .isEqualTo(ViewMessageBodyWriter.TEMPLATE_ERROR_MSG);
+        }
+    }
+
+    @Test
+    public void returnsA500ForViewsThatCantCompile() throws Exception {
+        try {
+            target("/test/error").request().get(String.class);
+            failBecauseExceptionWasNotThrown(WebApplicationException.class);
+        } catch (WebApplicationException e) {
+            assertThat(e.getResponse().getStatus())
+                    .isEqualTo(500);
+
+            assertThat(e.getResponse().readEntity(String.class))
+                    .isEqualTo(ViewMessageBodyWriter.TEMPLATE_ERROR_MSG);
         }
     }
 }

--- a/dropwizard-views-freemarker/src/test/resources/example-error.ftl
+++ b/dropwizard-views-freemarker/src/test/resources/example-error.ftl
@@ -1,0 +1,5 @@
+<#macro script>
+    <script>alert("hey");</script>
+</#macro>
+<@script j="<script>alert(\"hey\");</script>"/>
+

--- a/dropwizard-views-mustache/src/main/java/io/dropwizard/views/mustache/MustacheViewRenderer.java
+++ b/dropwizard-views-mustache/src/main/java/io/dropwizard/views/mustache/MustacheViewRenderer.java
@@ -2,8 +2,8 @@ package io.dropwizard.views.mustache;
 
 import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
-import com.github.mustachejava.MustacheException;
 import com.github.mustachejava.MustacheFactory;
+import com.github.mustachejava.MustacheNotFoundException;
 import com.google.common.base.Charsets;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -12,7 +12,6 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.dropwizard.views.View;
 import io.dropwizard.views.ViewRenderer;
 
-import javax.ws.rs.WebApplicationException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -52,8 +51,8 @@ public class MustacheViewRenderer implements ViewRenderer {
             try (OutputStreamWriter writer = new OutputStreamWriter(output, charset)) {
                 template.execute(writer, view);
             }
-        } catch (ExecutionException | UncheckedExecutionException | MustacheException ignored) {
-            throw new FileNotFoundException("Template " + view.getTemplateName() + " not found.");
+        } catch (Throwable e) {
+            throw new RuntimeException("Mustache template error: " + view.getTemplateName(), e);
         }
     }
 

--- a/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/ErrorView.java
+++ b/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/ErrorView.java
@@ -1,0 +1,9 @@
+package io.dropwizard.views.mustache;
+
+import io.dropwizard.views.View;
+
+public class ErrorView extends View {
+    protected ErrorView() {
+        super("/example-error.mustache");
+    }
+}

--- a/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererTest.java
+++ b/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererTest.java
@@ -45,6 +45,12 @@ public class MustacheViewRendererTest extends JerseyTest {
         public BadView showBad() {
             return new BadView();
         }
+
+        @GET
+        @Path("/error")
+        public ErrorView showError() {
+            return new ErrorView();
+        }
     }
 
     @Override
@@ -81,7 +87,21 @@ public class MustacheViewRendererTest extends JerseyTest {
                     .isEqualTo(500);
 
             assertThat(e.getResponse().readEntity(String.class))
-                    .isEqualTo("<html><head><title>Missing Template</title></head><body><h1>Missing Template</h1><p>Template \"/woo-oo-ahh.txt.mustache\" not found.</p></body></html>");
+                    .isEqualTo(ViewMessageBodyWriter.TEMPLATE_ERROR_MSG);
+        }
+    }
+
+    @Test
+    public void returnsA500ForViewsThatCantCompile() throws Exception {
+        try {
+            target("/test/error").request().get(String.class);
+            failBecauseExceptionWasNotThrown(WebApplicationException.class);
+        } catch (WebApplicationException e) {
+            assertThat(e.getResponse().getStatus())
+                    .isEqualTo(500);
+
+            assertThat(e.getResponse().readEntity(String.class))
+                .isEqualTo(ViewMessageBodyWriter.TEMPLATE_ERROR_MSG);
         }
     }
 }

--- a/dropwizard-views-mustache/src/test/resources/example-error.mustache
+++ b/dropwizard-views-mustache/src/test/resources/example-error.mustache
@@ -1,0 +1,1 @@
+Woop woop. {{/<script>alert("hey");</script>}}

--- a/dropwizard-views/src/main/java/io/dropwizard/views/ViewMessageBodyWriter.java
+++ b/dropwizard-views/src/main/java/io/dropwizard/views/ViewMessageBodyWriter.java
@@ -2,18 +2,18 @@ package io.dropwizard.views;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.*;
 import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.Provider;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.text.MessageFormat;
 import java.util.List;
 import java.util.Locale;
 import java.util.ServiceLoader;
@@ -23,10 +23,11 @@ import static com.codahale.metrics.MetricRegistry.name;
 @Provider
 @Produces({ MediaType.TEXT_HTML, MediaType.APPLICATION_XHTML_XML })
 public class ViewMessageBodyWriter implements MessageBodyWriter<View> {
-    private static final String MISSING_TEMPLATE_MSG =
+    private final static Logger logger = LoggerFactory.getLogger(MessageBodyWriter.class);
+    public final static String TEMPLATE_ERROR_MSG =
             "<html>" +
-                "<head><title>Missing Template</title></head>" +
-                "<body><h1>Missing Template</h1><p>Template \"{0}\" not found.</p></body>" +
+                "<head><title>Template Error</title></head>" +
+                "<body><h1>Template Error</h1><p>Something went wrong rendering the page</p></body>" +
             "</html>";
 
     @Context
@@ -77,11 +78,11 @@ public class ViewMessageBodyWriter implements MessageBodyWriter<View> {
                 }
             }
             throw new ViewRenderException("Unable to find a renderer for " + t.getTemplateName());
-        } catch (FileNotFoundException e) {
-            final String msg = MessageFormat.format(MISSING_TEMPLATE_MSG, t.getTemplateName());
+        } catch (Exception e) {
+            logger.debug("Template Error", e);
             throw new WebApplicationException(Response.serverError()
                                                       .type(MediaType.TEXT_HTML_TYPE)
-                                                      .entity(msg)
+                                                      .entity(TEMPLATE_ERROR_MSG)
                                                       .build());
         } finally {
             context.stop();


### PR DESCRIPTION
Instead of hiding behind a sometimes deceptive error message saying that the
template file was not found, ~~propagate the error message in an HTML safe
way~~ return a generic error message with the actual error going to the log
file. This makes the behavior more in line with validation errors (though this
doesn't deal with validation errors, itself)

Closes #1077