### PR TITLE
Fix for #1197 - Principal instance not injected when annotated

### DIFF
--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthValueFactoryProvider.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthValueFactoryProvider.java
@@ -48,13 +48,14 @@ public class AuthValueFactoryProvider<T extends Principal> extends AbstractValue
      * the type {@link T} being annotated with {@link Auth} annotation.
      *
      * @param parameter parameter that was annotated for being injected
-     * @return the factory if parameter matched type
+     * @return the factory if annotated parameter matched type
      */
     @Override
     public AbstractContainerRequestValueFactory<?> createValueFactory(Parameter parameter) {
-        if (!principalClass.equals(parameter.getRawType())) {
+        if (!parameter.isAnnotationPresent(Auth.class) || !principalClass.equals(parameter.getRawType())) {
             return null;
         }
+
         return new AbstractContainerRequestValueFactory<Principal>() {
 
             /**

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/AbstractAuthResourceConfig.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/AbstractAuthResourceConfig.java
@@ -1,0 +1,26 @@
+package io.dropwizard.auth;
+
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.jersey.DropwizardResourceConfig;
+import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
+
+import javax.ws.rs.container.ContainerRequestFilter;
+import java.security.Principal;
+
+public abstract class AbstractAuthResourceConfig extends DropwizardResourceConfig {
+
+    public AbstractAuthResourceConfig() {
+        super(true, new MetricRegistry());
+
+        register(new AuthDynamicFeature(getAuthFilter()));
+        register(new AuthValueFactoryProvider.Binder<>(getPrincipalClass()));
+        register(RolesAllowedDynamicFeature.class);
+    }
+
+    /**
+     * @return type of injected principal instance
+     */
+    protected abstract Class<? extends Principal> getPrincipalClass();
+
+    protected abstract ContainerRequestFilter getAuthFilter();
+}

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthBaseResourceConfig.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthBaseResourceConfig.java
@@ -1,21 +1,17 @@
 package io.dropwizard.auth;
 
-import com.codahale.metrics.MetricRegistry;
-import io.dropwizard.jersey.DropwizardResourceConfig;
-import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
-
 import javax.ws.rs.container.ContainerRequestFilter;
 import java.security.Principal;
 
-public abstract class AuthBaseResourceConfig extends DropwizardResourceConfig {
-    public AuthBaseResourceConfig() {
-        super(true, new MetricRegistry());
+public abstract class AuthBaseResourceConfig extends AbstractAuthResourceConfig {
 
-        register(new AuthDynamicFeature(getAuthFilter()));
-        register(new AuthValueFactoryProvider.Binder<>(Principal.class));
-        register(RolesAllowedDynamicFeature.class);
+    public AuthBaseResourceConfig() {
         register(AuthResource.class);
     }
 
     protected abstract ContainerRequestFilter getAuthFilter();
+
+    protected Class<? extends Principal> getPrincipalClass() {
+        return Principal.class;
+    }
 }

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/JsonPrincipal.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/JsonPrincipal.java
@@ -1,0 +1,16 @@
+package io.dropwizard.auth.principal;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.auth.PrincipalImpl;
+
+/**
+ * Principal instance supporting JSON deserialization.
+ */
+public class JsonPrincipal extends PrincipalImpl {
+
+    @JsonCreator
+    public JsonPrincipal(@JsonProperty("name") String name) {
+        super(name);
+    }
+}

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/NoAuthPrincipalEntityResource.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/NoAuthPrincipalEntityResource.java
@@ -1,0 +1,46 @@
+package io.dropwizard.auth.principal;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Contains resource methods which don't authenticate but use principal instance injection and thus might be affected by authentication logic.
+ */
+@Path("/no-auth-test")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.TEXT_PLAIN)
+public class NoAuthPrincipalEntityResource {
+
+    /**
+     * Principal instance must be injected even when no authentication is required.
+     */
+    @POST
+    @Path("principal-entity")
+    public String principalEntityWithoutAuth(JsonPrincipal principal) {
+        assertThat(principal).isNotNull();
+        return principal.getName();
+    }
+
+    /**
+     * Annotated principal instance must be injected even when no authentication is required.
+     */
+    @POST
+    @Path("annotated-principal-entity")
+    public String annotatedPrincipalEntityWithoutAuth(@DummyAnnotation JsonPrincipal principal) {
+        assertThat(principal).isNotNull();
+        return principal.getName();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.PARAMETER })
+    public @interface DummyAnnotation {}
+}

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/NoAuthPrincipalEntityTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/NoAuthPrincipalEntityTest.java
@@ -1,0 +1,86 @@
+package io.dropwizard.auth.principal;
+
+import io.dropwizard.auth.AbstractAuthResourceConfig;
+import io.dropwizard.logging.BootstrapLogging;
+import org.glassfish.jersey.server.model.Parameter;
+import org.glassfish.jersey.servlet.ServletProperties;
+import org.glassfish.jersey.test.DeploymentContext;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.glassfish.jersey.test.TestProperties;
+import org.junit.Test;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.security.Principal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Testing that principal entity is not affected by authentication logic and can be injected as any other entity.
+ */
+public class NoAuthPrincipalEntityTest extends JerseyTest {
+
+    static {
+        BootstrapLogging.bootstrap();
+    }
+
+    @Override
+    protected DeploymentContext configureDeployment() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
+        return ServletDeploymentContext
+                .builder(new NoAuthPrincipalInjectedResourceConfig())
+                .initParam(ServletProperties.JAXRS_APPLICATION_CLASS, NoAuthPrincipalInjectedResourceConfig.class.getName())
+                .build();
+    }
+
+    public static class NoAuthPrincipalInjectedResourceConfig extends AbstractAuthResourceConfig {
+
+        public NoAuthPrincipalInjectedResourceConfig() {
+            register(NoAuthPrincipalEntityResource.class);
+            packages("io.dropwizard.jersey.jackson");
+        }
+
+        @Override protected Class<? extends Principal> getPrincipalClass() {
+            return JsonPrincipal.class;
+        }
+
+        @Override protected ContainerRequestFilter getAuthFilter() {
+
+            return new ContainerRequestFilter() {
+                @Override public void filter(ContainerRequestContext requestContext) throws IOException {
+                    throw new AssertionError("Authentication must not be performed");
+                }
+            };
+        }
+    }
+
+    @Test
+    public void principalEntityResourceWithoutAuth200() {
+        String principalName = "Astar Seran";
+        assertThat(target("/no-auth-test/principal-entity").request()
+                .header(HttpHeaders.AUTHORIZATION, "Anything here")
+                .post(Entity.entity(new JsonPrincipal(principalName), MediaType.APPLICATION_JSON))
+                .readEntity(String.class))
+                .isEqualTo(principalName);
+    }
+
+    /**
+     * When parameter is annotated then Jersey classifies such parameter as {@link Parameter.Source#UNKNOWN} instead of
+     * {@link Parameter.Source#ENTITY} which is used for unannotated parameters. ValueFactoryProvider resolution logic is different for these
+     * two sources therefore must be tested separately.
+     */
+    @Test
+    public void annotatedPrincipalEntityResourceWithoutAuth200() {
+        String principalName = "Astar Seran";
+        assertThat(target("/no-auth-test/annotated-principal-entity").request()
+                .header(HttpHeaders.AUTHORIZATION, "Anything here")
+                .post(Entity.entity(new JsonPrincipal(principalName), MediaType.APPLICATION_JSON))
+                .readEntity(String.class))
+                .isEqualTo(principalName);
+    }
+}


### PR DESCRIPTION
Principal parameter which is not annotated with Auth annotation shouldn't be authenticated. This worked before but only when such parameter is not annotated with any annotation. Otherwise parameter injection failed. The prove that this didn't work is NoAuthPrincipalEntityTest.annotatedPrincipalEntityWithoutAuth test which fails without the fix.

Btw., still wondering why Auth annotation is allowed on method and type level..