### PR TITLE
Add additivity setting to LoggerConfiguration

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -414,6 +414,7 @@ Logging
         "io.dropwizard": INFO
         "org.hibernate.SQL":
           level: DEBUG
+          additive: false
           appenders:
             - type: file
               currentLogFilename: /var/log/myapplication-sql.log
@@ -427,6 +428,7 @@ Logging
 Name                   Default      Description
 ====================== ===========  ===========
 level                  Level.INFO   Logback logging level.
+additive               true         Logback additive setting.
 loggers                (none)       Individual logger configuration (both forms are acceptable).
 appenders              (none)       One of console, file or syslog.
 ====================== ===========  ===========

--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -693,6 +693,8 @@ acceptable.
         # Enables the SQL query log and redirect it to a separate file
         "org.hibernate.SQL":
           level: DEBUG
+          # This line stops org.hibernate.SQL (or anything under it) from using the root logger
+          additive: false
           appenders:
             - type: file
               currentLogFilename: ./logs/example-sql.log

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/DefaultLoggingFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/DefaultLoggingFactory.java
@@ -189,6 +189,7 @@ public class DefaultLoggingFactory implements LoggingFactory {
                     throw new IllegalArgumentException("Wrong format of logger '" + entry.getKey() + "'", e);
                 }
                 logger.setLevel(configuration.getLevel());
+                logger.setAdditive(configuration.isAdditive());
                 for (AppenderFactory appender : configuration.getAppenders()) {
                     logger.addAppender(appender.build(loggerContext, name, null));
                 }

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/LoggerConfiguration.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/LoggerConfiguration.java
@@ -22,6 +22,16 @@ public class LoggerConfiguration {
     @NotNull
     private ImmutableList<AppenderFactory> appenders = ImmutableList.of();
 
+    private boolean additive = true;
+
+    public boolean isAdditive() {
+        return additive;
+    }
+
+    public void setAdditive(boolean additive) {
+        this.additive = additive;
+    }
+
     public Level getLevel() {
         return level;
     }

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/DefaultLoggingFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/DefaultLoggingFactoryTest.java
@@ -101,6 +101,8 @@ public class DefaultLoggingFactoryTest {
         LoggerFactory.getLogger("com.example.newApp").info("New application info log");
         LoggerFactory.getLogger("com.example.legacyApp").debug("Legacy application debug log");
         LoggerFactory.getLogger("com.example.legacyApp").info("Legacy application info log");
+        LoggerFactory.getLogger("com.example.notAdditive").debug("Not additive application debug log");
+        LoggerFactory.getLogger("com.example.notAdditive").info("Not additive application info log");
 
         config.stop();
 
@@ -113,6 +115,8 @@ public class DefaultLoggingFactoryTest {
 
         assertThat(Files.readLines(newAppLog, Charsets.UTF_8)).containsOnly(
                 "DEBUG com.example.newApp: New application debug log",
-                "INFO  com.example.newApp: New application info log");
+                "INFO  com.example.newApp: New application info log",
+                "DEBUG com.example.notAdditive: Not additive application debug log",
+                "INFO  com.example.notAdditive: Not additive application info log");
     }
 }

--- a/dropwizard-logging/src/test/resources/yaml/logging_advanced.yml
+++ b/dropwizard-logging/src/test/resources/yaml/logging_advanced.yml
@@ -11,6 +11,15 @@ loggers:
         archivedFileCount: 5
   "com.example.legacyApp":
     level: DEBUG
+  "com.example.notAdditive":
+    level: DEBUG
+    additive: false
+    appenders:
+      - type: file
+        currentLogFilename: '${new_app}.log'
+        archivedLogFilenamePattern: '${new_app}-%d.log.gz'
+        logFormat: "%-5level %logger: %msg%n"
+        archivedFileCount: 5
 appenders:
   - type: console
   - type: file


### PR DESCRIPTION
This is related to dropwizard#868 and dropwizard@7ab73cd

With additive=true (the default), a logger writes to its appender -and- any appenders hierarchically above it, including the root logger. For true redirection as described in issue 868, we need to be able to set additive=false so a logger writes to its appender only.