### PR TITLE
Fix broken links to manual in javadoc

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientConfiguration.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientConfiguration.java
@@ -16,7 +16,7 @@ import javax.validation.constraints.NotNull;
 /**
  * The configuration class used by {@link HttpClientBuilder}.
  *
- * @see <a href="http://dropwizard.io/manual/configuration.html#httpclient">Http Client Configuration</a>
+ * @see <a href="http://dropwizard.io/0.9.1/docs/manual/configuration.html#httpclient">Http Client Configuration</a>
  */
 public class HttpClientConfiguration {
     @NotNull

--- a/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientConfiguration.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientConfiguration.java
@@ -12,7 +12,7 @@ import javax.validation.constraints.Min;
  * {@link HttpClientConfiguration}.
  *
  * @see HttpClientConfiguration
- * @see <a href="http://dropwizard.io/manual/configuration.html#jerseyclient">Jersey Client Configuration</a>
+ * @see <a href="http://dropwizard.io/0.9.1/docs/manual/configuration.html#jerseyclient">Jersey Client Configuration</a>
  */
 public class JerseyClientConfiguration extends HttpClientConfiguration {
     @Min(1)


### PR DESCRIPTION
Would be nice if the docs for the latest version were available at `/latest/docs` or something like that we one could point to the docs without specifying a particular version, but lacking that, pointing to `/0.9.1/docs` is the best I can think of.