### PR TITLE
Fix handling of empty request entities that don't have any annotation …

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProvider.java
@@ -69,14 +69,14 @@ public class JacksonMessageBodyProvider extends JacksonJaxbJsonProvider {
     }
 
     private Object validate(Annotation[] annotations, Object value) {
-        if (null == value) {
-            throw new ConstraintViolationException("The request entity was empty",
-                    Collections.<ConstraintViolation<Object>>emptySet());
-        }
-
         final Class<?>[] classes = findValidationGroups(annotations);
 
         if (classes != null) {
+            if (null == value) {
+                throw new ConstraintViolationException("The request entity was empty",
+                        Collections.<ConstraintViolation<Object>>emptySet());
+            }
+            
             Set<ConstraintViolation<Object>> violations = null;
 
             if (value instanceof Map) {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProviderTest.java
@@ -335,6 +335,18 @@ public class JacksonMessageBodyProviderTest {
                 new MultivaluedHashMap<String,String>(),
                 null);
     }
+    
+    @Test
+    public void throwsAConstraintViolationExceptionForEmptyRequestEntitiesNoAnnotations() throws Exception {
+        final Class<?> klass = Example.class;
+        assertThat(
+                provider.readFrom((Class<Object>) klass,
+                        Example.class,
+                        new Annotation[]{},
+                        MediaType.APPLICATION_JSON_TYPE,
+                        new MultivaluedHashMap<String, String>(),
+                        null)).isNull();
+    }
 
     @Test
     public void returnsValidatedArrayRequestEntities() throws Exception {


### PR DESCRIPTION
Some request bodies are optional and if you POST an empty request body with 0 annotations like @Valid then this code blows up.  This fix allows it to work as expected.