### PR TITLE
Add the ability for some enums to still deserialize properly

### DIFF
--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/FuzzyEnumModule.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/FuzzyEnumModule.java
@@ -26,11 +26,17 @@ import java.util.List;
  * </ul>
  */
 public class FuzzyEnumModule extends Module {
+
     private static class PermissiveEnumDeserializer extends StdScalarDeserializer<Enum<?>> {
+
         private static final long serialVersionUID = 1L;
 
         private final Enum<?>[] constants;
         private final List<String> acceptedValues;
+
+        //These values are only provided if the @JsonCreator annotation is provided
+        private DeserializationConfig config;
+        private AnnotatedMethod am;
 
         @SuppressWarnings("unchecked")
         protected PermissiveEnumDeserializer(Class<Enum<?>> clazz) {
@@ -42,28 +48,63 @@ public class FuzzyEnumModule extends Module {
             }
         }
 
+        @SuppressWarnings("unchecked")
+        protected PermissiveEnumDeserializer(Class<?> type,
+                DeserializationConfig config,
+                AnnotatedMethod am) {
+            super(type);
+            this.constants = ((Class<Enum<?>>) handledType()).getEnumConstants();
+            this.acceptedValues = Lists.newArrayList();
+            for (Enum<?> constant : constants) {
+                acceptedValues.add(constant.name());
+            }
+            this.config = config;
+            this.am = am;
+        }
+
         @Override
         public Enum<?> deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
             final String text = CharMatcher.WHITESPACE
                     .removeFrom(jp.getText())
                     .replace('-', '_')
                     .replace('.', '_');
+
             for (Enum<?> constant : constants) {
                 if (constant.name().equalsIgnoreCase(text)) {
                     return constant;
                 }
             }
 
-            throw ctxt.mappingException(text + " was not one of " + acceptedValues);
+            //In some cases there are certain enums that don't follow the same patter across an enterprise.  So this
+            //means that you have a mix of enums that use toString(), some use @JsonCreator, and some just use the
+            //standard constant name().  This block handles finding the proper enum by toString()
+            String toStringText = jp.getText()
+                    .replace('-', '_')
+                    .replace('.', '_');
+            for (Enum<?> constant : constants) {
+                if (constant.toString().equalsIgnoreCase(toStringText)) {
+                    return constant;
+                }
+            }
+
+            //If the config was provided then we're assuming that the class we're deserializing had @JsonCreator
+            //annotation so we'll try to deserialize with that if the we weren't able to find the enum yet.
+            if (config != null) {
+                return (Enum<?>) EnumDeserializer.deserializerForCreator(config, this.handledType(), am).deserialize(jp,
+                        ctxt);
+            } else {
+                throw ctxt.mappingException(text + " was not one of " + acceptedValues);
+            }
         }
     }
 
     private static class PermissiveEnumDeserializers extends Deserializers.Base {
+
         @Override
         @SuppressWarnings("unchecked")
         public JsonDeserializer<?> findEnumDeserializer(Class<?> type,
-                                                        DeserializationConfig config,
-                                                        BeanDescription desc) throws JsonMappingException {
+                DeserializationConfig config,
+                BeanDescription desc) throws JsonMappingException {
             // If the user configured to use `toString` method to deserialize enums
             if (config.hasDeserializationFeatures(
                     DeserializationFeature.READ_ENUMS_USING_TO_STRING.getMask())) {

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/FuzzyEnumModule.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/FuzzyEnumModule.java
@@ -34,10 +34,6 @@ public class FuzzyEnumModule extends Module {
         private final Enum<?>[] constants;
         private final List<String> acceptedValues;
 
-        //These values are only provided if the @JsonCreator annotation is provided
-        private DeserializationConfig config;
-        private AnnotatedMethod am;
-
         @SuppressWarnings("unchecked")
         protected PermissiveEnumDeserializer(Class<Enum<?>> clazz) {
             super(clazz);
@@ -46,20 +42,6 @@ public class FuzzyEnumModule extends Module {
             for (Enum<?> constant : constants) {
                 acceptedValues.add(constant.name());
             }
-        }
-
-        @SuppressWarnings("unchecked")
-        protected PermissiveEnumDeserializer(Class<?> type,
-                DeserializationConfig config,
-                AnnotatedMethod am) {
-            super(type);
-            this.constants = ((Class<Enum<?>>) handledType()).getEnumConstants();
-            this.acceptedValues = Lists.newArrayList();
-            for (Enum<?> constant : constants) {
-                acceptedValues.add(constant.name());
-            }
-            this.config = config;
-            this.am = am;
         }
 
         @Override
@@ -87,14 +69,7 @@ public class FuzzyEnumModule extends Module {
                 }
             }
 
-            //If the config was provided then we're assuming that the class we're deserializing had @JsonCreator
-            //annotation so we'll try to deserialize with that if the we weren't able to find the enum yet.
-            if (config != null) {
-                return (Enum<?>) EnumDeserializer.deserializerForCreator(config, this.handledType(), am).deserialize(jp,
-                        ctxt);
-            } else {
-                throw ctxt.mappingException(text + " was not one of " + acceptedValues);
-            }
+            throw ctxt.mappingException(text + " was not one of " + acceptedValues);
         }
     }
 

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/FuzzyEnumModuleTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/FuzzyEnumModuleTest.java
@@ -120,4 +120,9 @@ public class FuzzyEnumModuleTest {
                 .configure(DeserializationFeature.READ_ENUMS_USING_TO_STRING, true);
         assertThat(toStringEnumsMapper.readValue("\"Pound sterling\"", CurrencyCode.class)).isEqualTo(CurrencyCode.GBP);
     }
+    
+    @Test
+    public void readsEnumsUsingToStringWithDeserializationFeatureOff() throws Exception {
+        assertThat(mapper.readValue("\"Pound sterling\"", CurrencyCode.class)).isEqualTo(CurrencyCode.GBP);
+    }
 }


### PR DESCRIPTION
This is just a small enhancement to the fuzzy enum deserializer so that it works when some enums (but not all) use toString()