### PR TITLE
Add support for setting default headers in Apache HTTP client

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
@@ -13,6 +13,7 @@ import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Duration;
 import org.apache.http.ConnectionReuseStrategy;
+import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.auth.AuthScope;
@@ -41,6 +42,7 @@ import org.apache.http.impl.conn.SystemDefaultDnsResolver;
 import org.apache.http.protocol.HttpContext;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * A convenience class for building {@link HttpClient} instances.
@@ -74,6 +76,7 @@ public class HttpClientBuilder {
     private HttpRoutePlanner routePlanner = null;
     private RedirectStrategy redirectStrategy;
     private boolean disableContentCompression;
+    private List<? extends Header> defaultHeaders;
 
     public HttpClientBuilder(MetricRegistry metricRegistry) {
         this.metricRegistry = metricRegistry;
@@ -181,6 +184,17 @@ public class HttpClientBuilder {
      */
     public HttpClientBuilder using(RedirectStrategy redirectStrategy) {
         this.redirectStrategy = redirectStrategy;
+        return this;
+    }
+
+    /**
+     * Use the given default headers for each HTTP request
+     *
+     * @param defaultHeaders HTTP headers
+     * @return {@code} this
+     */
+    public HttpClientBuilder using(List<? extends Header> defaultHeaders) {
+        this.defaultHeaders = defaultHeaders;
         return this;
     }
 
@@ -317,6 +331,10 @@ public class HttpClientBuilder {
 
         if (redirectStrategy != null) {
             builder.setRedirectStrategy(redirectStrategy);
+        }
+
+        if (defaultHeaders != null) {
+            builder.setDefaultHeaders(defaultHeaders);
         }
 
         return new ConfiguredCloseableHttpClient(builder.build(), requestConfig);

--- a/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
@@ -513,6 +513,24 @@ public class HttpClientBuilderTest {
         assertThat(spyHttpClientBuilderField("redirectStrategy", apacheBuilder)).isSameAs(neverFollowRedirectStrategy);
     }
 
+    @Test
+    public void usesDefaultHeaders() throws Exception {
+        final ConfiguredCloseableHttpClient client =
+                builder.using(ImmutableList.of(new BasicHeader(HttpHeaders.ACCEPT_LANGUAGE, "de")))
+                        .createClient(apacheBuilder, connectionManager, "test");
+        assertThat(client).isNotNull();
+
+        @SuppressWarnings("unchecked")
+        List<? extends Header> defaultHeaders = (List<? extends Header>) FieldUtils
+                .getField(httpClientBuilderClass, "defaultHeaders", true)
+                .get(apacheBuilder);
+
+        assertThat(defaultHeaders).hasSize(1);
+        final Header header = defaultHeaders.get(0);
+        assertThat(header.getName()).isEqualTo(HttpHeaders.ACCEPT_LANGUAGE);
+        assertThat(header.getValue()).isEqualTo("de");
+    }
+
     private Object spyHttpClientBuilderField(final String fieldName, final Object obj) throws Exception {
         final Field field = FieldUtils.getField(httpClientBuilderClass, fieldName, true);
         return field.get(obj);


### PR DESCRIPTION
Add the ability to set predefined HTTP headers for each HTTP request of an HTTP client.

Apache `HttpClientBuilder` already supports such functionality and we should just delegate building from Dropwizard `HttpClientBuilder`.

In the result users can provide own headers without subclassing Dropwizard `HttpClientBuilder`.

Resolves #1353