### PR TITLE
Entities that can't be serialized now return a 500

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapper.java
@@ -2,6 +2,8 @@ package io.dropwizard.jersey.jackson;
 
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import io.dropwizard.jersey.errors.ErrorMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,11 +39,12 @@ public class JsonProcessingExceptionMapper implements ExceptionMapper<JsonProces
         final String message = exception.getOriginalMessage();
 
         /*
-         * If we can't deserialize the JSON because someone forgot a no-arg constructor, it's a
-         * server error and we should inform the developer.
+         * If we can't deserialize the JSON because someone forgot a no-arg
+         * constructor, or it is not known how to serialize the type it's
+         * a server error and we should inform the developer.
          */
-        if (message.startsWith("No suitable constructor found")) {
-            LOGGER.error("Unable to deserialize the specific type", exception);
+        if (exception instanceof JsonMappingException && !(exception instanceof UnrecognizedPropertyException)) {
+            LOGGER.error("Unable to serialize or deserialize the specific type", exception);
             return Response.serverError().build();
         }
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapperTest.java
@@ -48,6 +48,12 @@ public class JsonProcessingExceptionMapperTest extends JerseyTest {
     }
 
     @Test
+    public void returnsA500ForNonSerializableRepresentationClassesOutbound() throws Exception {
+        Response response = target("/json/brokenOutbound").request(MediaType.APPLICATION_JSON).get();
+        assertThat(response.getStatus()).isEqualTo(500);
+    }
+
+    @Test
     public void returnsA400ForNonDeserializableRequestEntities() throws Exception {
         Response response = target("/json/ok").request(MediaType.APPLICATION_JSON)
                 .post(Entity.entity(new UnknownRepresentation(100), MediaType.APPLICATION_JSON));

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonResource.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonResource.java
@@ -3,11 +3,11 @@ package io.dropwizard.jersey.jackson;
 import com.google.common.collect.ImmutableList;
 
 import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import java.io.IOException;
 import java.util.List;
 
 @Path("/json/")
@@ -16,13 +16,19 @@ import java.util.List;
 public class JsonResource {
     @POST
     @Path("/broken")
-    public void broken(BrokenRepresentation rep) throws IOException {
+    public void broken(BrokenRepresentation rep) {
         System.out.println(rep);
+    }
+
+    @GET
+    @Path("/brokenOutbound")
+    public NonBeanImplementation brokenOutbound() {
+        return new NonBeanImplementation();
     }
 
     @POST
     @Path("/ok")
-    public List<String> ok(OkRepresentation rep) throws IOException {
+    public List<String> ok(OkRepresentation rep) {
         return ImmutableList.of(rep.getMessage());
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/NonBeanImplementation.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/NonBeanImplementation.java
@@ -1,0 +1,12 @@
+package io.dropwizard.jersey.jackson;
+
+/**
+ * Jackson has less insight on how to serialize/deserialize an object that
+ * doesn't adhere to the Bean spec. This class needs additional annotations in
+ * order to be properly serialized/deserialized.
+ */
+public class NonBeanImplementation {
+    public Integer val() {
+        return 1;
+    }
+}


### PR DESCRIPTION
Jackson is good about serializing types that conform to the Bean spec, but
needs help serializing and deserializing types that don't (normally with
the use of annotations). Previous behavior would return a 400 (Bad
Request) when the server would attempt to return an entity that couldn't
be serialized. This is misleading because it gives the illusion that the
fault lies with the client instead of the server.