### PR TITLE
Fixed dropwizard jersey duplicate path logging

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -213,38 +213,6 @@ public class DropwizardResourceConfig extends ResourceConfig {
             return String.format("    %-7s %s (%s)", httpMethod, basePath, klass.getCanonicalName());
         }
 
-        @Override
-        public int hashCode() {
-            return Objects.hashCode(httpMethod, basePath, klass);
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj)
-                return true;
-            if (obj == null)
-                return false;
-            if (getClass() != obj.getClass())
-                return false;
-            EndpointLogLine other = (EndpointLogLine) obj;
-            if (basePath == null) {
-                if (other.basePath != null)
-                    return false;
-            } else if (!basePath.equals(other.basePath))
-                return false;
-            if (httpMethod == null) {
-                if (other.httpMethod != null)
-                    return false;
-            } else if (!httpMethod.equals(other.httpMethod))
-                return false;
-            if (klass == null) {
-                if (other.klass != null)
-                    return false;
-            } else if (klass != other.klass)
-                return false;
-            return true;
-        }
-
     }
 
     private static class EndpointComparator implements Comparator<EndpointLogLine>, Serializable {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
@@ -127,13 +127,8 @@ public class DropwizardResourceConfigTest {
                 + "    GET     /anotherMe (io.dropwizard.jersey.DropwizardResourceConfigTest.TestDuplicateResource)%n"
                 + "    GET     /callme (io.dropwizard.jersey.DropwizardResourceConfigTest.TestDuplicateResource)%n");
 
-        final String shouldNotContainLog = String.format(
-                  "    GET     /callme (io.dropwizard.jersey.DropwizardResourceConfigTest.TestDuplicateResource)%n"
-                + "    GET     /callme (io.dropwizard.jersey.DropwizardResourceConfigTest.TestDuplicateResource)%n"
-                + "    GET     /callme (io.dropwizard.jersey.DropwizardResourceConfigTest.TestDuplicateResource)%n");
-
         assertThat(rc.getEndpointsInfo()).contains(expectedLog);
-        assertThat(rc.getEndpointsInfo()).doesNotContain(shouldNotContainLog);
+        assertThat(rc.getEndpointsInfo()).containsOnlyOnce("    GET     /callme (io.dropwizard.jersey.DropwizardResourceConfigTest.TestDuplicateResource)");
     }
 
     @Path("/dummy")

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey;
 
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.dummy.DummyResource;
 import io.dropwizard.logging.BootstrapLogging;
 import org.junit.Before;
@@ -10,8 +9,11 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import com.codahale.metrics.MetricRegistry;
 
 public class DropwizardResourceConfigTest {
     static {
@@ -118,6 +120,22 @@ public class DropwizardResourceConfigTest {
                 .contains("    GET     /wrapper/bar (io.dropwizard.jersey.DropwizardResourceConfigTest.ResourcePathOnMethodLevel)");
     }
 
+    @Test
+    public void duplicatePathsTest() {
+        rc.register(TestDuplicateResource.class);
+        final String expectedLog = String.format("The following paths were found for the configured resources:%n" + "%n"
+                + "    GET     /anotherMe (io.dropwizard.jersey.DropwizardResourceConfigTest.TestDuplicateResource)%n"
+                + "    GET     /callme (io.dropwizard.jersey.DropwizardResourceConfigTest.TestDuplicateResource)%n");
+
+        final String shouldNotContainLog = String.format(
+                  "    GET     /callme (io.dropwizard.jersey.DropwizardResourceConfigTest.TestDuplicateResource)%n"
+                + "    GET     /callme (io.dropwizard.jersey.DropwizardResourceConfigTest.TestDuplicateResource)%n"
+                + "    GET     /callme (io.dropwizard.jersey.DropwizardResourceConfigTest.TestDuplicateResource)%n");
+
+        assertThat(rc.getEndpointsInfo()).contains(expectedLog);
+        assertThat(rc.getEndpointsInfo()).doesNotContain(shouldNotContainLog);
+    }
+
     @Path("/dummy")
     public static class TestResource {
         @GET
@@ -137,6 +155,38 @@ public class DropwizardResourceConfigTest {
         public String fooDelete() {
             return "bar";
         }
+    }
+
+    @Path("/")
+    public static class TestDuplicateResource {
+
+        @GET
+        @Path("callme")
+        @Produces(MediaType.APPLICATION_JSON)
+        public String fooGet() {
+            return "bar";
+        }
+
+        @GET
+        @Path("callme")
+        @Produces(MediaType.TEXT_HTML)
+        public String fooGet2() {
+            return "bar2";
+        }
+
+        @GET
+        @Path("callme")
+        @Produces(MediaType.APPLICATION_XML)
+        public String fooGet3() {
+            return "bar3";
+        }
+
+        @GET
+        @Path("anotherMe")
+        public String fooGet4() {
+            return "bar4";
+        }
+
     }
 
     @Path("/another")


### PR DESCRIPTION
So this was a tiny bug I discovered while using dropwizard (which is awesome by the way) on our project. The problem being if there are two separate functions present exposing same path in jersey but supporting different media type, then dropwizard logs duplicate paths.
Eg:
```
@Get
@Path("/abc")
@Produces(MediaType.TEXT_HTML)
public Respone functionA(){
   //some code produces html output
}

@Get
@Path("/abc")
@Produces(MediaType.APPLICATION_JSON)
public Respone functionB(){
   //some code produces json output
}
```
Now dropwizard logs the following
```
GET /abc MyResourceClass
GET /abc MyResourceClass
```
This PR fixes that and logs just one line by using a TreeSet instead of List. Its passive and doesn't affect anything outside this class (There could be an enhancement to log the one line and list all supported content types, for which I might do a PR later).

Thanks and continue being awesome guys!