### PR TITLE
Deprecate PooledDataSourceFactory#getHealthCheckValidation{Query,Timeout}

### DIFF
--- a/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
+++ b/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
@@ -461,14 +461,17 @@ public class DataSourceFactory implements PooledDataSourceFactory {
         this.maxWaitForConnection = maxWaitForConnection;
     }
 
+    @Override
     @JsonProperty
     public String getValidationQuery() {
         return validationQuery;
     }
 
     @Override
+    @Deprecated
+    @JsonIgnore
     public String getHealthCheckValidationQuery() {
-        return validationQuery;
+        return getValidationQuery();
     }
 
     @JsonProperty
@@ -726,6 +729,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
         this.validationInterval = validationInterval;
     }
 
+    @Override
     @JsonProperty
     public Optional<Duration> getValidationQueryTimeout() {
         return Optional.fromNullable(validationQueryTimeout);
@@ -742,8 +746,10 @@ public class DataSourceFactory implements PooledDataSourceFactory {
     }
 
     @Override
+    @Deprecated
+    @JsonIgnore
     public Optional<Duration> getHealthCheckValidationTimeout() {
-        return Optional.fromNullable(validationQueryTimeout);
+        return getValidationQueryTimeout();
     }
 
     @JsonProperty

--- a/dropwizard-db/src/main/java/io/dropwizard/db/PooledDataSourceFactory.java
+++ b/dropwizard-db/src/main/java/io/dropwizard/db/PooledDataSourceFactory.java
@@ -32,6 +32,16 @@ public interface PooledDataSourceFactory {
      *
      * @return the timeout as {@code Duration}
      */
+    Optional<Duration> getValidationQueryTimeout();
+
+    /**
+     * Returns the timeout for awaiting a response from the database
+     * during connection health checks.
+     *
+     * @return the timeout as {@code Duration}
+     * @deprecated Use {@link #getValidationQueryTimeout()}
+     */
+    @Deprecated
     Optional<Duration> getHealthCheckValidationTimeout();
 
     /**
@@ -40,6 +50,16 @@ public interface PooledDataSourceFactory {
      *
      * @return the SQL query as a string
      */
+    String getValidationQuery();
+
+    /**
+     * Returns the SQL query, which is being used for the database
+     * connection health check.
+     *
+     * @return the SQL query as a string
+     * @deprecated Use {@link #getValidationQuery()}
+     */
+    @Deprecated
     String getHealthCheckValidationQuery();
 
     /**

--- a/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceFactoryTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceFactoryTest.java
@@ -2,8 +2,11 @@ package io.dropwizard.db;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Optional;
+import io.dropwizard.configuration.ConfigurationFactory;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
+import io.dropwizard.jackson.Jackson;
 import io.dropwizard.util.Duration;
-import org.apache.tomcat.jdbc.pool.Validator;
+import io.dropwizard.validation.BaseValidator;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -95,5 +98,19 @@ public class DataSourceFactoryTest {
             }
         }
         assertThat(CustomConnectionValidator.loaded).isTrue();
+    }
+
+    @Test
+    public void createDefaultFactory() throws Exception {
+        final DataSourceFactory factory = new ConfigurationFactory<>(DataSourceFactory.class,
+            BaseValidator.newValidator(), Jackson.newObjectMapper(), "dw")
+            .build(new ResourceConfigurationSourceProvider(), "yaml/minimal_db_pool.yml");
+
+        assertThat(factory.getDriverClass()).isEqualTo("org.postgresql.Driver");
+        assertThat(factory.getUser()).isEqualTo("pg-user");
+        assertThat(factory.getPassword()).isEqualTo("iAMs00perSecrEET");
+        assertThat(factory.getUrl()).isEqualTo("jdbc:postgresql://db.example.com/db-prod");
+        assertThat(factory.getValidationQuery()).isEqualTo("/* Health Check */ SELECT 1");
+        assertThat(factory.getValidationQueryTimeout()).isEqualTo(Optional.absent());
     }
 }

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/HibernateBundle.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/HibernateBundle.java
@@ -58,9 +58,9 @@ public abstract class HibernateBundle<T extends Configuration> implements Config
         environment.healthChecks().register(name(),
                                             new SessionFactoryHealthCheck(
                                                     environment.getHealthCheckExecutorService(),
-                                                    dbConfig.getHealthCheckValidationTimeout().or(Duration.seconds(5)),
+                                                    dbConfig.getValidationQueryTimeout().or(Duration.seconds(5)),
                                                     sessionFactory,
-                                                    dbConfig.getHealthCheckValidationQuery()));
+                                                    dbConfig.getValidationQuery()));
     }
 
     private UnitOfWorkApplicationListener registerUnitOfWorkListerIfAbsent(Environment environment) {

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/DBIFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/DBIFactory.java
@@ -73,12 +73,12 @@ public class DBIFactory {
                      PooledDataSourceFactory configuration,
                      ManagedDataSource dataSource,
                      String name) {
-        final String validationQuery = configuration.getHealthCheckValidationQuery();
+        final String validationQuery = configuration.getValidationQuery();
         final DBI dbi = new DBI(dataSource);
         environment.lifecycle().manage(dataSource);
         environment.healthChecks().register(name, new DBIHealthCheck(
                 environment.getHealthCheckExecutorService(),
-                configuration.getHealthCheckValidationTimeout().or(Duration.seconds(5)),
+                configuration.getValidationQueryTimeout().or(Duration.seconds(5)),
                 dbi,
                 validationQuery));
         dbi.setSQLLog(new LogbackLog(LOGGER, Level.TRACE));


### PR DESCRIPTION
The `PooledDataSourceFactory#getHealthCheckValidation{Query,Timeout}` methods were introduced while refactoring `DataSourceFactory` to allow custom DB connection pools (PR #1030) but broke the serialization of the default configuration for `DataSourceFactory`.

By deprecating these methods and pulling the original `DataSourceFactory#getValidation{Query,Timeout}` methods into `PooledDataSourceFactory`, the
original behaviour was restored.

Fixes #1321, refs #1030