### PR TITLE
Don't require username in the data source configuration

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -973,7 +973,7 @@ driverClass                     REQUIRED                 The full name of the JD
 
 url                             REQUIRED                 The URL of the server.
 
-user                            REQUIRED                 The username used to connect to the server.
+user                            none                     The username used to connect to the server.
 
 password                        none                     The password used to connect to the server.
 

--- a/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
+++ b/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
@@ -40,7 +40,7 @@ import java.util.concurrent.TimeUnit;
  *     </tr>
  *     <tr>
  *         <td>{@code user}</td>
- *         <td><b>REQUIRED</b></td>
+ *         <td><b>none</b></td>
  *         <td>The username used to connect to the server.</td>
  *     </tr>
  *     <tr>
@@ -294,10 +294,9 @@ public class DataSourceFactory implements PooledDataSourceFactory {
 
     private Boolean readOnlyByDefault;
 
-    @NotNull
     private String user = null;
 
-    private String password = "";
+    private String password = null;
 
     @NotNull
     private String url = null;
@@ -769,7 +768,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
         poolConfig.setName(name);
         poolConfig.setUrl(url);
         poolConfig.setUsername(user);
-        poolConfig.setPassword(password);
+        poolConfig.setPassword(user != null && password == null ? "" : password);
         poolConfig.setTestWhileIdle(checkConnectionWhileIdle);
         poolConfig.setValidationQuery(validationQuery);
         poolConfig.setTestOnBorrow(checkConnectionOnBorrow);

--- a/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceConfigurationTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceConfigurationTest.java
@@ -91,6 +91,16 @@ public class DataSourceConfigurationTest {
         assertThat(ds.getValidationQueryTimeout()).isEqualTo(Optional.absent());
     }
 
+    @Test
+    public void testInlineUserPasswordConfiguration() throws Exception {
+        DataSourceFactory ds = getDataSourceFactory("yaml/inline_user_pass_db_pool.yml");
+
+        assertThat(ds.getDriverClass()).isEqualTo("org.postgresql.Driver");
+        assertThat(ds.getUrl()).isEqualTo("jdbc:postgresql://db.example.com/db-prod?user=scott&password=tiger");
+        assertThat(ds.getUser()).isNull();
+        assertThat(ds.getPassword()).isNull();
+    }
+
     private DataSourceFactory getDataSourceFactory(String resourceName) throws Exception {
         return new ConfigurationFactory<>(DataSourceFactory.class,
                 Validation.buildDefaultValidatorFactory().getValidator(), Jackson.newObjectMapper(), "dw")

--- a/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceFactoryTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceFactoryTest.java
@@ -24,8 +24,7 @@ public class DataSourceFactoryTest {
     @Before
     public void setUp() {
         factory = new DataSourceFactory();
-        factory.setUrl("jdbc:h2:mem:DbTest-" + System.currentTimeMillis());
-        factory.setUser("sa");
+        factory.setUrl("jdbc:h2:mem:DbTest-" + System.currentTimeMillis() + ";user=sa");
         factory.setDriverClass("org.h2.Driver");
         factory.setValidationQuery("SELECT 1");
     }

--- a/dropwizard-db/src/test/resources/yaml/inline_user_pass_db_pool.yml
+++ b/dropwizard-db/src/test/resources/yaml/inline_user_pass_db_pool.yml
@@ -1,0 +1,2 @@
+driverClass: org.postgresql.Driver
+url: jdbc:postgresql://db.example.com/db-prod?user=scott&password=tiger


### PR DESCRIPTION
Some platforms provide credentials to connect to a database inlined in the connection URL. Examples:

* `postgres://postgres:SOME_PASSWORD@172.17.0.1:5432/lolipop`
* ` jdbc:h2:file:~/sample;USER=sa;PASSWORD=123`
* `jdbc:postgresql://localhost/test?user=fred&password=secret`

JDBC drivers support such a type of configuration. We should respect it and provide users ability to use it.

It means we should not require the username field to be set in the data source configuration.

Fixes #1259