### PR TITLE
doc fix - set method is also required

### DIFF
--- a/docs/source/manual/client.rst
+++ b/docs/source/manual/client.rst
@@ -34,6 +34,11 @@ To create a :ref:`managed <man-core-managed>`, instrumented ``HttpClient`` insta
         public HttpClientConfiguration getHttpClientConfiguration() {
             return httpClient;
         }
+        
+        @JsonProperty("httpClient")
+        public void setHttpClientConfiguration(HttpClientConfiguration httpClient) {
+            this.httpClient = httpClient;
+        }
     }
 
 Then, in your application's ``run`` method, create a new ``HttpClientBuilder``:


### PR DESCRIPTION
In order to create a new configuration class you need to provide also a setter for HttpClientConfiguration