### PR TITLE
Use a minimally configured Hibernate Validator everywhere

### DIFF
--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryFactoryTest.java
@@ -1,34 +1,32 @@
 package io.dropwizard.configuration;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import com.google.common.io.Resources;
 import io.dropwizard.configuration.ConfigurationFactoryTest.Example;
 import io.dropwizard.jackson.Jackson;
-
-import java.io.File;
-
-import javax.validation.Validation;
-import javax.validation.Validator;
-
+import io.dropwizard.validation.BaseValidator;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.io.Resources;
+import javax.validation.Validator;
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 public class ConfigurationFactoryFactoryTest {
-        
+
     private final ConfigurationFactoryFactory<Example> factoryFactory = new DefaultConfigurationFactoryFactory<Example>();
-    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
-    private File validFile;    
-    
+    private final Validator validator = BaseValidator.newValidator();
+    private File validFile;
+
     @Before
     public void setUp() throws Exception {
         this.validFile = new File(Resources.getResource("factory-test-valid.yml").toURI());
     }
-            
+
      @Test
      public void createDefaultFactory() throws Exception {
-         ConfigurationFactory<Example> factory = factoryFactory.create(Example.class, validator, Jackson.newObjectMapper(), "dw");         
+         ConfigurationFactory<Example> factory = factoryFactory.create(Example.class, validator, Jackson.newObjectMapper(), "dw");
          final Example example = factory.build(validFile);
          assertThat(example.getName())
                  .isEqualTo("Coda Hale");

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryTest.java
@@ -7,13 +7,13 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Resources;
 import io.dropwizard.jackson.Jackson;
+import io.dropwizard.validation.BaseValidator;
 import org.assertj.core.data.MapEntry;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
@@ -110,7 +110,7 @@ public class ConfigurationFactoryTest {
         }
     }
 
-    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+    private final Validator validator = BaseValidator.newValidator();
     private final ConfigurationFactory<Example> factory =
             new ConfigurationFactory<>(Example.class, validator, Jackson.newObjectMapper(), "dw");
     private File malformedFile;

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationValidationExceptionTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationValidationExceptionTest.java
@@ -1,10 +1,10 @@
 package io.dropwizard.configuration;
 
+import io.dropwizard.validation.BaseValidator;
 import org.junit.Before;
 import org.junit.Test;
 
 import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.constraints.NotNull;
 import java.util.Locale;
@@ -26,7 +26,7 @@ public class ConfigurationValidationExceptionTest {
     public void setUp() throws Exception {
         assumeThat(Locale.getDefault().getLanguage(), is("en"));
 
-        final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        final Validator validator = BaseValidator.newValidator();
         final Set<ConstraintViolation<Example>> violations = validator.validate(new Example());
         this.e = new ConfigurationValidationException("config.yml", violations);
     }

--- a/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
@@ -17,6 +17,7 @@ import io.dropwizard.logging.ConsoleAppenderFactory;
 import io.dropwizard.logging.FileAppenderFactory;
 import io.dropwizard.logging.SyslogAppenderFactory;
 import io.dropwizard.setup.Environment;
+import io.dropwizard.validation.BaseValidator;
 import org.eclipse.jetty.server.AbstractNetworkConnector;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.NetworkConnector;
@@ -24,7 +25,6 @@ import org.eclipse.jetty.server.Server;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -34,6 +34,7 @@ import java.io.File;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -41,7 +42,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -57,8 +57,7 @@ public class DefaultServerFactoryTest {
                                                            HttpConnectorFactory.class);
 
         this.http = new ConfigurationFactory<>(DefaultServerFactory.class,
-                                               Validation.buildDefaultValidatorFactory()
-                                                                 .getValidator(),
+                                               BaseValidator.newValidator(),
                                                objectMapper, "dw")
                 .build(new File(Resources.getResource("yaml/server.yml").toURI()));
     }
@@ -140,7 +139,7 @@ public class DefaultServerFactoryTest {
 
         final ScheduledExecutorService executor = Executors.newScheduledThreadPool(3);
         final Server server = http.build(environment);
-        
+
         ((AbstractNetworkConnector)server.getConnectors()[0]).setPort(0);
 
         ScheduledFuture<Void> cleanup = executor.schedule(new Callable<Void>() {

--- a/dropwizard-core/src/test/java/io/dropwizard/server/SimpleServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/SimpleServerFactoryTest.java
@@ -17,6 +17,7 @@ import io.dropwizard.logging.FileAppenderFactory;
 import io.dropwizard.logging.SyslogAppenderFactory;
 import io.dropwizard.servlets.tasks.Task;
 import io.dropwizard.setup.Environment;
+import io.dropwizard.validation.BaseValidator;
 import org.eclipse.jetty.server.AbstractNetworkConnector;
 import org.eclipse.jetty.server.Server;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -24,7 +25,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -44,7 +44,7 @@ public class SimpleServerFactoryTest {
 
     private SimpleServerFactory http;
     private final ObjectMapper objectMapper = Jackson.newObjectMapper();
-    private Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+    private Validator validator = BaseValidator.newValidator();
 
     @Before
     public void setUp() throws Exception {

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/Validators.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/Validators.java
@@ -1,11 +1,9 @@
 package io.dropwizard.jersey.validation;
 
-import io.dropwizard.validation.valuehandling.OptionalValidatedValueUnwrapper;
-import org.hibernate.validator.HibernateValidator;
+import io.dropwizard.validation.BaseValidator;
 import org.hibernate.validator.HibernateValidatorConfiguration;
 import org.hibernate.validator.spi.valuehandling.ValidatedValueUnwrapper;
 
-import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 
@@ -34,10 +32,7 @@ public class Validators {
      * ValidatedValueUnwrapper} registered.
      */
     public static HibernateValidatorConfiguration newConfiguration() {
-        return Validation
-                .byProvider(HibernateValidator.class)
-                .configure()
-                .addValidatedValueHandler(new OptionalValidatedValueUnwrapper())
+        return BaseValidator.newConfiguration()
                 .addValidatedValueHandler(new NonEmptyStringParamUnwrapper())
                 .addValidatedValueHandler(new ParamValidatorUnwrapper());
     }

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/GzipFilterFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/GzipFilterFactoryTest.java
@@ -5,10 +5,10 @@ import com.google.common.io.Resources;
 import io.dropwizard.configuration.ConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.util.Size;
+import io.dropwizard.validation.BaseValidator;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.validation.Validation;
 import java.io.File;
 import java.util.regex.Pattern;
 import java.util.zip.Deflater;
@@ -21,8 +21,7 @@ public class GzipFilterFactoryTest {
     @Before
     public void setUp() throws Exception {
         this.gzip = new ConfigurationFactory<>(GzipFilterFactory.class,
-                Validation.buildDefaultValidatorFactory()
-                        .getValidator(),
+                BaseValidator.newValidator(),
                 Jackson.newObjectMapper(), "dw")
                 .build(new File(Resources.getResource("yaml/gzip.yml").toURI()));
     }

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
@@ -12,6 +12,7 @@ import io.dropwizard.logging.FileAppenderFactory;
 import io.dropwizard.logging.SyslogAppenderFactory;
 import io.dropwizard.util.Duration;
 import io.dropwizard.util.Size;
+import io.dropwizard.validation.BaseValidator;
 import org.eclipse.jetty.io.ArrayByteBufferPool;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.server.*;
@@ -21,7 +22,6 @@ import org.eclipse.jetty.util.thread.ThreadPool;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.validation.Validation;
 import javax.validation.Validator;
 import java.io.File;
 
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class HttpConnectorFactoryTest {
 
     private final ObjectMapper objectMapper = Jackson.newObjectMapper();
-    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+    private final Validator validator = BaseValidator.newValidator();
 
     @Before
     public void setUp() throws Exception {

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
@@ -9,9 +9,9 @@ import java.util.List;
 import java.util.Set;
 
 import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
 import javax.validation.Validator;
 
+import io.dropwizard.validation.BaseValidator;
 import org.apache.commons.lang3.SystemUtils;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.Test;
@@ -27,7 +27,7 @@ import static org.junit.Assume.assumeTrue;
 
 public class HttpsConnectorFactoryTest {
     private static final String WINDOWS_MY_KEYSTORE_NAME = "Windows-MY";
-    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+    private final Validator validator = BaseValidator.newValidator();
 
     @Test
     public void isDiscoverable() throws Exception {

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/RequestLogFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/RequestLogFactoryTest.java
@@ -7,10 +7,10 @@ import io.dropwizard.jackson.Jackson;
 import io.dropwizard.logging.ConsoleAppenderFactory;
 import io.dropwizard.logging.FileAppenderFactory;
 import io.dropwizard.logging.SyslogAppenderFactory;
+import io.dropwizard.validation.BaseValidator;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.validation.Validation;
 import java.io.File;
 import java.util.TimeZone;
 
@@ -26,8 +26,7 @@ public class RequestLogFactoryTest {
                                                            FileAppenderFactory.class,
                                                            SyslogAppenderFactory.class);
         this.requestLog = new ConfigurationFactory<>(RequestLogFactory.class,
-                                                     Validation.buildDefaultValidatorFactory()
-                                                                       .getValidator(),
+                                                     BaseValidator.newValidator(),
                                                      objectMapper, "dw")
                 .build(new File(Resources.getResource("yaml/requestLog.yml").toURI()));
     }

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/DefaultLoggingFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/DefaultLoggingFactoryTest.java
@@ -13,6 +13,7 @@ import io.dropwizard.configuration.ConfigurationFactory;
 import io.dropwizard.configuration.FileConfigurationSourceProvider;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.jackson.Jackson;
+import io.dropwizard.validation.BaseValidator;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.text.StrSubstitutor;
 import org.assertj.core.data.MapEntry;
@@ -22,7 +23,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.LoggerFactory;
 
-import javax.validation.Validation;
 import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,7 +31,7 @@ public class DefaultLoggingFactoryTest {
     private final ObjectMapper objectMapper = Jackson.newObjectMapper();
     private final ConfigurationFactory<DefaultLoggingFactory> factory = new ConfigurationFactory<>(
             DefaultLoggingFactory.class,
-            Validation.buildDefaultValidatorFactory().getValidator(),
+            BaseValidator.newValidator(),
             objectMapper, "dw");
 
     private DefaultLoggingFactory config;

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
@@ -12,13 +12,13 @@ import ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP;
 import ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
 import io.dropwizard.util.Size;
+import io.dropwizard.validation.BaseValidator;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.LoggerFactory;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.validation.ConstraintViolations;
-import javax.validation.Validation;
 import javax.validation.Validator;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,7 +29,7 @@ public class FileAppenderFactoryTest {
         BootstrapLogging.bootstrap();
     }
 
-    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+    private final Validator validator = BaseValidator.newValidator();
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/CsvReporterFactoryTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/CsvReporterFactoryTest.java
@@ -7,10 +7,10 @@ import io.dropwizard.configuration.ConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
+import io.dropwizard.validation.BaseValidator;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.validation.Validation;
 import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -19,7 +19,7 @@ public class CsvReporterFactoryTest {
     private final ObjectMapper objectMapper = Jackson.newObjectMapper();
     private final ConfigurationFactory<MetricsFactory> factory =
             new ConfigurationFactory<>(MetricsFactory.class,
-                                       Validation.buildDefaultValidatorFactory().getValidator(),
+                                       BaseValidator.newValidator(),
                                        objectMapper, "dw");
 
     @Before

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/MetricsFactoryTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/MetricsFactoryTest.java
@@ -6,6 +6,7 @@ import io.dropwizard.configuration.ConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.logging.BootstrapLogging;
 import io.dropwizard.util.Duration;
+import io.dropwizard.validation.BaseValidator;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -22,7 +23,7 @@ public class MetricsFactoryTest {
     private final ObjectMapper objectMapper = Jackson.newObjectMapper();
     private final ConfigurationFactory<MetricsFactory> factory =
             new ConfigurationFactory<>(MetricsFactory.class,
-                                       Validation.buildDefaultValidatorFactory().getValidator(),
+                                       BaseValidator.newValidator(),
                                        objectMapper, "dw");
     private MetricsFactory config;
 

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/BaseValidator.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/BaseValidator.java
@@ -1,0 +1,31 @@
+package io.dropwizard.validation;
+
+import io.dropwizard.validation.valuehandling.OptionalValidatedValueUnwrapper;
+import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.HibernateValidatorConfiguration;
+import org.hibernate.validator.spi.valuehandling.ValidatedValueUnwrapper;
+
+import javax.validation.Validation;
+import javax.validation.Validator;
+
+public class BaseValidator {
+    private BaseValidator() { /* singleton */ }
+
+    /**
+     * Creates a new {@link Validator} based on {@link #newConfiguration()}
+     */
+    public static Validator newValidator() {
+        return newConfiguration().buildValidatorFactory().getValidator();
+    }
+
+    /**
+     * Creates a new {@link HibernateValidatorConfiguration} with the base custom {@link
+     * ValidatedValueUnwrapper} registered.
+     */
+    public static HibernateValidatorConfiguration newConfiguration() {
+        return Validation
+            .byProvider(HibernateValidator.class)
+            .configure()
+            .addValidatedValueHandler(new OptionalValidatedValueUnwrapper());
+    }
+}

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/ConstraintViolationsTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/ConstraintViolationsTest.java
@@ -4,7 +4,6 @@ import org.junit.Test;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Valid;
-import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
@@ -17,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SuppressWarnings({"UnusedDeclaration"})
 public class ConstraintViolationsTest {
 
-    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+    private final Validator validator = BaseValidator.newValidator();
     private final ExecutableValidator execValidator = validator.forExecutables();
 
     @Max(3)

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/DurationValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/DurationValidatorTest.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableList;
 import io.dropwizard.util.Duration;
 import org.junit.Test;
 
-import javax.validation.Validation;
 import javax.validation.Validator;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
@@ -34,7 +33,7 @@ public class DurationValidatorTest {
         }
     }
 
-    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+    private final Validator validator = BaseValidator.newValidator();
 
     @Test
     public void returnsASetOfErrorsForAnObject() throws Exception {

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/MethodValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/MethodValidatorTest.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 
 import javax.validation.Valid;
-import javax.validation.Validation;
 import javax.validation.Validator;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,7 +32,7 @@ public class MethodValidatorTest {
         }
     }
 
-    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+    private final Validator validator = BaseValidator.newValidator();
 
     @Test
     public void complainsAboutMethodsWhichReturnFalse() throws Exception {

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/OneOfValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/OneOfValidatorTest.java
@@ -2,7 +2,6 @@ package io.dropwizard.validation;
 
 import org.junit.Test;
 
-import javax.validation.Validation;
 import javax.validation.Validator;
 import java.util.Locale;
 
@@ -23,7 +22,7 @@ public class OneOfValidatorTest {
         private String whitespaceInsensitive = "one";
     }
 
-    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+    private final Validator validator = BaseValidator.newValidator();
 
     @Test
     public void allowsExactElements() throws Exception {

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/PortRangeValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/PortRangeValidatorTest.java
@@ -3,7 +3,6 @@ package io.dropwizard.validation;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.validation.Validation;
 import javax.validation.Validator;
 import java.util.Locale;
 
@@ -22,7 +21,7 @@ public class PortRangeValidatorTest {
     }
 
 
-    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+    private final Validator validator = BaseValidator.newValidator();
     private final Example example = new Example();
 
     @Before

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/SizeValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/SizeValidatorTest.java
@@ -4,7 +4,6 @@ import io.dropwizard.util.Size;
 import io.dropwizard.util.SizeUnit;
 import org.junit.Test;
 
-import javax.validation.Validation;
 import javax.validation.Validator;
 import java.util.Locale;
 
@@ -33,7 +32,7 @@ public class SizeValidatorTest {
         }
     }
 
-    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+    private final Validator validator = BaseValidator.newValidator();
 
     @Test
     public void returnsASetOfErrorsForAnObject() throws Exception {


### PR DESCRIPTION
Use a minimally configured Hibernate Validator everywhere, instead of the
default unconfigured Hibernate Validator that doesn't have Optional support
enabled.

Good news, no other part of the code was affected by the behavior seen in #1309. So this pull request is more preventive than anything.

I do wonder if there is a better implementation out there (I'd rather not expose `BaseValidator` to the world, but it's the best I came up with). Let me know if a better implementation exists :wink: