### PR TITLE
Fixed failing CliTests by Setting Default Locale

### DIFF
--- a/dropwizard-core/src/test/java/io/dropwizard/cli/CliTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/cli/CliTest.java
@@ -11,13 +11,14 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 public class CliTest {
     private final JarLocation location = mock(JarLocation.class);
-    @SuppressWarnings("unchecked")
+    
     private final Application<Configuration> app = new Application<Configuration>() {
         @Override
         public void run(Configuration configuration, Environment environment) throws Exception {
@@ -32,6 +33,9 @@ public class CliTest {
     @Before
     @SuppressWarnings("unchecked")
     public void setUp() throws Exception {
+    	//set default locale because some tests assert localized error messages
+    	Locale.setDefault(Locale.ENGLISH);
+    	
         when(location.toString()).thenReturn("dw-thing.jar");
         when(location.getVersion()).thenReturn(Optional.of("1.0.0"));
         bootstrap.addCommand(command);


### PR DESCRIPTION
Multiple tests in CliTest will fail on systems with a default locale other than English.

ArgParse4j localizes some parts of the validation error message. The tests assert the equality of the whole text. As a fix, I set the default locale to English in the setup of the tests.

FMPOV it is not necessary to save the former default locale and to switch it back after the tests because tests are executed in a separate JVM. Let me know, if you think different.