### PR TITLE
Removed ancient TODOs from the code

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/cli/Cli.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/Cli.java
@@ -72,12 +72,10 @@ public class Cli {
             }
             return true;
         } catch (ArgumentParserException e) {
-            // TODO: 5/25/13 <coda> -- make ArgumentParser#handleError not depend on System.err
             stdErr.println(e.getMessage());
             e.getParser().printHelp(stdErr);
             return false;
         } catch (ConfigurationException e) {
-            // TODO: 7/26/13 <ntelford> -- as above, this probably shouldn't depend on System.err
             stdErr.println(e.getMessage());
             return false;
         }

--- a/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
@@ -56,8 +56,6 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.regex.Pattern;
 
-// TODO: 5/15/13 <coda> -- add tests for AbstractServerFactory
-
 /**
  * A base class for {@link ServerFactory} implementations.
  * <p/>

--- a/dropwizard-core/src/main/java/io/dropwizard/server/DefaultServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/DefaultServerFactory.java
@@ -26,8 +26,6 @@ import javax.validation.constraints.NotNull;
 import java.util.List;
 import java.util.Map;
 
-// TODO: 5/15/13 <coda> -- add tests for DefaultServerFactory
-
 /**
  * The default implementation of {@link ServerFactory}, which allows for multiple sets of
  * application and admin connectors, all running on separate ports. Admin connectors use a separate

--- a/dropwizard-core/src/main/java/io/dropwizard/setup/Environment.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/Environment.java
@@ -21,8 +21,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-// TODO: 5/15/13 <coda> -- add tests for Environment
-
 /**
  * A Dropwizard application's environment.
  */
@@ -169,8 +167,6 @@ public class Environment {
     /*
     * Internal Accessors
     */
-
-    // TODO: 5/4/13 <coda> -- figure out how to make these accessors not a public API
 
     public MutableServletContextHandler getApplicationContext() {
         return servletContext;

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
@@ -31,8 +31,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static com.codahale.metrics.MetricRegistry.name;
-
 /**
  * Builds HTTPS connectors (HTTP over TLS/SSL).
  * <p/>
@@ -678,12 +676,6 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
 
         factory.setRenegotiationAllowed(allowRenegotiation);
         factory.setEndpointIdentificationAlgorithm(endpointIdentificationAlgorithm);
-
-        // TODO: 6/20/13 <coda> -- figure out SSL session caching
-        // This doesn't seem to be hooked up to anything yet in Jetty.
-        // factory.setSessionCachingEnabled(false);
-        // factory.setSslSessionCacheSize(10);
-        // factory.setSslSessionTimeout(10);
 
         factory.setValidateCerts(validateCerts);
         factory.setValidatePeerCerts(validatePeers);


### PR DESCRIPTION
The beginning of going to a 1.0 Version is maybe a good timing to get rid of ancient list of TODOs. Important stuff pops up every day, no need to keep TODOs from two years ago.