### PR TITLE
link to jersey 2.22.1 docs, not 1.18

### DIFF
--- a/docs/source/manual/client.rst
+++ b/docs/source/manual/client.rst
@@ -124,7 +124,7 @@ If HttpClient_ is too low-level for you, Dropwizard also supports Jersey's `Clie
 Jersey's ``Client`` allows you to use all of the server-side media type support that your service
 uses to, for example, deserialize ``application/json`` request entities as POJOs.
 
-.. _Client API: https://jersey.java.net/documentation/1.18/client-api.html
+.. _Client API: https://jersey.java.net/documentation/2.22.1/client.html
 
 To create a :ref:`managed <man-core-managed>`, instrumented ``JerseyClient`` instance, your
 :ref:`configuration class <man-core-configuration>` needs an :ref:`jersey client configuration <man-configuration-clients-jersey>` instance:


### PR DESCRIPTION
Since dropwizard has upgraded to jersey 2, the dropwizard-client docs should link to jersey 2 docs.