### PR TITLE
Add support for optional JodaTime arguments in JDBI

### DIFF
--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/DBIFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/DBIFactory.java
@@ -12,6 +12,7 @@ import io.dropwizard.db.ManagedDataSource;
 import io.dropwizard.jdbi.args.JodaDateTimeArgumentFactory;
 import io.dropwizard.jdbi.args.JodaDateTimeMapper;
 import io.dropwizard.jdbi.args.OptionalArgumentFactory;
+import io.dropwizard.jdbi.args.OptionalJodaTimeArgumentFactory;
 import io.dropwizard.jdbi.logging.LogbackLog;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Duration;
@@ -93,6 +94,8 @@ public class DBIFactory {
 
         final Optional<TimeZone> timeZone = databaseTimeZone();
         dbi.registerArgumentFactory(new JodaDateTimeArgumentFactory(timeZone));
+        // Should be registered after OptionalArgumentFactory to be processed first
+        dbi.registerArgumentFactory(new OptionalJodaTimeArgumentFactory(timeZone));
         dbi.registerMapper(new JodaDateTimeMapper(timeZone));
 
         return dbi;

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalJodaTimeArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalJodaTimeArgumentFactory.java
@@ -1,0 +1,50 @@
+package io.dropwizard.jdbi.args;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+import org.skife.jdbi.v2.tweak.ArgumentFactory;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+/**
+ * An {@link ArgumentFactory} for Joda's {@link DateTime} arguments wrapped by Guava's {@link Optional}.
+ */
+public class OptionalJodaTimeArgumentFactory implements ArgumentFactory<Optional<DateTime>> {
+
+    private final Optional<Calendar> calendar;
+
+    public OptionalJodaTimeArgumentFactory() {
+        calendar = Optional.absent();
+    }
+
+    public OptionalJodaTimeArgumentFactory(Optional<TimeZone> timeZone) {
+        calendar = timeZone.transform(new Function<TimeZone, Calendar>() {
+            @Override
+            public Calendar apply(TimeZone tz) {
+                return new GregorianCalendar(tz);
+            }
+        });
+    }
+
+    @Override
+    public boolean accepts(Class<?> expectedType, Object value, StatementContext ctx) {
+        if (value instanceof Optional) {
+            final Optional<?> optionalValue = (Optional<?>) value;
+            // Fall through to OptionalArgumentFactory if absent.
+            // Fall through to OptionalArgumentFactory if present, but not DateTime.
+            return optionalValue.isPresent() && optionalValue.get() instanceof DateTime;
+        }
+        return false;
+    }
+
+    @Override
+    public Argument build(Class<?> expectedType, Optional<DateTime> value, StatementContext ctx) {
+        // accepts guarantees that the value is present
+        return new JodaDateTimeArgument(value.get(), calendar);
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/JDBIOptionalDateTimeTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/JDBIOptionalDateTimeTest.java
@@ -1,0 +1,86 @@
+package io.dropwizard.jdbi.timestamps;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Optional;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jdbi.DBIFactory;
+import io.dropwizard.jersey.validation.Validators;
+import io.dropwizard.setup.Environment;
+import org.joda.time.DateTime;
+import org.joda.time.format.ISODateTimeFormat;
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
+
+import java.io.IOException;
+import java.util.TimeZone;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JDBIOptionalDateTimeTest {
+
+    private final Environment env = new Environment("test-optional-date-time", Jackson.newObjectMapper(),
+            Validators.newValidator(), new MetricRegistry(), null);
+
+
+    private TaskDao dao;
+
+    @Before
+    public void setupTests() throws IOException {
+        final DataSourceFactory dataSourceFactory = new DataSourceFactory();
+        dataSourceFactory.setDriverClass("org.h2.Driver");
+        dataSourceFactory.setUrl("jdbc:h2:mem:date-time-optional-" + System.currentTimeMillis() + "?user=sa");
+        dataSourceFactory.setInitialSize(1);
+        final DBI dbi = new DBIFactory() {
+            @Override
+            protected Optional<TimeZone> databaseTimeZone() {
+                return Optional.of(TimeZone.getTimeZone("CET"));
+            }
+        }.build(env, dataSourceFactory, "test");
+        try (Handle h = dbi.open()) {
+            h.execute("CREATE TABLE tasks (" +
+                    "id INT PRIMARY KEY, " +
+                    "assignee VARCHAR(255) NOT NULL, " +
+                    "start_date TIMESTAMP, " +
+                    "end_date TIMESTAMP, " +
+                    "comments VARCHAR(1024) " +
+                    ")");
+        }
+        dao = dbi.onDemand(TaskDao.class);
+    }
+
+    @Test
+    public void testPresent() {
+        final Optional<DateTime> endDate = Optional.of(ISODateTimeFormat.date().parseDateTime("2015-11-03"));
+        dao.insert(1, Optional.of("John Hughes"), DateTime.now(), endDate, Optional.<String>absent());
+
+        assertThat(dao.findEndDateById(1)).isEqualTo(endDate);
+    }
+
+    @Test
+    public void testAbsent() {
+        dao.insert(2, Optional.of("Kate Johansen"), DateTime.now(),
+                Optional.<DateTime>absent(), Optional.of("To be done"));
+
+        assertThat(dao.findEndDateById(2).isPresent()).isFalse();
+    }
+
+    interface TaskDao {
+
+        @SqlUpdate("INSERT INTO tasks(id, assignee, start_date, end_date, comments) " +
+                "VALUES (:id, :assignee, :start_date, :end_date, :comments)")
+        void insert(@Bind("id") int id, @Bind("assignee") Optional<String> assignee,
+                    @Bind("start_date") DateTime startDate, @Bind("end_date") Optional<DateTime> endDate,
+                    @Bind("comments") Optional<String> comments);
+
+        @SqlQuery("SELECT end_date FROM tasks WHERE id = :id")
+        @SingleValueResult
+        Optional<DateTime> findEndDateById(@Bind("id") int id);
+    }
+}


### PR DESCRIPTION
An alternative implementation of an argument factory that handles JodaTime arguments wrapped by Guava's Optional.

It uses the fact that JDBI processes argument factories in the specific order, so we can process optional JodaTime arguments before other optional arguments.