### PR TITLE
1160 add shareConnectionManagerEnabled option with 'true' by default.

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -852,24 +852,25 @@ See HttpClientConfiguration_  for more options.
       userAgent: <application name> (<client name>)
 
 
-========================= ======================================  =============================================================================
-Name                      Default                                 Description
-========================= ======================================  =============================================================================
-timeout                   500 milliseconds                        The maximum idle time for a connection, once established.
-connectionTimeout         500 milliseconds                        The maximum time to wait for a connection to open.
-connectionRequestTimeout  500 milliseconds                        The maximum time to wait for a connection to be returned from the connection pool.
-timeToLive                1 hour                                  The maximum time a pooled connection can stay idle (not leased to any thread)
-                                                                  before it is shut down.
-cookiesEnabled            false                                   Whether or not to enable cookies.
-maxConnections            1024                                    The maximum number of concurrent open connections.
-maxConnectionsPerRoute    1024                                    The maximum number of concurrent open connections per route.
-keepAlive                 0 milliseconds                          The maximum time a connection will be kept alive before it is reconnected. If set
-                                                                  to 0, connections will be immediately closed after every request/response.
-retries                   0                                       The number of times to retry failed requests. Requests are only
-                                                                  retried if they throw an exception other than ``InterruptedIOException``,
-                                                                  ``UnknownHostException``, ``ConnectException``, or ``SSLException``.
-userAgent                 ``applicationName`` (``clientName``)    The User-Agent to send with requests.
-========================= ======================================  =============================================================================
+============================= ======================================  =============================================================================
+Name                          Default                                 Description
+============================= ======================================  =============================================================================
+timeout                       500 milliseconds                        The maximum idle time for a connection, once established.
+connectionTimeout             500 milliseconds                        The maximum time to wait for a connection to open.
+connectionRequestTimeout      500 milliseconds                        The maximum time to wait for a connection to be returned from the connection pool.
+timeToLive                    1 hour                                  The maximum time a pooled connection can stay idle (not leased to any thread)
+                                                                      before it is shut down.
+cookiesEnabled                false                                   Whether or not to enable cookies.
+shareConnectionManagerEnabled true                                    Whether or not to share the connection manager.
+maxConnections                1024                                    The maximum number of concurrent open connections.
+maxConnectionsPerRoute        1024                                    The maximum number of concurrent open connections per route.
+keepAlive                     0 milliseconds                          The maximum time a connection will be kept alive before it is reconnected. If set
+                                                                      to 0, connections will be immediately closed after every request/response.
+retries                       0                                       The number of times to retry failed requests. Requests are only
+                                                                      retried if they throw an exception other than ``InterruptedIOException``,
+                                                                      ``UnknownHostException``, ``ConnectException``, or ``SSLException``.
+userAgent                     ``applicationName`` (``clientName``)    The User-Agent to send with requests.
+============================= ======================================  =============================================================================
 
 
 .. _man-configuration-clients-jersey:

--- a/dropwizard-client/pom.xml
+++ b/dropwizard-client/pom.xml
@@ -28,6 +28,10 @@
             <version>${metrics3.version}</version>
             <exclusions>
                 <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
@@ -43,12 +47,12 @@
             <version>${jersey.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpclient</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
@@ -228,7 +228,8 @@ public class HttpClientBuilder {
                 .setDefaultSocketConfig(socketConfig)
                 .setConnectionReuseStrategy(reuseStrategy)
                 .setRetryHandler(retryHandler)
-                .setUserAgent(createUserAgent(name));
+                .setUserAgent(createUserAgent(name))
+                .setConnectionManagerShared(configuration.isShareConnectionManagerEnabled());
 
         if (keepAlive != 0) {
             // either keep alive based on response header Keep-Alive,

--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientConfiguration.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientConfiguration.java
@@ -28,6 +28,8 @@ public class HttpClientConfiguration {
 
     private boolean cookiesEnabled = false;
 
+    private boolean shareConnectionManagerEnabled = true;
+
     @Min(1)
     @Max(Integer.MAX_VALUE)
     private int maxConnections = 1024;
@@ -144,5 +146,15 @@ public class HttpClientConfiguration {
     @JsonProperty
     public void setUserAgent(Optional<String> userAgent) {
         this.userAgent = userAgent;
+    }
+
+    @JsonProperty
+    public boolean isShareConnectionManagerEnabled() {
+        return shareConnectionManagerEnabled;
+    }
+
+    @JsonProperty
+    public void setShareConnectionManagerEnabled(boolean shareConnectionManagerEnabled) {
+        this.shareConnectionManagerEnabled = shareConnectionManagerEnabled;
     }
 }

--- a/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
@@ -37,7 +37,7 @@ public class DropwizardApacheConnectorTest {
     private static final int DEFAULT_CONNECT_TIMEOUT_IN_MILLIS = 200;
     private static final int ERROR_MARGIN_IN_MILLIS = 300;
     private static final int INCREASE_IN_MILLIS = 100;
-    private static final String NON_ROUTABLE_IP_ADDRESS = "10.255.255.1"; 
+    private static final String NON_ROUTABLE_IP_ADDRESS = "10.255.255.1";
     public static final URI URI_THAT_TIMESOUT_ON_CONNECTION_ATTEMPT = URI.create("http://" + NON_ROUTABLE_IP_ADDRESS);
     @ClassRule
     public static DropwizardAppRule<Configuration> APP_RULE =
@@ -77,8 +77,40 @@ public class DropwizardApacheConnectorTest {
                 .get();
     }
 
+    @Test
+    public void force_to_shutdown_non_shared_connection_manager_pool() {
+        thrown.expect(javax.ws.rs.ProcessingException.class);
+        thrown.expectCause(any(IllegalStateException.class));
+        thrown.expectMessage("Connection pool shut down");
+
+        int retries = 5, i = 0;
+        JerseyClientConfiguration clientConfiguration = new JerseyClientConfiguration();
+        clientConfiguration.setShareConnectionManagerEnabled(false);
+        Client clientWithNonSharedPool = new JerseyClientBuilder(new MetricRegistry())
+                .using(Executors.newSingleThreadExecutor(), Jackson.newObjectMapper())
+                .using(clientConfiguration)
+                .build("test");
+        while (i < retries) {
+            System.gc();
+            clientWithNonSharedPool.target(testUri + "/success").property(ClientProperties.READ_TIMEOUT, SLEEP_TIME_IN_MILLIS * 2).request().get();
+            i++;
+        }
+    }
+
     /**
-     *
+     * shareConnectionManagerEnabled = true by default, then don't have any exceptions
+     */
+    @Test
+    public void shared_connection_manager_pool() {
+        int retries = 5, i = 0;
+        while (i < retries) {
+            System.gc();
+            client.target(testUri + "/success").property(ClientProperties.READ_TIMEOUT, SLEEP_TIME_IN_MILLIS * 2).request().get();
+            i++;
+        }
+    }
+
+    /**
      * In first assertion we prove, that a request takes no longer than:
      * request_time < set_connect_timeout + error_margin (1)
      *
@@ -130,6 +162,12 @@ public class DropwizardApacheConnectorTest {
         @Path("/long_running")
         public String getWithSleep() throws InterruptedException {
             TimeUnit.MILLISECONDS.sleep(SLEEP_TIME_IN_MILLIS);
+            return "success";
+        }
+
+        @GET
+        @Path("/success")
+        public String success() throws InterruptedException {
             return "success";
         }
 


### PR DESCRIPTION
This PR fix bug #1160. Generally, it's copied from https://github.com/dropwizard/dropwizard/issues/1179 with minor addition regarding dependency on org.apache.httpcomponents:httpclient.

Please fill free to reject it and grab the original one provided by @carlo-rtr. We really need this to be released in 0.8.3. Thank you!