### PR TITLE
Fix auth testing documentation

### DIFF
--- a/docs/source/manual/auth.rst
+++ b/docs/source/manual/auth.rst
@@ -252,25 +252,32 @@ When you build your ``ResourceTestRule``, add the ``GrizzlyWebTestContainerFacto
 .. code-block:: java
 
     @Rule
-    ResourceTestRule rule = ResourceTestRule
+    public ResourceTestRule rule = ResourceTestRule
             .builder()
             .setTestContainerFactory(new GrizzlyWebTestContainerFactory())
-            .addProvider(AuthFactory.binder(new BasicAuthProvider<>(new ExampleAuthenticator(), "SUPER SECRET STUFF")))
-            .addResource(...)
+            .addProvider(new AuthDynamicFeature(new OAuthCredentialAuthFilter.Builder<User>()
+                    .setAuthenticator(new MyOAuthAuthenticator())
+                    .setAuthorizer(new MyAuthorizer())
+                    .setRealm("SUPER SECRET STUFF")
+                    .setPrefix("Bearer")
+                    .buildAuthFilter()))
+            .addProvider(RolesAllowedDynamicFeature.class)
+            .addProvider(new AuthValueFactoryProvider.Binder<>(User.class))
+            .addResource(new ProtectedResource())
             .build();
 
-In this example we are testing the basic authentication so we need to set the header manually. Note the use of ``resources.getJerseyTest()`` to make the test work
+
+In this example we are testing the oauth authentication so we need to set the header manually. Note the use of ``resources.getJerseyTest()`` to make the test work
 
 .. code-block:: java
-        import java.nio.charset.StandardCharsets;
-        import org.apache.commons.codec.binary.Base64;
 
+    @Test
+    public void testProtected() throws Exception {
+        final Response response = rule.getJerseyTest().target("/protected")
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .header("Authorization", "Bearer TOKEN")
+                .get();
 
-        String authorizationHeader = "Basic " + new String(
-                Base64.encodeBase64("test@test.com:test".getBytes())), StandardCharsets.US_ASCII);
-        Builder builder = resources.getJerseyTest().target("/entities")
-                .request()
-                .header(Header.Authorization.name(), authorizationHeader);
-        Response response = builder.post(Entity.json(entity));
-        Assertions.assertThat(response.getStatus()).isEqualTo(
-                Status.CREATED.getStatusCode());
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+


### PR DESCRIPTION
The previous PR #1234 was for dropwizard 0.8.*, I updated it to work with dw 0.9 :)

I think that an empty line was missing after ```.. code-block:: java``` so the block was not displayed well.

Do we have to keep this part of the documentation in this file or should I move it to the **Testing** section?

