### PR TITLE
Fix HTTP Client Config User Agent Validation

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientConfiguration.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientConfiguration.java
@@ -5,6 +5,7 @@ import com.google.common.base.Optional;
 import io.dropwizard.client.proxy.ProxyConfiguration;
 import io.dropwizard.client.ssl.TlsConfiguration;
 import io.dropwizard.util.Duration;
+import org.hibernate.validator.valuehandling.UnwrapValidatedValue;
 
 import javax.annotation.Nullable;
 import javax.validation.Valid;
@@ -48,6 +49,7 @@ public class HttpClientConfiguration {
     private int retries = 0;
 
     @NotNull
+    @UnwrapValidatedValue(false)
     private Optional<String> userAgent = Optional.absent();
 
     @Valid


### PR DESCRIPTION
With Hibernate Validator 5.2.x, when an annotation such as `@NotNull` can be applied to either the inner or wrapper type (in this case, `String` or `Optional`), the code must explicitly define `@UnwrapValidatedValue`

Fixes #1292