### PR TITLE
Add logging of explicitly mentioned consumes and produces media type for jersey end points

### DIFF
--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
@@ -2,9 +2,11 @@ package io.dropwizard.jersey;
 
 import io.dropwizard.jersey.dummy.DummyResource;
 import io.dropwizard.logging.BootstrapLogging;
+
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -130,7 +132,21 @@ public class DropwizardResourceConfigTest {
         assertThat(rc.getEndpointsInfo()).contains(expectedLog);
         assertThat(rc.getEndpointsInfo()).containsOnlyOnce("    GET     /callme (io.dropwizard.jersey.DropwizardResourceConfigTest.TestDuplicateResource)");
     }
+    
+    @Test
+    public void correctMediaType() {
+        rc.register(TestMediaTypeResource.class);
+        final String expectedGetMethodLog = String.format(
+                 "    GET     /callme (io.dropwizard.jersey.DropwizardResourceConfigTest.TestMediaTypeResource)%n"
+               + "         Accepts  -  [application/xml]%n"
+               + "         Produces -  [application/json, text/html]");
+        final String expectedPostMethodLog = String.format(
+                "    POST    /callme (io.dropwizard.jersey.DropwizardResourceConfigTest.TestMediaTypeResource)%n"
+              + "         Accepts  -  [application/xml, application/xml]");
 
+        assertThat(rc.getEndpointsInfo()).contains(expectedGetMethodLog).contains(expectedPostMethodLog);
+    }
+    
     @Path("/dummy")
     public static class TestResource {
         @GET
@@ -152,6 +168,52 @@ public class DropwizardResourceConfigTest {
         }
     }
 
+    @Path("/")
+    public static class TestMediaTypeResource {
+
+        @GET
+        @Path("callme")
+        @Produces(MediaType.APPLICATION_JSON)
+        public String fooGet() {
+            return "bar";
+        }
+
+        @GET
+        @Path("callme")
+        @Produces(MediaType.TEXT_HTML)
+        public String fooGet2() {
+            return "bar2";
+        }
+
+        @GET
+        @Path("callme")
+        @Consumes(MediaType.APPLICATION_XML)
+        public String fooGet3() {
+            return "bar3";
+        }
+        
+        @POST
+        @Path("callme")
+        @Consumes(MediaType.APPLICATION_XML)
+        public String fooGet4() {
+            return "bar4";
+        }
+        
+        @POST
+        @Path("callme")
+        @Consumes(MediaType.APPLICATION_XML)
+        public String fooGet5() {
+            return "bar5";
+        }
+
+        @GET
+        @Path("anotherMe")
+        public String fooGetX() {
+            return "bar4";
+        }
+
+    }
+    
     @Path("/")
     public static class TestDuplicateResource {
 


### PR DESCRIPTION
This is a minor enhancement based on a discussion in yesterday's PR - <a href="https://github.com/dropwizard/dropwizard/pull/1200#issuecomment-126455960">Link</a>.

What this does it for cases where a person has two or three functions for handling different media types of the same endpont, this prints out the consumes & produces media types, if available. Note that if there are no @Produces or @Consumes annotation for an endpoint then nothing is logged, thereby making the logging appear the same to previous users of dropwizard. (I haven't had to modify any of the other unit tests, which prove this point)

Example:-
````
GET /abc MyResourceClass
        Accepts  - application/json,  text/html
        Produces - application/xml
GET /abc2 MyResourceClass
GET /abc3 MyResourceClass
GET /abc4 MyResourceClass
````

One caveat of this change is that I had to revert back to Lists from Sets (as Sets don't support get/set operation to add-on media types from different functions for the same end point) thereby rendering my PR yesterday useless :cry: .

I'm open to suggestions/modifications/even total rejection of this idea itself :wink: . No worries!