### PR TITLE
Support  `@UnitOfWork` outside of Jersey resources

### DIFF
--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWork.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWork.java
@@ -12,8 +12,11 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * When annotating a Jersey resource method, wraps the method in a Hibernate session.
+ * <p>To be used outside Jersey, one need to create a proxy of the component with the
+ * annotated method.</p.
  *
  * @see UnitOfWorkApplicationListener
+ * @see UnitOfWorkAwareProxyFactory
  */
 @Target(METHOD)
 @Retention(RUNTIME)

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAspect.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAspect.java
@@ -1,0 +1,121 @@
+package io.dropwizard.hibernate;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.context.internal.ManagedSessionContext;
+
+import java.util.Map;
+
+/**
+ * An aspect providing operations around a method with the {@link UnitOfWork} annotation.
+ * It opens a Hibernate session and optionally a transaction.
+ * <p>It should be created for every invocation of the method.</p>
+ */
+class UnitOfWorkAspect {
+
+    private final Map<String, SessionFactory> sessionFactories;
+
+    public UnitOfWorkAspect(Map<String, SessionFactory> sessionFactories) {
+        this.sessionFactories = sessionFactories;
+    }
+
+    // Context variables
+    private UnitOfWork unitOfWork;
+    private Session session;
+    private SessionFactory sessionFactory;
+
+    public void beforeStart(UnitOfWork unitOfWork) {
+        if (unitOfWork == null) {
+            return;
+        }
+        this.unitOfWork = unitOfWork;
+
+        sessionFactory = sessionFactories.get(unitOfWork.value());
+        if (sessionFactory == null) {
+            // If the user didn't specify the name of a session factory,
+            // and we have only one registered, we can assume that it's the right one.
+            if (unitOfWork.value().equals(HibernateBundle.DEFAULT_NAME) && sessionFactories.size() == 1) {
+                sessionFactory = sessionFactories.values().iterator().next();
+            } else {
+                throw new IllegalArgumentException("Unregistered Hibernate bundle: '" + unitOfWork.value() + "'");
+            }
+        }
+        session = sessionFactory.openSession();
+        try {
+            configureSession();
+            ManagedSessionContext.bind(session);
+            beginTransaction();
+        } catch (Throwable th) {
+            session.close();
+            session = null;
+            ManagedSessionContext.unbind(sessionFactory);
+            throw th;
+        }
+    }
+
+    public void afterEnd() {
+        if (session == null) {
+            return;
+        }
+
+        try {
+            commitTransaction();
+        } catch (Exception e) {
+            rollbackTransaction();
+            throw e;
+        } finally {
+            session.close();
+            session = null;
+            ManagedSessionContext.unbind(sessionFactory);
+        }
+
+    }
+
+    public void onError() {
+        if (session == null) {
+            return;
+        }
+
+        try {
+            rollbackTransaction();
+        } finally {
+            session.close();
+            session = null;
+            ManagedSessionContext.unbind(sessionFactory);
+        }
+    }
+
+    private void configureSession() {
+        session.setDefaultReadOnly(unitOfWork.readOnly());
+        session.setCacheMode(unitOfWork.cacheMode());
+        session.setFlushMode(unitOfWork.flushMode());
+    }
+
+    private void beginTransaction() {
+        if (!unitOfWork.transactional()) {
+            return;
+        }
+        session.beginTransaction();
+    }
+
+    private void rollbackTransaction() {
+        if (!unitOfWork.transactional()) {
+            return;
+        }
+        final Transaction txn = session.getTransaction();
+        if (txn != null && txn.isActive()) {
+            txn.rollback();
+        }
+    }
+
+    private void commitTransaction() {
+        if (!unitOfWork.transactional()) {
+            return;
+        }
+        final Transaction txn = session.getTransaction();
+        if (txn != null && txn.isActive()) {
+            txn.commit();
+        }
+    }
+}

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactory.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactory.java
@@ -1,0 +1,103 @@
+package io.dropwizard.hibernate;
+
+import com.google.common.collect.ImmutableMap;
+import javassist.util.proxy.MethodHandler;
+import javassist.util.proxy.Proxy;
+import javassist.util.proxy.ProxyFactory;
+import org.hibernate.SessionFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * A factory for creating proxies for components that use Hibernate data access objects
+ * outside Jersey resources.
+ * <p>A created proxy will be aware of the {@link UnitOfWork} annotation
+ * on the original class methods and will open a Hibernate session with a transaction
+ * around them.</p>
+ */
+public class UnitOfWorkAwareProxyFactory {
+
+    private final ImmutableMap<String, SessionFactory> sessionFactories;
+
+    public UnitOfWorkAwareProxyFactory(String name, SessionFactory sessionFactory) {
+        sessionFactories = ImmutableMap.of(name, sessionFactory);
+    }
+
+    public UnitOfWorkAwareProxyFactory(HibernateBundle<?>... bundles) {
+        final ImmutableMap.Builder<String, SessionFactory> sessionFactoriesBuilder = ImmutableMap.builder();
+        for (HibernateBundle<?> bundle : bundles) {
+            sessionFactoriesBuilder.put(bundle.name(), bundle.getSessionFactory());
+        }
+        sessionFactories = sessionFactoriesBuilder.build();
+    }
+
+
+    /**
+     * Creates a new <b>@UnitOfWork</b> aware proxy of a class with the default constructor.
+     *
+     * @param clazz the specified class definition
+     * @param <T>   the type of the class
+     * @return a new proxy
+     */
+    public <T> T create(Class<T> clazz) {
+        return create(clazz, new Class<?>[]{}, new Object[]{});
+    }
+
+    /**
+     * Creates a new <b>@UnitOfWork</b> aware proxy of a class with an one-parameter constructor.
+     *
+     * @param clazz                the specified class definition
+     * @param constructorParamType the type of the constructor parameter
+     * @param constructorArguments the argument passed to the constructor
+     * @param <T>                  the type of the class
+     * @return a new proxy
+     */
+    public <T> T create(Class<T> clazz, Class<?> constructorParamType, Object constructorArguments) {
+        return create(clazz, new Class<?>[]{constructorParamType}, new Object[]{constructorArguments});
+    }
+
+    /**
+     * Creates a new <b>@UnitOfWork</b> aware proxy of a class with a complex constructor.
+     *
+     * @param clazz                 the specified class definition
+     * @param constructorParamTypes the types of the constructor parameters
+     * @param constructorArguments  the arguments passed to the constructor
+     * @param <T>                   the type of the class
+     * @return a new proxy
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T create(Class<T> clazz, Class<?>[] constructorParamTypes, Object[] constructorArguments) {
+        final ProxyFactory factory = new ProxyFactory();
+        factory.setSuperclass(clazz);
+
+        try {
+            final Proxy proxy = (Proxy) (constructorParamTypes.length == 0 ?
+                    factory.createClass().newInstance() :
+                    factory.create(constructorParamTypes, constructorArguments));
+            proxy.setHandler(new MethodHandler() {
+                @Override
+                public Object invoke(Object self, Method overridden, Method proceed, Object[] args) throws Throwable {
+                    final UnitOfWork unitOfWork = overridden.getAnnotation(UnitOfWork.class);
+                    final UnitOfWorkAspect unitOfWorkAspect = new UnitOfWorkAspect(sessionFactories);
+                    try {
+                        unitOfWorkAspect.beforeStart(unitOfWork);
+                        Object result = proceed.invoke(self, args);
+                        unitOfWorkAspect.afterEnd();
+                        return result;
+                    } catch (InvocationTargetException e) {
+                        unitOfWorkAspect.onError();
+                        throw e.getCause();
+                    } catch (Exception e) {
+                        unitOfWorkAspect.onError();
+                        throw e;
+                    }
+                }
+            });
+            return (T) proxy;
+        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException |
+                InvocationTargetException e) {
+            throw new IllegalStateException("Unable to create a proxy for the class '" + clazz + "'", e);
+        }
+    }
+}

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
@@ -1,0 +1,139 @@
+package io.dropwizard.hibernate;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
+import io.dropwizard.logging.BootstrapLogging;
+import io.dropwizard.setup.Environment;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class UnitOfWorkAwareProxyFactoryTest {
+
+    static {
+        BootstrapLogging.bootstrap();
+    }
+
+    private SessionFactory sessionFactory;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Before
+    public void setUp() throws Exception {
+        final HibernateBundle<?> bundle = mock(HibernateBundle.class);
+        final Environment environment = mock(Environment.class);
+        when(environment.lifecycle()).thenReturn(mock(LifecycleEnvironment.class));
+        when(environment.metrics()).thenReturn(new MetricRegistry());
+
+        final DataSourceFactory dataSourceFactory = new DataSourceFactory();
+        dataSourceFactory.setUrl("jdbc:hsqldb:mem:unit-of-work-" + UUID.randomUUID().toString());
+        dataSourceFactory.setUser("sa");
+        dataSourceFactory.setDriverClass("org.hsqldb.jdbcDriver");
+        dataSourceFactory.setValidationQuery("SELECT 1 FROM INFORMATION_SCHEMA.SYSTEM_USERS");
+        dataSourceFactory.setProperties(ImmutableMap.of("hibernate.dialect", "org.hibernate.dialect.HSQLDialect"));
+        dataSourceFactory.setInitialSize(1);
+        dataSourceFactory.setMinSize(1);
+
+        sessionFactory = new SessionFactoryFactory()
+                .build(bundle, environment, dataSourceFactory, ImmutableList.<Class<?>>of());
+        final Session session = sessionFactory.openSession();
+        try {
+            session.createSQLQuery("create table user_sessions (token varchar(64) primary key, username varchar(16))")
+                    .executeUpdate();
+            session.createSQLQuery("insert into user_sessions values ('67ab89d', 'jeff_28')")
+                    .executeUpdate();
+        } finally {
+            session.close();
+        }
+    }
+
+    @Test
+    public void testProxyWorks() throws Exception {
+        final SessionDao sessionDao = new SessionDao(sessionFactory);
+        final UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory =
+                new UnitOfWorkAwareProxyFactory("default", sessionFactory);
+
+        final OAuthAuthenticator oAuthAuthenticator = unitOfWorkAwareProxyFactory
+                .create(OAuthAuthenticator.class, SessionDao.class, sessionDao);
+        assertThat(oAuthAuthenticator.authenticate("67ab89d")).isTrue();
+        assertThat(oAuthAuthenticator.authenticate("bd1e23a")).isFalse();
+    }
+
+    @Test
+    public void testProxyWorksWithoutUnitOfWork() {
+        assertThat(new UnitOfWorkAwareProxyFactory("default", sessionFactory)
+                .create(PlainAuthenticator.class)
+                .authenticate("c82d11e"))
+                .isTrue();
+    }
+
+    @Test
+    public void testProxyHandlesErrors() {
+        thrown.expect(IllegalStateException.class);
+        thrown.expectMessage("Session cluster is down");
+
+        new UnitOfWorkAwareProxyFactory("default", sessionFactory)
+                .create(BrokenAuthenticator.class)
+                .authenticate("b812ae4");
+    }
+
+    static class SessionDao {
+
+        private SessionFactory sessionFactory;
+
+        public SessionDao(SessionFactory sessionFactory) {
+            this.sessionFactory = sessionFactory;
+        }
+
+        public boolean isExist(String token) {
+            return sessionFactory.getCurrentSession()
+                    .createSQLQuery("select username from user_sessions where token=:token")
+                    .setParameter("token", token)
+                    .list()
+                    .size() > 0;
+        }
+
+    }
+
+    static class OAuthAuthenticator {
+
+        private SessionDao sessionDao;
+
+        public OAuthAuthenticator(SessionDao sessionDao) {
+            this.sessionDao = sessionDao;
+        }
+
+        @UnitOfWork
+        public boolean authenticate(String token) {
+            return sessionDao.isExist(token);
+        }
+    }
+
+    static class PlainAuthenticator {
+
+        public boolean authenticate(String token) {
+            return true;
+        }
+    }
+
+    static class BrokenAuthenticator {
+
+        @UnitOfWork
+        public boolean authenticate(String token) {
+            throw new IllegalStateException("Session cluster is down");
+        }
+    }
+}


### PR DESCRIPTION
This PR provides the ability to use the `@UnitOfWork` annotation outside of Jersey resources.
It consists from two changes: 
* In first we move operations over `@UnitOfWork` methods from `UnitOfWorkApplicationListener` into  an aspect. It allows to perform these operations outside of the listener (for example, in proxies or AOP providers).
* In second we provide a factory for creating `@UnitOfWork` aware proxies. A created proxy will
detect the annotation on component methods and will open/close a Hibernate session around them.
It uses aforementioned aspect for this. Javassist is used for creating proxies, because it has a
simple API for that and it's shipped with Hibernate.

Now to use `@UnitOfWork` in authenticators, one need just to create proxy like this:
```java
SessionDao dao = new SessionDao(hibernateBundle.getSessionFactory());
ExampleAuthenticator exampleAuthenticator = 
                new UnitOfWorkAwareProxyFactory(hibernateBundle)
                .create(ExampleAuthenticator.class, SessionDao.class, dao);
```

This change is intended to 0.9.* branch. Reference issues: #1334 , #1240 