### PR TITLE
Fixing issue with ChainedAuthFactory to allow not required authentication

### DIFF
--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/ChainedAuthFactory.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/ChainedAuthFactory.java
@@ -59,7 +59,7 @@ public class ChainedAuthFactory<T> extends AuthFactory<Object, T> {
     public AuthFactory<Object, T> clone(boolean required) {
         ChainedAuthFactory<T> clone = new ChainedAuthFactory<>();
         for (AuthFactory<?, T> factory : factories) {
-            clone.addChainedProvider(factory.clone(true));
+            clone.addChainedProvider(factory.clone(required));
         }
         return clone;
     }

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthResource.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthResource.java
@@ -12,4 +12,14 @@ public class AuthResource {
     public String show(@Auth String principal) {
         return principal;
     }
+
+    @GET
+    @Path("/optional")
+    public String showOptional(@Auth(required = false) String principal) {
+        if (principal == null) {
+            return "missing";
+        } else {
+            return principal;
+        }
+    }
 }

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/ChainedAuthProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/ChainedAuthProviderTest.java
@@ -16,12 +16,8 @@ import org.glassfish.jersey.test.spi.TestContainerException;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
 import org.junit.Test;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
@@ -104,13 +100,11 @@ public class ChainedAuthProviderTest extends JerseyTest {
         }
     }
 
-    @Path("/test/")
-    @Produces(MediaType.TEXT_PLAIN)
-    public static class ProtectedResource {
-        @GET
-        public String show(@Auth String principal) {
-            return principal;
-        }
+    @Test
+    public void doesntFailWithMissingCredentialsOnNonRequiredResource()
+            throws Exception {
+        assertThat(target("/test/optional").request().get(String.class))
+                .isEqualTo("missing");
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Fixing issue #1201.

`ChainedAuthFactory` currently defaults `required` parameter to true, instead of using the annotation `required` value.