### PR TITLE
fix typo in document comments

### DIFF
--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/LoggingUtil.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/LoggingUtil.java
@@ -55,7 +55,7 @@ public class LoggingUtil {
 
     /**
      * Gets the root j.u.l.Logger and removes all registered handlers
-     * then redirects all active j.u.l. to SL4J
+     * then redirects all active j.u.l. to SLF4J
      * <p/>
      * N.B. This should only happen once, hence the flag and locking
      */


### PR DESCRIPTION
Missing a single letter in the document comments

SL4J -> SLF4J