### PR TITLE
Guava Optional<T>: Treat null values after conversion as absent value.

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/guava/OptionalParamConverterProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/guava/OptionalParamConverterProvider.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey.guava;
 
-import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.jersey.internal.inject.Providers;
@@ -55,13 +54,8 @@ public class OptionalParamConverterProvider implements ParamConverterProvider {
                     return new ParamConverter<T>() {
                         @Override
                         public T fromString(final String value) {
-                            return rawType.cast(Optional.fromNullable(value)
-                                    .transform(new Function<String, Object>() {
-                                        @Override
-                                        public Object apply(final String s) {
-                                            return converter.fromString(value);
-                                        }
-                                    }));
+                            final Object convertedValue = value == null ? null : converter.fromString(value);
+                            return rawType.cast(Optional.fromNullable(convertedValue));
                         }
 
                         @Override

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalQueryParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalQueryParamResourceTest.java
@@ -92,6 +92,25 @@ public class OptionalQueryParamResourceTest extends JerseyTest {
         assertThat(response).isEqualTo(uuid);
     }
 
+    @Test
+    public void shouldReturnDefaultValueWhenValueIsAbsent() {
+        String response = target("/optional/value").request().get(String.class);
+        assertThat(response).isEqualTo("42");
+    }
+
+    @Test
+    public void shouldReturnDefaultValueWhenEmptyValueIsGiven() {
+        String response = target("/optional/value").queryParam("value", "").request().get(String.class);
+        assertThat(response).isEqualTo("42");
+    }
+
+    @Test
+    public void shouldReturnValueWhenValueIsPresent() {
+        String value = "123456";
+        String response = target("/optional/value").queryParam("value", value).request().get(String.class);
+        assertThat(response).isEqualTo(value);
+    }
+
     @Path("/optional")
     public static class OptionalQueryParamResource {
 
@@ -111,6 +130,12 @@ public class OptionalQueryParamResourceTest extends JerseyTest {
         @Path("/uuid")
         public String getUUID(@QueryParam("uuid") Optional<UUIDParam> uuid) {
             return uuid.or(new UUIDParam("d5672fa8-326b-40f6-bf71-d9dacf44bcdc")).get().toString();
+        }
+
+        @GET
+        @Path("/value")
+        public String getValue(@QueryParam("value") Optional<Integer> value) {
+            return value.or(42).toString();
         }
     }
 }


### PR DESCRIPTION
Some converters return a null value (e.g. in case of empty input).