### PR TITLE
Add a development profile to Maven

### DIFF
--- a/dropwizard-archetypes/pom.xml
+++ b/dropwizard-archetypes/pom.xml
@@ -163,4 +163,14 @@
       </resource>
     </resources>
   </build>
+
+  <profiles>
+    <profile>
+      <id>dev</id>
+      <properties>
+        <archetype.test.skip>true</archetype.test.skip>
+        <invoker.skip>true</invoker.skip>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/dropwizard-example/pom.xml
+++ b/dropwizard-example/pom.xml
@@ -253,4 +253,23 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,13 @@
                 <javadoc.doclint.none>-Xdoclint:none</javadoc.doclint.none>
             </properties>
         </profile>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <maven.javadoc.skip>true</maven.javadoc.skip>
+                <findbugs.skip>true</findbugs.skip>
+            </properties>
+        </profile>
     </profiles>
 
     <dependencyManagement>


### PR DESCRIPTION
Add a development profile that allow to skip following things during project installation:

* Running Findbugs checks;
* Generating Javadoc;
* Creating a verifying a sample project from the archetype;
* Generating a shadowed artifact for the example project.

This allows to decrease the time to clean and install project from 4-5 minutes to 20-30 seconds during development.