### PR TITLE
Replace default validator in tests

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
@@ -9,6 +9,7 @@ import com.google.common.collect.Maps;
 import io.dropwizard.jersey.gzip.ConfiguredGZipEncoder;
 import io.dropwizard.jersey.gzip.GZipDecoder;
 import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
+import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.setup.Environment;
 import org.apache.http.client.CredentialsProvider;
@@ -21,7 +22,6 @@ import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.spi.Connector;
 import org.glassfish.jersey.client.spi.ConnectorProvider;
 
-import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -58,7 +58,7 @@ public class JerseyClientBuilder {
     private JerseyClientConfiguration configuration = new JerseyClientConfiguration();
 
     private HttpClientBuilder apacheHttpClientBuilder;
-    private Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+    private Validator validator = Validators.newValidator();
     private Environment environment;
     private ObjectMapper objectMapper;
     private ExecutorService executorService;

--- a/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
@@ -5,6 +5,7 @@ import com.codahale.metrics.health.HealthCheck;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
@@ -16,26 +17,22 @@ import org.assertj.core.api.AbstractLongAssert;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.JerseyClient;
-import org.junit.Before;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import javax.validation.Validation;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.ProcessingException;
-import javax.ws.rs.client.Client;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import java.net.NoRouteToHostException;
 import java.net.SocketTimeoutException;
 import java.net.URI;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -70,7 +67,7 @@ public class DropwizardApacheConnectorTest {
         clientConfiguration.setTimeout(Duration.milliseconds(DEFAULT_CONNECT_TIMEOUT_IN_MILLIS));
 
         environment = new Environment("test-dropwizard-apache-connector", Jackson.newObjectMapper(),
-                Validation.buildDefaultValidatorFactory().getValidator(), new MetricRegistry(),
+                Validators.newValidator(), new MetricRegistry(),
                 getClass().getClassLoader());
         client = (JerseyClient) new JerseyClientBuilder(environment)
                 .using(clientConfiguration)

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
@@ -9,6 +9,7 @@ import com.google.common.collect.Iterables;
 import io.dropwizard.jersey.gzip.ConfiguredGZipEncoder;
 import io.dropwizard.jersey.gzip.GZipDecoder;
 import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
+import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.lifecycle.setup.ExecutorServiceBuilder;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import io.dropwizard.setup.Environment;
@@ -72,7 +73,7 @@ public class JerseyClientBuilderTest {
     private final Environment environment = mock(Environment.class);
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
     private final ObjectMapper objectMapper = mock(ObjectMapper.class);
-    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+    private final Validator validator = Validators.newValidator();
     private final HttpClientBuilder apacheHttpClientBuilder = mock(HttpClientBuilder.class);
 
     @Before

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientConfigurationTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientConfigurationTest.java
@@ -3,9 +3,9 @@ package io.dropwizard.client;
 import com.google.common.io.Resources;
 import io.dropwizard.configuration.ConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jersey.validation.Validators;
 import org.junit.Test;
 
-import javax.validation.Validation;
 import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -15,9 +15,8 @@ public class JerseyClientConfigurationTest {
     @Test
     public void testBasicJerseyClient() throws Exception {
         final JerseyClientConfiguration configuration = new ConfigurationFactory<>(JerseyClientConfiguration.class,
-                Validation.buildDefaultValidatorFactory().getValidator(), Jackson.newObjectMapper(), "dw")
+                Validators.newValidator(), Jackson.newObjectMapper(), "dw")
                 .build(new File(Resources.getResource("yaml/jersey-client.yml").toURI()));
-
         assertThat(configuration.getMinThreads()).isEqualTo(8);
         assertThat(configuration.getMaxThreads()).isEqualTo(64);
         assertThat(configuration.getWorkQueueSize()).isEqualTo(16);

--- a/dropwizard-client/src/test/java/io/dropwizard/client/proxy/HttpClientConfigurationTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/proxy/HttpClientConfigurationTest.java
@@ -8,9 +8,9 @@ import io.dropwizard.configuration.ConfigurationFactory;
 import io.dropwizard.configuration.ConfigurationParsingException;
 import io.dropwizard.configuration.ConfigurationValidationException;
 import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jersey.validation.Validators;
 import org.junit.Test;
 
-import javax.validation.Validation;
 import java.io.File;
 import java.util.List;
 
@@ -24,7 +24,7 @@ public class HttpClientConfigurationTest {
 
     private void load(String configLocation) throws Exception {
         configuration = new ConfigurationFactory<>(HttpClientConfiguration.class,
-                Validation.buildDefaultValidatorFactory().getValidator(),
+                Validators.newValidator(),
                 objectMapper, "dw")
                 .build(new File(Resources.getResource(configLocation).toURI()));
     }

--- a/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
@@ -11,6 +11,7 @@ import io.dropwizard.jersey.errors.EarlyEofExceptionMapper;
 import io.dropwizard.jersey.errors.LoggingExceptionMapper;
 import io.dropwizard.jersey.jackson.JsonProcessingExceptionMapper;
 import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
+import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.jetty.HttpConnectorFactory;
 import io.dropwizard.logging.ConsoleAppenderFactory;
 import io.dropwizard.logging.FileAppenderFactory;
@@ -100,7 +101,7 @@ public class DefaultServerFactoryTest {
     public void registersDefaultExceptionMappers() throws Exception {
         assertThat(http.getRegisterDefaultExceptionMappers()).isTrue();
         Environment environment = new Environment("test", Jackson.newObjectMapper(),
-                Validation.buildDefaultValidatorFactory().getValidator(), new MetricRegistry(),
+                Validators.newValidator(), new MetricRegistry(),
                 ClassLoader.getSystemClassLoader());
         http.build(environment);
         Set<Object> singletons = environment.jersey().getResourceConfig().getSingletons();
@@ -116,7 +117,7 @@ public class DefaultServerFactoryTest {
         http.setRegisterDefaultExceptionMappers(false);
         assertThat(http.getRegisterDefaultExceptionMappers()).isFalse();
         Environment environment = new Environment("test", Jackson.newObjectMapper(),
-                Validation.buildDefaultValidatorFactory().getValidator(), new MetricRegistry(),
+                Validators.newValidator(), new MetricRegistry(),
                 ClassLoader.getSystemClassLoader());
         http.build(environment);
         for (Object singleton : environment.jersey().getResourceConfig().getSingletons()) {
@@ -127,7 +128,7 @@ public class DefaultServerFactoryTest {
     @Test
     public void testGracefulShutdown() throws Exception {
         ObjectMapper objectMapper = Jackson.newObjectMapper();
-        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        Validator validator = Validators.newValidator();
         MetricRegistry metricRegistry = new MetricRegistry();
         Environment environment = new Environment("test", objectMapper, validator, metricRegistry,
                 ClassLoader.getSystemClassLoader());

--- a/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceConfigurationTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceConfigurationTest.java
@@ -4,10 +4,10 @@ import com.google.common.base.Optional;
 import com.google.common.io.Resources;
 import io.dropwizard.configuration.ConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.util.Duration;
 import org.junit.Test;
 
-import javax.validation.Validation;
 import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -107,7 +107,7 @@ public class DataSourceConfigurationTest {
 
     private DataSourceFactory getDataSourceFactory(String resourceName) throws Exception {
         return new ConfigurationFactory<>(DataSourceFactory.class,
-                Validation.buildDefaultValidatorFactory().getValidator(), Jackson.newObjectMapper(), "dw")
+                Validators.newValidator(), Jackson.newObjectMapper(), "dw")
                 .build(new File(Resources.getResource(resourceName).toURI()));
     }
 }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
@@ -8,6 +8,7 @@ import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.errors.ErrorMessage;
 import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
+import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import io.dropwizard.logging.BootstrapLogging;
 import io.dropwizard.setup.Environment;
@@ -21,7 +22,6 @@ import org.joda.time.DateTimeZone;
 import org.junit.After;
 import org.junit.Test;
 
-import javax.validation.Validation;
 import javax.ws.rs.*;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Application;
@@ -128,7 +128,7 @@ public class JerseyIntegrationTest extends JerseyTest {
         config.register(new UnitOfWorkApplicationListener("hr-db", sessionFactory));
         config.register(new PersonResource(new PersonDAO(sessionFactory)));
         config.register(new JacksonMessageBodyProvider(Jackson.newObjectMapper(),
-                                                       Validation.buildDefaultValidatorFactory().getValidator()));
+                                                       Validators.newValidator()));
         config.register(new DataExceptionMapper());
 
         return config;
@@ -137,7 +137,7 @@ public class JerseyIntegrationTest extends JerseyTest {
     @Override
     protected void configureClient(ClientConfig config) {
         config.register(new JacksonMessageBodyProvider(Jackson.newObjectMapper(),
-                Validation.buildDefaultValidatorFactory().getValidator()));
+                Validators.newValidator()));
     }
 
     @Test

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/DBIClient.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/DBIClient.java
@@ -5,12 +5,12 @@ import com.google.common.base.Optional;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jdbi.DBIFactory;
+import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.setup.Environment;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.rules.ExternalResource;
 import org.skife.jdbi.v2.DBI;
 
-import javax.validation.Validation;
 import java.util.List;
 import java.util.TimeZone;
 
@@ -35,7 +35,7 @@ public class DBIClient extends ExternalResource {
     @Override
     protected void before() throws Throwable {
         final Environment environment = new Environment("test", Jackson.newObjectMapper(),
-                Validation.buildDefaultValidatorFactory().getValidator(), new MetricRegistry(),
+                Validators.newValidator(), new MetricRegistry(),
                 getClass().getClassLoader());
 
         final DataSourceFactory dataSourceFactory = new DataSourceFactory();

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/DefaultJacksonMessageBodyProvider.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/DefaultJacksonMessageBodyProvider.java
@@ -2,13 +2,13 @@ package io.dropwizard.jersey.errors;
 
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
+import io.dropwizard.jersey.validation.Validators;
 
-import javax.validation.Validation;
 import javax.ws.rs.ext.Provider;
 
 @Provider
 public class DefaultJacksonMessageBodyProvider extends JacksonMessageBodyProvider {
     public DefaultJacksonMessageBodyProvider() {
-        super(Jackson.newObjectMapper(), Validation.buildDefaultValidatorFactory().getValidator());
+        super(Jackson.newObjectMapper(), Validators.newValidator());
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/DefaultJacksonMessageBodyProvider.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/DefaultJacksonMessageBodyProvider.java
@@ -1,13 +1,13 @@
 package io.dropwizard.jersey.jackson;
 
 import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jersey.validation.Validators;
 
-import javax.validation.Validation;
 import javax.ws.rs.ext.Provider;
 
 @Provider
 public class DefaultJacksonMessageBodyProvider extends JacksonMessageBodyProvider {
     public DefaultJacksonMessageBodyProvider() {
-        super(Jackson.newObjectMapper(), Validation.buildDefaultValidatorFactory().getValidator());
+        super(Jackson.newObjectMapper(), Validators.newValidator());
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProviderTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.reflect.TypeToken;
 import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.validation.ConstraintViolations;
 import io.dropwizard.validation.Validated;
 import org.hibernate.validator.constraints.NotEmpty;
@@ -14,7 +15,6 @@ import org.junit.Test;
 
 import javax.validation.ConstraintViolationException;
 import javax.validation.Valid;
-import javax.validation.Validation;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.WebApplicationException;
@@ -102,7 +102,7 @@ public class JacksonMessageBodyProviderTest {
     private final ObjectMapper mapper = spy(Jackson.newObjectMapper());
     private final JacksonMessageBodyProvider provider =
             new JacksonMessageBodyProvider(mapper,
-                                           Validation.buildDefaultValidatorFactory().getValidator());
+                                           Validators.newValidator());
 
     @Before
     public void setUp() throws Exception {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapperTest.java
@@ -5,13 +5,13 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.jersey.DropwizardResourceConfig;
+import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.logging.BootstrapLogging;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.TestProperties;
 import org.junit.Test;
 
-import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Application;
@@ -34,7 +34,7 @@ public class JsonProcessingExceptionMapperTest extends JerseyTest {
 
     @Override
     protected void configureClient(ClientConfig config) {
-        final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        final Validator validator = Validators.newValidator();
         final ObjectMapper mapper = new ObjectMapper();
         final JacksonMessageBodyProvider provider = new JacksonMessageBodyProvider(mapper, validator);
         config.register(provider);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/DefaultJacksonMessageBodyProvider.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/DefaultJacksonMessageBodyProvider.java
@@ -3,13 +3,12 @@ package io.dropwizard.jersey.validation;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
 
-import javax.validation.Validation;
 import javax.ws.rs.ext.Provider;
 
 @Provider
 public class DefaultJacksonMessageBodyProvider extends JacksonMessageBodyProvider {
     public DefaultJacksonMessageBodyProvider() {
-        super(Jackson.newObjectMapper(), Validation.buildDefaultValidatorFactory().getValidator());
+        super(Jackson.newObjectMapper(), Validators.newValidator());
     }
 }
 


### PR DESCRIPTION
The validator used in tests
(`Validation.buildDefaultValidatorFactory().getValidator()`) is not dropwizard
configured, thus bugs like #1292 slipped through. This pull request moves the
tests to the dropwizard configured validator. Note that this doesn't cover all
cases as some classes are not able to import dropwizard-jersey (where the
dropwizard configured validator lies) into the tests, so more work will need
to be done to cover all the bases.

~~This pull request also fixes #1292~~