### PR TITLE
Make HealthCheck ExecutorService configurable in the yml-file

### DIFF
--- a/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheck;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
+import io.dropwizard.health.ManagedExecutorServiceFactory;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.setup.Environment;
@@ -68,7 +69,8 @@ public class DropwizardApacheConnectorTest {
 
         environment = new Environment("test-dropwizard-apache-connector", Jackson.newObjectMapper(),
                 Validators.newValidator(), new MetricRegistry(),
-                getClass().getClassLoader());
+                getClass().getClassLoader(),
+                new ManagedExecutorServiceFactory("Only-Testing-HealthCheck-pool-%d"));
         client = (JerseyClient) new JerseyClientBuilder(environment)
                 .using(clientConfiguration)
                 .build("test");

--- a/dropwizard-core/src/main/java/io/dropwizard/Configuration.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/Configuration.java
@@ -2,6 +2,7 @@ package io.dropwizard;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
+import io.dropwizard.health.HealthFactory;
 import io.dropwizard.logging.DefaultLoggingFactory;
 import io.dropwizard.logging.LoggingFactory;
 import io.dropwizard.metrics.MetricsFactory;
@@ -72,6 +73,10 @@ public class Configuration {
     @NotNull
     private MetricsFactory metrics = new MetricsFactory();
 
+    @Valid
+    @NotNull
+    private HealthFactory health = new HealthFactory();
+
     /**
      * Returns the server-specific section of the configuration file.
      *
@@ -116,6 +121,16 @@ public class Configuration {
     @JsonProperty("metrics")
     public void setMetricsFactory(MetricsFactory metrics) {
         this.metrics = metrics;
+    }
+
+    @JsonProperty("health")
+    public HealthFactory getHealth() {
+        return health;
+    }
+
+    @JsonProperty("health")
+    public void setHealth(HealthFactory health) {
+        this.health = health;
     }
 
     @Override

--- a/dropwizard-core/src/main/java/io/dropwizard/cli/EnvironmentCommand.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/EnvironmentCommand.java
@@ -33,7 +33,8 @@ public abstract class EnvironmentCommand<T extends Configuration> extends Config
                                                         bootstrap.getObjectMapper(),
                                                         bootstrap.getValidatorFactory().getValidator(),
                                                         bootstrap.getMetricRegistry(),
-                                                        bootstrap.getClassLoader());
+                                                        bootstrap.getClassLoader(),
+                                                        configuration.getHealth().getExecutorService());
         configuration.getMetricsFactory().configure(environment.lifecycle(),
                                                     bootstrap.getMetricRegistry());
         bootstrap.run(configuration, environment);

--- a/dropwizard-core/src/main/java/io/dropwizard/health/ExecutorServiceFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/health/ExecutorServiceFactory.java
@@ -1,0 +1,25 @@
+package io.dropwizard.health;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.dropwizard.jackson.Discoverable;
+import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
+import io.dropwizard.setup.Environment;
+import org.eclipse.jetty.util.component.LifeCycle;
+
+import java.util.concurrent.ExecutorService;
+
+/**
+ * A factory for building {@link java.util.concurrent.ExecutorService} instances for Dropwizard applications.
+ *
+ * @see io.dropwizard.health.ManagedExecutorServiceFactory
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = ManagedExecutorServiceFactory.class)
+public interface ExecutorServiceFactory extends Discoverable{
+  /**
+   * Build an executorService for the given Dropwizard application.
+   *
+   * @param environment the application's environment
+   * @return a {@link java.util.concurrent.ExecutorService} running used by the Dropwizard application
+   */
+  ExecutorService build(LifecycleEnvironment environment);
+}

--- a/dropwizard-core/src/main/java/io/dropwizard/health/HealthFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/health/HealthFactory.java
@@ -1,0 +1,24 @@
+package io.dropwizard.health;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.server.DefaultServerFactory;
+import io.dropwizard.server.ServerFactory;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+public class HealthFactory {
+  @Valid
+  @NotNull
+  private ExecutorServiceFactory executorService = new ManagedExecutorServiceFactory("TimeBoundHealthCheck-pool-%d");
+
+  @JsonProperty("executorService")
+  public ExecutorServiceFactory getExecutorService() {
+    return executorService;
+  }
+
+  @JsonProperty("executorService")
+  public void setExecutorService(ExecutorServiceFactory executorService) {
+    this.executorService = executorService;
+  }
+}

--- a/dropwizard-core/src/main/java/io/dropwizard/health/ManagedExecutorServiceFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/health/ManagedExecutorServiceFactory.java
@@ -1,0 +1,87 @@
+package io.dropwizard.health;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
+import io.dropwizard.setup.Environment;
+import org.hibernate.validator.constraints.NotEmpty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.validation.constraints.Min;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+
+public class ManagedExecutorServiceFactory implements ExecutorServiceFactory {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ManagedExecutorServiceFactory.class);
+
+  public ManagedExecutorServiceFactory() {
+  }
+  public ManagedExecutorServiceFactory(String nameFormat) {
+    this.nameFormat = nameFormat;
+  }
+
+  @NotEmpty
+  private String nameFormat;
+
+  @Min(1)
+  private int workQueueCapacity = 1;
+
+  @Min(2)
+  private int maxThreads = 4;
+
+  @Min(1)
+  private int minThreads = 1;
+
+  @JsonProperty
+  public String getNameFormat() {
+    return nameFormat;
+  }
+
+  @JsonProperty
+  public void setNameFormat(String nameFormat) {
+    this.nameFormat = nameFormat;
+  }
+
+  @JsonProperty
+  public int getWorkQueueCapacity() {
+    return workQueueCapacity;
+  }
+
+  @JsonProperty
+  public void setWorkQueueCapacity(int workQueueCapacity) {
+    this.workQueueCapacity = workQueueCapacity;
+  }
+
+  @JsonProperty
+  public int getMaxThreads() {
+    return maxThreads;
+  }
+
+  @JsonProperty
+  public void setMaxThreads(int maxThreads) {
+    this.maxThreads = maxThreads;
+  }
+
+  @JsonProperty
+  public int getMinThreads() {
+    return minThreads;
+  }
+
+  @JsonProperty
+  public void setMinThreads(int minThreads) {
+    this.minThreads = minThreads;
+  }
+
+  @Override
+  public ExecutorService build(LifecycleEnvironment lifecycle) {
+    return lifecycle.executorService(nameFormat)
+        .workQueue(new ArrayBlockingQueue<Runnable>(workQueueCapacity))
+        .minThreads(minThreads)
+        .maxThreads(maxThreads)
+        .threadFactory(new ThreadFactoryBuilder().setDaemon(true).build())
+        .rejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy())
+        .build();
+  }
+}

--- a/dropwizard-core/src/main/java/io/dropwizard/setup/Environment.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/Environment.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.dropwizard.health.ExecutorServiceFactory;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.setup.JerseyContainerHolder;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
@@ -57,7 +58,8 @@ public class Environment {
                        ObjectMapper objectMapper,
                        Validator validator,
                        MetricRegistry metricRegistry,
-                       ClassLoader classLoader) {
+                       ClassLoader classLoader,
+                       ExecutorServiceFactory executorServiceFactory) {
         this.name = name;
         this.objectMapper = objectMapper;
         this.metricRegistry = metricRegistry;
@@ -79,14 +81,7 @@ public class Environment {
         this.jerseyServletContainer = new JerseyContainerHolder(new JerseyServletContainer(jerseyConfig));
         this.jerseyEnvironment = new JerseyEnvironment(jerseyServletContainer, jerseyConfig);
 
-
-        this.healthCheckExecutorService = this.lifecycle().executorService("TimeBoundHealthCheck-pool-%d")
-                .workQueue(new ArrayBlockingQueue<Runnable>(1))
-                .minThreads(1)
-                .maxThreads(4)
-                .threadFactory(new ThreadFactoryBuilder().setDaemon(true).build())
-                .rejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy())
-                .build();
+        this.healthCheckExecutorService = executorServiceFactory.build(this.lifecycleEnvironment);
     }
 
     /**

--- a/dropwizard-core/src/main/java/io/dropwizard/setup/HealthEnvironment.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/HealthEnvironment.java
@@ -1,0 +1,4 @@
+package io.dropwizard.setup;
+
+public class HealthEnvironment {
+}

--- a/dropwizard-core/src/main/resources/META-INF/services/io.dropwizard.health.ExecutorServiceFactory
+++ b/dropwizard-core/src/main/resources/META-INF/services/io.dropwizard.health.ExecutorServiceFactory
@@ -1,0 +1,1 @@
+io.dropwizard.health.ManagedExecutorServiceFactory

--- a/dropwizard-core/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
+++ b/dropwizard-core/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
@@ -1,1 +1,2 @@
 io.dropwizard.server.ServerFactory
+io.dropwizard.health.ExecutorServiceFactory

--- a/dropwizard-core/src/test/java/io/dropwizard/health/HealthFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/health/HealthFactoryTest.java
@@ -1,0 +1,93 @@
+package io.dropwizard.health;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.Resources;
+import io.dropwizard.configuration.ConfigurationFactory;
+import io.dropwizard.jackson.DiscoverableSubtypeResolver;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
+import io.dropwizard.logging.ConsoleAppenderFactory;
+import io.dropwizard.logging.FileAppenderFactory;
+import io.dropwizard.logging.SyslogAppenderFactory;
+import io.dropwizard.validation.BaseValidator;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.validation.Validator;
+import java.io.File;
+import java.util.Iterator;
+import java.util.concurrent.ExecutorService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HealthFactoryTest {
+  private HealthFactory health;
+  private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+  private final Validator validator = BaseValidator.newValidator();
+
+  @Before
+  public void setUp() throws Exception {
+    objectMapper.getSubtypeResolver().registerSubtypes(ConsoleAppenderFactory.class,
+        FileAppenderFactory.class, SyslogAppenderFactory.class, ExecutorServiceFactory.class);
+    File ymlFile = new File(Resources.getResource("yaml/health.yml").toURI());
+    health = new ConfigurationFactory<>(HealthFactory.class, validator, objectMapper, "dw")
+        .build(ymlFile);
+  }
+
+  @Test
+  public void isDiscoverable() throws Exception {
+    assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
+        .contains(ManagedExecutorServiceFactory.class);
+  }
+
+  @Test
+  public void testExecutorServiceNameFormat() {
+    assertThat(getManagedExecutorService().getNameFormat()).isEqualTo("for-testing-pool-%d");
+  }
+
+  @Test
+  public void testExecutorServiceWorkQueueCapacity() {
+    assertThat(getManagedExecutorService().getWorkQueueCapacity()).isEqualTo(2);
+  }
+
+  @Test
+  public void testExecutorServiceMinThreads() {
+    assertThat(getManagedExecutorService().getMinThreads()).isEqualTo(3);
+  }
+
+  @Test
+  public void testExecutorServiceMaxThreads() {
+    assertThat(getManagedExecutorService().getMaxThreads()).isEqualTo(6);
+  }
+
+  @Test
+  public void testExecutorServiceBuild() throws Exception {
+    LifecycleEnvironment lifecycle = new LifecycleEnvironment();
+    ExecutorService executorService = health.getExecutorService().build(lifecycle);
+    try {
+      assertThat(executorService.isShutdown()).isFalse();
+      assertThat(executorService.isTerminated()).isFalse();
+      assertThat(lifecycle.getManagedObjects().isEmpty()).isFalse();
+      Iterator<LifeCycle> managedObjectsIterator = lifecycle.getManagedObjects().iterator();
+      while (managedObjectsIterator.hasNext()) {
+        managedObjectsIterator.next().start();
+      }
+      managedObjectsIterator = lifecycle.getManagedObjects().iterator();
+      while (managedObjectsIterator.hasNext()) {
+        managedObjectsIterator.next().stop();
+      }
+      assertThat(executorService.isShutdown()).isTrue();
+      assertThat(executorService.isTerminated()).isTrue();
+    } finally {
+      if (!executorService.isShutdown()) {
+        executorService.shutdown();
+      }
+    }
+  }
+
+  private ManagedExecutorServiceFactory getManagedExecutorService() {
+    assertThat(health.getExecutorService() instanceof ManagedExecutorServiceFactory);
+    return (ManagedExecutorServiceFactory)health.getExecutorService();
+  }
+}

--- a/dropwizard-core/src/test/resources/yaml/health.yml
+++ b/dropwizard-core/src/test/resources/yaml/health.yml
@@ -1,0 +1,5 @@
+executorService:
+  nameFormat: "for-testing-pool-%d"
+  workQueueCapacity: 2
+  minThreads: 3
+  maxThreads: 6

--- a/dropwizard-forms/src/test/java/io/dropwizard/forms/MultiPartBundleTest.java
+++ b/dropwizard-forms/src/test/java/io/dropwizard/forms/MultiPartBundleTest.java
@@ -1,6 +1,7 @@
 package io.dropwizard.forms;
 
 import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.health.ManagedExecutorServiceFactory;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.setup.Environment;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
@@ -17,7 +18,8 @@ public class MultiPartBundleTest {
                 Jackson.newObjectMapper(),
                 null,
                 new MetricRegistry(),
-                getClass().getClassLoader()
+                getClass().getClassLoader(),
+                new ManagedExecutorServiceFactory("Testing-HealthCheck-pool-%d")
         );
 
         new MultiPartBundle().run(environment);

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/DBIClient.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/DBIClient.java
@@ -3,6 +3,7 @@ package io.dropwizard.jdbi.timestamps;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Optional;
 import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.health.ManagedExecutorServiceFactory;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jdbi.DBIFactory;
 import io.dropwizard.jersey.validation.Validators;
@@ -36,7 +37,7 @@ public class DBIClient extends ExternalResource {
     protected void before() throws Throwable {
         final Environment environment = new Environment("test", Jackson.newObjectMapper(),
                 Validators.newValidator(), new MetricRegistry(),
-                getClass().getClassLoader());
+                getClass().getClassLoader(), new ManagedExecutorServiceFactory("Testing-HealthCheck-pool-%d"));
 
         final DataSourceFactory dataSourceFactory = new DataSourceFactory();
         dataSourceFactory.setDriverClass("org.h2.Driver");

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/JDBIOptionalDateTimeTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/JDBIOptionalDateTimeTest.java
@@ -3,6 +3,7 @@ package io.dropwizard.jdbi.timestamps;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Optional;
 import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.health.ManagedExecutorServiceFactory;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jdbi.DBIFactory;
 import io.dropwizard.jersey.validation.Validators;
@@ -26,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JDBIOptionalDateTimeTest {
 
     private final Environment env = new Environment("test-optional-date-time", Jackson.newObjectMapper(),
-            Validators.newValidator(), new MetricRegistry(), null);
+            Validators.newValidator(), new MetricRegistry(), null, new ManagedExecutorServiceFactory("Testing-HealthCheck-pool-%d"));
 
 
     private TaskDao dao;


### PR DESCRIPTION
Currently the threadpool used by the HealthChecks executorservice is hardcoded.
Perhaps it is useful to make it configurable from the yml-file.

Please provide feedback ...
