### PR TITLE
Fix issue with validation message caching when a field has more than …

### DIFF
--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
@@ -80,6 +80,25 @@ public class ConstraintViolationExceptionMapperTest extends JerseyTest {
     }
 
     @Test
+    public void cacheIsForParamNamesOnly() throws Exception {
+        // query parameter must not be null, and must be at least 3
+        final Response response = target("/valid/fhqwhgads")
+                .queryParam("num", 2).request().get();
+
+        assertThat(response.getStatus()).isEqualTo(400);
+
+        String ret = "{\"errors\":[\"query param num must be greater than or equal to 3\"]}";
+        assertThat(response.readEntity(String.class)).isEqualTo(ret);
+
+        // Send another request to trigger reflection cache. This one is invalid in a different way
+        // and should get a different message.
+        final Response cache = target("/valid/fhqwhgads").request().get();
+        assertThat(cache.getStatus()).isEqualTo(400);
+        ret = "{\"errors\":[\"query param num may not be null\"]}";
+        assertThat(cache.readEntity(String.class)).isEqualTo(ret);
+    }
+
+    @Test
     public void getInvalidCustomTypeIs400() throws Exception {
         // query parameter is too short and so will fail validation
         final Response response = target("/valid/barter")

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
@@ -1,5 +1,7 @@
 package io.dropwizard.jersey.validation;
 
+import javax.validation.constraints.Min;
+
 import io.dropwizard.jersey.params.IntParam;
 import io.dropwizard.jersey.params.NonEmptyStringParam;
 import io.dropwizard.validation.Validated;
@@ -7,7 +9,6 @@ import org.hibernate.validator.constraints.Email;
 import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.NotEmpty;
 import org.hibernate.validator.valuehandling.UnwrapValidatedValue;
-
 import javax.servlet.ServletContext;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -36,6 +37,12 @@ public class ValidatingResource {
     @Path("barter")
     public String isnt(@QueryParam("name") @Length(min = 3) @UnwrapValidatedValue NonEmptyStringParam name) {
         return name.get().orNull();
+    }
+    
+    @GET
+    @Path("fhqwhgads")
+    public String everybody(@QueryParam("num") @Min(3L) @NotNull Long param) {
+        return param.toString();
     }
 
     @GET


### PR DESCRIPTION
…one constraint

Some hibernate validator constraints (@Min, and @Max come to mind) accept nulls as valid. This motivates you to slap @NotNull on the parameter in addition to @Min (or whatever). The Path -> validation message caching that goes on in ConstraintMessage.java generates bogus messages in these cases - with the right call pattern, you can pass in a non-null-but-still-invalid value and be told "query param foo may not be null."

This should fix it. I didn't quite follow the returnValueName-related stuff, but I believe I kept the behavior intact.