### PR TITLE
LoggingFactory in io.dropwizard.jackson.Discoverable

### DIFF
--- a/dropwizard-logging/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
+++ b/dropwizard-logging/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
@@ -1,2 +1,2 @@
 io.dropwizard.logging.AppenderFactory
-io.dropwizard.logging.LoggerFactory
+io.dropwizard.logging.LoggingFactory


### PR DESCRIPTION
Changed LoggerFactory to LoggingFactory in META-INF/services/io.dropwizard.jackson.Discoverable
Solves issue #1248 : "Unable to load io.dropwizard.logging.LoggerFactory"