### PR TITLE
configuration: SubstitutingSourceProvider: close the delegate's stream

### DIFF
--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/SubstitutingSourceProvider.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/SubstitutingSourceProvider.java
@@ -34,9 +34,11 @@ public class SubstitutingSourceProvider implements ConfigurationSourceProvider {
      */
     @Override
     public InputStream open(String path) throws IOException {
-        final String config = new String(ByteStreams.toByteArray(delegate.open(path)), StandardCharsets.UTF_8);
-        final String substituted = substitutor.replace(config);
+        try (final InputStream in = delegate.open(path)) {
+            final String config = new String(ByteStreams.toByteArray(in), StandardCharsets.UTF_8);
+            final String substituted = substitutor.replace(config);
 
-        return new ByteArrayInputStream(substituted.getBytes(StandardCharsets.UTF_8));
+            return new ByteArrayInputStream(substituted.getBytes(StandardCharsets.UTF_8));
+        }
     }
 }

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/SubstitutingSourceProviderTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/SubstitutingSourceProviderTest.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 public class SubstitutingSourceProviderTest {
     @Test
@@ -32,7 +32,7 @@ public class SubstitutingSourceProviderTest {
         // ensure that opened streams are closed
         try {
             dummyProvider.lastStream.read();
-            fail("IOException expected; stream should be closed");
+            failBecauseExceptionWasNotThrown(IOException.class);
         } catch (IOException e) {
             assertThat(e).hasMessage("Stream closed");
         }

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/SubstitutingSourceProviderTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/SubstitutingSourceProviderTest.java
@@ -5,12 +5,14 @@ import org.apache.commons.lang3.text.StrLookup;
 import org.apache.commons.lang3.text.StrSubstitutor;
 import org.junit.Test;
 
+import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class SubstitutingSourceProviderTest {
     @Test
@@ -21,10 +23,19 @@ public class SubstitutingSourceProviderTest {
                 return "baz";
             }
         };
-        SubstitutingSourceProvider provider = new SubstitutingSourceProvider(new DummySourceProvider(), new StrSubstitutor(dummyLookup));
+        DummySourceProvider dummyProvider = new DummySourceProvider();
+        SubstitutingSourceProvider provider = new SubstitutingSourceProvider(dummyProvider, new StrSubstitutor(dummyLookup));
         String results = new String(ByteStreams.toByteArray(provider.open("foo: ${bar}")), StandardCharsets.UTF_8);
 
         assertThat(results).isEqualTo("foo: baz");
+
+        // ensure that opened streams are closed
+        try {
+            dummyProvider.lastStream.read();
+            fail("IOException expected; stream should be closed");
+        } catch (IOException e) {
+            assertThat(e).hasMessage("Stream closed");
+        }
     }
 
     @Test
@@ -56,9 +67,13 @@ public class SubstitutingSourceProviderTest {
     }
 
     private static class DummySourceProvider implements ConfigurationSourceProvider {
+        public InputStream lastStream;
+
         @Override
         public InputStream open(String s) throws IOException {
-            return new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8));
+            // used to test that the stream is properly closed
+            lastStream = new BufferedInputStream(new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8)));
+            return lastStream;
         }
     }
 }


### PR DESCRIPTION
This probably doesn't ever cause problems, but closing streams is important
if it gets called repeatedly (e.g if it is actually a zlib InputStream, it
holds on to native memory until closed). Fixing this will help prevent future
copy and paste bugs.


I found this because I was doing some quick code searching to determine if Dropwizard might have any obvious places where a zlib InputStream might not get closed right away, that might have caused the following native memory leak. I suspect this is *not* the actual cause of the bug, but it might as well be fixed also.