### PR TITLE
Don't close the client instance in DropwizardApacheConnector

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardApacheConnector.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardApacheConnector.java
@@ -215,11 +215,7 @@ public class DropwizardApacheConnector implements Connector {
      */
     @Override
     public void close() {
-        try {
-            client.close();
-        } catch (IOException e) {
-            throw new ProcessingException(LocalizationMessages.FAILED_TO_STOP_CLIENT(), e);
-        }
+        // Should not close the client here, because it's managed by the Dropwizard environment
     }
 
     /**

--- a/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
@@ -154,6 +154,18 @@ public class DropwizardApacheConnectorTest {
         ).isEqualTo(HttpStatus.SC_TEMPORARY_REDIRECT);
     }
 
+    @Test
+    public void when_jersey_client_runtime_is_garbage_collected_apache_client_is_not_closed() {
+        for (int j = 0; j < 5; j++) {
+            System.gc(); // We actually want GC here
+            final String response = client.target(testUri + "/long_running")
+                    .property(ClientProperties.READ_TIMEOUT, SLEEP_TIME_IN_MILLIS * 2)
+                    .request()
+                    .get(String.class);
+            assertThat(response).isEqualTo("success");
+        }
+    }
+
     @Path("/")
     public static class TestResource {
 


### PR DESCRIPTION
Jersey expects that we create a new instance of the Apache HTTP client every time, when we create a new instance of the connector.

So, when `ClientRuntime` is garbage collected, the client is closed and new requests, that work with a new connector, use already closed client.

The fix is to not close the client in the connector. We can rely on the fact, that the client is managed by Dropwizard environment and it will be closed, when the application will be shut down.

Also users of Apache HTTP Client keep the ability to close the client manually, if they want to.

Fix #1160