### PR TITLE
Encoding of properties files is ISO-8859-1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,9 @@ indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.properties]
+charset = latin1
+
 [travis.yml]
 indent_size = 2
 indent_style = space


### PR DESCRIPTION
Java properties files are assumed to be ISO-8859-1 (latin-1) encoded.