### PR TITLE
Add support for custom arguments to OptionalArgumentFactory

### DIFF
--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/DBIFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/DBIFactory.java
@@ -7,6 +7,7 @@ import com.codahale.metrics.jdbi.strategies.DelegatingStatementNameStrategy;
 import com.codahale.metrics.jdbi.strategies.NameStrategies;
 import com.codahale.metrics.jdbi.strategies.StatementNameStrategy;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import io.dropwizard.db.ManagedDataSource;
 import io.dropwizard.db.PooledDataSourceFactory;
 import io.dropwizard.jdbi.args.DelegatingArgumentFactory;
@@ -16,13 +17,13 @@ import io.dropwizard.jdbi.args.OptionalArgumentFactory;
 import io.dropwizard.jdbi.logging.LogbackLog;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Duration;
+import org.skife.jdbi.v2.BuiltInArgumentFactoryFactory;
 import org.skife.jdbi.v2.ColonPrefixNamedParamStatementRewriter;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ArgumentFactory;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.TimeZone;
 
 import static com.codahale.metrics.MetricRegistry.name;
@@ -95,7 +96,7 @@ public class DBIFactory {
         dbi.registerMapper(new JodaDateTimeMapper(timeZone));
 
         final ArgumentFactory delegatingArgumentFactory = new DelegatingArgumentFactory(
-            Collections.<ArgumentFactory>singleton(new JodaDateTimeArgumentFactory())
+            ImmutableList.<ArgumentFactory>of(BuiltInArgumentFactoryFactory.create(), new JodaDateTimeArgumentFactory())
         );
 
         dbi.registerArgumentFactory(new OptionalArgumentFactory(configuration.getDriverClass(), delegatingArgumentFactory));

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/DelegatingArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/DelegatingArgumentFactory.java
@@ -1,0 +1,41 @@
+package io.dropwizard.jdbi.args;
+
+import com.google.common.collect.ImmutableList;
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+import org.skife.jdbi.v2.tweak.ArgumentFactory;
+
+import java.util.Collection;
+import java.util.List;
+
+public class DelegatingArgumentFactory implements ArgumentFactory {
+    private final List<ArgumentFactory> argumentFactories;
+
+    public DelegatingArgumentFactory(Collection<ArgumentFactory> argumentFactories) {
+        this.argumentFactories = ImmutableList.copyOf(argumentFactories);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean accepts(Class expectedType, Object value, StatementContext ctx) {
+        for (ArgumentFactory argumentFactory : argumentFactories) {
+            if (argumentFactory.accepts(expectedType, value, ctx)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Argument build(Class expectedType, Object value, StatementContext ctx) {
+        for (ArgumentFactory argumentFactory : argumentFactories) {
+            if (argumentFactory.accepts(expectedType, value, ctx)) {
+                return argumentFactory.build(expectedType, value, ctx);
+            }
+        }
+
+        throw new IllegalArgumentException("Type " + expectedType + " not supported.");
+    }
+}

--- a/dropwizard-jdbi/src/main/java/org/skife/jdbi/v2/BuiltInArgumentFactoryFactory.java
+++ b/dropwizard-jdbi/src/main/java/org/skife/jdbi/v2/BuiltInArgumentFactoryFactory.java
@@ -1,0 +1,15 @@
+package org.skife.jdbi.v2;
+
+/**
+ * A dirty hack to get an instance of {@link BuiltInArgumentFactory}.
+ */
+public final class BuiltInArgumentFactoryFactory {
+    /**
+     * Get a new instance of {@link BuiltInArgumentFactory}.
+     *
+     * @return A new instance of {@link BuiltInArgumentFactory}.
+     */
+    public static BuiltInArgumentFactory create() {
+        return new BuiltInArgumentFactory();
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/JDBIOptionalTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/JDBIOptionalTest.java
@@ -1,0 +1,66 @@
+package io.dropwizard.jdbi;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Optional;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jersey.validation.Validators;
+import io.dropwizard.setup.Environment;
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JDBIOptionalTest {
+    private final Environment env = new Environment("test", Jackson.newObjectMapper(), Validators.newValidator(), new MetricRegistry(), null);
+    private final DataSourceFactory dataSourceFactory;
+    private DBI dbi;
+
+    public JDBIOptionalTest() {
+        dataSourceFactory = new DataSourceFactory();
+        dataSourceFactory.setDriverClass("org.h2.Driver");
+        dataSourceFactory.setUrl("jdbc:h2:mem:" + JDBIOptionalTest.class + "-" + System.currentTimeMillis());
+        dataSourceFactory.setUser("sa");
+        dataSourceFactory.setPassword("");
+    }
+
+    @Before
+    public void setupTests() throws IOException {
+        dbi = new DBIFactory().build(env, dataSourceFactory, "test");
+        dbi.open().createStatement("CREATE TABLE IF NOT EXISTS test ( id INT PRIMARY KEY, time TIMESTAMP);").execute();
+    }
+
+    @Test
+    public void testInsert() {
+        final DateTime now = DateTime.now();
+        final JDBIDao dao = dbi.onDemand(JDBIDao.class);
+        dao.insert(1, Optional.of(now));
+
+        final DateTime dateTime = dao.findById(1);
+        assertThat(dateTime).isEqualTo(now);
+    }
+
+    @Test
+    public void testAbsent() {
+        final JDBIDao dao = dbi.onDemand(JDBIDao.class);
+        dao.insert(1, Optional.<DateTime>absent());
+
+        final DateTime dateTime = dao.findById(1);
+        assertThat(dateTime).isNull();
+    }
+
+    public interface JDBIDao {
+        @SqlUpdate("INSERT INTO test VALUES (:id, :ts)")
+        void insert(@Bind("id") int id, @Bind("ts") Optional<DateTime> dt);
+
+        @SqlQuery("SELECT time FROM test WHERE id = :id")
+        DateTime findById(@Bind("id") int id);
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/DelegatingArgumentFactoryTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/DelegatingArgumentFactoryTest.java
@@ -1,0 +1,23 @@
+package io.dropwizard.jdbi.args;
+
+import org.junit.Test;
+import org.skife.jdbi.v2.tweak.ArgumentFactory;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DelegatingArgumentFactoryTest {
+    @Test
+    public void emptyDelegatingArgumentFactoryDoesNotAcceptAnything() throws Exception {
+        final ArgumentFactory<?> factory = new DelegatingArgumentFactory(Collections.<ArgumentFactory>emptySet());
+        assertThat(factory.accepts(String.class, "Test", null)).isFalse();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    @SuppressWarnings("unchecked")
+    public void emptyDelegatingArgumentFactoryThrowsIllegalArgumentExceptionOnBuild() throws Exception {
+        final ArgumentFactory factory = new DelegatingArgumentFactory(Collections.<ArgumentFactory>emptySet());
+        factory.build(String.class, "Test", null);
+    }
+}


### PR DESCRIPTION
This PR adds support for custom arguments (e. g. `JodaDateTimeArgumentFactory`) to `OptionalArgumentFactory`.

The implementation is rather clumsy because jDBI doesn't seem to provide extension points for this kind of customization.

Refs #1297.