### PR TITLE
Support for disabling decompression of HTTP responses

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
@@ -71,6 +71,7 @@ public class HttpClientBuilder {
     private CredentialsProvider credentialsProvider = null;
     private HttpClientMetricNameStrategy metricNameStrategy = HttpClientMetricNameStrategies.METHOD_ONLY;
     private HttpRoutePlanner routePlanner = null;
+    private boolean disableContentCompression;
 
     public HttpClientBuilder(MetricRegistry metricRegistry) {
         this.metricRegistry = metricRegistry;
@@ -171,6 +172,17 @@ public class HttpClientBuilder {
     }
 
     /**
+     * Disable support of decompression of responses
+     *
+     * @param disableContentCompression {@code true}, if disabled
+     * @return {@code this}
+     */
+    public HttpClientBuilder disableContentCompression(boolean disableContentCompression) {
+        this.disableContentCompression = disableContentCompression;
+        return this;
+    }
+
+    /**
      * Builds the {@link HttpClient}.
      *
      * @param name
@@ -196,6 +208,7 @@ public class HttpClientBuilder {
 
     /**
      * For internal use only, used in {@link io.dropwizard.client.JerseyClientBuilder} to create an instance of {@link io.dropwizard.client.DropwizardApacheConnector}
+     *
      * @param name
      * @return an {@link io.dropwizard.client.ConfiguredCloseableHttpClient}
      */
@@ -286,6 +299,10 @@ public class HttpClientBuilder {
             builder.setRoutePlanner(routePlanner);
         }
 
+        if (disableContentCompression) {
+            builder.disableContentCompression();
+        }
+
         return new ConfiguredCloseableHttpClient(builder.build(), requestConfig);
     }
 
@@ -331,7 +348,7 @@ public class HttpClientBuilder {
         }
 
         final SSLConnectionSocketFactory sslConnectionSocketFactory;
-        if(configuration.getTlsConfiguration() == null) {
+        if (configuration.getTlsConfiguration() == null) {
             sslConnectionSocketFactory = SSLConnectionSocketFactory.getSocketFactory();
         } else {
             sslConnectionSocketFactory = new DropwizardSSLConnectionSocketFactory(configuration.getTlsConfiguration()).getSocketFactory();

--- a/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
@@ -313,6 +313,10 @@ public class JerseyClientBuilder {
     private Client build(String name, ExecutorService threadPool,
                          ObjectMapper objectMapper,
                          Validator validator) {
+        if (!configuration.isGzipEnabled()) {
+            apacheHttpClientBuilder.disableContentCompression(true);
+        }
+
         final Client client = ClientBuilder.newClient(buildConfig(name, threadPool, objectMapper, validator));
         client.register(new JerseyIgnoreRequestUserAgentHeaderFilter());
 

--- a/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
@@ -406,7 +406,7 @@ public class HttpClientBuilderTest {
 
         return httpClient;
     }
-    
+
     @Test
     public void setValidateAfterInactivityPeriodFromConfiguration() throws Exception {
         int validateAfterInactivityPeriod = 50000;
@@ -446,6 +446,19 @@ public class HttpClientBuilderTest {
         assertThat(client).isNotNull();
 
         assertThat(spyHttpClientField("defaultConfig", client.getClient())).isEqualTo(client.getDefaultRequestConfig());
+    }
+
+    @Test
+    public void disablesContentCompression() throws Exception {
+        ConfiguredCloseableHttpClient client = builder
+                .disableContentCompression(true)
+                .createClient(apacheBuilder, connectionManager, "test");
+        assertThat(client).isNotNull();
+
+        final Boolean contentCompressionDisabled = (Boolean) FieldUtils
+                .getField(httpClientBuilderClass, "contentCompressionDisabled", true)
+                .get(apacheBuilder);
+        assertThat(contentCompressionDisabled).isTrue();
     }
 
     @Test

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
@@ -64,6 +64,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.never;
 
 public class JerseyClientBuilderTest {
     private final JerseyClientBuilder builder = new JerseyClientBuilder(new MetricRegistry());
@@ -190,6 +191,7 @@ public class JerseyClientBuilderTest {
                 .iterator().hasNext()).isTrue();
         assertThat(Iterables.filter(client.getConfiguration().getInstances(), ConfiguredGZipEncoder.class)
                 .iterator().hasNext()).isTrue();
+        verify(apacheHttpClientBuilder, never()).disableContentCompression(true);
     }
 
     @Test
@@ -204,6 +206,7 @@ public class JerseyClientBuilderTest {
                 .iterator().hasNext()).isFalse();
         assertThat(Iterables.filter(client.getConfiguration().getInstances(), ConfiguredGZipEncoder.class)
                 .iterator().hasNext()).isFalse();
+        verify(apacheHttpClientBuilder).disableContentCompression(true);
     }
 
     @Test


### PR DESCRIPTION
By default Apache HTTP client builder enables decompression of responses. If we want to disable this feature in Jersey HTTP client, we should explicitly disable it in the underlying Apache HTTP client
during building.