### PR TITLE
Print help once on invalid command line arguments

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/cli/Cli.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/Cli.java
@@ -75,7 +75,9 @@ public class Cli {
                 command.run(bootstrap, namespace);
             }
             return true;
-        } catch (HelpScreenException e) {
+        } catch (HelpScreenException ignored) {
+            // This exception is triggered when the user passes in a help flag.
+            // Return true to signal that the process executed normally.
             return true;
         } catch (ArgumentParserException e) {
             stdErr.println(e.getMessage());

--- a/dropwizard-core/src/main/java/io/dropwizard/cli/Cli.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/Cli.java
@@ -11,6 +11,7 @@ import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
+import net.sourceforge.argparse4j.internal.HelpScreenException;
 
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -70,11 +71,11 @@ public class Cli {
                 parser.printVersion(stdOut);
             } else {
                 final Namespace namespace = parser.parseArgs(arguments);
-                if (namespace.get("is-help") == null) {
-                    final Command command = commands.get(namespace.getString(COMMAND_NAME_ATTR));
-                    command.run(bootstrap, namespace);
-                }
+                final Command command = commands.get(namespace.getString(COMMAND_NAME_ATTR));
+                command.run(bootstrap, namespace);
             }
+            return true;
+        } catch (HelpScreenException e) {
             return true;
         } catch (ArgumentParserException e) {
             stdErr.println(e.getMessage());
@@ -138,7 +139,7 @@ public class Cli {
                         Map<String, Object> attrs, String flag, Object value)
                 throws ArgumentParserException {
             parser.printHelp(out);
-            attrs.put("is-help", Boolean.TRUE);
+            throw new HelpScreenException(parser);
         }
 
         @Override

--- a/dropwizard-core/src/test/java/io/dropwizard/cli/CommandTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/cli/CommandTest.java
@@ -1,0 +1,81 @@
+package io.dropwizard.cli;
+
+import com.google.common.base.Optional;
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.util.JarLocation;
+import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparser;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CommandTest {
+    private static class TestCommand extends Command {
+        protected TestCommand() {
+            super("test", "test");
+        }
+
+        @Override
+        public void configure(Subparser subparser) {
+            subparser.addArgument("types").choices("a", "b", "c").help("Type to use");
+        }
+
+        @Override
+        public void run(Bootstrap<?> bootstrap, Namespace namespace) throws Exception {
+        }
+    }
+
+    private final Application<Configuration> app = new Application<Configuration>() {
+        @Override
+        public void run(Configuration configuration, Environment environment) throws Exception {
+        }
+    };
+
+    private final ByteArrayOutputStream stdOut = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream stdErr = new ByteArrayOutputStream();
+    private final Command command = new TestCommand();
+    private Cli cli;
+
+    @Before
+    public void setUp() throws Exception {
+        final JarLocation location = mock(JarLocation.class);
+        final Bootstrap<Configuration> bootstrap = new Bootstrap<>(app);
+        when(location.toString()).thenReturn("dw-thing.jar");
+        when(location.getVersion()).thenReturn(Optional.of("1.0.0"));
+        bootstrap.addCommand(command);
+
+        cli = new Cli(location, bootstrap, stdOut, stdErr);
+    }
+
+    @Test
+    public void listHelpOnceOnArgumentOmission() throws Exception {
+        assertThat(cli.run("test", "-h"))
+            .isTrue();
+
+        assertThat(stdOut.toString())
+            .isEqualTo(String.format(
+                "usage: java -jar dw-thing.jar test [-h] {a,b,c}%n" +
+                    "%n" +
+                    "test%n" +
+                    "%n" +
+                    "positional arguments:%n" +
+                    "  {a,b,c}                Type to use%n" +
+                    "%n" +
+                    "optional arguments:%n" +
+                    "  -h, --help             show this help message and exit%n"
+            ));
+
+        assertThat(stdErr.toString())
+            .isEmpty();
+    }
+}


### PR DESCRIPTION
Currently, if `-h` is provided on the commandline and invalid arguments are specified as well, the help message will be printed twice. This is not desired (the help message should only be printed once)

This change is not backwards compatible for those who need to see that `is-help` is set in the `run` command (this would only be when the case when all arguments are optional)

Closes #1357