### PR TITLE
Allow clients to override HttpClientBuilder#createClient method

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/ConfiguredCloseableHttpClient.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/ConfiguredCloseableHttpClient.java
@@ -3,7 +3,7 @@ package io.dropwizard.client;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.CloseableHttpClient;
 
-/* package */ class ConfiguredCloseableHttpClient {
+public class ConfiguredCloseableHttpClient {
     private final CloseableHttpClient closeableHttpClient;
     private final RequestConfig defaultRequestConfig;
 

--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
@@ -226,7 +226,6 @@ public class HttpClientBuilder {
      * @param name
      * @return the configured {@link CloseableHttpClient}
      */
-    @VisibleForTesting
     protected ConfiguredCloseableHttpClient createClient(
             final org.apache.http.impl.client.HttpClientBuilder builder,
             final InstrumentedHttpClientConnectionManager manager,


### PR DESCRIPTION
This PR is to allow clients to override HttpClientBuilder's createClient method. Since not all configuration values can be set directly using the class or the YML configuration, this would allow clients fine grain control over the underlaying Apache's HttpClientBuilder in case they need to.

See https://github.com/dropwizard/dropwizard/issues/1186#issuecomment-148188882