### PR TITLE
Fix DefaultLoggingFactoryTest on Windows

### DIFF
--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
@@ -10,7 +10,9 @@ import ch.qos.logback.core.rolling.RollingFileAppender;
 import ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
 import io.dropwizard.util.Size;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -20,6 +22,9 @@ public class FileAppenderFactoryTest {
     static {
         BootstrapLogging.bootstrap();
     }
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
 
     @Test
     public void isDiscoverable() throws Exception {
@@ -49,19 +54,19 @@ public class FileAppenderFactoryTest {
             }
         };
 
-        fileAppenderFactory.setCurrentLogFilename("logfile.log");
+        fileAppenderFactory.setCurrentLogFilename(folder.newFile("logfile.log").toString());
         fileAppenderFactory.setArchive(true);
-        fileAppenderFactory.setArchivedLogFilenamePattern("example-%d.log.gz");
+        fileAppenderFactory.setArchivedLogFilenamePattern(folder.newFile("example-%d.log.gz").toString());
         assertThat(fileAppenderFactory.buildAppender(new LoggerContext())).isInstanceOf(RollingFileAppender.class);
     }
 
     @Test
     public void hasMaxFileSize() throws Exception {
         FileAppenderFactory fileAppenderFactory = new FileAppenderFactory();
-        fileAppenderFactory.setCurrentLogFilename("logfile.log");
+        fileAppenderFactory.setCurrentLogFilename(folder.newFile("logfile.log").toString());
         fileAppenderFactory.setArchive(true);
         fileAppenderFactory.setMaxFileSize(Size.kilobytes(1));
-        fileAppenderFactory.setArchivedLogFilenamePattern("example-%d-%i.log.gz");
+        fileAppenderFactory.setArchivedLogFilenamePattern(folder.newFile("example-%d-%i.log.gz").toString());
         RollingFileAppender<ILoggingEvent> appender = (RollingFileAppender<ILoggingEvent>) fileAppenderFactory.buildAppender(new LoggerContext());
 
         assertThat(appender.getTriggeringPolicy()).isInstanceOf(SizeAndTimeBasedFNATP.class);
@@ -72,7 +77,7 @@ public class FileAppenderFactoryTest {
     public void appenderContextIsSet() throws Exception {
         final Logger root = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
         final FileAppenderFactory appenderFactory = new FileAppenderFactory();
-        appenderFactory.setArchivedLogFilenamePattern("example-%d.log.gz");
+        appenderFactory.setArchivedLogFilenamePattern(folder.newFile("example-%d.log.gz").toString());
         final Appender<ILoggingEvent> appender = appenderFactory.build(root.getLoggerContext(), "test", null);
 
         assertThat(appender.getContext()).isEqualTo(root.getLoggerContext());
@@ -82,7 +87,7 @@ public class FileAppenderFactoryTest {
     public void appenderNameIsSet() throws Exception {
         final Logger root = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
         final FileAppenderFactory appenderFactory = new FileAppenderFactory();
-        appenderFactory.setArchivedLogFilenamePattern("example-%d.log.gz");
+        appenderFactory.setArchivedLogFilenamePattern(folder.newFile("example-%d.log.gz").toString());
         final Appender<ILoggingEvent> appender = appenderFactory.build(root.getLoggerContext(), "test", null);
 
         assertThat(appender.getName()).isEqualTo("async-file-appender");

--- a/dropwizard-logging/src/test/resources/yaml/logging_advanced.yml
+++ b/dropwizard-logging/src/test/resources/yaml/logging_advanced.yml
@@ -5,8 +5,8 @@ loggers:
     level: DEBUG
     appenders:
       - type: file
-        currentLogFilename: "/tmp/example-new-app.log"
-        archivedLogFilenamePattern: "/tmp/example-new-app-%d.log.gz"
+        currentLogFilename: '${new_app}.log'
+        archivedLogFilenamePattern: '${new_app}-%d.log.gz'
         logFormat: "%-5level %logger: %msg%n"
         archivedFileCount: 5
   "com.example.legacyApp":
@@ -14,7 +14,7 @@ loggers:
 appenders:
   - type: console
   - type: file
-    currentLogFilename: "/tmp/example.log"
-    archivedLogFilenamePattern: "/tmp/example-%d.log.gz"
+    currentLogFilename: '${default}.log'
+    archivedLogFilenamePattern: '${default}-%d.log.gz'
     logFormat: "%-5level %logger: %msg%n"
     archivedFileCount: 5


### PR DESCRIPTION
Also it is unnecessary to delete the log files after the test is done
because the log files are zeroed out when the test runs.