### PR TITLE
Add support for several Hibernate bundles

### DIFF
--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/HibernateBundle.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/HibernateBundle.java
@@ -12,7 +12,7 @@ import io.dropwizard.util.Duration;
 import org.hibernate.SessionFactory;
 
 public abstract class HibernateBundle<T extends Configuration> implements ConfiguredBundle<T>, DatabaseConfiguration<T> {
-    private static final String DEFAULT_NAME = "hibernate";
+    public static final String DEFAULT_NAME = "hibernate";
 
     private SessionFactory sessionFactory;
 
@@ -54,13 +54,24 @@ public abstract class HibernateBundle<T extends Configuration> implements Config
     public final void run(T configuration, Environment environment) throws Exception {
         final PooledDataSourceFactory dbConfig = getDataSourceFactory(configuration);
         this.sessionFactory = sessionFactoryFactory.build(this, environment, dbConfig, entities, name());
-        environment.jersey().register(new UnitOfWorkApplicationListener(sessionFactory));
+        registerUnitOfWorkListerIfAbsent(environment).registerSessionFactory(name(), sessionFactory);
         environment.healthChecks().register(name(),
                                             new SessionFactoryHealthCheck(
                                                     environment.getHealthCheckExecutorService(),
                                                     dbConfig.getHealthCheckValidationTimeout().or(Duration.seconds(5)),
                                                     sessionFactory,
                                                     dbConfig.getHealthCheckValidationQuery()));
+    }
+
+    private UnitOfWorkApplicationListener registerUnitOfWorkListerIfAbsent(Environment environment) {
+        for (Object singleton : environment.jersey().getResourceConfig().getSingletons()) {
+            if (singleton instanceof UnitOfWorkApplicationListener) {
+                return (UnitOfWorkApplicationListener) singleton;
+            }
+        }
+        final UnitOfWorkApplicationListener listener = new UnitOfWorkApplicationListener();
+        environment.jersey().register(listener);
+        return listener;
     }
 
     public SessionFactory getSessionFactory() {

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWork.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWork.java
@@ -47,4 +47,10 @@ public @interface UnitOfWork {
      * @see org.hibernate.Session#setFlushMode(org.hibernate.FlushMode)
      */
     FlushMode flushMode() default FlushMode.AUTO;
+
+    /**
+     * The name of a hibernate bundle (session factory) that specifies
+     * a datasource against which a transaction will be opened.
+     */
+    String value() default HibernateBundle.DEFAULT_NAME;
 }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/HibernateBundleTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/HibernateBundleTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.datatype.hibernate4.Hibernate4Module;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.Configuration;
 import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
@@ -39,6 +40,8 @@ public class HibernateBundleTest {
     public void setUp() throws Exception {
         when(environment.healthChecks()).thenReturn(healthChecks);
         when(environment.jersey()).thenReturn(jerseyEnvironment);
+        when(jerseyEnvironment.getResourceConfig()).thenReturn(new DropwizardResourceConfig());
+
 
         when(factory.build(eq(bundle),
                            any(Environment.class),

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
@@ -125,7 +125,7 @@ public class JerseyIntegrationTest extends JerseyTest {
         }
 
         final DropwizardResourceConfig config = DropwizardResourceConfig.forTesting(new MetricRegistry());
-        config.register(new UnitOfWorkApplicationListener(sessionFactory));
+        config.register(new UnitOfWorkApplicationListener("hr-db", sessionFactory));
         config.register(new PersonResource(new PersonDAO(sessionFactory)));
         config.register(new JacksonMessageBodyProvider(Jackson.newObjectMapper(),
                                                        Validation.buildDefaultValidatorFactory().getValidator()));


### PR DESCRIPTION
In some cases one need to simultaneously connect to several relational databases. Users want to use Hibernate to access each database. The problem that the current implementation of
`UnitOfWorkApplicationListener` supports only one session factory, which ultimately restricts ability to support several session factories.

Another problem is that users should have the ability to specify the name of datasource, against which a transaction should be opened in a resource method.

This change:

* Adds the method `value` to the `@UnitOfWork` annotation. It allows to specify the name of Hibernate bundle (session factory). By default it specifies the default bundle.

* Replaces the single session factory in `UnitOfWorkApplicationListener` to a map of session factories by names of bundles.

* The correct session factory is determined in runtime, based on the `value` method in the corresponding `@UnitOfWork` annotation.

In the result users can simultaneously use declarative transactions on several databases, access to which is managed by Hibernate.

Fixes #1217