### PR TITLE
Should reset mock DAO in tear down

### DIFF
--- a/docs/source/manual/testing.rst
+++ b/docs/source/manual/testing.rst
@@ -177,6 +177,10 @@ loads a given resource instance in an in-memory Jersey server:
         @Before
         public void setup() {
             when(dao.fetchPerson(eq("blah"))).thenReturn(person);
+        }
+
+        @After
+        public void tearDown(){
             // we have to reset the mock after each test because of the
             // @ClassRule, or use a @Rule as mentioned below.
             reset(dao);


### PR DESCRIPTION
It doesn't make sense in the docs to setup mock _and_ then reset immediately. It was very confusing for me when I was setting up test