### PR TITLE
Dropwizard always adds "server" and "check" commands. This is restrictive

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/Application.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/Application.java
@@ -87,11 +87,9 @@ public abstract class Application<T extends Configuration> {
      *
      * @param bootstrap the bootstrap instance
      */
-    protected void addDefaultCommands(Bootstrap<T> bootstrap)
-    {
+    protected void addDefaultCommands(Bootstrap<T> bootstrap) {
         bootstrap.addCommand(new ServerCommand<>(this));
         bootstrap.addCommand(new CheckCommand<>(this));
     }
-
 
 }

--- a/dropwizard-core/src/main/java/io/dropwizard/Application.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/Application.java
@@ -70,8 +70,7 @@ public abstract class Application<T extends Configuration> {
      */
     public void run(String... arguments) throws Exception {
         final Bootstrap<T> bootstrap = new Bootstrap<>(this);
-        bootstrap.addCommand(new ServerCommand<>(this));
-        bootstrap.addCommand(new CheckCommand<>(this));
+        addDefaultCommands(bootstrap);
         initialize(bootstrap);
         // Should by called after initialize to give an opportunity to set a custom metric registry
         bootstrap.registerMetrics();
@@ -81,6 +80,17 @@ public abstract class Application<T extends Configuration> {
             // only exit if there's an error running the command
             System.exit(1);
         }
+    }
+
+    /**
+     * Called by {@link #run(String...)} to add the standard "server" and "check" commands
+     *
+     * @param bootstrap the bootstrap instance
+     */
+    protected void addDefaultCommands(Bootstrap<T> bootstrap)
+    {
+        bootstrap.addCommand(new ServerCommand<>(this));
+        bootstrap.addCommand(new CheckCommand<>(this));
     }
 
 


### PR DESCRIPTION
I've started using Dropwizard for CLI apps and other types of things. This way, I can create an entire system that consumes config in the same way, etc. However, DW always adds server and check commands. I don't always want this. Add a method to not add these.