### PR TITLE
Add a config option to validate inactive connections

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -789,24 +789,26 @@ See HttpClientConfiguration_  for more options.
       userAgent: <application name> (<client name>)
 
 
-========================= ======================================  =============================================================================
-Name                      Default                                 Description
-========================= ======================================  =============================================================================
-timeout                   500 milliseconds                        The maximum idle time for a connection, once established.
-connectionTimeout         500 milliseconds                        The maximum time to wait for a connection to open.
-connectionRequestTimeout  500 milliseconds                        The maximum time to wait for a connection to be returned from the connection pool.
-timeToLive                1 hour                                  The maximum time a pooled connection can stay idle (not leased to any thread)
-                                                                  before it is shut down.
-cookiesEnabled            false                                   Whether or not to enable cookies.
-maxConnections            1024                                    The maximum number of concurrent open connections.
-maxConnectionsPerRoute    1024                                    The maximum number of concurrent open connections per route.
-keepAlive                 0 milliseconds                          The maximum time a connection will be kept alive before it is reconnected. If set
-                                                                  to 0, connections will be immediately closed after every request/response.
-retries                   0                                       The number of times to retry failed requests. Requests are only
-                                                                  retried if they throw an exception other than ``InterruptedIOException``,
-                                                                  ``UnknownHostException``, ``ConnectException``, or ``SSLException``.
-userAgent                 ``applicationName`` (``clientName``)    The User-Agent to send with requests.
-========================= ======================================  =============================================================================
+=============================  ======================================  =============================================================================
+Name                           Default                                 Description
+=============================  ======================================  =============================================================================
+timeout                        500 milliseconds                        The maximum idle time for a connection, once established.
+connectionTimeout              500 milliseconds                        The maximum time to wait for a connection to open.
+connectionRequestTimeout       500 milliseconds                        The maximum time to wait for a connection to be returned from the connection pool.
+timeToLive                     1 hour                                  The maximum time a pooled connection can stay idle (not leased to any thread)
+                                                                       before it is shut down.
+cookiesEnabled                 false                                   Whether or not to enable cookies.
+maxConnections                 1024                                    The maximum number of concurrent open connections.
+maxConnectionsPerRoute         1024                                    The maximum number of concurrent open connections per route.
+keepAlive                      0 milliseconds                          The maximum time a connection will be kept alive before it is reconnected. If set
+                                                                       to 0, connections will be immediately closed after every request/response.
+retries                        0                                       The number of times to retry failed requests. Requests are only
+                                                                       retried if they throw an exception other than ``InterruptedIOException``,
+                                                                       ``UnknownHostException``, ``ConnectException``, or ``SSLException``.
+userAgent                      ``applicationName`` (``clientName``)    The User-Agent to send with requests.
+validateAfterInactivityPeriod  0 milliseconds                          The maximum time before a persistent connection is checked to remain active.
+                                                                       If set to 0, no inactivity check will be performed.
+=============================  ======================================  =============================================================================
 
 
 .. _man-configuration-clients-http-proxy:

--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
@@ -46,7 +46,7 @@ import java.io.IOException;
  * <p>
  * Among other things,
  * <ul>
- * <li>Disables stale connection checks</li>
+ * <li>Disables stale connection checks by default</li>
  * <li>Disables Nagle's algorithm</li>
  * <li>Disables cookie management by default</li>
  * </ul>
@@ -333,7 +333,7 @@ public class HttpClientBuilder {
             InstrumentedHttpClientConnectionManager connectionManager) {
         connectionManager.setDefaultMaxPerRoute(configuration.getMaxConnectionsPerRoute());
         connectionManager.setMaxTotal(configuration.getMaxConnections());
-        connectionManager.setValidateAfterInactivity(0);
+        connectionManager.setValidateAfterInactivity((int) configuration.getValidateAfterInactivityPeriod().toMilliseconds());
         return connectionManager;
     }
 }

--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientConfiguration.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientConfiguration.java
@@ -53,7 +53,9 @@ public class HttpClientConfiguration {
     @Nullable
     private ProxyConfiguration proxyConfiguration;
 
-    @JsonProperty
+    @NotNull
+    private Duration validateAfterInactivityPeriod = Duration.microseconds(0);
+
     public Duration getKeepAlive() {
         return keepAlive;
     }
@@ -161,5 +163,15 @@ public class HttpClientConfiguration {
     @JsonProperty("proxy")
     public void setProxyConfiguration(ProxyConfiguration proxyConfiguration) {
         this.proxyConfiguration = proxyConfiguration;
+    }
+
+    @JsonProperty
+    public Duration getValidateAfterInactivityPeriod() {
+        return validateAfterInactivityPeriod;
+    }
+
+    @JsonProperty
+    public void setValidateAfterInactivityPeriod(Duration validateAfterInactivityPeriod) {
+        this.validateAfterInactivityPeriod = validateAfterInactivityPeriod;
     }
 }


### PR DESCRIPTION
This adds an option to `HttpClientConfiguration` named `validateAfterInactivityPeriod` which enables a 'stale' connection check with the frequency of the given period.

This check helps detect connections that have become stale (half-closed) while kept inactive in a client's connection pool.

This check is disabled by default, but is configurable as a duration.

##### Reason for introduction
The HTTP/1.1 specification indicates the responsibility is with the client to handle closed keep-alive connections gracefully, and that the server can be expected to close that session at any time with or without intention.

In the HTTP/1.1 RFC#7230 it is stated in section 6.3.1 that:

 >Connections can be closed at any time, with or without intention.
 >Implementations ought to anticipate the need to recover from asynchronous close events.

Without the 'stale' connection check in place we see regular broken connections due to this behaviour.