### PR TITLE
Added beforeSessionFactoryCreation method to SessionFactoryFactory

### DIFF
--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryFactory.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryFactory.java
@@ -91,7 +91,12 @@ public class SessionFactoryFactory {
                 .applySettings(properties)
                 .build();
 
+        beforeSessionFactoryCreation(configuration, registry);
+
         return configuration.buildSessionFactory(registry);
+    }
+
+    protected void beforeSessionFactoryCreation(Configuration configuration, ServiceRegistry registry){
     }
 
     private void addAnnotatedClasses(Configuration configuration,

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryFactoryTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryFactoryTest.java
@@ -10,6 +10,7 @@ import io.dropwizard.setup.Environment;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.cfg.Configuration;
+import org.hibernate.service.ServiceRegistry;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.After;
@@ -111,6 +112,16 @@ public class SessionFactoryFactoryTest {
         } finally {
             session.close();
         }
+    }
+
+    @Test
+    public void beforeSessionFactoryCreation(){
+        SessionFactoryFactory spy = spy(factory);
+        this.sessionFactory = spy.build(bundle,
+                                            environment,
+                                            config,
+                                            ImmutableList.<Class<?>>of(Person.class));
+        verify(spy).beforeSessionFactoryCreation(any(Configuration.class), any(ServiceRegistry.class));
     }
 
     private void build() {


### PR DESCRIPTION
This pull request follows the creation of the issue #1182 .
It aims at allowing developers to create a custom SessionFactoryFactory class with which he will be able to modify programmatically the Hibernate configuration used to create session factory.
For instance, it could allow the developer to define a Hibernate interceptor or Hibernate events... See   