### PR TITLE
docs: Explain HTTP based log level configuration

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -804,6 +804,19 @@ appender with different configurations:
           archivedLogFilenamePattern: ./logs/debug-%d{yyyy-MM-dd-hh}.log.gz
           archivedFileCount: 6
 
+.. _man-core-logging-http-config:
+
+Logging Configuration via HTTP
+------------------------------
+
+Active log levels can be changed during the runtime of a Dropwizard application via HTTP using
+the ``LogConfigurationTask``. For instance, to configure the log level for a
+single ``Logger``:
+
+.. code-block:: shell
+
+    curl -X POST -d "logger=com.example.helloworld&level=INFO" http://localhost:8081/tasks/log-level
+
 .. _man-core-testing-applications:
 
 Testing Applications


### PR DESCRIPTION
Dropwizard contains the task `LogConfigurationTask` and adds it by
default to the [admin environment](https://github.com/dropwizard/dropwizard/blob/49ff92712a936554d2cf9bd7a2b09a0fc07eaf25/dropwizard-core/src/main/java/io/dropwizard/setup/AdminEnvironment.java#L42). Unfortunately this task is not
yet documented.
