### PR TITLE
Update hibernate validator to 5.2.1.Final

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -48,6 +48,7 @@ v0.9.0
 * Upgraded to Jadira Usertype Core 4.0.0.GA
 * Upgraded to Jersey 2.20
 * Upgraded to Jetty 9.2.13.v20150730
+* Upgraded to Hibernate Validator 5.2.1.Final
 * Upgraded to Jetty ALPN boot 7.1.3.v20150130
 * Upgraded to Jetty SetUID support 1.0.3
 * Upgraded to Liquibase 3.4.1

--- a/dropwizard-core/src/test/java/io/dropwizard/setup/BootstrapTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/setup/BootstrapTest.java
@@ -96,19 +96,16 @@ public class BootstrapTest {
         assertThat(bootstrap.getValidatorFactory()).isInstanceOf(ValidatorFactoryImpl.class);
 
         ValidatorFactoryImpl validatorFactory = (ValidatorFactoryImpl)bootstrap.getValidatorFactory();
-        assertThat(validatorFactory.getValidatedValueHandlers()).hasSize(3);
-        assertThat(validatorFactory.getValidatedValueHandlers().get(0))
-                .isInstanceOf(OptionalValidatedValueUnwrapper.class);
 
         // It's imperative that the NonEmptyString validator come before the general param validator
         // because a NonEmptyString is a param that wraps an optional and the Hibernate Validator
         // can't unwrap nested classes it knows how to unwrap.
         // https://hibernate.atlassian.net/browse/HV-904
-        assertThat(validatorFactory.getValidatedValueHandlers().get(1))
-                .isInstanceOf(NonEmptyStringParamUnwrapper.class);
-
-        assertThat(validatorFactory.getValidatedValueHandlers().get(2))
-                .isInstanceOf(ParamValidatorUnwrapper.class);
+        assertThat(validatorFactory.getValidatedValueHandlers())
+                .extractingResultOf("getClass")
+                .containsSubsequence(OptionalValidatedValueUnwrapper.class,
+                                     NonEmptyStringParamUnwrapper.class,
+                                     ParamValidatorUnwrapper.class);
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
@@ -52,7 +52,7 @@ public class ValidatingResource {
 
     @GET
     @Path("headCopy")
-    public String heads(@QueryParam("cheese") @NotNull IntParam secretSauce) {
+    public String heads(@QueryParam("cheese") @NotNull @UnwrapValidatedValue(false) IntParam secretSauce) {
         return secretSauce.get().toString();
     }
 

--- a/dropwizard-validation/pom.xml
+++ b/dropwizard-validation/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>5.1.3.Final</version>
+            <version>5.2.1.Final</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/valuehandling/OptionalValidatedValueUnwrapperTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/valuehandling/OptionalValidatedValueUnwrapperTest.java
@@ -20,7 +20,6 @@ public class OptionalValidatedValueUnwrapperTest {
     public static class Example {
 
         @Min(3)
-        @UnwrapValidatedValue
         public Optional<Integer> three = Optional.absent();
 
         @NotNull


### PR DESCRIPTION
Picked out a few interesting bits:

In some cases, when validating `Optional`, the `UnwrapValidatedValue` is not needed. Only one line of code in the entire code base was changed as the result of this. Since it's not entirely intuitive when `UnwrapValidatedValue` is needed, I've omitted changing the documentation because it still works with the annotation applied.

This doesn't affect dropwizard immediately, since we're not targeting jdk 8 right now, but with [new type annotations](https://blogs.oracle.com/java-platform-group/entry/java_8_s_new_type), it is possible to write code like:

```java
List<@NotEmpty String> strs; 
```