### PR TITLE
Use inmemory jersey server for view tests

### DIFF
--- a/dropwizard-views-freemarker/pom.xml
+++ b/dropwizard-views-freemarker/pom.xml
@@ -24,7 +24,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-            <artifactId>jersey-test-framework-provider-jdk-http</artifactId>
+            <artifactId>jersey-test-framework-provider-inmemory</artifactId>
             <version>${jersey.version}</version>
             <scope>test</scope>
         </dependency>

--- a/dropwizard-views-mustache/pom.xml
+++ b/dropwizard-views-mustache/pom.xml
@@ -30,7 +30,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-            <artifactId>jersey-test-framework-provider-jdk-http</artifactId>
+            <artifactId>jersey-test-framework-provider-inmemory</artifactId>
             <version>${jersey.version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
The view tests were the only ones that used the `jdk-http` provider. Once I swapped it out for `inmemory`, the tests ran 25 seconds faster.