### PR TITLE
Merge dropwizard-java8 addon into mainline

### DIFF
--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/Authenticator.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/Authenticator.java
@@ -1,8 +1,7 @@
 package io.dropwizard.auth;
 
-import com.google.common.base.Optional;
-
 import java.security.Principal;
+import java.util.Optional;
 
 /**
  * An interface for classes which authenticate user-provided credentials and return principal
@@ -14,10 +13,10 @@ import java.security.Principal;
 public interface Authenticator<C, P extends Principal> {
     /**
      * Given a set of user-provided credentials, return an optional principal.
-     * <p/>
-     * If the credentials are valid and map to a principal, returns an {@code Optional.of(p)}.
-     * <p/>
-     * If the credentials are invalid, returns an {@code Optional.absent()}.
+     *
+     * If the credentials are valid and map to a principal, returns an {@link Optional#of(Object)}.
+     *
+     * If the credentials are invalid, returns an {@link Optional#empty()}.
      *
      * @param credentials a set of user-provided credentials
      * @return either an authenticated principal or an absent optional

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/CachingAuthenticator.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/CachingAuthenticator.java
@@ -3,7 +3,6 @@ package io.dropwizard.auth;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -11,6 +10,8 @@ import com.google.common.cache.CacheBuilderSpec;
 import com.google.common.cache.CacheStats;
 import com.google.common.collect.Sets;
 import java.security.Principal;
+import java.util.Optional;
+
 import static com.codahale.metrics.MetricRegistry.name;
 
 /**

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/basic/BasicCredentialAuthFilter.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/basic/BasicCredentialAuthFilter.java
@@ -1,6 +1,5 @@
 package io.dropwizard.auth.basic;
 
-import com.google.common.base.Optional;
 import com.google.common.io.BaseEncoding;
 import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.AuthFilter;
@@ -17,6 +16,7 @@ import javax.ws.rs.core.SecurityContext;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.Principal;
+import java.util.Optional;
 
 @Priority(Priorities.AUTHENTICATION)
 public class BasicCredentialAuthFilter<P extends Principal> extends AuthFilter<BasicCredentials, P> {

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/oauth/OAuthCredentialAuthFilter.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/oauth/OAuthCredentialAuthFilter.java
@@ -1,6 +1,5 @@
 package io.dropwizard.auth.oauth;
 
-import com.google.common.base.Optional;
 import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.AuthFilter;
 import io.dropwizard.auth.Authenticator;
@@ -16,6 +15,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.SecurityContext;
 import java.io.IOException;
 import java.security.Principal;
+import java.util.Optional;
 
 @Priority(Priorities.AUTHENTICATION)
 public class OAuthCredentialAuthFilter<P extends Principal> extends AuthFilter<String, P> {

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/chained/ChainedAuthProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/chained/ChainedAuthProviderTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ChainedAuthProviderTest extends AuthBaseTest<ChainedAuthProviderTest.ChainedAuthTestResourceConfig>{
     private static final String BEARER_USER = "A12B3C4D";
     public static class ChainedAuthTestResourceConfig extends DropwizardResourceConfig {
+        @SuppressWarnings("unchecked")
         public ChainedAuthTestResourceConfig() {
             super(true, new MetricRegistry());
 

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/util/AuthUtil.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/util/AuthUtil.java
@@ -1,69 +1,58 @@
 package io.dropwizard.auth.util;
 
-import com.google.common.base.Optional;
-import io.dropwizard.auth.*;
+import io.dropwizard.auth.AuthenticationException;
+import io.dropwizard.auth.Authenticator;
+import io.dropwizard.auth.Authorizer;
+import io.dropwizard.auth.PrincipalImpl;
 import io.dropwizard.auth.basic.BasicCredentials;
 
 import java.security.Principal;
 import java.util.List;
+import java.util.Optional;
 
 public class AuthUtil {
 
     public static Authenticator<BasicCredentials, Principal> getBasicAuthenticator(final List<String> validUsers) {
-        return new Authenticator<BasicCredentials, Principal>() {
-            @Override
-            public Optional<Principal> authenticate(BasicCredentials credentials) throws AuthenticationException {
-                if (validUsers.contains(credentials.getUsername()) && "secret".equals(credentials.getPassword())) {
-                    return Optional.<Principal>of(new PrincipalImpl(credentials.getUsername()));
-                }
-                if ("bad-guy".equals(credentials.getUsername())) {
-                    throw new AuthenticationException("CRAP");
-                }
-                return Optional.absent();
+        return credentials -> {
+            if (validUsers.contains(credentials.getUsername()) && "secret".equals(credentials.getPassword())) {
+                return Optional.<Principal>of(new PrincipalImpl(credentials.getUsername()));
             }
+            if ("bad-guy".equals(credentials.getUsername())) {
+                throw new AuthenticationException("CRAP");
+            }
+            return Optional.empty();
         };
     }
 
     public static Authenticator<String, Principal> getSingleUserOAuthAuthenticator(final String presented,
                                                                                    final String returned) {
-        return new Authenticator<String, Principal>() {
-            @Override
-            public Optional<Principal> authenticate(String user) throws AuthenticationException {
-                if (presented.equals(user)) {
-                    return Optional.<Principal>of(new PrincipalImpl(returned));
-                }
-                if ("bad-guy".equals(user)) {
-                    throw new AuthenticationException("CRAP");
-                }
-                return Optional.absent();
+        return user -> {
+            if (presented.equals(user)) {
+                return Optional.<Principal>of(new PrincipalImpl(returned));
             }
+            if ("bad-guy".equals(user)) {
+                throw new AuthenticationException("CRAP");
+            }
+            return Optional.empty();
         };
     }
 
     public static Authenticator<String, Principal> getMultiplyUsersOAuthAuthenticator(final List<String> validUsers) {
-        return new Authenticator<String, Principal>() {
-            @Override
-            public Optional<Principal> authenticate(String credentials) throws AuthenticationException {
-                if (validUsers.contains(credentials)) {
-                    return Optional.<Principal>of(new PrincipalImpl(credentials));
-                }
-                if (credentials.equals("bad-guy")) {
-                    throw new AuthenticationException("CRAP");
-                }
-                return Optional.absent();
+        return credentials -> {
+            if (validUsers.contains(credentials)) {
+                return Optional.<Principal>of(new PrincipalImpl(credentials));
             }
+            if ("bad-guy".equals(credentials)) {
+                throw new AuthenticationException("CRAP");
+            }
+            return Optional.empty();
         };
     }
 
     public static Authorizer<Principal> getTestAuthorizer(final String validUser,
                                                           final String validRole) {
-        return new Authorizer<Principal>() {
-            @Override
-            public boolean authorize(Principal principal, String role) {
-                return principal != null
-                        && validUser.equals(principal.getName())
-                        && validRole.equals(role);
-            }
-        };
+        return (principal, role) -> principal != null
+            && validUser.equals(principal.getName())
+            && validRole.equals(role);
     }
 }

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -276,6 +276,16 @@
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jdk8</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
                 <artifactId>jackson-datatype-guava</artifactId>
                 <version>${jackson.version}</version>
                 <exclusions>

--- a/dropwizard-core/src/test/java/io/dropwizard/setup/BootstrapTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/setup/BootstrapTest.java
@@ -8,10 +8,10 @@ import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.configuration.DefaultConfigurationFactoryFactory;
 import io.dropwizard.configuration.FileConfigurationSourceProvider;
-
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.validation.NonEmptyStringParamUnwrapper;
 import io.dropwizard.jersey.validation.ParamValidatorUnwrapper;
+import io.dropwizard.validation.valuehandling.GuavaOptionalValidatedValueUnwrapper;
 import io.dropwizard.validation.valuehandling.OptionalValidatedValueUnwrapper;
 import org.hibernate.validator.HibernateValidator;
 import org.hibernate.validator.internal.engine.ValidatorFactoryImpl;
@@ -103,7 +103,8 @@ public class BootstrapTest {
         // https://hibernate.atlassian.net/browse/HV-904
         assertThat(validatorFactory.getValidatedValueHandlers())
                 .extractingResultOf("getClass")
-                .containsSubsequence(OptionalValidatedValueUnwrapper.class,
+                .containsSubsequence(GuavaOptionalValidatedValueUnwrapper.class,
+                                     OptionalValidatedValueUnwrapper.class,
                                      NonEmptyStringParamUnwrapper.class,
                                      ParamValidatorUnwrapper.class);
     }

--- a/dropwizard-example/src/main/java/com/example/helloworld/auth/ExampleAuthenticator.java
+++ b/dropwizard-example/src/main/java/com/example/helloworld/auth/ExampleAuthenticator.java
@@ -1,10 +1,11 @@
 package com.example.helloworld.auth;
 
 import com.example.helloworld.core.User;
-import com.google.common.base.Optional;
 import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.Authenticator;
 import io.dropwizard.auth.basic.BasicCredentials;
+
+import java.util.Optional;
 
 public class ExampleAuthenticator implements Authenticator<BasicCredentials, User> {
     @Override
@@ -12,6 +13,6 @@ public class ExampleAuthenticator implements Authenticator<BasicCredentials, Use
         if ("secret".equals(credentials.getPassword())) {
             return Optional.of(new User(credentials.getUsername()));
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 }

--- a/dropwizard-jackson/pom.xml
+++ b/dropwizard-jackson/pom.xml
@@ -53,6 +53,14 @@
             <artifactId>jackson-datatype-guava</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-afterburner</artifactId>
         </dependency>

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk7.Jdk7Module;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 
 /**
@@ -57,6 +59,8 @@ public class Jackson {
         mapper.registerModule(new AfterburnerModule());
         mapper.registerModule(new FuzzyEnumModule());
         mapper.registerModule(new Jdk7Module());
+        mapper.registerModules(new Jdk8Module());
+        mapper.registerModules(new JavaTimeModule());
         mapper.setPropertyNamingStrategy(new AnnotationSensitivePropertyNamingStrategy());
         mapper.setSubtypeResolver(new DiscoverableSubtypeResolver());
 

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/DBIHealthCheck.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/DBIHealthCheck.java
@@ -6,6 +6,7 @@ import io.dropwizard.db.TimeBoundHealthCheck;
 import io.dropwizard.util.Duration;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
+
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 
@@ -13,13 +14,13 @@ public class DBIHealthCheck extends HealthCheck {
     private final DBI dbi;
     private final String validationQuery;
     private final TimeBoundHealthCheck timeBoundHealthCheck;
-    
+
     public DBIHealthCheck(ExecutorService executorService, Duration duration, DBI dbi, String validationQuery) {
         this.dbi = dbi;
         this.validationQuery = validationQuery;
         this.timeBoundHealthCheck = new TimeBoundHealthCheck(executorService, duration);
     }
-    
+
     public DBIHealthCheck(DBI dbi, String validationQuery) {
         this(MoreExecutors.newDirectExecutorService(), Duration.seconds(0), dbi, validationQuery);
     }

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/GuavaOptionalContainerFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/GuavaOptionalContainerFactory.java
@@ -1,0 +1,34 @@
+package io.dropwizard.jdbi;
+
+import com.google.common.base.Optional;
+import org.skife.jdbi.v2.ContainerBuilder;
+import org.skife.jdbi.v2.tweak.ContainerFactory;
+
+public class GuavaOptionalContainerFactory implements ContainerFactory<Optional<?>> {
+
+    @Override
+    public boolean accepts(Class<?> type) {
+        return Optional.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public ContainerBuilder<Optional<?>> newContainerBuilderFor(Class<?> type) {
+        return new OptionalContainerBuilder();
+    }
+
+    private static class OptionalContainerBuilder implements ContainerBuilder<Optional<?>> {
+
+        private Optional<?> optional = Optional.absent();
+
+        @Override
+        public ContainerBuilder<Optional<?>> add(Object it) {
+            optional = Optional.fromNullable(it);
+            return this;
+        }
+
+        @Override
+        public Optional<?> build() {
+            return optional;
+        }
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/OptionalContainerFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/OptionalContainerFactory.java
@@ -1,8 +1,9 @@
 package io.dropwizard.jdbi;
 
-import com.google.common.base.Optional;
 import org.skife.jdbi.v2.ContainerBuilder;
 import org.skife.jdbi.v2.tweak.ContainerFactory;
+
+import java.util.Optional;
 
 public class OptionalContainerFactory implements ContainerFactory<Optional<?>> {
 
@@ -18,11 +19,11 @@ public class OptionalContainerFactory implements ContainerFactory<Optional<?>> {
 
     private static class OptionalContainerBuilder implements ContainerBuilder<Optional<?>> {
 
-        private Optional<?> optional = Optional.absent();
+        Optional<?> optional = Optional.empty();
 
         @Override
         public ContainerBuilder<Optional<?>> add(Object it) {
-            optional = Optional.fromNullable(it);
+            optional = Optional.ofNullable(it);
             return this;
         }
 

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/GuavaOptionalArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/GuavaOptionalArgumentFactory.java
@@ -1,0 +1,65 @@
+package io.dropwizard.jdbi.args;
+
+import com.google.common.base.Optional;
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+import org.skife.jdbi.v2.tweak.ArgumentFactory;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+
+public class GuavaOptionalArgumentFactory implements ArgumentFactory<Optional<Object>> {
+    private static class DefaultOptionalArgument implements Argument {
+        private final Optional<?> value;
+
+        private DefaultOptionalArgument(Optional<?> value) {
+            this.value = value;
+        }
+
+        @Override
+        public void apply(int position,
+                          PreparedStatement statement,
+                          StatementContext ctx) throws SQLException {
+            if (value.isPresent()) {
+                statement.setObject(position, value.get());
+            } else {
+                statement.setNull(position, Types.OTHER);
+            }
+        }
+    }
+
+    private static class MsSqlOptionalArgument implements Argument {
+        private final Optional<?> value;
+
+        private MsSqlOptionalArgument(Optional<?> value) {
+            this.value = value;
+        }
+
+        @Override
+        public void apply(int position,
+                          PreparedStatement statement,
+                          StatementContext ctx) throws SQLException {
+            statement.setObject(position, value.orNull());
+        }
+    }
+
+    private final String jdbcDriver;
+
+    public GuavaOptionalArgumentFactory(String jdbcDriver) {
+        this.jdbcDriver = jdbcDriver;
+    }
+
+    @Override
+    public boolean accepts(Class<?> expectedType, Object value, StatementContext ctx) {
+        return value instanceof Optional;
+    }
+
+    @Override
+    public Argument build(Class<?> expectedType, Optional<Object> value, StatementContext ctx) {
+        if ("com.microsoft.sqlserver.jdbc.SQLServerDriver".equals(jdbcDriver)) {
+            return new MsSqlOptionalArgument(value);
+        }
+        return new DefaultOptionalArgument(value);
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/GuavaOptionalInstantArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/GuavaOptionalInstantArgumentFactory.java
@@ -1,0 +1,44 @@
+package io.dropwizard.jdbi.args;
+
+import com.google.common.base.Optional;
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+import org.skife.jdbi.v2.tweak.ArgumentFactory;
+
+import java.time.Instant;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+/**
+ * An {@link ArgumentFactory} for {@link Instant} arguments wrapped by Guava's {@link Optional}.
+ */
+public class GuavaOptionalInstantArgumentFactory implements ArgumentFactory<Optional<Instant>> {
+
+    private final java.util.Optional<Calendar> calendar;
+
+    public GuavaOptionalInstantArgumentFactory() {
+        calendar = java.util.Optional.empty();
+    }
+
+    public GuavaOptionalInstantArgumentFactory(java.util.Optional<TimeZone> timeZone) {
+        calendar = timeZone.map(GregorianCalendar::new);
+    }
+
+    @Override
+    public boolean accepts(Class<?> expectedType, Object value, StatementContext ctx) {
+        if (value instanceof Optional) {
+            final Optional<?> optionalValue = (Optional<?>) value;
+            // Fall through to OptionalArgumentFactory if absent.
+            // Fall through to OptionalArgumentFactory if present, but not Instant.
+            return optionalValue.isPresent() && optionalValue.get() instanceof Instant;
+        }
+        return false;
+    }
+
+    @Override
+    public Argument build(Class<?> expectedType, Optional<Instant> value, StatementContext ctx) {
+        // accepts guarantees that the value is present
+        return new InstantArgument(value.get(), calendar);
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/GuavaOptionalJodaTimeArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/GuavaOptionalJodaTimeArgumentFactory.java
@@ -1,0 +1,44 @@
+package io.dropwizard.jdbi.args;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+import org.skife.jdbi.v2.tweak.ArgumentFactory;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+/**
+ * An {@link ArgumentFactory} for Joda's {@link DateTime} arguments wrapped by Guava's {@link Optional}.
+ */
+public class GuavaOptionalJodaTimeArgumentFactory implements ArgumentFactory<Optional<DateTime>> {
+
+    private final java.util.Optional<Calendar> calendar;
+
+    public GuavaOptionalJodaTimeArgumentFactory() {
+        calendar = java.util.Optional.empty();
+    }
+
+    public GuavaOptionalJodaTimeArgumentFactory(java.util.Optional<TimeZone> timeZone) {
+        calendar = timeZone.map(GregorianCalendar::new);
+    }
+
+    @Override
+    public boolean accepts(Class<?> expectedType, Object value, StatementContext ctx) {
+        if (value instanceof Optional) {
+            final Optional<?> optionalValue = (Optional<?>) value;
+            // Fall through to OptionalArgumentFactory if absent.
+            // Fall through to OptionalArgumentFactory if present, but not DateTime.
+            return optionalValue.isPresent() && optionalValue.get() instanceof DateTime;
+        }
+        return false;
+    }
+
+    @Override
+    public Argument build(Class<?> expectedType, Optional<DateTime> value, StatementContext ctx) {
+        // accepts guarantees that the value is present
+        return new JodaDateTimeArgument(value.get(), calendar);
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/GuavaOptionalLocalDateArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/GuavaOptionalLocalDateArgumentFactory.java
@@ -1,0 +1,30 @@
+package io.dropwizard.jdbi.args;
+
+import com.google.common.base.Optional;
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+import org.skife.jdbi.v2.tweak.ArgumentFactory;
+
+import java.time.LocalDate;
+
+/**
+ * An {@link ArgumentFactory} for {@link LocalDate} arguments wrapped by Guava's {@link Optional}.
+ */
+public class GuavaOptionalLocalDateArgumentFactory implements ArgumentFactory<Optional<LocalDate>> {
+    @Override
+    public boolean accepts(Class<?> expectedType, Object value, StatementContext ctx) {
+        if (value instanceof Optional) {
+            final Optional<?> optionalValue = (Optional<?>) value;
+            // Fall through to OptionalArgumentFactory if absent.
+            // Fall through to OptionalArgumentFactory if present, but not LocalDate.
+            return optionalValue.isPresent() && optionalValue.get() instanceof LocalDate;
+        }
+        return false;
+    }
+
+    @Override
+    public Argument build(Class<?> expectedType, Optional<LocalDate> value, StatementContext ctx) {
+        // accepts guarantees that the value is present
+        return new LocalDateArgument(value.get());
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/GuavaOptionalLocalDateTimeArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/GuavaOptionalLocalDateTimeArgumentFactory.java
@@ -1,0 +1,30 @@
+package io.dropwizard.jdbi.args;
+
+import com.google.common.base.Optional;
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+import org.skife.jdbi.v2.tweak.ArgumentFactory;
+
+import java.time.LocalDateTime;
+
+/**
+ * An {@link ArgumentFactory} for {@link LocalDateTime} arguments wrapped by Guava's {@link Optional}.
+ */
+public class GuavaOptionalLocalDateTimeArgumentFactory implements ArgumentFactory<Optional<LocalDateTime>> {
+    @Override
+    public boolean accepts(Class<?> expectedType, Object value, StatementContext ctx) {
+        if (value instanceof Optional) {
+            final Optional<?> optionalValue = (Optional<?>) value;
+            // Fall through to OptionalArgumentFactory if absent.
+            // Fall through to OptionalArgumentFactory if present, but not LocalDateTime.
+            return optionalValue.isPresent() && optionalValue.get() instanceof LocalDateTime;
+        }
+        return false;
+    }
+
+    @Override
+    public Argument build(Class<?> expectedType, Optional<LocalDateTime> value, StatementContext ctx) {
+        // accepts guarantees that the value is present
+        return new LocalDateTimeArgument(value.get());
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/GuavaOptionalOffsetTimeArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/GuavaOptionalOffsetTimeArgumentFactory.java
@@ -1,0 +1,44 @@
+package io.dropwizard.jdbi.args;
+
+import com.google.common.base.Optional;
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+import org.skife.jdbi.v2.tweak.ArgumentFactory;
+
+import java.time.OffsetDateTime;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+/**
+ * An {@link ArgumentFactory} for {@link OffsetDateTime} arguments wrapped by Guava's {@link Optional}.
+ */
+public class GuavaOptionalOffsetTimeArgumentFactory implements ArgumentFactory<Optional<OffsetDateTime>> {
+
+    private final java.util.Optional<Calendar> calendar;
+
+    public GuavaOptionalOffsetTimeArgumentFactory() {
+        calendar = java.util.Optional.empty();
+    }
+
+    public GuavaOptionalOffsetTimeArgumentFactory(java.util.Optional<TimeZone> timeZone) {
+        calendar = timeZone.map(GregorianCalendar::new);
+    }
+
+    @Override
+    public boolean accepts(Class<?> expectedType, Object value, StatementContext ctx) {
+        if (value instanceof Optional) {
+            final Optional<?> optionalValue = (Optional<?>) value;
+            // Fall through to OptionalArgumentFactory if absent.
+            // Fall through to OptionalArgumentFactory if present, but not OffsetDateTime.
+            return optionalValue.isPresent() && optionalValue.get() instanceof OffsetDateTime;
+        }
+        return false;
+    }
+
+    @Override
+    public Argument build(Class<?> expectedType, Optional<OffsetDateTime> value, StatementContext ctx) {
+        // accepts guarantees that the value is present
+        return new OffsetDateTimeArgument(value.get(), calendar);
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/GuavaOptionalZonedTimeArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/GuavaOptionalZonedTimeArgumentFactory.java
@@ -1,0 +1,44 @@
+package io.dropwizard.jdbi.args;
+
+import com.google.common.base.Optional;
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+import org.skife.jdbi.v2.tweak.ArgumentFactory;
+
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+/**
+ * An {@link ArgumentFactory} for {@link ZonedDateTime} arguments wrapped by Guava's {@link Optional}.
+ */
+public class GuavaOptionalZonedTimeArgumentFactory implements ArgumentFactory<Optional<ZonedDateTime>> {
+
+    private final java.util.Optional<Calendar> calendar;
+
+    public GuavaOptionalZonedTimeArgumentFactory() {
+        calendar = java.util.Optional.empty();
+    }
+
+    public GuavaOptionalZonedTimeArgumentFactory(java.util.Optional<TimeZone> timeZone) {
+        calendar = timeZone.map(GregorianCalendar::new);
+    }
+
+    @Override
+    public boolean accepts(Class<?> expectedType, Object value, StatementContext ctx) {
+        if (value instanceof Optional) {
+            final Optional<?> optionalValue = (Optional<?>) value;
+            // Fall through to OptionalArgumentFactory if absent.
+            // Fall through to OptionalArgumentFactory if present, but not ZonedDateTime.
+            return optionalValue.isPresent() && optionalValue.get() instanceof ZonedDateTime;
+        }
+        return false;
+    }
+
+    @Override
+    public Argument build(Class<?> expectedType, Optional<ZonedDateTime> value, StatementContext ctx) {
+        // accepts guarantees that the value is present
+        return new ZonedDateTimeArgument(value.get(), calendar);
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/InstantArgument.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/InstantArgument.java
@@ -1,0 +1,41 @@
+package io.dropwizard.jdbi.args;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.Instant;
+import java.util.Calendar;
+import java.util.Optional;
+
+/**
+ * An {@link Argument} for {@link Instant} objects.
+ */
+public class InstantArgument implements Argument {
+    private final Instant instant;
+    private final Optional<Calendar> calendar;
+
+    protected InstantArgument(final Instant instant, final Optional<Calendar> calendar) {
+        this.instant = instant;
+        this.calendar = calendar;
+    }
+
+    @Override
+    public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException {
+        if (instant != null) {
+            if (calendar.isPresent()) {
+                // We need to make a clone, because Calendar is not thread-safe
+                // and some JDBC drivers mutate it during time calculations
+                final Calendar calendarClone = (Calendar) calendar.get().clone();
+                statement.setTimestamp(position, Timestamp.from(instant), calendarClone);
+            } else {
+                statement.setTimestamp(position, Timestamp.from(instant));
+            }
+        } else {
+            statement.setNull(position, Types.TIMESTAMP);
+        }
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/InstantArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/InstantArgumentFactory.java
@@ -1,0 +1,43 @@
+package io.dropwizard.jdbi.args;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+import org.skife.jdbi.v2.tweak.ArgumentFactory;
+
+import java.time.Instant;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.Optional;
+import java.util.TimeZone;
+
+/**
+ * An {@link ArgumentFactory} for {@link Instant} arguments.
+ */
+public class InstantArgumentFactory implements ArgumentFactory<Instant> {
+    /**
+     * <p>{@link Calendar} for representing a database time zone.<p>
+     * If a field is not represented in a database as
+     * {@code TIMESTAMP WITH TIME ZONE}, we need to set its time zone
+     * explicitly. Otherwise it will not be correctly represented in
+     * a time zone different from the time zone of the database.
+     */
+    private final Optional<Calendar> calendar;
+
+    public InstantArgumentFactory() {
+        this(Optional.empty());
+    }
+
+    public InstantArgumentFactory(final Optional<TimeZone> tz) {
+        this.calendar = tz.map(GregorianCalendar::new);
+    }
+
+    @Override
+    public boolean accepts(Class<?> expectedType, Object value, StatementContext ctx) {
+        return value instanceof Instant;
+    }
+
+    @Override
+    public Argument build(Class<?> expectedType, Instant value, StatementContext ctx) {
+        return new InstantArgument(value, calendar);
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/InstantMapper.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/InstantMapper.java
@@ -1,0 +1,51 @@
+package io.dropwizard.jdbi.args;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultColumnMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.Optional;
+import java.util.TimeZone;
+
+/**
+ * A {@link ResultColumnMapper} to map {@link Instant} objects.
+ */
+public class InstantMapper implements ResultColumnMapper<Instant> {
+    /**
+     * <p>{@link Calendar} for representing a database time zone.<p>
+     * If a field is not represented in a database as
+     * {@code TIMESTAMP WITH TIME ZONE}, we need to set its time zone
+     * explicitly. Otherwise it will not be correctly represented in
+     * a time zone different from the time zone of the database.
+     */
+    private final Optional<Calendar> calendar;
+
+    public InstantMapper() {
+        this(Optional.empty());
+    }
+
+    public InstantMapper(final Optional<TimeZone> tz) {
+        this.calendar = tz.map(GregorianCalendar::new);
+    }
+
+    @Override
+    public Instant mapColumn(ResultSet r, int columnNumber, StatementContext ctx) throws SQLException {
+        final Timestamp timestamp = calendar.isPresent() ? r.getTimestamp(columnNumber, cloneCalendar()) : r.getTimestamp(columnNumber);
+        return timestamp == null ? null : timestamp.toInstant();
+    }
+
+    @Override
+    public Instant mapColumn(ResultSet r, String columnLabel, StatementContext ctx) throws SQLException {
+        final Timestamp timestamp = calendar.isPresent() ? r.getTimestamp(columnLabel, cloneCalendar()) : r.getTimestamp(columnLabel);
+        return timestamp == null ? null : timestamp.toInstant();
+    }
+
+    private Calendar cloneCalendar() {
+        return (Calendar) calendar.get().clone();
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/JodaDateTimeArgument.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/JodaDateTimeArgument.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jdbi.args;
 
-import com.google.common.base.Optional;
 import org.joda.time.DateTime;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.Argument;
@@ -10,6 +9,7 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.Calendar;
+import java.util.Optional;
 
 /**
  * An {@link Argument} for Joda {@link DateTime} objects.

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/JodaDateTimeArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/JodaDateTimeArgumentFactory.java
@@ -1,7 +1,5 @@
 package io.dropwizard.jdbi.args;
 
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
 import org.joda.time.DateTime;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.Argument;
@@ -9,6 +7,7 @@ import org.skife.jdbi.v2.tweak.ArgumentFactory;
 
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.util.Optional;
 import java.util.TimeZone;
 
 /**
@@ -26,7 +25,7 @@ public class JodaDateTimeArgumentFactory implements ArgumentFactory<DateTime> {
     private final Optional<Calendar> calendar;
 
     public JodaDateTimeArgumentFactory() {
-        calendar = Optional.absent();
+        calendar = Optional.empty();
     }
 
     /**
@@ -35,12 +34,7 @@ public class JodaDateTimeArgumentFactory implements ArgumentFactory<DateTime> {
      * @param timeZone a time zone representing an offset
      */
     public JodaDateTimeArgumentFactory(Optional<TimeZone> timeZone) {
-        calendar = timeZone.transform(new Function<TimeZone, Calendar>() {
-            @Override
-            public Calendar apply(TimeZone tz) {
-                return new GregorianCalendar(tz);
-            }
-        });
+        calendar = timeZone.map(GregorianCalendar::new);
     }
 
     @Override

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/LocalDateArgument.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/LocalDateArgument.java
@@ -1,0 +1,31 @@
+package io.dropwizard.jdbi.args;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.LocalDate;
+
+/**
+ * An {@link Argument} for {@link LocalDate} objects.
+ */
+public class LocalDateArgument implements Argument {
+
+    private final LocalDate value;
+
+    public LocalDateArgument(LocalDate value) {
+        this.value = value;
+    }
+
+    @Override
+    public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException {
+        if (value != null) {
+            statement.setTimestamp(position, Timestamp.valueOf(value.atStartOfDay()));
+        } else {
+            statement.setNull(position, Types.TIMESTAMP);
+        }
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/LocalDateArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/LocalDateArgumentFactory.java
@@ -1,0 +1,23 @@
+package io.dropwizard.jdbi.args;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+import org.skife.jdbi.v2.tweak.ArgumentFactory;
+
+import java.time.LocalDate;
+
+/**
+ * An {@link ArgumentFactory} for {@link LocalDate} arguments.
+ */
+public class LocalDateArgumentFactory implements ArgumentFactory<LocalDate> {
+
+    @Override
+    public boolean accepts(Class<?> expectedType, Object value, StatementContext ctx) {
+        return value instanceof LocalDate;
+    }
+
+    @Override
+    public Argument build(Class<?> expectedType, LocalDate value, StatementContext ctx) {
+        return new LocalDateArgument(value);
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/LocalDateMapper.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/LocalDateMapper.java
@@ -1,0 +1,32 @@
+package io.dropwizard.jdbi.args;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultColumnMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+
+/**
+ * A {@link ResultColumnMapper} to map {@link LocalDate} objects.
+ */
+public class LocalDateMapper implements ResultColumnMapper<LocalDate> {
+    @Override
+    public LocalDate mapColumn(ResultSet r, String columnLabel, StatementContext ctx) throws SQLException {
+        Timestamp timestamp = r.getTimestamp(columnLabel);
+        if (timestamp == null) {
+            return null;
+        }
+        return timestamp.toLocalDateTime().toLocalDate();
+    }
+
+    @Override
+    public LocalDate mapColumn(ResultSet r, int columnNumber, StatementContext ctx) throws SQLException {
+        Timestamp timestamp = r.getTimestamp(columnNumber);
+        if (timestamp == null) {
+            return null;
+        }
+        return timestamp.toLocalDateTime().toLocalDate();
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/LocalDateTimeArgument.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/LocalDateTimeArgument.java
@@ -1,0 +1,33 @@
+package io.dropwizard.jdbi.args;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.LocalDateTime;
+
+/**
+ * An {@link Argument} for {@link LocalDateTime} objects.
+ */
+public class LocalDateTimeArgument implements Argument {
+
+    private final LocalDateTime value;
+
+    LocalDateTimeArgument(final LocalDateTime value) {
+        this.value = value;
+    }
+
+    @Override
+    public void apply(final int position,
+                      final PreparedStatement statement,
+                      final StatementContext ctx) throws SQLException {
+        if (value != null) {
+            statement.setTimestamp(position, Timestamp.valueOf(value));
+        } else {
+            statement.setNull(position, Types.TIMESTAMP);
+        }
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/LocalDateTimeArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/LocalDateTimeArgumentFactory.java
@@ -1,0 +1,27 @@
+package io.dropwizard.jdbi.args;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+import org.skife.jdbi.v2.tweak.ArgumentFactory;
+
+import java.time.LocalDateTime;
+
+/**
+ * An {@link ArgumentFactory} for {@link LocalDateTime} arguments.
+ */
+public class LocalDateTimeArgumentFactory implements ArgumentFactory<LocalDateTime> {
+
+    @Override
+    public boolean accepts(final Class<?> expectedType,
+                           final Object value,
+                           final StatementContext ctx) {
+        return value instanceof LocalDateTime;
+    }
+
+    @Override
+    public Argument build(final Class<?> expectedType,
+                          final LocalDateTime value,
+                          final StatementContext ctx) {
+        return new LocalDateTimeArgument(value);
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/LocalDateTimeMapper.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/LocalDateTimeMapper.java
@@ -1,0 +1,33 @@
+package io.dropwizard.jdbi.args;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultColumnMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+/**
+ * A {@link ResultColumnMapper} to map {@link LocalDateTime} objects.
+ */
+public class LocalDateTimeMapper implements ResultColumnMapper<LocalDateTime> {
+
+    @Override
+    public LocalDateTime mapColumn(ResultSet r, String columnLabel, StatementContext ctx) throws SQLException {
+        final Timestamp timestamp = r.getTimestamp(columnLabel);
+        if (timestamp == null) {
+            return null;
+        }
+        return timestamp.toLocalDateTime();
+    }
+
+    @Override
+    public LocalDateTime mapColumn(ResultSet r, int columnNumber, StatementContext ctx) throws SQLException {
+        final Timestamp timestamp = r.getTimestamp(columnNumber);
+        if (timestamp == null) {
+            return null;
+        }
+        return timestamp.toLocalDateTime();
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OffsetDateTimeArgument.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OffsetDateTimeArgument.java
@@ -1,0 +1,44 @@
+package io.dropwizard.jdbi.args;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.OffsetDateTime;
+import java.util.Calendar;
+import java.util.Optional;
+
+/**
+ * An {@link Argument} for {@link OffsetDateTime} objects.
+ */
+public class OffsetDateTimeArgument implements Argument {
+
+    private final OffsetDateTime value;
+    private final Optional<Calendar> calendar;
+
+    OffsetDateTimeArgument(final OffsetDateTime value, final Optional<Calendar> calendar) {
+        this.value = value;
+        this.calendar = calendar;
+    }
+
+    @Override
+    public void apply(final int position,
+                      final PreparedStatement statement,
+                      final StatementContext ctx) throws SQLException {
+        if (value != null) {
+            if (calendar.isPresent()) {
+                // We need to make a clone, because Calendar is not thread-safe
+                // and some JDBC drivers mutate it during time calculations
+                Calendar calendarClone = (Calendar) calendar.get().clone();
+                statement.setTimestamp(position, new Timestamp(value.toInstant().toEpochMilli()), calendarClone);
+            } else {
+                statement.setTimestamp(position, new Timestamp(value.toInstant().toEpochMilli()));
+            }
+        } else {
+            statement.setNull(position, Types.TIMESTAMP);
+        }
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OffsetDateTimeArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OffsetDateTimeArgumentFactory.java
@@ -1,0 +1,53 @@
+package io.dropwizard.jdbi.args;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+import org.skife.jdbi.v2.tweak.ArgumentFactory;
+
+import java.time.OffsetDateTime;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.Optional;
+import java.util.TimeZone;
+
+/**
+ * An {@link ArgumentFactory} for {@link OffsetDateTime} arguments.
+ */
+public class OffsetDateTimeArgumentFactory implements ArgumentFactory<OffsetDateTime> {
+
+    /**
+     * <p>{@link Calendar} for representing a database time zone.<p>
+     * It's needed when an argument is not represented in a database
+     * as {@code TIMESTAMP WITH TIME ZONE}. In this case for correct
+     * representing of a timestamp an explicit cast to the database
+     * time zone is needed at the JDBC driver level.
+     */
+    private final Optional<Calendar> calendar;
+
+    public OffsetDateTimeArgumentFactory() {
+        calendar = Optional.empty();
+    }
+
+    /**
+     * Create an argument factory with a custom time zone offset
+     *
+     * @param timeZone a time zone representing an offset
+     */
+    public OffsetDateTimeArgumentFactory(Optional<TimeZone> timeZone) {
+        calendar = timeZone.map(GregorianCalendar::new);
+    }
+
+    @Override
+    public boolean accepts(final Class<?> expectedType,
+                           final Object value,
+                           final StatementContext ctx) {
+        return value instanceof OffsetDateTime;
+    }
+
+    @Override
+    public Argument build(final Class<?> expectedType,
+                          final OffsetDateTime value,
+                          final StatementContext ctx) {
+        return new OffsetDateTimeArgument(value, calendar);
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OffsetDateTimeMapper.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OffsetDateTimeMapper.java
@@ -1,0 +1,75 @@
+package io.dropwizard.jdbi.args;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultColumnMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.Optional;
+import java.util.TimeZone;
+
+/**
+ * A {@link ResultColumnMapper} to map {@link OffsetDateTime} objects.
+ */
+public class OffsetDateTimeMapper implements ResultColumnMapper<OffsetDateTime> {
+
+    /**
+     * <p>{@link Calendar} for representing a database time zone.<p>
+     * If a field is not represented in a database as
+     * {@code TIMESTAMP WITH TIME ZONE}, we need to set its time zone
+     * explicitly. Otherwise it will not be correctly represented in
+     * a time zone different from the time zone of the database.
+     */
+    private Optional<Calendar> calendar;
+
+    public OffsetDateTimeMapper() {
+        calendar = Optional.empty();
+    }
+
+    public OffsetDateTimeMapper(Optional<TimeZone> timeZone) {
+        calendar = timeZone.map(GregorianCalendar::new);
+    }
+
+    /**
+     * Make a clone of a calendar.
+     * <p>Despite the fact that {@link Calendar} is used only for
+     * representing a time zone, some JDBC drivers actually use it
+     * for time calculations,</p>
+     * <p>Also {@link Calendar} is not immutable, which makes it
+     * thread-unsafe. Therefore we need to make a copy to avoid
+     * state mutation problems.</p>
+     *
+     * @return a clone of calendar, representing a database time zone
+     */
+    private Calendar cloneCalendar() {
+        return (Calendar) calendar.get().clone();
+    }
+
+    @Override
+    public OffsetDateTime mapColumn(ResultSet r, int columnNumber, StatementContext ctx) throws SQLException {
+        final Timestamp timestamp = calendar.isPresent() ? r.getTimestamp(columnNumber, cloneCalendar()) :
+            r.getTimestamp(columnNumber);
+        return convertToOffsetDateTime(timestamp);
+    }
+
+    @Override
+    public OffsetDateTime mapColumn(ResultSet r, String columnLabel, StatementContext ctx) throws SQLException {
+        final Timestamp timestamp = calendar.isPresent() ? r.getTimestamp(columnLabel, cloneCalendar()) :
+            r.getTimestamp(columnLabel);
+        return convertToOffsetDateTime(timestamp);
+    }
+
+    private OffsetDateTime convertToOffsetDateTime(Timestamp timestamp) {
+        if (timestamp == null) {
+            return null;
+        }
+        final Optional<ZoneId> zoneId = calendar.flatMap(c -> Optional.of(c.getTimeZone().toZoneId()));
+        return OffsetDateTime.ofInstant(Instant.ofEpochMilli(timestamp.getTime()), zoneId.orElse(ZoneId.systemDefault()));
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalArgumentFactory.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jdbi.args;
 
-import com.google.common.base.Optional;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.Argument;
 import org.skife.jdbi.v2.tweak.ArgumentFactory;
@@ -8,13 +7,20 @@ import org.skife.jdbi.v2.tweak.ArgumentFactory;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.Optional;
 
 public class OptionalArgumentFactory implements ArgumentFactory<Optional<Object>> {
     private static class DefaultOptionalArgument implements Argument {
         private final Optional<?> value;
+        private final int nullType;
+
+        private DefaultOptionalArgument(Optional<?> value, int nullType) {
+            this.value = value;
+            this.nullType = nullType;
+        }
 
         private DefaultOptionalArgument(Optional<?> value) {
-            this.value = value;
+            this(value, Types.OTHER);
         }
 
         @Override
@@ -24,7 +30,7 @@ public class OptionalArgumentFactory implements ArgumentFactory<Optional<Object>
             if (value.isPresent()) {
                 statement.setObject(position, value.get());
             } else {
-                statement.setNull(position, Types.OTHER);
+                statement.setNull(position, nullType);
             }
         }
     }
@@ -40,7 +46,7 @@ public class OptionalArgumentFactory implements ArgumentFactory<Optional<Object>
         public void apply(int position,
                           PreparedStatement statement,
                           StatementContext ctx) throws SQLException {
-            statement.setObject(position, value.orNull());
+            statement.setObject(position, value.orElse(null));
         }
     }
 
@@ -59,6 +65,8 @@ public class OptionalArgumentFactory implements ArgumentFactory<Optional<Object>
     public Argument build(Class<?> expectedType, Optional<Object> value, StatementContext ctx) {
         if ("com.microsoft.sqlserver.jdbc.SQLServerDriver".equals(jdbcDriver)) {
             return new MsSqlOptionalArgument(value);
+        } else if ("oracle.jdbc.OracleDriver".equals(jdbcDriver)) {
+            return new DefaultOptionalArgument(value, Types.NULL);
         }
         return new DefaultOptionalArgument(value);
     }

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalDoubleArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalDoubleArgumentFactory.java
@@ -1,0 +1,41 @@
+package io.dropwizard.jdbi.args;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+import org.skife.jdbi.v2.tweak.ArgumentFactory;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.OptionalDouble;
+
+public class OptionalDoubleArgumentFactory implements ArgumentFactory<OptionalDouble> {
+    private static class DefaultOptionalArgument implements Argument {
+        private final OptionalDouble value;
+
+        private DefaultOptionalArgument(OptionalDouble value) {
+            this.value = value;
+        }
+
+        @Override
+        public void apply(int position,
+                          PreparedStatement statement,
+                          StatementContext ctx) throws SQLException {
+            if (value.isPresent()) {
+                statement.setDouble(position, value.getAsDouble());
+            } else {
+                statement.setNull(position, Types.DOUBLE);
+            }
+        }
+    }
+
+    @Override
+    public boolean accepts(Class<?> expectedType, Object value, StatementContext ctx) {
+        return value instanceof OptionalDouble;
+    }
+
+    @Override
+    public Argument build(Class<?> expectedType, OptionalDouble value, StatementContext ctx) {
+        return new DefaultOptionalArgument(value);
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalDoubleMapper.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalDoubleMapper.java
@@ -1,0 +1,25 @@
+package io.dropwizard.jdbi.args;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultColumnMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.OptionalDouble;
+
+/**
+ * A {@link ResultColumnMapper} to map {@link OptionalDouble} objects.
+ */
+public class OptionalDoubleMapper implements ResultColumnMapper<OptionalDouble> {
+    @Override
+    public OptionalDouble mapColumn(ResultSet r, int columnNumber, StatementContext ctx) throws SQLException {
+        final double value = r.getDouble(columnNumber);
+        return r.wasNull() ? OptionalDouble.empty() : OptionalDouble.of(value);
+    }
+
+    @Override
+    public OptionalDouble mapColumn(ResultSet r, String columnLabel, StatementContext ctx) throws SQLException {
+        final double value = r.getDouble(columnLabel);
+        return r.wasNull() ? OptionalDouble.empty() : OptionalDouble.of(value);
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalInstantArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalInstantArgumentFactory.java
@@ -1,0 +1,44 @@
+package io.dropwizard.jdbi.args;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+import org.skife.jdbi.v2.tweak.ArgumentFactory;
+
+import java.time.Instant;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.Optional;
+import java.util.TimeZone;
+
+/**
+ * An {@link ArgumentFactory} for {@link Instant} arguments wrapped by {@link Optional}.
+ */
+public class OptionalInstantArgumentFactory implements ArgumentFactory<Optional<Instant>> {
+
+    private final Optional<Calendar> calendar;
+
+    public OptionalInstantArgumentFactory() {
+        calendar = Optional.empty();
+    }
+
+    public OptionalInstantArgumentFactory(Optional<TimeZone> timeZone) {
+        calendar = timeZone.map(GregorianCalendar::new);
+    }
+
+    @Override
+    public boolean accepts(Class<?> expectedType, Object value, StatementContext ctx) {
+        if (value instanceof Optional) {
+            final Optional<?> optionalValue = (Optional<?>) value;
+            // Fall through to OptionalArgumentFactory if absent.
+            // Fall through to OptionalArgumentFactory if present, but not Instant.
+            return optionalValue.isPresent() && optionalValue.get() instanceof Instant;
+        }
+        return false;
+    }
+
+    @Override
+    public Argument build(Class<?> expectedType, Optional<Instant> value, StatementContext ctx) {
+        // accepts guarantees that the value is present
+        return new InstantArgument(value.get(), calendar);
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalIntArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalIntArgumentFactory.java
@@ -1,0 +1,41 @@
+package io.dropwizard.jdbi.args;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+import org.skife.jdbi.v2.tweak.ArgumentFactory;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.OptionalInt;
+
+public class OptionalIntArgumentFactory implements ArgumentFactory<OptionalInt> {
+    private static class DefaultOptionalArgument implements Argument {
+        private final OptionalInt value;
+
+        private DefaultOptionalArgument(OptionalInt value) {
+            this.value = value;
+        }
+
+        @Override
+        public void apply(int position,
+                          PreparedStatement statement,
+                          StatementContext ctx) throws SQLException {
+            if (value.isPresent()) {
+                statement.setInt(position, value.getAsInt());
+            } else {
+                statement.setNull(position, Types.INTEGER);
+            }
+        }
+    }
+
+    @Override
+    public boolean accepts(Class<?> expectedType, Object value, StatementContext ctx) {
+        return value instanceof OptionalInt;
+    }
+
+    @Override
+    public Argument build(Class<?> expectedType, OptionalInt value, StatementContext ctx) {
+        return new DefaultOptionalArgument(value);
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalIntMapper.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalIntMapper.java
@@ -1,0 +1,25 @@
+package io.dropwizard.jdbi.args;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultColumnMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.OptionalInt;
+
+/**
+ * A {@link ResultColumnMapper} to map {@link OptionalInt} objects.
+ */
+public class OptionalIntMapper implements ResultColumnMapper<OptionalInt> {
+    @Override
+    public OptionalInt mapColumn(ResultSet r, int columnNumber, StatementContext ctx) throws SQLException {
+        final int value = r.getInt(columnNumber);
+        return r.wasNull() ? OptionalInt.empty() : OptionalInt.of(value);
+    }
+
+    @Override
+    public OptionalInt mapColumn(ResultSet r, String columnLabel, StatementContext ctx) throws SQLException {
+        final int value = r.getInt(columnLabel);
+        return r.wasNull() ? OptionalInt.empty() : OptionalInt.of(value);
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalJodaTimeArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalJodaTimeArgumentFactory.java
@@ -1,7 +1,5 @@
 package io.dropwizard.jdbi.args;
 
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
 import org.joda.time.DateTime;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.Argument;
@@ -9,26 +7,22 @@ import org.skife.jdbi.v2.tweak.ArgumentFactory;
 
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.util.Optional;
 import java.util.TimeZone;
 
 /**
- * An {@link ArgumentFactory} for Joda's {@link DateTime} arguments wrapped by Guava's {@link Optional}.
+ * An {@link ArgumentFactory} for Joda's {@link DateTime} arguments wrapped by {@link Optional}.
  */
 public class OptionalJodaTimeArgumentFactory implements ArgumentFactory<Optional<DateTime>> {
 
     private final Optional<Calendar> calendar;
 
     public OptionalJodaTimeArgumentFactory() {
-        calendar = Optional.absent();
+        calendar = Optional.empty();
     }
 
     public OptionalJodaTimeArgumentFactory(Optional<TimeZone> timeZone) {
-        calendar = timeZone.transform(new Function<TimeZone, Calendar>() {
-            @Override
-            public Calendar apply(TimeZone tz) {
-                return new GregorianCalendar(tz);
-            }
-        });
+        calendar = timeZone.map(GregorianCalendar::new);
     }
 
     @Override

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalLocalDateArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalLocalDateArgumentFactory.java
@@ -1,0 +1,30 @@
+package io.dropwizard.jdbi.args;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+import org.skife.jdbi.v2.tweak.ArgumentFactory;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+/**
+ * An {@link ArgumentFactory} for {@link LocalDate} arguments wrapped by {@link Optional}.
+ */
+public class OptionalLocalDateArgumentFactory implements ArgumentFactory<Optional<LocalDate>> {
+    @Override
+    public boolean accepts(Class<?> expectedType, Object value, StatementContext ctx) {
+        if (value instanceof Optional) {
+            final Optional<?> optionalValue = (Optional<?>) value;
+            // Fall through to OptionalArgumentFactory if absent.
+            // Fall through to OptionalArgumentFactory if present, but not DateTime.
+            return optionalValue.isPresent() && optionalValue.get() instanceof LocalDate;
+        }
+        return false;
+    }
+
+    @Override
+    public Argument build(Class<?> expectedType, Optional<LocalDate> value, StatementContext ctx) {
+        // accepts guarantees that the value is present
+        return new LocalDateArgument(value.get());
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalLocalDateTimeArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalLocalDateTimeArgumentFactory.java
@@ -1,0 +1,30 @@
+package io.dropwizard.jdbi.args;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+import org.skife.jdbi.v2.tweak.ArgumentFactory;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+/**
+ * An {@link ArgumentFactory} for {@link LocalDateTime} arguments wrapped by {@link Optional}.
+ */
+public class OptionalLocalDateTimeArgumentFactory implements ArgumentFactory<Optional<LocalDateTime>> {
+    @Override
+    public boolean accepts(Class<?> expectedType, Object value, StatementContext ctx) {
+        if (value instanceof Optional) {
+            final Optional<?> optionalValue = (Optional<?>) value;
+            // Fall through to OptionalArgumentFactory if absent.
+            // Fall through to OptionalArgumentFactory if present, but not LocalDateTime.
+            return optionalValue.isPresent() && optionalValue.get() instanceof LocalDateTime;
+        }
+        return false;
+    }
+
+    @Override
+    public Argument build(Class<?> expectedType, Optional<LocalDateTime> value, StatementContext ctx) {
+        // accepts guarantees that the value is present
+        return new LocalDateTimeArgument(value.get());
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalLongArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalLongArgumentFactory.java
@@ -1,0 +1,41 @@
+package io.dropwizard.jdbi.args;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+import org.skife.jdbi.v2.tweak.ArgumentFactory;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.OptionalLong;
+
+public class OptionalLongArgumentFactory implements ArgumentFactory<OptionalLong> {
+    private static class DefaultOptionalArgument implements Argument {
+        private final OptionalLong value;
+
+        private DefaultOptionalArgument(OptionalLong value) {
+            this.value = value;
+        }
+
+        @Override
+        public void apply(int position,
+                          PreparedStatement statement,
+                          StatementContext ctx) throws SQLException {
+            if (value.isPresent()) {
+                statement.setLong(position, value.getAsLong());
+            } else {
+                statement.setNull(position, Types.BIGINT);
+            }
+        }
+    }
+
+    @Override
+    public boolean accepts(Class<?> expectedType, Object value, StatementContext ctx) {
+        return value instanceof OptionalLong;
+    }
+
+    @Override
+    public Argument build(Class<?> expectedType, OptionalLong value, StatementContext ctx) {
+        return new DefaultOptionalArgument(value);
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalLongMapper.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalLongMapper.java
@@ -1,0 +1,25 @@
+package io.dropwizard.jdbi.args;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultColumnMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.OptionalLong;
+
+/**
+ * A {@link ResultColumnMapper} to map {@link OptionalLong} objects.
+ */
+public class OptionalLongMapper implements ResultColumnMapper<OptionalLong> {
+    @Override
+    public OptionalLong mapColumn(ResultSet r, int columnNumber, StatementContext ctx) throws SQLException {
+        final long value = r.getLong(columnNumber);
+        return r.wasNull() ? OptionalLong.empty() : OptionalLong.of(value);
+    }
+
+    @Override
+    public OptionalLong mapColumn(ResultSet r, String columnLabel, StatementContext ctx) throws SQLException {
+        final long value = r.getLong(columnLabel);
+        return r.wasNull() ? OptionalLong.empty() : OptionalLong.of(value);
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalOffsetTimeArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalOffsetTimeArgumentFactory.java
@@ -1,0 +1,44 @@
+package io.dropwizard.jdbi.args;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+import org.skife.jdbi.v2.tweak.ArgumentFactory;
+
+import java.time.OffsetDateTime;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.Optional;
+import java.util.TimeZone;
+
+/**
+ * An {@link ArgumentFactory} for {@link OffsetDateTime} arguments wrapped by {@link Optional}.
+ */
+public class OptionalOffsetTimeArgumentFactory implements ArgumentFactory<Optional<OffsetDateTime>> {
+
+    private final Optional<Calendar> calendar;
+
+    public OptionalOffsetTimeArgumentFactory() {
+        calendar = Optional.empty();
+    }
+
+    public OptionalOffsetTimeArgumentFactory(Optional<TimeZone> timeZone) {
+        calendar = timeZone.map(GregorianCalendar::new);
+    }
+
+    @Override
+    public boolean accepts(Class<?> expectedType, Object value, StatementContext ctx) {
+        if (value instanceof Optional) {
+            final Optional<?> optionalValue = (Optional<?>) value;
+            // Fall through to OptionalArgumentFactory if absent.
+            // Fall through to OptionalArgumentFactory if present, but not DateTime.
+            return optionalValue.isPresent() && optionalValue.get() instanceof OffsetDateTime;
+        }
+        return false;
+    }
+
+    @Override
+    public Argument build(Class<?> expectedType, Optional<OffsetDateTime> value, StatementContext ctx) {
+        // accepts guarantees that the value is present
+        return new OffsetDateTimeArgument(value.get(), calendar);
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalZonedTimeArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalZonedTimeArgumentFactory.java
@@ -1,0 +1,44 @@
+package io.dropwizard.jdbi.args;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+import org.skife.jdbi.v2.tweak.ArgumentFactory;
+
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.Optional;
+import java.util.TimeZone;
+
+/**
+ * An {@link ArgumentFactory} for {@link ZonedDateTime} arguments wrapped by {@link Optional}.
+ */
+public class OptionalZonedTimeArgumentFactory implements ArgumentFactory<Optional<ZonedDateTime>> {
+
+    private final Optional<Calendar> calendar;
+
+    public OptionalZonedTimeArgumentFactory() {
+        calendar = Optional.empty();
+    }
+
+    public OptionalZonedTimeArgumentFactory(Optional<TimeZone> timeZone) {
+        calendar = timeZone.map(GregorianCalendar::new);
+    }
+
+    @Override
+    public boolean accepts(Class<?> expectedType, Object value, StatementContext ctx) {
+        if (value instanceof Optional) {
+            final Optional<?> optionalValue = (Optional<?>) value;
+            // Fall through to OptionalArgumentFactory if absent.
+            // Fall through to OptionalArgumentFactory if present, but not DateTime.
+            return optionalValue.isPresent() && optionalValue.get() instanceof ZonedDateTime;
+        }
+        return false;
+    }
+
+    @Override
+    public Argument build(Class<?> expectedType, Optional<ZonedDateTime> value, StatementContext ctx) {
+        // accepts guarantees that the value is present
+        return new ZonedDateTimeArgument(value.get(), calendar);
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/ZonedDateTimeArgument.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/ZonedDateTimeArgument.java
@@ -1,0 +1,44 @@
+package io.dropwizard.jdbi.args;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.Optional;
+
+/**
+ * An {@link Argument} for {@link ZonedDateTime} objects.
+ */
+public class ZonedDateTimeArgument implements Argument {
+
+    private final ZonedDateTime value;
+    private final Optional<Calendar> calendar;
+
+    ZonedDateTimeArgument(final ZonedDateTime value, final Optional<Calendar> calendar) {
+        this.value = value;
+        this.calendar = calendar;
+    }
+
+    @Override
+    public void apply(final int position,
+                      final PreparedStatement statement,
+                      final StatementContext ctx) throws SQLException {
+        if (value != null) {
+            if (calendar.isPresent()) {
+                // We need to make a clone, because Calendar is not thread-safe
+                // and some JDBC drivers mutate it during time calculations
+                Calendar calendarClone = (Calendar) calendar.get().clone();
+                statement.setTimestamp(position, new Timestamp(value.toInstant().toEpochMilli()), calendarClone);
+            } else {
+                statement.setTimestamp(position, new Timestamp(value.toInstant().toEpochMilli()));
+            }
+        } else {
+            statement.setNull(position, Types.TIMESTAMP);
+        }
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/ZonedDateTimeArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/ZonedDateTimeArgumentFactory.java
@@ -1,0 +1,53 @@
+package io.dropwizard.jdbi.args;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+import org.skife.jdbi.v2.tweak.ArgumentFactory;
+
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.Optional;
+import java.util.TimeZone;
+
+/**
+ * An {@link ArgumentFactory} for {@link ZonedDateTime} arguments.
+ */
+public class ZonedDateTimeArgumentFactory implements ArgumentFactory<ZonedDateTime> {
+
+    /**
+     * <p>{@link Calendar} for representing a database time zone.<p>
+     * It's needed when an argument is not represented in a database
+     * as {@code TIMESTAMP WITH TIME ZONE}. In this case for correct
+     * representing of a timestamp an explicit cast to the database
+     * time zone is needed at the JDBC driver level.
+     */
+    private final Optional<Calendar> calendar;
+
+    public ZonedDateTimeArgumentFactory() {
+        calendar = Optional.empty();
+    }
+
+    /**
+     * Create an argument factory with a custom time zone offset
+     *
+     * @param timeZone a time zone representing an offset
+     */
+    public ZonedDateTimeArgumentFactory(Optional<TimeZone> timeZone) {
+        calendar = timeZone.map(GregorianCalendar::new);
+    }
+
+    @Override
+    public boolean accepts(final Class<?> expectedType,
+                           final Object value,
+                           final StatementContext ctx) {
+        return value instanceof ZonedDateTime;
+    }
+
+    @Override
+    public Argument build(final Class<?> expectedType,
+                          final ZonedDateTime value,
+                          final StatementContext ctx) {
+        return new ZonedDateTimeArgument(value, calendar);
+    }
+}

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/ZonedDateTimeMapper.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/ZonedDateTimeMapper.java
@@ -1,0 +1,75 @@
+package io.dropwizard.jdbi.args;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultColumnMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.Optional;
+import java.util.TimeZone;
+
+/**
+ * A {@link ResultColumnMapper} to map {@link ZonedDateTime} objects.
+ */
+public class ZonedDateTimeMapper implements ResultColumnMapper<ZonedDateTime> {
+
+    /**
+     * <p>{@link Calendar} for representing a database time zone.<p>
+     * If a field is not represented in a database as
+     * {@code TIMESTAMP WITH TIME ZONE}, we need to set its time zone
+     * explicitly. Otherwise it will not be correctly represented in
+     * a time zone different from the time zone of the database.
+     */
+    private Optional<Calendar> calendar;
+
+    public ZonedDateTimeMapper() {
+        calendar = Optional.empty();
+    }
+
+    public ZonedDateTimeMapper(Optional<TimeZone> timeZone) {
+        calendar = timeZone.map(GregorianCalendar::new);
+    }
+
+    /**
+     * Make a clone of a calendar.
+     * <p>Despite the fact that {@link Calendar} is used only for
+     * representing a time zone, some JDBC drivers actually use it
+     * for time calculations,</p>
+     * <p>Also {@link Calendar} is not immutable, which makes it
+     * thread-unsafe. Therefore we need to make a copy to avoid
+     * state mutation problems.</p>
+     *
+     * @return a clone of calendar, representing a database time zone
+     */
+    private Calendar cloneCalendar() {
+        return (Calendar) calendar.get().clone();
+    }
+
+    @Override
+    public ZonedDateTime mapColumn(ResultSet r, int columnNumber, StatementContext ctx) throws SQLException {
+        final Timestamp timestamp = calendar.isPresent() ? r.getTimestamp(columnNumber, cloneCalendar()) :
+            r.getTimestamp(columnNumber);
+        return convertToZonedDateTime(timestamp);
+    }
+
+    @Override
+    public ZonedDateTime mapColumn(ResultSet r, String columnLabel, StatementContext ctx) throws SQLException {
+        final Timestamp timestamp = calendar.isPresent() ? r.getTimestamp(columnLabel, cloneCalendar()) :
+            r.getTimestamp(columnLabel);
+        return convertToZonedDateTime(timestamp);
+    }
+
+    private ZonedDateTime convertToZonedDateTime(Timestamp timestamp) {
+        if (timestamp == null) {
+            return null;
+        }
+        final Optional<ZoneId> zoneId = calendar.flatMap(c -> Optional.of(c.getTimeZone().toZoneId()));
+        return ZonedDateTime.ofInstant(Instant.ofEpochMilli(timestamp.getTime()), zoneId.orElse(ZoneId.systemDefault()));
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/GuavaJDBITest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/GuavaJDBITest.java
@@ -1,0 +1,184 @@
+package io.dropwizard.jdbi;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.db.ManagedDataSource;
+import io.dropwizard.lifecycle.Managed;
+import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
+import io.dropwizard.logging.BootstrapLogging;
+import io.dropwizard.setup.Environment;
+import org.joda.time.DateTime;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.Query;
+import org.skife.jdbi.v2.util.StringColumnMapper;
+
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.util.List;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class GuavaJDBITest {
+    private final DataSourceFactory hsqlConfig = new DataSourceFactory();
+
+    {
+        BootstrapLogging.bootstrap();
+        hsqlConfig.setUrl("jdbc:h2:mem:GuavaJDBITest-" + System.currentTimeMillis());
+        hsqlConfig.setUser("sa");
+        hsqlConfig.setDriverClass("org.h2.Driver");
+        hsqlConfig.setValidationQuery("SELECT 1");
+    }
+
+    private final HealthCheckRegistry healthChecks = mock(HealthCheckRegistry.class);
+    private final LifecycleEnvironment lifecycleEnvironment = mock(LifecycleEnvironment.class);
+    private final Environment environment = mock(Environment.class);
+    private final DBIFactory factory = new DBIFactory();
+    private final List<Managed> managed = Lists.newArrayList();
+    private final MetricRegistry metricRegistry = new MetricRegistry();
+    private DBI dbi;
+
+    @Before
+    public void setUp() throws Exception {
+        when(environment.healthChecks()).thenReturn(healthChecks);
+        when(environment.lifecycle()).thenReturn(lifecycleEnvironment);
+        when(environment.metrics()).thenReturn(metricRegistry);
+        when(environment.getHealthCheckExecutorService()).thenReturn(Executors.newSingleThreadExecutor());
+
+        this.dbi = factory.build(environment, hsqlConfig, "hsql");
+        final ArgumentCaptor<Managed> managedCaptor = ArgumentCaptor.forClass(Managed.class);
+        verify(lifecycleEnvironment).manage(managedCaptor.capture());
+        managed.addAll(managedCaptor.getAllValues());
+        for (Managed obj : managed) {
+            obj.start();
+        }
+
+        try (Handle handle = dbi.open()) {
+            handle.createCall("DROP TABLE people IF EXISTS").invoke();
+            handle.createCall(
+                    "CREATE TABLE people (name varchar(100) primary key, email varchar(100), age int, created_at timestamp)")
+                  .invoke();
+            handle.createStatement("INSERT INTO people VALUES (?, ?, ?, ?)")
+                  .bind(0, "Coda Hale")
+                  .bind(1, "chale@yammer-inc.com")
+                  .bind(2, 30)
+                  .bind(3, new Timestamp(1365465078000L))
+                  .execute();
+            handle.createStatement("INSERT INTO people VALUES (?, ?, ?, ?)")
+                  .bind(0, "Kris Gale")
+                  .bind(1, "kgale@yammer-inc.com")
+                  .bind(2, 32)
+                  .bind(3, new Timestamp(1365465078000L))
+                  .execute();
+            handle.createStatement("INSERT INTO people VALUES (?, ?, ?, ?)")
+                  .bind(0, "Old Guy")
+                  .bindNull(1, Types.VARCHAR)
+                  .bind(2, 99)
+                  .bind(3, new Timestamp(1365465078000L))
+                  .execute();
+            handle.createStatement("INSERT INTO people VALUES (?, ?, ?, ?)")
+                  .bind(0, "Alice Example")
+                  .bind(1, "alice@example.org")
+                  .bind(2, 99)
+                  .bindNull(3, Types.TIMESTAMP)
+                  .execute();
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        for (Managed obj : managed) {
+            obj.stop();
+        }
+        this.dbi = null;
+    }
+
+    @Test
+    public void createsAValidDBI() throws Exception {
+        final Handle handle = dbi.open();
+
+        final Query<String> names = handle.createQuery("SELECT name FROM people WHERE age < ?")
+                                          .bind(0, 50)
+                                          .map(StringColumnMapper.INSTANCE);
+        assertThat(names).containsOnly("Coda Hale", "Kris Gale");
+    }
+
+    @Test
+    public void managesTheDatabaseWithTheEnvironment() throws Exception {
+        verify(lifecycleEnvironment).manage(any(ManagedDataSource.class));
+    }
+
+    @Test
+    public void sqlObjectsCanAcceptOptionalParams() throws Exception {
+        final GuavaPersonDAO dao = dbi.open(GuavaPersonDAO.class);
+
+        assertThat(dao.findByName(Optional.of("Coda Hale")))
+                .isEqualTo("Coda Hale");
+    }
+
+    @Test
+    public void sqlObjectsCanReturnImmutableLists() throws Exception {
+        final GuavaPersonDAO dao = dbi.open(GuavaPersonDAO.class);
+
+        assertThat(dao.findAllNames())
+                .containsOnly("Coda Hale", "Kris Gale", "Old Guy", "Alice Example");
+    }
+
+    @Test
+    public void sqlObjectsCanReturnImmutableSets() throws Exception {
+        final GuavaPersonDAO dao = dbi.open(GuavaPersonDAO.class);
+
+        assertThat(dao.findAllUniqueNames())
+                .containsOnly("Coda Hale", "Kris Gale", "Old Guy", "Alice Example");
+    }
+
+    @Test
+    public void sqlObjectsCanReturnOptional() throws Exception {
+        final GuavaPersonDAO dao = dbi.open(GuavaPersonDAO.class);
+
+        final Optional<String> found = dao.findByEmail("chale@yammer-inc.com");
+        assertThat(found).isNotNull();
+        assertThat(found.isPresent()).isTrue();
+        assertThat(found.get()).isEqualTo("Coda Hale");
+
+
+        final Optional<String> missing = dao.findByEmail("cemalettin.koc@gmail.com");
+        assertThat(missing).isNotNull();
+        assertThat(missing.isPresent()).isFalse();
+        assertThat(missing.orNull()).isNull();
+    }
+
+    @Test
+    public void sqlObjectsCanReturnJodaDateTime() throws Exception {
+        final GuavaPersonDAO dao = dbi.open(GuavaPersonDAO.class);
+
+        final DateTime found = dao.getLatestCreatedAt(new DateTime(1365465077000L));
+        assertThat(found).isNotNull();
+        assertThat(found.getMillis()).isEqualTo(1365465078000L);
+        assertThat(found).isEqualTo(new DateTime(1365465078000L));
+
+        final DateTime notFound = dao.getCreatedAtByEmail("alice@example.org");
+        assertThat(notFound).isNull();
+
+        final Optional<DateTime> absentDateTime = dao.getCreatedAtByName("Alice Example");
+        assertThat(absentDateTime).isNotNull();
+        assertThat(absentDateTime.isPresent()).isFalse();
+
+        final Optional<DateTime> presentDateTime = dao.getCreatedAtByName("Coda Hale");
+        assertThat(presentDateTime).isNotNull();
+        assertThat(presentDateTime.isPresent()).isTrue();
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/GuavaPersonDAO.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/GuavaPersonDAO.java
@@ -1,0 +1,34 @@
+package io.dropwizard.jdbi;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.joda.time.DateTime;
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
+
+public interface GuavaPersonDAO {
+    @SqlQuery("SELECT name FROM people WHERE name = :name")
+    String findByName(@Bind("name") Optional<String> name);
+
+    @SqlQuery("SELECT name FROM people ORDER BY name ASC")
+    ImmutableList<String> findAllNames();
+
+    @SqlQuery("SELECT DISTINCT name FROM people")
+    ImmutableSet<String> findAllUniqueNames();
+
+    @SqlQuery("SELECT name FROM people WHERE email = :email ")
+    @SingleValueResult(String.class)
+    Optional<String> findByEmail(@Bind("email") String email);
+
+    @SqlQuery("SELECT created_at FROM people WHERE created_at > :from ORDER BY created_at DESC LIMIT 1")
+    DateTime getLatestCreatedAt(@Bind("from") DateTime from);
+
+    @SqlQuery("SELECT created_at FROM people WHERE name = :name")
+    @SingleValueResult(DateTime.class)
+    Optional<DateTime> getCreatedAtByName(@Bind("name") String name);
+
+    @SqlQuery("SELECT created_at FROM people WHERE email = :email")
+    DateTime getCreatedAtByEmail(@Bind("email") String email);
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/JDBITest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/JDBITest.java
@@ -2,8 +2,6 @@ package io.dropwizard.jdbi;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.db.ManagedDataSource;
@@ -19,23 +17,26 @@ import org.mockito.ArgumentCaptor;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.Query;
-import org.skife.jdbi.v2.util.StringMapper;
+import org.skife.jdbi.v2.util.StringColumnMapper;
 
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class JDBITest {
     private final DataSourceFactory hsqlConfig = new DataSourceFactory();
 
     {
         BootstrapLogging.bootstrap();
-        hsqlConfig.setUrl("jdbc:h2:mem:DbTest-" + System.currentTimeMillis());
+        hsqlConfig.setUrl("jdbc:h2:mem:JDBITest-" + System.currentTimeMillis());
         hsqlConfig.setUser("sa");
         hsqlConfig.setDriverClass("org.h2.Driver");
         hsqlConfig.setValidationQuery("SELECT 1");
@@ -67,32 +68,32 @@ public class JDBITest {
         try (Handle handle = dbi.open()) {
             handle.createCall("DROP TABLE people IF EXISTS").invoke();
             handle.createCall(
-                    "CREATE TABLE people (name varchar(100) primary key, email varchar(100), age int, created_at timestamp)")
-                  .invoke();
+                "CREATE TABLE people (name varchar(100) primary key, email varchar(100), age int, created_at timestamp)")
+                .invoke();
             handle.createStatement("INSERT INTO people VALUES (?, ?, ?, ?)")
-                  .bind(0, "Coda Hale")
-                  .bind(1, "chale@yammer-inc.com")
-                  .bind(2, 30)
-                  .bind(3, new Timestamp(1365465078000L))
-                  .execute();
+                .bind(0, "Coda Hale")
+                .bind(1, "chale@yammer-inc.com")
+                .bind(2, 30)
+                .bind(3, new Timestamp(1365465078000L))
+                .execute();
             handle.createStatement("INSERT INTO people VALUES (?, ?, ?, ?)")
-                  .bind(0, "Kris Gale")
-                  .bind(1, "kgale@yammer-inc.com")
-                  .bind(2, 32)
-                  .bind(3, new Timestamp(1365465078000L))
-                  .execute();
+                .bind(0, "Kris Gale")
+                .bind(1, "kgale@yammer-inc.com")
+                .bind(2, 32)
+                .bind(3, new Timestamp(1365465078000L))
+                .execute();
             handle.createStatement("INSERT INTO people VALUES (?, ?, ?, ?)")
-                  .bind(0, "Old Guy")
-                  .bindNull(1, Types.VARCHAR)
-                  .bind(2, 99)
-                  .bind(3, new Timestamp(1365465078000L))
-                  .execute();
+                .bind(0, "Old Guy")
+                .bindNull(1, Types.VARCHAR)
+                .bind(2, 99)
+                .bind(3, new Timestamp(1365465078000L))
+                .execute();
             handle.createStatement("INSERT INTO people VALUES (?, ?, ?, ?)")
-                  .bind(0, "Alice Example")
-                  .bind(1, "alice@example.org")
-                  .bind(2, 99)
-                  .bindNull(3, Types.TIMESTAMP)
-                  .execute();
+                .bind(0, "Alice Example")
+                .bind(1, "alice@example.org")
+                .bind(2, 99)
+                .bindNull(3, Types.TIMESTAMP)
+                .execute();
         }
     }
 
@@ -109,10 +110,9 @@ public class JDBITest {
         final Handle handle = dbi.open();
 
         final Query<String> names = handle.createQuery("SELECT name FROM people WHERE age < ?")
-                                          .bind(0, 50)
-                                          .map(StringMapper.FIRST);
-        assertThat(ImmutableList.copyOf(names))
-                .containsOnly("Coda Hale", "Kris Gale");
+            .bind(0, 50)
+            .map(StringColumnMapper.INSTANCE);
+        assertThat(names).containsOnly("Coda Hale", "Kris Gale");
     }
 
     @Test
@@ -125,7 +125,7 @@ public class JDBITest {
         final PersonDAO dao = dbi.open(PersonDAO.class);
 
         assertThat(dao.findByName(Optional.of("Coda Hale")))
-                .isEqualTo("Coda Hale");
+            .isEqualTo("Coda Hale");
     }
 
     @Test
@@ -133,7 +133,7 @@ public class JDBITest {
         final PersonDAO dao = dbi.open(PersonDAO.class);
 
         assertThat(dao.findAllNames())
-                .containsOnly("Coda Hale", "Kris Gale", "Old Guy", "Alice Example");
+            .containsOnly("Coda Hale", "Kris Gale", "Old Guy", "Alice Example");
     }
 
     @Test
@@ -141,7 +141,7 @@ public class JDBITest {
         final PersonDAO dao = dbi.open(PersonDAO.class);
 
         assertThat(dao.findAllUniqueNames())
-                .containsOnly("Coda Hale", "Kris Gale", "Old Guy", "Alice Example");
+            .containsOnly("Coda Hale", "Kris Gale", "Old Guy", "Alice Example");
     }
 
     @Test
@@ -157,7 +157,7 @@ public class JDBITest {
         final Optional<String> missing = dao.findByEmail("cemalettin.koc@gmail.com");
         assertThat(missing).isNotNull();
         assertThat(missing.isPresent()).isFalse();
-        assertThat(missing.orNull()).isNull();
+        assertThat(missing.orElse(null)).isNull();
     }
 
     @Test

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/PersonDAO.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/PersonDAO.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jdbi;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.joda.time.DateTime;
@@ -8,27 +7,29 @@ import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
 
+import java.util.Optional;
+
 public interface PersonDAO {
     @SqlQuery("SELECT name FROM people WHERE name = :name")
-    public String findByName(@Bind("name") Optional<String> name);
+    String findByName(@Bind("name") Optional<String> name);
 
     @SqlQuery("SELECT name FROM people ORDER BY name ASC")
-    public ImmutableList<String> findAllNames();
+    ImmutableList<String> findAllNames();
 
     @SqlQuery("SELECT DISTINCT name FROM people")
-    public ImmutableSet<String> findAllUniqueNames();
+    ImmutableSet<String> findAllUniqueNames();
 
     @SqlQuery("SELECT name FROM people WHERE email = :email ")
     @SingleValueResult(String.class)
-    public Optional<String> findByEmail(@Bind("email")String email);
+    Optional<String> findByEmail(@Bind("email") String email);
 
     @SqlQuery("SELECT created_at FROM people WHERE created_at > :from ORDER BY created_at DESC LIMIT 1")
-    public DateTime getLatestCreatedAt(@Bind("from") DateTime from);
+    DateTime getLatestCreatedAt(@Bind("from") DateTime from);
 
     @SqlQuery("SELECT created_at FROM people WHERE name = :name")
     @SingleValueResult(DateTime.class)
-    public Optional<DateTime> getCreatedAtByName(@Bind("name") String name);
+    Optional<DateTime> getCreatedAtByName(@Bind("name") String name);
 
     @SqlQuery("SELECT created_at FROM people WHERE email = :email")
-    public DateTime getCreatedAtByEmail(@Bind("email") String email);
+    DateTime getCreatedAtByEmail(@Bind("email") String email);
 }

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/InstantArgumentTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/InstantArgumentTest.java
@@ -1,0 +1,53 @@
+package io.dropwizard.jdbi.args;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.skife.jdbi.v2.StatementContext;
+
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.Optional;
+import java.util.TimeZone;
+
+public class InstantArgumentTest {
+
+    private final PreparedStatement statement = Mockito.mock(PreparedStatement.class);
+    private final StatementContext context = Mockito.mock(StatementContext.class);
+
+    @Test
+    public void apply() throws Exception {
+        ZonedDateTime zonedDateTime = ZonedDateTime.parse("2012-12-21T00:00:00.000Z");
+        ZonedDateTime expected = zonedDateTime.withZoneSameInstant(ZoneId.systemDefault());
+
+        new InstantArgument(zonedDateTime.toInstant(), Optional.empty()).apply(1, statement, context);
+
+        Mockito.verify(statement).setTimestamp(1, Timestamp.from(expected.toInstant()));
+    }
+
+    @Test
+    public void apply_ValueIsNull() throws Exception {
+        new InstantArgument(null, Optional.empty()).apply(1, statement, context);
+
+        Mockito.verify(statement).setNull(1, Types.TIMESTAMP);
+    }
+
+    @Test
+    public void applyCalendar() throws Exception {
+        final ZoneId systemDefault = ZoneId.systemDefault();
+
+        // this test only asserts that a calendar was passed in. Not that the JDBC driver
+        // will do the right thing and adjust the time.
+        final ZonedDateTime zonedDateTime = ZonedDateTime.parse("2012-12-21T00:00:00.000Z");
+        final ZonedDateTime expected = zonedDateTime.withZoneSameInstant(systemDefault);
+        final Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone(systemDefault));
+
+        new InstantArgument(zonedDateTime.toInstant(), Optional.of(calendar)).apply(1, statement, context);
+
+        Mockito.verify(statement).setTimestamp(1, Timestamp.from(expected.toInstant()), calendar);
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/InstantMapperTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/InstantMapperTest.java
@@ -1,0 +1,58 @@
+package io.dropwizard.jdbi.args;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public class InstantMapperTest {
+
+    private final ResultSet resultSet = Mockito.mock(ResultSet.class);
+
+    @Test
+    public void mapColumnByName() throws Exception {
+        ZonedDateTime expected = ZonedDateTime.parse("2012-12-21T00:00:00.000Z");
+        ZonedDateTime stored = expected.withZoneSameInstant(ZoneId.systemDefault());
+        when(resultSet.getTimestamp("instant")).thenReturn(Timestamp.from(stored.toInstant()));
+
+        Instant actual = new InstantMapper().mapColumn(resultSet, "instant", null);
+
+        assertThat(actual).isEqualTo(expected.toInstant());
+    }
+
+    @Test
+    public void mapColumnByName_TimestampIsNull() throws Exception {
+        when(resultSet.getTimestamp("instant")).thenReturn(null);
+
+        Instant actual = new InstantMapper().mapColumn(resultSet, "instant", null);
+
+        assertThat(actual).isNull();
+    }
+
+    @Test
+    public void mapColumnByIndex() throws Exception {
+        ZonedDateTime expected = ZonedDateTime.parse("2012-12-21T00:00:00.000Z");
+        ZonedDateTime stored = expected.withZoneSameInstant(ZoneId.systemDefault());
+        when(resultSet.getTimestamp(1)).thenReturn(Timestamp.from(stored.toInstant()));
+
+        Instant actual = new InstantMapper().mapColumn(resultSet, 1, null);
+
+        assertThat(actual).isEqualTo(expected.toInstant());
+    }
+
+    @Test
+    public void mapColumnByIndex_TimestampIsNull() throws Exception {
+        when(resultSet.getTimestamp(1)).thenReturn(null);
+
+        Instant actual = new InstantMapper().mapColumn(resultSet, 1, null);
+
+        assertThat(actual).isNull();
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/JodaDateTimeArgumentTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/JodaDateTimeArgumentTest.java
@@ -1,0 +1,33 @@
+package io.dropwizard.jdbi.args;
+
+import org.joda.time.DateTime;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.skife.jdbi.v2.StatementContext;
+
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.util.Optional;
+
+public class JodaDateTimeArgumentTest {
+
+    private final PreparedStatement statement = Mockito.mock(PreparedStatement.class);
+    private final StatementContext context = Mockito.mock(StatementContext.class);
+
+    @Test
+    public void apply() throws Exception {
+        DateTime dateTime = DateTime.parse("2007-12-03T10:15:30.375");
+
+        new JodaDateTimeArgument(dateTime, Optional.empty()).apply(1, statement, context);
+
+        Mockito.verify(statement).setTimestamp(1, Timestamp.valueOf("2007-12-03 10:15:30.375"));
+    }
+
+    @Test
+    public void apply_ValueIsNull() throws Exception {
+        new JodaDateTimeArgument(null, Optional.empty()).apply(1, statement, context);
+
+        Mockito.verify(statement).setNull(1, Types.TIMESTAMP);
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/JodaDateTimeMapperTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/JodaDateTimeMapperTest.java
@@ -1,0 +1,52 @@
+package io.dropwizard.jdbi.args;
+
+import org.joda.time.DateTime;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public class JodaDateTimeMapperTest {
+
+    private final ResultSet resultSet = Mockito.mock(ResultSet.class);
+
+    @Test
+    public void mapColumnByName() throws Exception {
+        when(resultSet.getTimestamp("name")).thenReturn(Timestamp.valueOf("2007-12-03 10:15:30.375"));
+
+        DateTime actual = new JodaDateTimeMapper().mapColumn(resultSet, "name", null);
+
+        assertThat(actual).isEqualTo(DateTime.parse("2007-12-03T10:15:30.375"));
+    }
+
+    @Test
+    public void mapColumnByName_TimestampIsNull() throws Exception {
+        when(resultSet.getTimestamp("name")).thenReturn(null);
+
+        DateTime actual = new JodaDateTimeMapper().mapColumn(resultSet, "name", null);
+
+        assertThat(actual).isNull();
+    }
+
+    @Test
+    public void mapColumnByIndex() throws Exception {
+        when(resultSet.getTimestamp(1)).thenReturn(Timestamp.valueOf("2007-12-03 10:15:30.375"));
+
+        DateTime actual = new JodaDateTimeMapper().mapColumn(resultSet, 1, null);
+
+        assertThat(actual).isEqualTo(DateTime.parse("2007-12-03T10:15:30.375"));
+    }
+
+    @Test
+    public void mapColumnByIndex_TimestampIsNull() throws Exception {
+        when(resultSet.getTimestamp(1)).thenReturn(null);
+
+        DateTime actual = new JodaDateTimeMapper().mapColumn(resultSet, 1, null);
+
+        assertThat(actual).isNull();
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/LocalDateArgumentTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/LocalDateArgumentTest.java
@@ -1,0 +1,32 @@
+package io.dropwizard.jdbi.args;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.skife.jdbi.v2.StatementContext;
+
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.LocalDate;
+
+public class LocalDateArgumentTest {
+
+    private final PreparedStatement statement = Mockito.mock(PreparedStatement.class);
+    private final StatementContext context = Mockito.mock(StatementContext.class);
+
+    @Test
+    public void apply() throws Exception {
+        LocalDate localDate = LocalDate.parse("2007-12-03");
+
+        new LocalDateArgument(localDate).apply(1, statement, context);
+
+        Mockito.verify(statement).setTimestamp(1, Timestamp.valueOf("2007-12-03 00:00:00.000"));
+    }
+
+    @Test
+    public void apply_ValueIsNull() throws Exception {
+        new LocalDateArgument(null).apply(1, statement, context);
+
+        Mockito.verify(statement).setNull(1, Types.TIMESTAMP);
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/LocalDateMapperTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/LocalDateMapperTest.java
@@ -1,0 +1,52 @@
+package io.dropwizard.jdbi.args;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public class LocalDateMapperTest {
+
+    private final ResultSet resultSet = Mockito.mock(ResultSet.class);
+
+    @Test
+    public void mapColumnByName() throws Exception {
+        when(resultSet.getTimestamp("name")).thenReturn(Timestamp.valueOf("2007-12-03 00:00:00.000"));
+
+        LocalDate actual = new LocalDateMapper().mapColumn(resultSet, "name", null);
+
+        assertThat(actual).isEqualTo(LocalDate.parse("2007-12-03"));
+    }
+
+    @Test
+    public void mapColumnByName_TimestampIsNull() throws Exception {
+        when(resultSet.getTimestamp("name")).thenReturn(null);
+
+        LocalDate actual = new LocalDateMapper().mapColumn(resultSet, "name", null);
+
+        assertThat(actual).isNull();
+    }
+
+    @Test
+    public void mapColumnByIndex() throws Exception {
+        when(resultSet.getTimestamp(1)).thenReturn(Timestamp.valueOf("2007-12-03 00:00:00.000"));
+
+        LocalDate actual = new LocalDateMapper().mapColumn(resultSet, 1, null);
+
+        assertThat(actual).isEqualTo(LocalDate.parse("2007-12-03"));
+    }
+
+    @Test
+    public void mapColumnByIndex_TimestampIsNull() throws Exception {
+        when(resultSet.getTimestamp(1)).thenReturn(null);
+
+        LocalDate actual = new LocalDateMapper().mapColumn(resultSet, 1, null);
+
+        assertThat(actual).isNull();
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/LocalDateTimeArgumentTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/LocalDateTimeArgumentTest.java
@@ -1,0 +1,32 @@
+package io.dropwizard.jdbi.args;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.skife.jdbi.v2.StatementContext;
+
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.LocalDateTime;
+
+public class LocalDateTimeArgumentTest {
+
+    private final PreparedStatement statement = Mockito.mock(PreparedStatement.class);
+    private final StatementContext context = Mockito.mock(StatementContext.class);
+
+    @Test
+    public void apply() throws Exception {
+        LocalDateTime localDateTime = LocalDateTime.parse("2007-12-03T10:15:30.375");
+
+        new LocalDateTimeArgument(localDateTime).apply(1, statement, context);
+
+        Mockito.verify(statement).setTimestamp(1, Timestamp.valueOf("2007-12-03 10:15:30.375"));
+    }
+
+    @Test
+    public void apply_ValueIsNull() throws Exception {
+        new LocalDateTimeArgument(null).apply(1, statement, context);
+
+        Mockito.verify(statement).setNull(1, Types.TIMESTAMP);
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/LocalDateTimeMapperTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/LocalDateTimeMapperTest.java
@@ -1,0 +1,52 @@
+package io.dropwizard.jdbi.args;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public class LocalDateTimeMapperTest {
+
+    private final ResultSet resultSet = Mockito.mock(ResultSet.class);
+
+    @Test
+    public void mapColumnByName() throws Exception {
+        when(resultSet.getTimestamp("name")).thenReturn(Timestamp.valueOf("2007-12-03 10:15:30.375"));
+
+        LocalDateTime actual = new LocalDateTimeMapper().mapColumn(resultSet, "name", null);
+
+        assertThat(actual).isEqualTo(LocalDateTime.parse("2007-12-03T10:15:30.375"));
+    }
+
+    @Test
+    public void mapColumnByName_TimestampIsNull() throws Exception {
+        when(resultSet.getTimestamp("name")).thenReturn(null);
+
+        LocalDateTime actual = new LocalDateTimeMapper().mapColumn(resultSet, "name", null);
+
+        assertThat(actual).isNull();
+    }
+
+    @Test
+    public void mapColumnByIndex() throws Exception {
+        when(resultSet.getTimestamp(1)).thenReturn(Timestamp.valueOf("2007-12-03 10:15:30.375"));
+
+        LocalDateTime actual = new LocalDateTimeMapper().mapColumn(resultSet, 1, null);
+
+        assertThat(actual).isEqualTo(LocalDateTime.parse("2007-12-03T10:15:30.375"));
+    }
+
+    @Test
+    public void mapColumnByIndex_TimestampIsNull() throws Exception {
+        when(resultSet.getTimestamp(1)).thenReturn(null);
+
+        LocalDateTime actual = new LocalDateTimeMapper().mapColumn(resultSet, 1, null);
+
+        assertThat(actual).isNull();
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OffsetDateTimeArgumentTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OffsetDateTimeArgumentTest.java
@@ -1,0 +1,35 @@
+package io.dropwizard.jdbi.args;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.skife.jdbi.v2.StatementContext;
+
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+
+public class OffsetDateTimeArgumentTest {
+
+    private final PreparedStatement statement = Mockito.mock(PreparedStatement.class);
+    private final StatementContext context = Mockito.mock(StatementContext.class);
+
+    @Test
+    public void apply() throws Exception {
+        final ZoneOffset localOffset = ZoneOffset.from(OffsetDateTime.now());
+        OffsetDateTime dateTime = OffsetDateTime.of(2007, 12, 3, 10, 15, 30, 375_000_000, localOffset);
+
+        new OffsetDateTimeArgument(dateTime, Optional.empty()).apply(1, statement, context);
+
+        Mockito.verify(statement).setTimestamp(1, Timestamp.valueOf("2007-12-03 10:15:30.375"));
+    }
+
+    @Test
+    public void apply_ValueIsNull() throws Exception {
+        new OffsetDateTimeArgument(null, Optional.empty()).apply(1, statement, context);
+
+        Mockito.verify(statement).setNull(1, Types.TIMESTAMP);
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OffsetDateTimeMapperTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OffsetDateTimeMapperTest.java
@@ -1,0 +1,55 @@
+package io.dropwizard.jdbi.args;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public class OffsetDateTimeMapperTest {
+
+    private final ResultSet resultSet = Mockito.mock(ResultSet.class);
+
+    @Test
+    public void mapColumnByName() throws Exception {
+        when(resultSet.getTimestamp("name")).thenReturn(Timestamp.valueOf("2007-12-03 10:15:30.375"));
+
+        OffsetDateTime actual = new OffsetDateTimeMapper().mapColumn(resultSet, "name", null);
+
+        final ZoneOffset localOffset = ZoneOffset.from(OffsetDateTime.now());
+        assertThat(actual).isEqualTo(OffsetDateTime.of(2007, 12, 3, 10, 15, 30, 375_000_000, localOffset));
+    }
+
+    @Test
+    public void mapColumnByName_TimestampIsNull() throws Exception {
+        when(resultSet.getTimestamp("name")).thenReturn(null);
+
+        OffsetDateTime actual = new OffsetDateTimeMapper().mapColumn(resultSet, "name", null);
+
+        assertThat(actual).isNull();
+    }
+
+    @Test
+    public void mapColumnByIndex() throws Exception {
+        when(resultSet.getTimestamp(1)).thenReturn(Timestamp.valueOf("2007-12-03 10:15:30.375"));
+
+        OffsetDateTime actual = new OffsetDateTimeMapper().mapColumn(resultSet, 1, null);
+
+        final ZoneOffset localOffset = ZoneOffset.from(OffsetDateTime.now());
+        assertThat(actual).isEqualTo(OffsetDateTime.of(2007, 12, 3, 10, 15, 30, 375_000_000, localOffset));
+    }
+
+    @Test
+    public void mapColumnByIndex_TimestampIsNull() throws Exception {
+        when(resultSet.getTimestamp(1)).thenReturn(null);
+
+        OffsetDateTime actual = new OffsetDateTimeMapper().mapColumn(resultSet, 1, null);
+
+        assertThat(actual).isNull();
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OptionalDoubleTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OptionalDoubleTest.java
@@ -1,0 +1,63 @@
+package io.dropwizard.jdbi.args;
+
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jdbi.DBIFactory;
+import io.dropwizard.jersey.validation.Validators;
+import io.dropwizard.setup.Environment;
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+
+import java.io.IOException;
+import java.util.OptionalDouble;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OptionalDoubleTest {
+    private final Environment env = new Environment("test-optional-double", Jackson.newObjectMapper(),
+        Validators.newValidator(), new MetricRegistry(), null);
+
+    private TestDao dao;
+
+    @Before
+    public void setupTests() throws IOException {
+        final DataSourceFactory dataSourceFactory = new DataSourceFactory();
+        dataSourceFactory.setDriverClass("org.h2.Driver");
+        dataSourceFactory.setUrl("jdbc:h2:mem:optional-double-" + System.currentTimeMillis() + "?user=sa");
+        dataSourceFactory.setInitialSize(1);
+        final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
+        try (Handle h = dbi.open()) {
+            h.execute("CREATE TABLE test (id INT PRIMARY KEY, optional DOUBLE)");
+        }
+        dao = dbi.onDemand(TestDao.class);
+    }
+
+    @Test
+    public void testPresent() {
+        dao.insert(1, OptionalDouble.of(123.456D));
+
+        assertThat(dao.findOptionalDoubleById(1).getAsDouble()).isEqualTo(123.456D);
+    }
+
+    @Test
+    public void testAbsent() {
+        dao.insert(2, OptionalDouble.empty());
+
+        assertThat(dao.findOptionalDoubleById(2).isPresent()).isFalse();
+    }
+
+    interface TestDao {
+
+        @SqlUpdate("INSERT INTO test(id, optional) VALUES (:id, :optional)")
+        void insert(@Bind("id") int id, @Bind("optional") OptionalDouble optional);
+
+        @SqlQuery("SELECT optional FROM test WHERE id = :id")
+        OptionalDouble findOptionalDoubleById(@Bind("id") int id);
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OptionalIntTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OptionalIntTest.java
@@ -1,0 +1,63 @@
+package io.dropwizard.jdbi.args;
+
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jdbi.DBIFactory;
+import io.dropwizard.jersey.validation.Validators;
+import io.dropwizard.setup.Environment;
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+
+import java.io.IOException;
+import java.util.OptionalInt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OptionalIntTest {
+    private final Environment env = new Environment("test-optional-int", Jackson.newObjectMapper(),
+        Validators.newValidator(), new MetricRegistry(), null);
+
+    private TestDao dao;
+
+    @Before
+    public void setupTests() throws IOException {
+        final DataSourceFactory dataSourceFactory = new DataSourceFactory();
+        dataSourceFactory.setDriverClass("org.h2.Driver");
+        dataSourceFactory.setUrl("jdbc:h2:mem:optional-int-" + System.currentTimeMillis() + "?user=sa");
+        dataSourceFactory.setInitialSize(1);
+        final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
+        try (Handle h = dbi.open()) {
+            h.execute("CREATE TABLE test (id INT PRIMARY KEY, optional INT)");
+        }
+        dao = dbi.onDemand(TestDao.class);
+    }
+
+    @Test
+    public void testPresent() {
+        dao.insert(1, OptionalInt.of(42));
+
+        assertThat(dao.findOptionalIntById(1).getAsInt()).isEqualTo(42);
+    }
+
+    @Test
+    public void testAbsent() {
+        dao.insert(2, OptionalInt.empty());
+
+        assertThat(dao.findOptionalIntById(2).isPresent()).isFalse();
+    }
+
+    interface TestDao {
+
+        @SqlUpdate("INSERT INTO test(id, optional) VALUES (:id, :optional)")
+        void insert(@Bind("id") int id, @Bind("optional") OptionalInt optional);
+
+        @SqlQuery("SELECT optional FROM test WHERE id = :id")
+        OptionalInt findOptionalIntById(@Bind("id") int id);
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OptionalLongTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OptionalLongTest.java
@@ -1,0 +1,63 @@
+package io.dropwizard.jdbi.args;
+
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jdbi.DBIFactory;
+import io.dropwizard.jersey.validation.Validators;
+import io.dropwizard.setup.Environment;
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+
+import java.io.IOException;
+import java.util.OptionalLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OptionalLongTest {
+    private final Environment env = new Environment("test-optional-long", Jackson.newObjectMapper(),
+        Validators.newValidator(), new MetricRegistry(), null);
+
+    private TestDao dao;
+
+    @Before
+    public void setupTests() throws IOException {
+        final DataSourceFactory dataSourceFactory = new DataSourceFactory();
+        dataSourceFactory.setDriverClass("org.h2.Driver");
+        dataSourceFactory.setUrl("jdbc:h2:mem:optional-long-" + System.currentTimeMillis() + "?user=sa");
+        dataSourceFactory.setInitialSize(1);
+        final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
+        try (Handle h = dbi.open()) {
+            h.execute("CREATE TABLE test (id INT PRIMARY KEY, optional BIGINT)");
+        }
+        dao = dbi.onDemand(TestDao.class);
+    }
+
+    @Test
+    public void testPresent() {
+        dao.insert(1, OptionalLong.of(42L));
+
+        assertThat(dao.findOptionalLongById(1).getAsLong()).isEqualTo(42);
+    }
+
+    @Test
+    public void testAbsent() {
+        dao.insert(2, OptionalLong.empty());
+
+        assertThat(dao.findOptionalLongById(2).isPresent()).isFalse();
+    }
+
+    interface TestDao {
+
+        @SqlUpdate("INSERT INTO test(id, optional) VALUES (:id, :optional)")
+        void insert(@Bind("id") int id, @Bind("optional") OptionalLong optional);
+
+        @SqlQuery("SELECT optional FROM test WHERE id = :id")
+        OptionalLong findOptionalLongById(@Bind("id") int id);
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/ZonedDateTimeArgumentTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/ZonedDateTimeArgumentTest.java
@@ -1,0 +1,34 @@
+package io.dropwizard.jdbi.args;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.skife.jdbi.v2.StatementContext;
+
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+public class ZonedDateTimeArgumentTest {
+
+    private final PreparedStatement statement = Mockito.mock(PreparedStatement.class);
+    private final StatementContext context = Mockito.mock(StatementContext.class);
+
+    @Test
+    public void apply() throws Exception {
+        ZonedDateTime dateTime = ZonedDateTime.of(2007, 12, 3, 10, 15, 30, 375_000_000, ZoneId.systemDefault());
+
+        new ZonedDateTimeArgument(dateTime, Optional.empty()).apply(1, statement, context);
+
+        Mockito.verify(statement).setTimestamp(1, Timestamp.valueOf("2007-12-03 10:15:30.375"));
+    }
+
+    @Test
+    public void apply_ValueIsNull() throws Exception {
+        new ZonedDateTimeArgument(null, Optional.empty()).apply(1, statement, context);
+
+        Mockito.verify(statement).setNull(1, Types.TIMESTAMP);
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/ZonedDateTimeMapperTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/ZonedDateTimeMapperTest.java
@@ -1,0 +1,53 @@
+package io.dropwizard.jdbi.args;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public class ZonedDateTimeMapperTest {
+
+    private final ResultSet resultSet = Mockito.mock(ResultSet.class);
+
+    @Test
+    public void mapColumnByName() throws Exception {
+        when(resultSet.getTimestamp("name")).thenReturn(Timestamp.valueOf("2007-12-03 10:15:30.375"));
+
+        ZonedDateTime actual = new ZonedDateTimeMapper().mapColumn(resultSet, "name", null);
+
+        assertThat(actual).isEqualTo(ZonedDateTime.of(2007, 12, 3, 10, 15, 30, 375_000_000, ZoneId.systemDefault()));
+    }
+
+    @Test
+    public void mapColumnByName_TimestampIsNull() throws Exception {
+        when(resultSet.getTimestamp("name")).thenReturn(null);
+
+        ZonedDateTime actual = new ZonedDateTimeMapper().mapColumn(resultSet, "name", null);
+
+        assertThat(actual).isNull();
+    }
+
+    @Test
+    public void mapColumnByIndex() throws Exception {
+        when(resultSet.getTimestamp(1)).thenReturn(Timestamp.valueOf("2007-12-03 10:15:30.375"));
+
+        ZonedDateTime actual = new ZonedDateTimeMapper().mapColumn(resultSet, 1, null);
+
+        assertThat(actual).isEqualTo(ZonedDateTime.of(2007, 12, 3, 10, 15, 30, 375_000_000, ZoneId.systemDefault()));
+    }
+
+    @Test
+    public void mapColumnByIndex_TimestampIsNull() throws Exception {
+        when(resultSet.getTimestamp(1)).thenReturn(null);
+
+        ZonedDateTime actual = new ZonedDateTimeMapper().mapColumn(resultSet, 1, null);
+
+        assertThat(actual).isNull();
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/bundles/DBIExceptionsBundleTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/bundles/DBIExceptionsBundleTest.java
@@ -6,7 +6,11 @@ import io.dropwizard.jersey.setup.JerseyEnvironment;
 import io.dropwizard.setup.Environment;
 import org.junit.Test;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class DBIExceptionsBundleTest {
 

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/jersey/LoggingDBIExceptionMapperTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/jersey/LoggingDBIExceptionMapperTest.java
@@ -10,7 +10,9 @@ import org.slf4j.Logger;
 
 import java.sql.SQLException;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 public class LoggingDBIExceptionMapperTest {
 

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/DBIClient.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/DBIClient.java
@@ -1,7 +1,6 @@
 package io.dropwizard.jdbi.timestamps;
 
 import com.codahale.metrics.MetricRegistry;
-import com.google.common.base.Optional;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jdbi.DBIFactory;
@@ -12,6 +11,7 @@ import org.junit.rules.ExternalResource;
 import org.skife.jdbi.v2.DBI;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.TimeZone;
 
 /**

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalDateTimeTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalDateTimeTest.java
@@ -1,0 +1,78 @@
+package io.dropwizard.jdbi.timestamps;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Optional;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jdbi.DBIFactory;
+import io.dropwizard.jersey.validation.Validators;
+import io.dropwizard.setup.Environment;
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GuavaOptionalDateTimeTest {
+
+    private final Environment env = new Environment("test-guava-date-time", Jackson.newObjectMapper(),
+            Validators.newValidator(), new MetricRegistry(), null);
+
+    private TaskDao dao;
+
+    @Before
+    public void setupTests() throws IOException {
+        final DataSourceFactory dataSourceFactory = new DataSourceFactory();
+        dataSourceFactory.setDriverClass("org.h2.Driver");
+        dataSourceFactory.setUrl("jdbc:h2:mem:guava-date-time-" + System.currentTimeMillis() + "?user=sa");
+        dataSourceFactory.setInitialSize(1);
+        final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
+        try (Handle h = dbi.open()) {
+            h.execute("CREATE TABLE tasks (" +
+                    "id INT PRIMARY KEY, " +
+                    "assignee VARCHAR(255) NOT NULL, " +
+                    "start_date TIMESTAMP, " +
+                    "end_date TIMESTAMP, " +
+                    "comments VARCHAR(1024) " +
+                    ")");
+        }
+        dao = dbi.onDemand(TaskDao.class);
+    }
+
+    @Test
+    public void testPresent() {
+        final DateTime startDate = DateTime.now();
+        final DateTime endDate = startDate.plusDays(1);
+        dao.insert(1, Optional.of("John Hughes"), startDate, Optional.of(endDate), Optional.<String>absent());
+
+        assertThat(dao.findEndDateById(1).get()).isEqualTo(endDate);
+    }
+
+    @Test
+    public void testAbsent() {
+        dao.insert(2, Optional.of("Kate Johansen"), DateTime.now(), Optional.<DateTime>absent(), Optional.of("To be done"));
+
+        assertThat(dao.findEndDateById(2).isPresent()).isFalse();
+    }
+
+    interface TaskDao {
+
+        @SqlUpdate("INSERT INTO tasks(id, assignee, start_date, end_date, comments) " +
+                "VALUES (:id, :assignee, :start_date, :end_date, :comments)")
+        void insert(@Bind("id") int id, @Bind("assignee") Optional<String> assignee,
+                    @Bind("start_date") DateTime startDate, @Bind("end_date") Optional<DateTime> endDate,
+                    @Bind("comments") Optional<String> comments);
+
+        @SqlQuery("SELECT end_date FROM tasks WHERE id = :id")
+        @SingleValueResult
+        Optional<DateTime> findEndDateById(@Bind("id") int id);
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalInstantTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalInstantTest.java
@@ -1,0 +1,79 @@
+package io.dropwizard.jdbi.timestamps;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Optional;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jdbi.DBIFactory;
+import io.dropwizard.jersey.validation.Validators;
+import io.dropwizard.setup.Environment;
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GuavaOptionalInstantTest {
+    private final Environment env = new Environment("test-guava-instant", Jackson.newObjectMapper(),
+            Validators.newValidator(), new MetricRegistry(), null);
+
+    private TaskDao dao;
+
+    @Before
+    public void setupTests() throws IOException {
+        final DataSourceFactory dataSourceFactory = new DataSourceFactory();
+        dataSourceFactory.setDriverClass("org.h2.Driver");
+        dataSourceFactory.setUrl("jdbc:h2:mem:guava-instant-" + System.currentTimeMillis() + "?user=sa");
+        dataSourceFactory.setInitialSize(1);
+        final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
+        try (Handle h = dbi.open()) {
+            h.execute("CREATE TABLE tasks (" +
+                    "id INT PRIMARY KEY, " +
+                    "assignee VARCHAR(255) NOT NULL, " +
+                    "start_date TIMESTAMP, " +
+                    "end_date TIMESTAMP, " +
+                    "comments VARCHAR(1024) " +
+                    ")");
+        }
+        dao = dbi.onDemand(TaskDao.class);
+    }
+
+    @Test
+    public void testPresent() {
+        final Instant startDate = Instant.now();
+        final Instant endDate = startDate.plus(1L, ChronoUnit.DAYS);
+        dao.insert(1, Optional.of("John Hughes"), startDate, Optional.of(endDate), Optional.<String>absent());
+
+        assertThat(dao.findEndDateById(1).get()).isEqualTo(endDate);
+    }
+
+    @Test
+    public void testAbsent() {
+        dao.insert(2, Optional.of("Kate Johansen"), Instant.now(),
+                Optional.<Instant>absent(), Optional.of("To be done"));
+
+        assertThat(dao.findEndDateById(2).isPresent()).isFalse();
+    }
+
+    interface TaskDao {
+
+        @SqlUpdate("INSERT INTO tasks(id, assignee, start_date, end_date, comments) " +
+                "VALUES (:id, :assignee, :start_date, :end_date, :comments)")
+        void insert(@Bind("id") int id, @Bind("assignee") Optional<String> assignee,
+                    @Bind("start_date") Instant startDate, @Bind("end_date") Optional<Instant> endDate,
+                    @Bind("comments") Optional<String> comments);
+
+        @SqlQuery("SELECT end_date FROM tasks WHERE id = :id")
+        @SingleValueResult
+        Optional<Instant> findEndDateById(@Bind("id") int id);
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalLocalDateTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalLocalDateTest.java
@@ -1,0 +1,78 @@
+package io.dropwizard.jdbi.timestamps;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Optional;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jdbi.DBIFactory;
+import io.dropwizard.jersey.validation.Validators;
+import io.dropwizard.setup.Environment;
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
+
+import java.io.IOException;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GuavaOptionalLocalDateTest {
+    private final Environment env = new Environment("test-guava-local-date", Jackson.newObjectMapper(),
+            Validators.newValidator(), new MetricRegistry(), null);
+
+    private TaskDao dao;
+
+    @Before
+    public void setupTests() throws IOException {
+        final DataSourceFactory dataSourceFactory = new DataSourceFactory();
+        dataSourceFactory.setDriverClass("org.h2.Driver");
+        dataSourceFactory.setUrl("jdbc:h2:mem:guava-local-date-" + System.currentTimeMillis() + "?user=sa");
+        dataSourceFactory.setInitialSize(1);
+        final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
+        try (Handle h = dbi.open()) {
+            h.execute("CREATE TABLE tasks (" +
+                    "id INT PRIMARY KEY, " +
+                    "assignee VARCHAR(255) NOT NULL, " +
+                    "start_date TIMESTAMP, " +
+                    "end_date TIMESTAMP, " +
+                    "comments VARCHAR(1024) " +
+                    ")");
+        }
+        dao = dbi.onDemand(TaskDao.class);
+    }
+
+    @Test
+    public void testPresent() {
+        final LocalDate startDate = LocalDate.now();
+        final LocalDate endDate = startDate.plusDays(1L);
+        dao.insert(1, Optional.of("John Hughes"), startDate, Optional.of(endDate), Optional.<String>absent());
+
+        assertThat(dao.findEndDateById(1).get()).isEqualTo(endDate);
+    }
+
+    @Test
+    public void testAbsent() {
+        dao.insert(2, Optional.of("Kate Johansen"), LocalDate.now(),
+                Optional.<LocalDate>absent(), Optional.of("To be done"));
+
+        assertThat(dao.findEndDateById(2).isPresent()).isFalse();
+    }
+
+    interface TaskDao {
+
+        @SqlUpdate("INSERT INTO tasks(id, assignee, start_date, end_date, comments) " +
+                "VALUES (:id, :assignee, :start_date, :end_date, :comments)")
+        void insert(@Bind("id") int id, @Bind("assignee") Optional<String> assignee,
+                    @Bind("start_date") LocalDate startDate, @Bind("end_date") Optional<LocalDate> endDate,
+                    @Bind("comments") Optional<String> comments);
+
+        @SqlQuery("SELECT end_date FROM tasks WHERE id = :id")
+        @SingleValueResult
+        Optional<LocalDate> findEndDateById(@Bind("id") int id);
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalLocalDateTimeTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalLocalDateTimeTest.java
@@ -1,0 +1,78 @@
+package io.dropwizard.jdbi.timestamps;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Optional;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jdbi.DBIFactory;
+import io.dropwizard.jersey.validation.Validators;
+import io.dropwizard.setup.Environment;
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GuavaOptionalLocalDateTimeTest {
+    private final Environment env = new Environment("test-guava-local-date-time", Jackson.newObjectMapper(),
+            Validators.newValidator(), new MetricRegistry(), null);
+
+    private TaskDao dao;
+
+    @Before
+    public void setupTests() throws IOException {
+        final DataSourceFactory dataSourceFactory = new DataSourceFactory();
+        dataSourceFactory.setDriverClass("org.h2.Driver");
+        dataSourceFactory.setUrl("jdbc:h2:mem:guava-local-date-time-" + System.currentTimeMillis() + "?user=sa");
+        dataSourceFactory.setInitialSize(1);
+        final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
+        try (Handle h = dbi.open()) {
+            h.execute("CREATE TABLE tasks (" +
+                    "id INT PRIMARY KEY, " +
+                    "assignee VARCHAR(255) NOT NULL, " +
+                    "start_date TIMESTAMP, " +
+                    "end_date TIMESTAMP, " +
+                    "comments VARCHAR(1024) " +
+                    ")");
+        }
+        dao = dbi.onDemand(TaskDao.class);
+    }
+
+    @Test
+    public void testPresent() {
+        final LocalDateTime startDate = LocalDateTime.now();
+        final LocalDateTime endDate = startDate.plusDays(1L);
+        dao.insert(1, Optional.of("John Hughes"), startDate, Optional.of(endDate), Optional.<String>absent());
+
+        assertThat(dao.findEndDateById(1).get()).isEqualTo(endDate);
+    }
+
+    @Test
+    public void testAbsent() {
+        dao.insert(2, Optional.of("Kate Johansen"), LocalDateTime.now(),
+                Optional.<LocalDateTime>absent(), Optional.of("To be done"));
+
+        assertThat(dao.findEndDateById(2).isPresent()).isFalse();
+    }
+
+    interface TaskDao {
+
+        @SqlUpdate("INSERT INTO tasks(id, assignee, start_date, end_date, comments) " +
+                "VALUES (:id, :assignee, :start_date, :end_date, :comments)")
+        void insert(@Bind("id") int id, @Bind("assignee") Optional<String> assignee,
+                    @Bind("start_date") LocalDateTime startDate, @Bind("end_date") Optional<LocalDateTime> endDate,
+                    @Bind("comments") Optional<String> comments);
+
+        @SqlQuery("SELECT end_date FROM tasks WHERE id = :id")
+        @SingleValueResult
+        Optional<LocalDateTime> findEndDateById(@Bind("id") int id);
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalOffsetDateTimeTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalOffsetDateTimeTest.java
@@ -1,0 +1,79 @@
+package io.dropwizard.jdbi.timestamps;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Optional;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jdbi.DBIFactory;
+import io.dropwizard.jersey.validation.Validators;
+import io.dropwizard.setup.Environment;
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
+
+import java.io.IOException;
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GuavaOptionalOffsetDateTimeTest {
+
+    private final Environment env = new Environment("test-guava-offset-date-time", Jackson.newObjectMapper(),
+            Validators.newValidator(), new MetricRegistry(), null);
+
+    private TaskDao dao;
+
+    @Before
+    public void setupTests() throws IOException {
+        final DataSourceFactory dataSourceFactory = new DataSourceFactory();
+        dataSourceFactory.setDriverClass("org.h2.Driver");
+        dataSourceFactory.setUrl("jdbc:h2:mem:guava-offset-date-time-" + System.currentTimeMillis() + "?user=sa");
+        dataSourceFactory.setInitialSize(1);
+        final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
+        try (Handle h = dbi.open()) {
+            h.execute("CREATE TABLE tasks (" +
+                    "id INT PRIMARY KEY, " +
+                    "assignee VARCHAR(255) NOT NULL, " +
+                    "start_date TIMESTAMP, " +
+                    "end_date TIMESTAMP, " +
+                    "comments VARCHAR(1024) " +
+                    ")");
+        }
+        dao = dbi.onDemand(TaskDao.class);
+    }
+
+    @Test
+    public void testPresent() {
+        final OffsetDateTime startDate = OffsetDateTime.now();
+        final OffsetDateTime endDate = startDate.plusDays(1L);
+        dao.insert(1, Optional.of("John Hughes"), startDate, Optional.of(endDate), Optional.<String>absent());
+
+        assertThat(dao.findEndDateById(1).get()).isEqualTo(endDate);
+    }
+
+    @Test
+    public void testAbsent() {
+        dao.insert(2, Optional.of("Kate Johansen"), OffsetDateTime.now(),
+                Optional.<OffsetDateTime>absent(), Optional.of("To be done"));
+
+        assertThat(dao.findEndDateById(2).isPresent()).isFalse();
+    }
+
+    interface TaskDao {
+
+        @SqlUpdate("INSERT INTO tasks(id, assignee, start_date, end_date, comments) " +
+                "VALUES (:id, :assignee, :start_date, :end_date, :comments)")
+        void insert(@Bind("id") int id, @Bind("assignee") Optional<String> assignee,
+                    @Bind("start_date") OffsetDateTime startDate, @Bind("end_date") Optional<OffsetDateTime> endDate,
+                    @Bind("comments") Optional<String> comments);
+
+        @SqlQuery("SELECT end_date FROM tasks WHERE id = :id")
+        @SingleValueResult
+        Optional<OffsetDateTime> findEndDateById(@Bind("id") int id);
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalZonedDateTimeTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalZonedDateTimeTest.java
@@ -1,0 +1,79 @@
+package io.dropwizard.jdbi.timestamps;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Optional;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jdbi.DBIFactory;
+import io.dropwizard.jersey.validation.Validators;
+import io.dropwizard.setup.Environment;
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GuavaOptionalZonedDateTimeTest {
+
+    private final Environment env = new Environment("test-guava-zoned-date-time", Jackson.newObjectMapper(),
+            Validators.newValidator(), new MetricRegistry(), null);
+
+    private TaskDao dao;
+
+    @Before
+    public void setupTests() throws IOException {
+        final DataSourceFactory dataSourceFactory = new DataSourceFactory();
+        dataSourceFactory.setDriverClass("org.h2.Driver");
+        dataSourceFactory.setUrl("jdbc:h2:mem:guava-zoned-date-time-" + System.currentTimeMillis() + "?user=sa");
+        dataSourceFactory.setInitialSize(1);
+        final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
+        try (Handle h = dbi.open()) {
+            h.execute("CREATE TABLE tasks (" +
+                    "id INT PRIMARY KEY, " +
+                    "assignee VARCHAR(255) NOT NULL, " +
+                    "start_date TIMESTAMP, " +
+                    "end_date TIMESTAMP, " +
+                    "comments VARCHAR(1024) " +
+                    ")");
+        }
+        dao = dbi.onDemand(TaskDao.class);
+    }
+
+    @Test
+    public void testPresent() {
+        final ZonedDateTime startDate = ZonedDateTime.now();
+        final ZonedDateTime endDate = startDate.plusDays(1L);
+        dao.insert(1, Optional.of("John Hughes"), startDate, Optional.of(endDate), Optional.<String>absent());
+
+        assertThat(dao.findEndDateById(1).get()).isEqualTo(endDate);
+    }
+
+    @Test
+    public void testAbsent() {
+        dao.insert(2, Optional.of("Kate Johansen"), ZonedDateTime.now(),
+                Optional.<ZonedDateTime>absent(), Optional.of("To be done"));
+
+        assertThat(dao.findEndDateById(2).isPresent()).isFalse();
+    }
+
+    interface TaskDao {
+
+        @SqlUpdate("INSERT INTO tasks(id, assignee, start_date, end_date, comments) " +
+                "VALUES (:id, :assignee, :start_date, :end_date, :comments)")
+        void insert(@Bind("id") int id, @Bind("assignee") Optional<String> assignee,
+                    @Bind("start_date") ZonedDateTime startDate, @Bind("end_date") Optional<ZonedDateTime> endDate,
+                    @Bind("comments") Optional<String> comments);
+
+        @SqlQuery("SELECT end_date FROM tasks WHERE id = :id")
+        @SingleValueResult
+        Optional<ZonedDateTime> findEndDateById(@Bind("id") int id);
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/JodaDateTimeSqlTimestampTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/JodaDateTimeSqlTimestampTest.java
@@ -25,11 +25,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Test for handling translation between DateTime to SQL TIMESTAMP
  * in a different time zone
  */
-public class DateTimeSqlTimestampTest {
+public class JodaDateTimeSqlTimestampTest {
 
     private static final DateTimeFormatter ISO_FMT = ISODateTimeFormat.dateTimeNoMillis();
 
-    private static TimeZone timeZone;
     private static TemporaryFolder temporaryFolder;
     private static DatabaseInTimeZone databaseInTimeZone;
     private static DateTimeZone dbTimeZone;
@@ -41,7 +40,7 @@ public class DateTimeSqlTimestampTest {
         boolean done = false;
         while (!done) {
             try {
-                timeZone = getRandomTimeZone();
+                final TimeZone timeZone = getRandomTimeZone();
                 dbTimeZone = DateTimeZone.forTimeZone(timeZone);
                 temporaryFolder = new TemporaryFolder();
                 databaseInTimeZone = new DatabaseInTimeZone(temporaryFolder, timeZone);

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalDateTimeTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalDateTimeTest.java
@@ -1,0 +1,80 @@
+package io.dropwizard.jdbi.timestamps;
+
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jdbi.DBIFactory;
+import io.dropwizard.jersey.validation.Validators;
+import io.dropwizard.setup.Environment;
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OptionalDateTimeTest {
+
+    private final Environment env = new Environment("test-optional-date-time", Jackson.newObjectMapper(),
+            Validators.newValidator(), new MetricRegistry(), null);
+
+
+    private TaskDao dao;
+
+    @Before
+    public void setupTests() throws IOException {
+        final DataSourceFactory dataSourceFactory = new DataSourceFactory();
+        dataSourceFactory.setDriverClass("org.h2.Driver");
+        dataSourceFactory.setUrl("jdbc:h2:mem:date-time-optional-" + System.currentTimeMillis() + "?user=sa");
+        dataSourceFactory.setInitialSize(1);
+        final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
+        try (Handle h = dbi.open()) {
+            h.execute("CREATE TABLE tasks (" +
+                    "id INT PRIMARY KEY, " +
+                    "assignee VARCHAR(255) NOT NULL, " +
+                    "start_date TIMESTAMP, " +
+                    "end_date TIMESTAMP, " +
+                    "comments VARCHAR(1024) " +
+                    ")");
+        }
+        dao = dbi.onDemand(TaskDao.class);
+    }
+
+    @Test
+    public void testPresent() {
+        final DateTime startDate = DateTime.now();
+        final DateTime endDate = startDate.plusDays(1);
+        dao.insert(1, Optional.of("John Hughes"), startDate, Optional.of(endDate), Optional.<String>empty());
+
+        assertThat(dao.findEndDateById(1).get()).isEqualTo(endDate);
+    }
+
+    @Test
+    public void testAbsent() {
+        dao.insert(2, Optional.of("Kate Johansen"), DateTime.now(),
+                Optional.<DateTime>empty(), Optional.of("To be done"));
+
+        assertThat(dao.findEndDateById(2).isPresent()).isFalse();
+    }
+
+    interface TaskDao {
+
+        @SqlUpdate("INSERT INTO tasks(id, assignee, start_date, end_date, comments) " +
+                "VALUES (:id, :assignee, :start_date, :end_date, :comments)")
+        void insert(@Bind("id") int id, @Bind("assignee") Optional<String> assignee,
+                    @Bind("start_date") DateTime startDate, @Bind("end_date") Optional<DateTime> endDate,
+                    @Bind("comments") Optional<String> comments);
+
+        @SqlQuery("SELECT end_date FROM tasks WHERE id = :id")
+        @SingleValueResult
+        Optional<DateTime> findEndDateById(@Bind("id") int id);
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalLocalDateTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalLocalDateTest.java
@@ -1,0 +1,78 @@
+package io.dropwizard.jdbi.timestamps;
+
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jdbi.DBIFactory;
+import io.dropwizard.jersey.validation.Validators;
+import io.dropwizard.setup.Environment;
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OptionalLocalDateTest {
+    private final Environment env = new Environment("test-optional-local-date", Jackson.newObjectMapper(),
+            Validators.newValidator(), new MetricRegistry(), null);
+
+    private TaskDao dao;
+
+    @Before
+    public void setupTests() throws IOException {
+        final DataSourceFactory dataSourceFactory = new DataSourceFactory();
+        dataSourceFactory.setDriverClass("org.h2.Driver");
+        dataSourceFactory.setUrl("jdbc:h2:mem:optional-local-date-" + System.currentTimeMillis() + "?user=sa");
+        dataSourceFactory.setInitialSize(1);
+        final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
+        try (Handle h = dbi.open()) {
+            h.execute("CREATE TABLE tasks (" +
+                    "id INT PRIMARY KEY, " +
+                    "assignee VARCHAR(255) NOT NULL, " +
+                    "start_date TIMESTAMP, " +
+                    "end_date TIMESTAMP, " +
+                    "comments VARCHAR(1024) " +
+                    ")");
+        }
+        dao = dbi.onDemand(TaskDao.class);
+    }
+
+    @Test
+    public void testPresent() {
+        final LocalDate startDate = LocalDate.now();
+        final LocalDate endDate = startDate.plusDays(1L);
+        dao.insert(1, Optional.of("John Hughes"), startDate, Optional.of(endDate), Optional.<String>empty());
+
+        assertThat(dao.findEndDateById(1).get()).isEqualTo(endDate);
+    }
+
+    @Test
+    public void testAbsent() {
+        dao.insert(2, Optional.of("Kate Johansen"), LocalDate.now(),
+                Optional.<LocalDate>empty(), Optional.of("To be done"));
+
+        assertThat(dao.findEndDateById(2).isPresent()).isFalse();
+    }
+
+    interface TaskDao {
+
+        @SqlUpdate("INSERT INTO tasks(id, assignee, start_date, end_date, comments) " +
+                "VALUES (:id, :assignee, :start_date, :end_date, :comments)")
+        void insert(@Bind("id") int id, @Bind("assignee") Optional<String> assignee,
+                    @Bind("start_date") LocalDate startDate, @Bind("end_date") Optional<LocalDate> endDate,
+                    @Bind("comments") Optional<String> comments);
+
+        @SqlQuery("SELECT end_date FROM tasks WHERE id = :id")
+        @SingleValueResult
+        Optional<LocalDate> findEndDateById(@Bind("id") int id);
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalLocalDateTimeTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalLocalDateTimeTest.java
@@ -1,0 +1,78 @@
+package io.dropwizard.jdbi.timestamps;
+
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jdbi.DBIFactory;
+import io.dropwizard.jersey.validation.Validators;
+import io.dropwizard.setup.Environment;
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OptionalLocalDateTimeTest {
+    private final Environment env = new Environment("test-optional-local-date-time", Jackson.newObjectMapper(),
+            Validators.newValidator(), new MetricRegistry(), null);
+
+    private TaskDao dao;
+
+    @Before
+    public void setupTests() throws IOException {
+        final DataSourceFactory dataSourceFactory = new DataSourceFactory();
+        dataSourceFactory.setDriverClass("org.h2.Driver");
+        dataSourceFactory.setUrl("jdbc:h2:mem:optional-local-date-time" + System.currentTimeMillis() + "?user=sa");
+        dataSourceFactory.setInitialSize(1);
+        final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
+        try (Handle h = dbi.open()) {
+            h.execute("CREATE TABLE tasks (" +
+                    "id INT PRIMARY KEY, " +
+                    "assignee VARCHAR(255) NOT NULL, " +
+                    "start_date TIMESTAMP, " +
+                    "end_date TIMESTAMP, " +
+                    "comments VARCHAR(1024) " +
+                    ")");
+        }
+        dao = dbi.onDemand(TaskDao.class);
+    }
+
+    @Test
+    public void testPresent() {
+        final LocalDateTime startDate = LocalDateTime.now();
+        final LocalDateTime endDate = startDate.plusDays(1L);
+        dao.insert(1, Optional.of("John Hughes"), startDate, Optional.of(endDate), Optional.<String>empty());
+
+        assertThat(dao.findEndDateById(1).get()).isEqualTo(endDate);
+    }
+
+    @Test
+    public void testAbsent() {
+        dao.insert(2, Optional.of("Kate Johansen"), LocalDateTime.now(),
+                Optional.<LocalDateTime>empty(), Optional.of("To be done"));
+
+        assertThat(dao.findEndDateById(2).isPresent()).isFalse();
+    }
+
+    interface TaskDao {
+
+        @SqlUpdate("INSERT INTO tasks(id, assignee, start_date, end_date, comments) " +
+                "VALUES (:id, :assignee, :start_date, :end_date, :comments)")
+        void insert(@Bind("id") int id, @Bind("assignee") Optional<String> assignee,
+                    @Bind("start_date") LocalDateTime startDate, @Bind("end_date") Optional<LocalDateTime> endDate,
+                    @Bind("comments") Optional<String> comments);
+
+        @SqlQuery("SELECT end_date FROM tasks WHERE id = :id")
+        @SingleValueResult
+        Optional<LocalDateTime> findEndDateById(@Bind("id") int id);
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalOffsetDateTimeTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalOffsetDateTimeTest.java
@@ -1,0 +1,79 @@
+package io.dropwizard.jdbi.timestamps;
+
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jdbi.DBIFactory;
+import io.dropwizard.jersey.validation.Validators;
+import io.dropwizard.setup.Environment;
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
+
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OptionalOffsetDateTimeTest {
+
+    private final Environment env = new Environment("test-optional-offset-date-time", Jackson.newObjectMapper(),
+            Validators.newValidator(), new MetricRegistry(), null);
+
+    private TaskDao dao;
+
+    @Before
+    public void setupTests() throws IOException {
+        final DataSourceFactory dataSourceFactory = new DataSourceFactory();
+        dataSourceFactory.setDriverClass("org.h2.Driver");
+        dataSourceFactory.setUrl("jdbc:h2:mem:optional-offset-date-time-" + System.currentTimeMillis() + "?user=sa");
+        dataSourceFactory.setInitialSize(1);
+        final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
+        try (Handle h = dbi.open()) {
+            h.execute("CREATE TABLE tasks (" +
+                    "id INT PRIMARY KEY, " +
+                    "assignee VARCHAR(255) NOT NULL, " +
+                    "start_date TIMESTAMP, " +
+                    "end_date TIMESTAMP, " +
+                    "comments VARCHAR(1024) " +
+                    ")");
+        }
+        dao = dbi.onDemand(TaskDao.class);
+    }
+
+    @Test
+    public void testPresent() {
+        final OffsetDateTime startDate = OffsetDateTime.now();
+        final OffsetDateTime endDate = startDate.plusDays(1L);
+        dao.insert(1, Optional.of("John Hughes"), startDate, Optional.of(endDate), Optional.<String>empty());
+
+        assertThat(dao.findEndDateById(1).get()).isEqualTo(endDate);
+    }
+
+    @Test
+    public void testAbsent() {
+        dao.insert(2, Optional.of("Kate Johansen"), OffsetDateTime.now(),
+                Optional.<OffsetDateTime>empty(), Optional.of("To be done"));
+
+        assertThat(dao.findEndDateById(2).isPresent()).isFalse();
+    }
+
+    interface TaskDao {
+
+        @SqlUpdate("INSERT INTO tasks(id, assignee, start_date, end_date, comments) " +
+                "VALUES (:id, :assignee, :start_date, :end_date, :comments)")
+        void insert(@Bind("id") int id, @Bind("assignee") Optional<String> assignee,
+                    @Bind("start_date") OffsetDateTime startDate, @Bind("end_date") Optional<OffsetDateTime> endDate,
+                    @Bind("comments") Optional<String> comments);
+
+        @SqlQuery("SELECT end_date FROM tasks WHERE id = :id")
+        @SingleValueResult
+        Optional<OffsetDateTime> findEndDateById(@Bind("id") int id);
+    }
+}

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalZonedDateTimeTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalZonedDateTimeTest.java
@@ -1,0 +1,79 @@
+package io.dropwizard.jdbi.timestamps;
+
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jdbi.DBIFactory;
+import io.dropwizard.jersey.validation.Validators;
+import io.dropwizard.setup.Environment;
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OptionalZonedDateTimeTest {
+
+    private final Environment env = new Environment("test-optional-zoned-date-time", Jackson.newObjectMapper(),
+            Validators.newValidator(), new MetricRegistry(), null);
+
+    private TaskDao dao;
+
+    @Before
+    public void setupTests() throws IOException {
+        final DataSourceFactory dataSourceFactory = new DataSourceFactory();
+        dataSourceFactory.setDriverClass("org.h2.Driver");
+        dataSourceFactory.setUrl("jdbc:h2:mem:optional-zoned-date-time-" + System.currentTimeMillis() + "?user=sa");
+        dataSourceFactory.setInitialSize(1);
+        final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
+        try (Handle h = dbi.open()) {
+            h.execute("CREATE TABLE tasks (" +
+                    "id INT PRIMARY KEY, " +
+                    "assignee VARCHAR(255) NOT NULL, " +
+                    "start_date TIMESTAMP, " +
+                    "end_date TIMESTAMP, " +
+                    "comments VARCHAR(1024) " +
+                    ")");
+        }
+        dao = dbi.onDemand(TaskDao.class);
+    }
+
+    @Test
+    public void testPresent() {
+        final ZonedDateTime startDate = ZonedDateTime.now();
+        final ZonedDateTime endDate = startDate.plusDays(1L);
+        dao.insert(1, Optional.of("John Hughes"), startDate, Optional.of(endDate), Optional.<String>empty());
+
+        assertThat(dao.findEndDateById(1).get()).isEqualTo(endDate);
+    }
+
+    @Test
+    public void testAbsent() {
+        dao.insert(2, Optional.of("Kate Johansen"), ZonedDateTime.now(),
+                Optional.<ZonedDateTime>empty(), Optional.of("To be done"));
+
+        assertThat(dao.findEndDateById(2).isPresent()).isFalse();
+    }
+
+    interface TaskDao {
+
+        @SqlUpdate("INSERT INTO tasks(id, assignee, start_date, end_date, comments) " +
+                "VALUES (:id, :assignee, :start_date, :end_date, :comments)")
+        void insert(@Bind("id") int id, @Bind("assignee") Optional<String> assignee,
+                    @Bind("start_date") ZonedDateTime startDate, @Bind("end_date") Optional<ZonedDateTime> endDate,
+                    @Bind("comments") Optional<String> comments);
+
+        @SqlQuery("SELECT end_date FROM tasks WHERE id = :id")
+        @SingleValueResult
+        Optional<ZonedDateTime> findEndDateById(@Bind("id") int id);
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -8,8 +8,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Sets;
 import io.dropwizard.jersey.caching.CacheControlledResponseFeature;
-import io.dropwizard.jersey.guava.OptionalMessageBodyWriter;
-import io.dropwizard.jersey.guava.OptionalParamFeature;
 import io.dropwizard.jersey.params.NonEmptyStringParamFeature;
 import io.dropwizard.jersey.sessions.SessionFactoryProvider;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -60,8 +58,10 @@ public class DropwizardResourceConfig extends ResourceConfig {
 
         register(new InstrumentedResourceMethodApplicationListener(metricRegistry));
         register(CacheControlledResponseFeature.class);
-        register(OptionalMessageBodyWriter.class);
-        register(OptionalParamFeature.class);
+        register(io.dropwizard.jersey.guava.OptionalMessageBodyWriter.class);
+        register(io.dropwizard.jersey.guava.OptionalParamFeature.class);
+        register(io.dropwizard.jersey.optional.OptionalMessageBodyWriter.class);
+        register(io.dropwizard.jersey.optional.OptionalParamFeature.class);
         register(NonEmptyStringParamFeature.class);
         register(new SessionFactoryProvider.Binder());
     }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/LocalDateParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/LocalDateParam.java
@@ -1,0 +1,22 @@
+package io.dropwizard.jersey.jsr310;
+
+import io.dropwizard.jersey.params.AbstractParam;
+
+import java.time.LocalDate;
+
+/**
+ * A parameter encapsulating date values. All non-parsable values will return a {@code 400 Bad
+ * Request} response.
+ *
+ * @see LocalDate
+ */
+public class LocalDateParam extends AbstractParam<LocalDate> {
+    public LocalDateParam(final String input) {
+        super(input);
+    }
+
+    @Override
+    protected LocalDate parse(final String input) throws Exception {
+        return LocalDate.parse(input);
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/LocalDateTimeParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/LocalDateTimeParam.java
@@ -1,0 +1,22 @@
+package io.dropwizard.jersey.jsr310;
+
+import io.dropwizard.jersey.params.AbstractParam;
+
+import java.time.LocalDateTime;
+
+/**
+ * A parameter encapsulating date/time values. All non-parsable values will return a {@code 400 Bad
+ * Request} response.
+ *
+ * @see LocalDateTime
+ */
+public class LocalDateTimeParam extends AbstractParam<LocalDateTime> {
+    public LocalDateTimeParam(final String input) {
+        super(input);
+    }
+
+    @Override
+    protected LocalDateTime parse(final String input) throws Exception {
+        return LocalDateTime.parse(input);
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/LocalTimeParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/LocalTimeParam.java
@@ -1,0 +1,22 @@
+package io.dropwizard.jersey.jsr310;
+
+import io.dropwizard.jersey.params.AbstractParam;
+
+import java.time.LocalTime;
+
+/**
+ * A parameter encapsulating time values. All non-parsable values will return a {@code 400 Bad
+ * Request} response.
+ *
+ * @see LocalTime
+ */
+public class LocalTimeParam extends AbstractParam<LocalTime> {
+    public LocalTimeParam(final String input) {
+        super(input);
+    }
+
+    @Override
+    protected LocalTime parse(final String input) throws Exception {
+        return LocalTime.parse(input);
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/OffsetDateTimeParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/OffsetDateTimeParam.java
@@ -1,0 +1,22 @@
+package io.dropwizard.jersey.jsr310;
+
+import io.dropwizard.jersey.params.AbstractParam;
+
+import java.time.OffsetDateTime;
+
+/**
+ * A parameter encapsulating date/time values containing an offset from UTC.
+ * All non-parsable values will return a {@code 400 Bad Request} response.
+ *
+ * @see OffsetDateTime
+ */
+public class OffsetDateTimeParam extends AbstractParam<OffsetDateTime> {
+    public OffsetDateTimeParam(final String input) {
+        super(input);
+    }
+
+    @Override
+    protected OffsetDateTime parse(final String input) throws Exception {
+        return OffsetDateTime.parse(input);
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/YearMonthParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/YearMonthParam.java
@@ -1,0 +1,22 @@
+package io.dropwizard.jersey.jsr310;
+
+import io.dropwizard.jersey.params.AbstractParam;
+
+import java.time.YearMonth;
+
+/**
+ * A parameter encapsulating year and month values. All non-parsable values will return a {@code 400 Bad
+ * Request} response.
+ *
+ * @see YearMonth
+ */
+public class YearMonthParam extends AbstractParam<YearMonth> {
+    public YearMonthParam(final String input) {
+        super(input);
+    }
+
+    @Override
+    protected YearMonth parse(final String input) throws Exception {
+        return YearMonth.parse(input);
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/YearParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/YearParam.java
@@ -1,0 +1,22 @@
+package io.dropwizard.jersey.jsr310;
+
+import io.dropwizard.jersey.params.AbstractParam;
+
+import java.time.Year;
+
+/**
+ * A parameter encapsulating year values. All non-parsable values will return a {@code 400 Bad
+ * Request} response.
+ *
+ * @see java.time.YearMonth
+ */
+public class YearParam extends AbstractParam<Year> {
+    public YearParam(final String input) {
+        super(input);
+    }
+
+    @Override
+    protected Year parse(final String input) throws Exception {
+        return Year.parse(input);
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/ZoneIdParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/ZoneIdParam.java
@@ -1,0 +1,22 @@
+package io.dropwizard.jersey.jsr310;
+
+import io.dropwizard.jersey.params.AbstractParam;
+
+import java.time.ZoneId;
+
+/**
+ * A parameter encapsulating time-zone IDs, such as Europe/Paris.
+ * All non-parsable values will return a {@code 400 Bad Request} response.
+ *
+ * @see ZoneId
+ */
+public class ZoneIdParam extends AbstractParam<ZoneId> {
+    public ZoneIdParam(final String input) {
+        super(input);
+    }
+
+    @Override
+    protected ZoneId parse(final String input) throws Exception {
+        return ZoneId.of(input);
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/ZonedDateTimeParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/ZonedDateTimeParam.java
@@ -1,0 +1,22 @@
+package io.dropwizard.jersey.jsr310;
+
+import io.dropwizard.jersey.params.AbstractParam;
+
+import java.time.ZonedDateTime;
+
+/**
+ * A parameter encapsulating date/time values containing timezone information.
+ * All non-parsable values will return a {@code 400 Bad Request} response.
+ *
+ * @see ZonedDateTime
+ */
+public class ZonedDateTimeParam extends AbstractParam<ZonedDateTime> {
+    public ZonedDateTimeParam(final String input) {
+        super(input);
+    }
+
+    @Override
+    protected ZonedDateTime parse(final String input) throws Exception {
+        return ZonedDateTime.parse(input);
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalMessageBodyWriter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalMessageBodyWriter.java
@@ -1,0 +1,62 @@
+package io.dropwizard.jersey.optional;
+
+import org.glassfish.jersey.message.MessageBodyWorkers;
+
+import javax.inject.Inject;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Optional;
+
+@Provider
+@Produces(MediaType.WILDCARD)
+public class OptionalMessageBodyWriter implements MessageBodyWriter<Optional<?>> {
+
+    @Inject
+    private javax.inject.Provider<MessageBodyWorkers> mbw;
+
+    // Jersey ignores this
+    @Override
+    public long getSize(Optional<?> entity, Class<?> type, Type genericType,
+                        Annotation[] annotations, MediaType mediaType) {
+        return 0;
+    }
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType,
+                               Annotation[] annotations, MediaType mediaType) {
+        return (Optional.class.isAssignableFrom(type));
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Override
+    public void writeTo(Optional<?> entity,
+                        Class<?> type,
+                        Type genericType,
+                        Annotation[] annotations,
+                        MediaType mediaType,
+                        MultivaluedMap<String, Object> httpHeaders,
+                        OutputStream entityStream)
+            throws IOException {
+        if (!entity.isPresent()) {
+            throw new NotFoundException();
+        }
+
+        final Type innerGenericType = (genericType instanceof ParameterizedType) ?
+            ((ParameterizedType) genericType).getActualTypeArguments()[0] : entity.get().getClass();
+
+        MessageBodyWriter writer = mbw.get().getMessageBodyWriter(entity.get().getClass(),
+            innerGenericType, annotations, mediaType);
+        writer.writeTo(entity.get(), entity.get().getClass(),
+            innerGenericType, annotations, mediaType, httpHeaders, entityStream);
+    }
+
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalParamBinder.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalParamBinder.java
@@ -1,0 +1,14 @@
+package io.dropwizard.jersey.optional;
+
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+
+import javax.inject.Singleton;
+import javax.ws.rs.ext.ParamConverterProvider;
+
+final class OptionalParamBinder extends AbstractBinder {
+    @Override
+    protected void configure() {
+        // Param converter providers
+        bind(OptionalParamConverterProvider.class).to(ParamConverterProvider.class).in(Singleton.class);
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalParamConverterProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalParamConverterProvider.java
@@ -1,0 +1,71 @@
+package io.dropwizard.jersey.optional;
+
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.jersey.internal.inject.Providers;
+import org.glassfish.jersey.internal.util.ReflectionHelper;
+import org.glassfish.jersey.internal.util.collection.ClassTypePair;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.ws.rs.ext.ParamConverter;
+import javax.ws.rs.ext.ParamConverterProvider;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@Singleton
+public class OptionalParamConverterProvider implements ParamConverterProvider {
+    private final ServiceLocator locator;
+
+    @Inject
+    public OptionalParamConverterProvider(final ServiceLocator locator) {
+        this.locator = locator;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> ParamConverter<T> getConverter(final Class<T> rawType, final Type genericType, final Annotation[] annotations) {
+        if (Optional.class.equals(rawType)) {
+            final List<ClassTypePair> ctps = ReflectionHelper.getTypeArgumentAndClass(genericType);
+            final ClassTypePair ctp = (ctps.size() == 1) ? ctps.get(0) : null;
+
+            if (ctp == null || ctp.rawClass() == String.class) {
+                return new ParamConverter<T>() {
+                    @Override
+                    public T fromString(final String value) {
+                        return rawType.cast(Optional.ofNullable(value));
+                    }
+
+                    @Override
+                    public String toString(final T value) {
+                        return value.toString();
+                    }
+                };
+            }
+
+            final Set<ParamConverterProvider> converterProviders = Providers.getProviders(locator, ParamConverterProvider.class);
+            for (ParamConverterProvider provider : converterProviders) {
+                final ParamConverter<?> converter = provider.getConverter(ctp.rawClass(), ctp.type(), annotations);
+                if (converter != null) {
+                    return new ParamConverter<T>() {
+                        @Override
+                        public T fromString(final String value) {
+                            return rawType.cast(Optional.ofNullable(value).map(s -> converter.fromString(value)));
+                        }
+
+                        @Override
+                        public String toString(final T value) {
+                            return value.toString();
+                        }
+                    };
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalParamFeature.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalParamFeature.java
@@ -1,0 +1,12 @@
+package io.dropwizard.jersey.optional;
+
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+
+public class OptionalParamFeature implements Feature {
+    @Override
+    public boolean configure(final FeatureContext context) {
+        context.register(new OptionalParamBinder());
+        return true;
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/MyMessage.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/MyMessage.java
@@ -1,4 +1,4 @@
-package io.dropwizard.jersey.guava;
+package io.dropwizard.jersey;
 
 public class MyMessage {
     private final String message;

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/MyMessageParamConverterProvider.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/MyMessageParamConverterProvider.java
@@ -1,4 +1,4 @@
-package io.dropwizard.jersey.guava;
+package io.dropwizard.jersey;
 
 import javax.ws.rs.ext.ParamConverter;
 import javax.ws.rs.ext.ParamConverterProvider;

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalCookieParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalCookieParamResourceTest.java
@@ -3,6 +3,8 @@ package io.dropwizard.jersey.guava;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Optional;
 import io.dropwizard.jersey.DropwizardResourceConfig;
+import io.dropwizard.jersey.MyMessage;
+import io.dropwizard.jersey.MyMessageParamConverterProvider;
 import io.dropwizard.jersey.params.UUIDParam;
 import io.dropwizard.logging.BootstrapLogging;
 import org.glassfish.jersey.test.JerseyTest;

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalFormParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalFormParamResourceTest.java
@@ -3,6 +3,8 @@ package io.dropwizard.jersey.guava;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Optional;
 import io.dropwizard.jersey.DropwizardResourceConfig;
+import io.dropwizard.jersey.MyMessage;
+import io.dropwizard.jersey.MyMessageParamConverterProvider;
 import io.dropwizard.jersey.params.UUIDParam;
 import io.dropwizard.logging.BootstrapLogging;
 import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap;

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalHeaderParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalHeaderParamResourceTest.java
@@ -3,6 +3,8 @@ package io.dropwizard.jersey.guava;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Optional;
 import io.dropwizard.jersey.DropwizardResourceConfig;
+import io.dropwizard.jersey.MyMessage;
+import io.dropwizard.jersey.MyMessageParamConverterProvider;
 import io.dropwizard.jersey.params.UUIDParam;
 import io.dropwizard.logging.BootstrapLogging;
 import org.glassfish.jersey.test.JerseyTest;

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalQueryParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalQueryParamResourceTest.java
@@ -3,6 +3,8 @@ package io.dropwizard.jersey.guava;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Optional;
 import io.dropwizard.jersey.DropwizardResourceConfig;
+import io.dropwizard.jersey.MyMessage;
+import io.dropwizard.jersey.MyMessageParamConverterProvider;
 import io.dropwizard.jersey.params.UUIDParam;
 import io.dropwizard.logging.BootstrapLogging;
 import org.glassfish.jersey.test.JerseyTest;

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/LocalDateParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/LocalDateParamTest.java
@@ -1,0 +1,17 @@
+package io.dropwizard.jersey.jsr310;
+
+import org.junit.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LocalDateParamTest {
+    @Test
+    public void parsesDateTimes() throws Exception {
+        final LocalDateParam param = new LocalDateParam("2012-11-19");
+
+        assertThat(param.get())
+                .isEqualTo(LocalDate.of(2012, 11, 19));
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/LocalDateTimeParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/LocalDateTimeParamTest.java
@@ -1,0 +1,17 @@
+package io.dropwizard.jersey.jsr310;
+
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LocalDateTimeParamTest {
+    @Test
+    public void parsesDateTimes() throws Exception {
+        final LocalDateTimeParam param = new LocalDateTimeParam("2012-11-19T13:37");
+
+        assertThat(param.get())
+                .isEqualTo(LocalDateTime.of(2012, 11, 19, 13, 37));
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/LocalTimeParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/LocalTimeParamTest.java
@@ -1,0 +1,17 @@
+package io.dropwizard.jersey.jsr310;
+
+import org.junit.Test;
+
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LocalTimeParamTest {
+    @Test
+    public void parsesDateTimes() throws Exception {
+        final LocalTimeParam param = new LocalTimeParam("12:34:56");
+
+        assertThat(param.get())
+                .isEqualTo(LocalTime.of(12, 34, 56));
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/OffsetDateTimeParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/OffsetDateTimeParamTest.java
@@ -1,0 +1,18 @@
+package io.dropwizard.jersey.jsr310;
+
+import org.junit.Test;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OffsetDateTimeParamTest {
+    @Test
+    public void parsesDateTimes() throws Exception {
+        final OffsetDateTimeParam param = new OffsetDateTimeParam("2012-11-19T13:37+01:00");
+
+        assertThat(param.get())
+                .isEqualTo(OffsetDateTime.of(2012, 11, 19, 13, 37, 0, 0, ZoneOffset.ofHours(1)));
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/YearMonthParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/YearMonthParamTest.java
@@ -1,0 +1,18 @@
+package io.dropwizard.jersey.jsr310;
+
+import org.junit.Test;
+
+import java.time.Month;
+import java.time.YearMonth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class YearMonthParamTest {
+    @Test
+    public void parsesDateTimes() throws Exception {
+        final YearMonthParam param = new YearMonthParam("2012-11");
+
+        assertThat(param.get())
+                .isEqualTo(YearMonth.of(2012, Month.NOVEMBER));
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/YearParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/YearParamTest.java
@@ -1,0 +1,17 @@
+package io.dropwizard.jersey.jsr310;
+
+import org.junit.Test;
+
+import java.time.Year;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class YearParamTest {
+    @Test
+    public void parsesDateTimes() throws Exception {
+        final YearParam param = new YearParam("2012");
+
+        assertThat(param.get())
+                .isEqualTo(Year.of(2012));
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/ZoneIdParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/ZoneIdParamTest.java
@@ -1,0 +1,17 @@
+package io.dropwizard.jersey.jsr310;
+
+import org.junit.Test;
+
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ZoneIdParamTest {
+    @Test
+    public void parsesDateTimes() throws Exception {
+        final ZoneIdParam param = new ZoneIdParam("Europe/Berlin");
+
+        assertThat(param.get())
+                .isEqualTo(ZoneId.of("Europe/Berlin"));
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/ZonedDateTimeParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/ZonedDateTimeParamTest.java
@@ -1,0 +1,18 @@
+package io.dropwizard.jersey.jsr310;
+
+import org.junit.Test;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ZonedDateTimeParamTest {
+    @Test
+    public void parsesDateTimes() throws Exception {
+        final ZonedDateTimeParam param = new ZonedDateTimeParam("2012-11-19T13:37+01:00[Europe/Berlin]");
+
+        assertThat(param.get())
+                .isEqualTo(ZonedDateTime.of(2012, 11, 19, 13, 37, 0, 0, ZoneId.of("Europe/Berlin")));
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalCookieParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalCookieParamResourceTest.java
@@ -1,0 +1,110 @@
+package io.dropwizard.jersey.optional;
+
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.jersey.DropwizardResourceConfig;
+import io.dropwizard.jersey.MyMessage;
+import io.dropwizard.jersey.MyMessageParamConverterProvider;
+import io.dropwizard.jersey.params.UUIDParam;
+import io.dropwizard.logging.BootstrapLogging;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
+import org.junit.Test;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.CookieParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Application;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OptionalCookieParamResourceTest extends JerseyTest {
+    static {
+        BootstrapLogging.bootstrap();
+    }
+
+    @Override
+    protected Application configure() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
+        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+                .register(OptionalParamFeature.class)
+                .register(OptionalCookieParamResource.class)
+                .register(MyMessageParamConverterProvider.class);
+    }
+
+    @Test
+    public void shouldReturnDefaultMessageWhenMessageIsNotPresent() {
+        String defaultMessage = "Default Message";
+        String response = target("/optional/message").request().get(String.class);
+        assertThat(response).isEqualTo(defaultMessage);
+    }
+
+    @Test
+    public void shouldReturnMessageWhenMessageIsBlank() {
+        String response = target("/optional/message").request().cookie("message", "").get(String.class);
+        assertThat(response).isEqualTo("");
+    }
+
+    @Test
+    public void shouldReturnMessageWhenMessageIsPresent() {
+        String customMessage = "Custom Message";
+        String response = target("/optional/message").request().cookie("message", customMessage).get(String.class);
+        assertThat(response).isEqualTo(customMessage);
+    }
+
+    @Test
+    public void shouldReturnDefaultMessageWhenMyMessageIsNotPresent() {
+        String defaultMessage = "My Default Message";
+        String response = target("/optional/my-message").request().get(String.class);
+        assertThat(response).isEqualTo(defaultMessage);
+    }
+
+    @Test
+    public void shouldReturnMyMessageWhenMyMessageIsPresent() {
+        String myMessage = "My Message";
+        String response = target("/optional/my-message").request().cookie("mymessage", myMessage).get(String.class);
+        assertThat(response).isEqualTo(myMessage);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() {
+        String invalidUUID = "invalid-uuid";
+        target("/optional/uuid").request().cookie("uuid", invalidUUID).get(String.class);
+    }
+
+    @Test
+    public void shouldReturnDefaultUUIDWhenUUIDIsNotPresent() {
+        String defaultUUID = "d5672fa8-326b-40f6-bf71-d9dacf44bcdc";
+        String response = target("/optional/uuid").request().get(String.class);
+        assertThat(response).isEqualTo(defaultUUID);
+    }
+
+    @Test
+    public void shouldReturnUUIDWhenValidUUIDIsPresent() {
+        String uuid = "fd94b00d-bd50-46b3-b42f-905a9c9e7d78";
+        String response = target("/optional/uuid").request().cookie("uuid", uuid).get(String.class);
+        assertThat(response).isEqualTo(uuid);
+    }
+
+    @Path("/optional")
+    public static class OptionalCookieParamResource {
+        @GET
+        @Path("/message")
+        public String getMessage(@CookieParam("message") Optional<String> message) {
+            return message.orElse("Default Message");
+        }
+
+        @GET
+        @Path("/my-message")
+        public String getMyMessage(@CookieParam("mymessage") Optional<MyMessage> myMessage) {
+            return myMessage.orElse(new MyMessage("My Default Message")).getMessage();
+        }
+
+        @GET
+        @Path("/uuid")
+        public String getUUID(@CookieParam("uuid") Optional<UUIDParam> uuid) {
+            return uuid.orElse(new UUIDParam("d5672fa8-326b-40f6-bf71-d9dacf44bcdc")).get().toString();
+        }
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalFormParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalFormParamResourceTest.java
@@ -1,0 +1,129 @@
+package io.dropwizard.jersey.optional;
+
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.jersey.DropwizardResourceConfig;
+import io.dropwizard.jersey.MyMessage;
+import io.dropwizard.jersey.MyMessageParamConverterProvider;
+import io.dropwizard.jersey.params.UUIDParam;
+import io.dropwizard.logging.BootstrapLogging;
+import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
+import org.junit.Test;
+
+import javax.ws.rs.FormParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Form;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OptionalFormParamResourceTest extends JerseyTest {
+    static {
+        BootstrapLogging.bootstrap();
+    }
+
+    @Override
+    protected Application configure() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
+        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+                .register(OptionalParamFeature.class)
+                .register(OptionalFormParamResource.class)
+                .register(MyMessageParamConverterProvider.class);
+    }
+
+    @Test
+    public void shouldReturnDefaultMessageWhenMessageIsNotPresent() throws IOException {
+        final String defaultMessage = "Default Message";
+        final Response response = target("/optional/message").request().post(Entity.form(new MultivaluedStringMap()));
+
+        assertThat(response.readEntity(String.class)).isEqualTo(defaultMessage);
+    }
+
+    @Test
+    public void shouldReturnMessageWhenMessageBlank() throws IOException {
+        final Form form = new Form("message", "");
+        final Response response = target("/optional/message").request().post(Entity.form(form));
+
+        assertThat(response.readEntity(String.class)).isEqualTo("");
+    }
+
+    @Test
+    public void shouldReturnMessageWhenMessageIsPresent() throws IOException {
+        final String customMessage = "Custom Message";
+        final Form form = new Form("message", customMessage);
+        final Response response = target("/optional/message").request().post(Entity.form(form));
+
+        assertThat(response.readEntity(String.class)).isEqualTo(customMessage);
+    }
+
+    @Test
+    public void shouldReturnDefaultMessageWhenMyMessageIsNotPresent() throws IOException {
+        final String defaultMessage = "My Default Message";
+        final Response response = target("/optional/my-message").request().post(Entity.form(new MultivaluedStringMap()));
+
+        assertThat(response.readEntity(String.class)).isEqualTo(defaultMessage);
+    }
+
+    @Test
+    public void shouldReturnMyMessageWhenMyMessageIsPresent() throws IOException {
+        final String myMessage = "My Message";
+        final Form form = new Form("mymessage", myMessage);
+        final Response response = target("/optional/my-message").request().post(Entity.form(form));
+
+        assertThat(response.readEntity(String.class)).isEqualTo(myMessage);
+    }
+
+    @Test
+    public void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() throws IOException {
+        final String invalidUUID = "invalid-uuid";
+        final Form form = new Form("uuid", invalidUUID);
+        final Response response = target("/optional/uuid").request().post(Entity.form(form));
+
+        assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+    }
+
+    @Test
+    public void shouldReturnDefaultUUIDWhenUUIDIsNotPresent() throws IOException {
+        final String defaultUUID = "d5672fa8-326b-40f6-bf71-d9dacf44bcdc";
+        final Response response = target("/optional/uuid").request().post(Entity.form(new MultivaluedStringMap()));
+
+        assertThat(response.readEntity(String.class)).isEqualTo(defaultUUID);
+    }
+
+    @Test
+    public void shouldReturnUUIDWhenValidUUIDIsPresent() throws IOException {
+        final String uuid = "fd94b00d-bd50-46b3-b42f-905a9c9e7d78";
+        final Form form = new Form("uuid", uuid);
+        final Response response = target("/optional/uuid").request().post(Entity.form(form));
+
+        assertThat(response.readEntity(String.class)).isEqualTo(uuid);
+    }
+
+    @Path("/optional")
+    public static class OptionalFormParamResource {
+
+        @POST
+        @Path("/message")
+        public String getMessage(@FormParam("message") Optional<String> message) {
+            return message.orElse("Default Message");
+        }
+
+        @POST
+        @Path("/my-message")
+        public String getMyMessage(@FormParam("mymessage") Optional<MyMessage> myMessage) {
+            return myMessage.orElse(new MyMessage("My Default Message")).getMessage();
+        }
+
+        @POST
+        @Path("/uuid")
+        public String getUUID(@FormParam("uuid") Optional<UUIDParam> uuid) {
+            return uuid.orElse(new UUIDParam("d5672fa8-326b-40f6-bf71-d9dacf44bcdc")).get().toString();
+        }
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalHeaderParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalHeaderParamResourceTest.java
@@ -1,0 +1,110 @@
+package io.dropwizard.jersey.optional;
+
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.jersey.DropwizardResourceConfig;
+import io.dropwizard.jersey.MyMessage;
+import io.dropwizard.jersey.MyMessageParamConverterProvider;
+import io.dropwizard.jersey.params.UUIDParam;
+import io.dropwizard.logging.BootstrapLogging;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
+import org.junit.Test;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Application;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OptionalHeaderParamResourceTest extends JerseyTest {
+    static {
+        BootstrapLogging.bootstrap();
+    }
+
+    @Override
+    protected Application configure() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
+        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+                .register(OptionalParamFeature.class)
+                .register(OptionalHeaderParamResource.class)
+                .register(MyMessageParamConverterProvider.class);
+    }
+
+    @Test
+    public void shouldReturnDefaultMessageWhenMessageIsNotPresent() {
+        String defaultMessage = "Default Message";
+        String response = target("/optional/message").request().get(String.class);
+        assertThat(response).isEqualTo(defaultMessage);
+    }
+
+    @Test
+    public void shouldReturnMessageWhenMessageIsBlank() {
+        String response = target("/optional/message").request().header("message", "").get(String.class);
+        assertThat(response).isEqualTo("");
+    }
+
+    @Test
+    public void shouldReturnMessageWhenMessageIsPresent() {
+        String customMessage = "Custom Message";
+        String response = target("/optional/message").request().header("message", customMessage).get(String.class);
+        assertThat(response).isEqualTo(customMessage);
+    }
+
+    @Test
+    public void shouldReturnDefaultMessageWhenMyMessageIsNotPresent() {
+        String defaultMessage = "My Default Message";
+        String response = target("/optional/my-message").request().get(String.class);
+        assertThat(response).isEqualTo(defaultMessage);
+    }
+
+    @Test
+    public void shouldReturnMyMessageWhenMyMessageIsPresent() {
+        String myMessage = "My Message";
+        String response = target("/optional/my-message").request().header("mymessage", myMessage).get(String.class);
+        assertThat(response).isEqualTo(myMessage);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() {
+        String invalidUUID = "invalid-uuid";
+        target("/optional/uuid").request().header("uuid", invalidUUID).get(String.class);
+    }
+
+    @Test
+    public void shouldReturnDefaultUUIDWhenUUIDIsNotPresent() {
+        String defaultUUID = "d5672fa8-326b-40f6-bf71-d9dacf44bcdc";
+        String response = target("/optional/uuid").request().get(String.class);
+        assertThat(response).isEqualTo(defaultUUID);
+    }
+
+    @Test
+    public void shouldReturnUUIDWhenValidUUIDIsPresent() {
+        String uuid = "fd94b00d-bd50-46b3-b42f-905a9c9e7d78";
+        String response = target("/optional/uuid").request().header("uuid", uuid).get(String.class);
+        assertThat(response).isEqualTo(uuid);
+    }
+
+    @Path("/optional")
+    public static class OptionalHeaderParamResource {
+        @GET
+        @Path("/message")
+        public String getMessage(@HeaderParam("message") Optional<String> message) {
+            return message.orElse("Default Message");
+        }
+
+        @GET
+        @Path("/my-message")
+        public String getMyMessage(@HeaderParam("mymessage") Optional<MyMessage> myMessage) {
+            return myMessage.orElse(new MyMessage("My Default Message")).getMessage();
+        }
+
+        @GET
+        @Path("/uuid")
+        public String getUUID(@HeaderParam("uuid") Optional<UUIDParam> uuid) {
+            return uuid.orElse(new UUIDParam("d5672fa8-326b-40f6-bf71-d9dacf44bcdc")).get().toString();
+        }
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalMessageBodyWriterTest.java
@@ -1,0 +1,84 @@
+package io.dropwizard.jersey.optional;
+
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.jersey.DropwizardResourceConfig;
+import io.dropwizard.logging.BootstrapLogging;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
+import org.junit.Test;
+
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+public class OptionalMessageBodyWriterTest extends JerseyTest {
+    static {
+        BootstrapLogging.bootstrap();
+    }
+
+    @Override
+    protected Application configure() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
+        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+                .register(OptionalMessageBodyWriter.class)
+                .register(OptionalReturnResource.class);
+    }
+
+    @Test
+    public void presentOptionalsReturnTheirValue() throws Exception {
+        assertThat(target("optional-return")
+                .queryParam("id", "woo").request()
+                .get(String.class))
+                .isEqualTo("woo");
+    }
+
+    @Test
+    public void presentOptionalsReturnTheirValueWithResponse() throws Exception {
+        assertThat(target("optional-return/response-wrapped")
+                .queryParam("id", "woo").request()
+                .get(String.class))
+                .isEqualTo("woo");
+    }
+
+    @Test
+    public void absentOptionalsThrowANotFound() throws Exception {
+        try {
+            target("optional-return").request().get(String.class);
+            failBecauseExceptionWasNotThrown(WebApplicationException.class);
+        } catch (WebApplicationException e) {
+            assertThat(e.getResponse().getStatus())
+                    .isEqualTo(404);
+        }
+    }
+
+    @Path("optional-return")
+    @Produces(MediaType.TEXT_PLAIN)
+    public static class OptionalReturnResource {
+        @GET
+        public Optional<String> showWithQueryParam(@QueryParam("id") String id) {
+            return Optional.ofNullable(id);
+        }
+
+        @POST
+        public Optional<String> showWithFormParam(@FormParam("id") String id) {
+            return Optional.ofNullable(id);
+        }
+
+        @Path("response-wrapped")
+        @GET
+        public Response showWithQueryParamResponse(@QueryParam("id") String id) {
+            return Response.ok(Optional.ofNullable(id)).build();
+        }
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalQueryParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalQueryParamResourceTest.java
@@ -1,0 +1,119 @@
+package io.dropwizard.jersey.optional;
+
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.jersey.DropwizardResourceConfig;
+import io.dropwizard.jersey.MyMessage;
+import io.dropwizard.jersey.MyMessageParamConverterProvider;
+import io.dropwizard.jersey.params.UUIDParam;
+import io.dropwizard.logging.BootstrapLogging;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
+import org.junit.Test;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Application;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OptionalQueryParamResourceTest extends JerseyTest {
+    static {
+        BootstrapLogging.bootstrap();
+    }
+
+    @Override
+    protected Application configure() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
+        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+                .register(OptionalParamFeature.class)
+                .register(OptionalQueryParamResource.class)
+                .register(MyMessageParamConverterProvider.class);
+    }
+
+    @Test
+    public void shouldReturnDefaultMessageWhenMessageIsNotPresent() {
+        String defaultMessage = "Default Message";
+        String response = target("/optional/message").request().get(String.class);
+        assertThat(response).isEqualTo(defaultMessage);
+    }
+
+    @Test
+    public void shouldReturnMessageWhenMessageIsPresent() {
+        String customMessage = "Custom Message";
+        String response = target("/optional/message").queryParam("message", customMessage).request().get(String.class);
+        assertThat(response).isEqualTo(customMessage);
+    }
+
+    @Test
+    public void shouldReturnMessageWhenMessageIsBlank() {
+        String response = target("/optional/message").queryParam("message", "").request().get(String.class);
+        assertThat(response).isEqualTo("");
+    }
+
+    @Test
+    public void shouldReturnDecodedMessageWhenEncodedMessageIsPresent() {
+        String encodedMessage = "Custom%20Message";
+        String decodedMessage = "Custom Message";
+        String response = target("/optional/message").queryParam("message", encodedMessage).request().get(String.class);
+        assertThat(response).isEqualTo(decodedMessage);
+    }
+
+    @Test
+    public void shouldReturnDefaultMessageWhenMyMessageIsNotPresent() {
+        String defaultMessage = "My Default Message";
+        String response = target("/optional/my-message").request().get(String.class);
+        assertThat(response).isEqualTo(defaultMessage);
+    }
+
+    @Test
+    public void shouldReturnMyMessageWhenMyMessageIsPresent() {
+        String myMessage = "My Message";
+        String response = target("/optional/my-message").queryParam("mymessage", myMessage).request().get(String.class);
+        assertThat(response).isEqualTo(myMessage);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() {
+        String invalidUUID = "invalid-uuid";
+        target("/optional/uuid").queryParam("uuid", invalidUUID).request().get(String.class);
+    }
+
+    @Test
+    public void shouldReturnDefaultUUIDWhenUUIDIsNotPresent() {
+        String defaultUUID = "d5672fa8-326b-40f6-bf71-d9dacf44bcdc";
+        String response = target("/optional/uuid").request().get(String.class);
+        assertThat(response).isEqualTo(defaultUUID);
+    }
+
+    @Test
+    public void shouldReturnUUIDWhenValidUUIDIsPresent() {
+        String uuid = "fd94b00d-bd50-46b3-b42f-905a9c9e7d78";
+        String response = target("/optional/uuid").queryParam("uuid", uuid).request().get(String.class);
+        assertThat(response).isEqualTo(uuid);
+    }
+
+    @Path("/optional")
+    public static class OptionalQueryParamResource {
+
+        @GET
+        @Path("/message")
+        public String getMessage(@QueryParam("message") Optional<String> message) {
+            return message.orElse("Default Message");
+        }
+
+        @GET
+        @Path("/my-message")
+        public String getMyMessage(@QueryParam("mymessage") Optional<MyMessage> myMessage) {
+            return myMessage.orElse(new MyMessage("My Default Message")).getMessage();
+        }
+
+        @GET
+        @Path("/uuid")
+        public String getUUID(@QueryParam("uuid") Optional<UUIDParam> uuid) {
+            return uuid.orElse(new UUIDParam("d5672fa8-326b-40f6-bf71-d9dacf44bcdc")).get().toString();
+        }
+    }
+}

--- a/dropwizard-util/src/main/java/io/dropwizard/util/Optionals.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Optionals.java
@@ -1,0 +1,25 @@
+package io.dropwizard.util;
+
+import java.util.Optional;
+
+public abstract class Optionals {
+    /**
+     * Convert a Guava {@link com.google.common.base.Optional} to an {@link Optional}.
+     *
+     * @param guavaOptional The Guava {@link com.google.common.base.Optional}
+     * @return An equivalent {@link Optional}
+     */
+    public static <T> Optional<T> fromGuavaOptional(final com.google.common.base.Optional<T> guavaOptional) {
+        return Optional.ofNullable(guavaOptional.orNull());
+    }
+
+    /**
+     * Convert an {@link Optional} to a Guava {@link com.google.common.base.Optional}.
+     *
+     * @param optional The {@link Optional}
+     * @return An equivalent Guava {@link com.google.common.base.Optional}
+     */
+    public static <T> com.google.common.base.Optional<T> toGuavaOptional(final Optional<T> optional) {
+        return com.google.common.base.Optional.fromNullable(optional.orElse(null));
+    }
+}

--- a/dropwizard-util/src/test/java/io/dropwizard/util/OptionalsTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/OptionalsTest.java
@@ -1,0 +1,29 @@
+package io.dropwizard.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class OptionalsTest {
+    @Test
+    public void testFromGuavaOptional() throws Exception {
+        assertFalse(Optionals.fromGuavaOptional(com.google.common.base.Optional.absent()).isPresent());
+        assertTrue(Optionals.fromGuavaOptional(com.google.common.base.Optional.of("Foo")).isPresent());
+        assertEquals(
+            java.util.Optional.of("Foo"),
+            Optionals.fromGuavaOptional(com.google.common.base.Optional.of("Foo"))
+        );
+    }
+
+    @Test
+    public void testToGuavaOptional() throws Exception {
+        assertFalse(Optionals.toGuavaOptional(java.util.Optional.empty()).isPresent());
+        assertTrue(Optionals.toGuavaOptional(java.util.Optional.of("Foo")).isPresent());
+        assertEquals(
+            com.google.common.base.Optional.of("Foo"),
+            Optionals.toGuavaOptional(java.util.Optional.of("Foo"))
+        );
+    }
+}

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/BaseValidator.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/BaseValidator.java
@@ -1,5 +1,6 @@
 package io.dropwizard.validation;
 
+import io.dropwizard.validation.valuehandling.GuavaOptionalValidatedValueUnwrapper;
 import io.dropwizard.validation.valuehandling.OptionalValidatedValueUnwrapper;
 import org.hibernate.validator.HibernateValidator;
 import org.hibernate.validator.HibernateValidatorConfiguration;
@@ -26,6 +27,7 @@ public class BaseValidator {
         return Validation
             .byProvider(HibernateValidator.class)
             .configure()
+            .addValidatedValueHandler(new GuavaOptionalValidatedValueUnwrapper())
             .addValidatedValueHandler(new OptionalValidatedValueUnwrapper());
     }
 }

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/valuehandling/GuavaOptionalValidatedValueUnwrapper.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/valuehandling/GuavaOptionalValidatedValueUnwrapper.java
@@ -1,0 +1,29 @@
+package io.dropwizard.validation.valuehandling;
+
+import com.fasterxml.classmate.ResolvedType;
+import com.fasterxml.classmate.TypeResolver;
+import com.google.common.base.Optional;
+import org.hibernate.validator.spi.valuehandling.ValidatedValueUnwrapper;
+
+import java.lang.reflect.Type;
+
+/**
+ * A {@link ValidatedValueUnwrapper} for Guava's {@link Optional}.
+ *
+ * Extracts the value contained by the {@link Optional} for validation, or produces {@code null}.
+ */
+public class GuavaOptionalValidatedValueUnwrapper extends ValidatedValueUnwrapper<Optional<?>> {
+
+    private final TypeResolver resolver = new TypeResolver();
+
+    @Override
+    public Object handleValidatedValue(final Optional<?> optional) {
+        return optional.orNull();
+    }
+
+    @Override
+    public Type getValidatedValueType(final Type type) {
+        ResolvedType resolvedType = resolver.resolve(type);
+        return resolvedType.typeParametersFor(Optional.class).get(0).getErasedType();
+    }
+}

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/valuehandling/OptionalValidatedValueUnwrapper.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/valuehandling/OptionalValidatedValueUnwrapper.java
@@ -2,14 +2,14 @@ package io.dropwizard.validation.valuehandling;
 
 import com.fasterxml.classmate.ResolvedType;
 import com.fasterxml.classmate.TypeResolver;
-import com.google.common.base.Optional;
 import org.hibernate.validator.spi.valuehandling.ValidatedValueUnwrapper;
 
 import java.lang.reflect.Type;
+import java.util.Optional;
 
 /**
- * A {@link ValidatedValueUnwrapper} for Guava's {@link Optional}.
- * <p/>
+ * A {@link ValidatedValueUnwrapper} for {@link Optional}.
+ *
  * Extracts the value contained by the {@link Optional} for validation, or produces {@code null}.
  */
 public class OptionalValidatedValueUnwrapper extends ValidatedValueUnwrapper<Optional<?>> {
@@ -18,7 +18,7 @@ public class OptionalValidatedValueUnwrapper extends ValidatedValueUnwrapper<Opt
 
     @Override
     public Object handleValidatedValue(final Optional<?> optional) {
-        return optional.orNull();
+        return optional.orElse(null);
     }
 
     @Override

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/valuehandling/GuavaOptionalValidatedValueUnwrapperTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/valuehandling/GuavaOptionalValidatedValueUnwrapperTest.java
@@ -1,0 +1,83 @@
+package io.dropwizard.validation.valuehandling;
+
+import com.google.common.base.Optional;
+import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.valuehandling.UnwrapValidatedValue;
+import org.junit.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GuavaOptionalValidatedValueUnwrapperTest {
+
+    public static class Example {
+
+        @Min(3)
+        public Optional<Integer> three = Optional.absent();
+
+        @NotNull
+        @UnwrapValidatedValue
+        public Optional<Integer> notNull = Optional.of(123);
+    }
+
+    private final Validator validator = Validation
+            .byProvider(HibernateValidator.class)
+            .configure()
+            .addValidatedValueHandler(new GuavaOptionalValidatedValueUnwrapper())
+            .buildValidatorFactory()
+            .getValidator();
+
+    @Test
+    public void succeedsWhenAbsent() {
+        Example example = new Example();
+        Set<ConstraintViolation<Example>> violations = validator.validate(example);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void failsWhenFailingConstraint() {
+        Example example = new Example();
+        example.three = Optional.of(2);
+        Set<ConstraintViolation<Example>> violations = validator.validate(example);
+        assertThat(violations).hasSize(1);
+    }
+
+    @Test
+    public void succeedsWhenPresentButNull() {
+        Example example = new Example();
+        example.three = Optional.fromNullable(null);
+        Set<ConstraintViolation<Example>> violations = validator.validate(example);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void succeedsWhenConstraintsMet() {
+        Example example = new Example();
+        example.three = Optional.of(10);
+        Set<ConstraintViolation<Example>> violations = validator.validate(example);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void notNullFailsWhenAbsent() {
+        Example example = new Example();
+        example.notNull = Optional.absent();
+        Set<ConstraintViolation<Example>> violations = validator.validate(example);
+        assertThat(violations).hasSize(1);
+    }
+
+    @Test
+    public void notNullFailsWhenPresentButNull() {
+        Example example = new Example();
+        example.notNull = Optional.fromNullable(null);
+        Set<ConstraintViolation<Example>> violations = validator.validate(example);
+        assertThat(violations).hasSize(1);
+    }
+}

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/valuehandling/OptionalValidatedValueUnwrapperTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/valuehandling/OptionalValidatedValueUnwrapperTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.validation.valuehandling;
 
-import com.google.common.base.Optional;
 import org.hibernate.validator.HibernateValidator;
 import org.hibernate.validator.valuehandling.UnwrapValidatedValue;
 import org.junit.Test;
@@ -10,7 +9,7 @@ import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
-
+import java.util.Optional;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -20,7 +19,8 @@ public class OptionalValidatedValueUnwrapperTest {
     public static class Example {
 
         @Min(3)
-        public Optional<Integer> three = Optional.absent();
+        @UnwrapValidatedValue
+        public Optional<Integer> three = Optional.empty();
 
         @NotNull
         @UnwrapValidatedValue
@@ -52,7 +52,7 @@ public class OptionalValidatedValueUnwrapperTest {
     @Test
     public void succeedsWhenPresentButNull() {
         Example example = new Example();
-        example.three = Optional.fromNullable(null);
+        example.three = Optional.ofNullable(null);
         Set<ConstraintViolation<Example>> violations = validator.validate(example);
         assertThat(violations).isEmpty();
     }
@@ -68,7 +68,7 @@ public class OptionalValidatedValueUnwrapperTest {
     @Test
     public void notNullFailsWhenAbsent() {
         Example example = new Example();
-        example.notNull = Optional.absent();
+        example.notNull = Optional.empty();
         Set<ConstraintViolation<Example>> violations = validator.validate(example);
         assertThat(violations).hasSize(1);
     }
@@ -76,7 +76,7 @@ public class OptionalValidatedValueUnwrapperTest {
     @Test
     public void notNullFailsWhenPresentButNull() {
         Example example = new Example();
-        example.notNull = Optional.fromNullable(null);
+        example.notNull = Optional.ofNullable(null);
         Set<ConstraintViolation<Example>> violations = validator.validate(example);
         assertThat(violations).hasSize(1);
     }


### PR DESCRIPTION
[`dropwizard-java8`](https://github.com/dropwizard/dropwizard-java8) used to provide support for Java 8 classes like `Optional<T>` and the Java Date and Time API (JSR-310) for Dropwizard. Given that the baseline for Dropwizard is now Java 8, those additions can be maintained in the mainline repository.

The only backward-incompatible change is in the `io.dropwizard.auth.Authenticator` interface which is now using `java.util.Optional` instead of the equivalent class from Google Guava.

Closes #962