### PR TITLE
Add RegisterDefaultExceptionMappers to TestRule

### DIFF
--- a/docs/source/manual/testing.rst
+++ b/docs/source/manual/testing.rst
@@ -215,6 +215,18 @@ easily.
 
     You can trust ``PeopleStore`` works because you've got working unit tests for it, right?
 
+Default Exception Mappers
+-------------------------
+
+By default, a ``ResourceTestRule`` will register all the default exception mappers (this behavior is new in 1.0). If
+``registerDefaultExceptionMappers`` in the configuration yaml is planned to be set to ``false``,
+``ResourceTestRule.Builder#setRegisterDefaultExceptionMappers(boolean)`` will also need to be set to ``false``. Then,
+all custom exception mappers will need to be registered on the builder, similarly to how they are registered in an
+``Application`` class.
+
+Test Containers
+---------------
+
 Note that the in-memory Jersey test container does not support all features, such as the ``@Context`` injection used by
 ``BasicAuthFactory`` and ``OAuthFactory``. A different `test container`__ can be used via
 ``ResourceTestRule.Builder#setTestContainerFactory(TestContainerFactory)``.
@@ -314,7 +326,7 @@ The ``DropwizardClientRule`` takes care of:
 Integration Testing
 ===================
 
-It can be useful to start up your entire app and hit it with real HTTP requests during testing. 
+It can be useful to start up your entire app and hit it with real HTTP requests during testing.
 
 JUnit
 -----
@@ -343,7 +355,7 @@ running and stop it again when they've completed (roughly equivalent to having u
             assertThat(response.getStatus()).isEqualTo(302);
         }
     }
-    
+
 Non-JUnit
 ---------
 By creating a DropwizardTestSupport instance in your test you can manually start and stop the app in your tests, you do this by calling its ``before`` and ``after`` methods. ``DropwizardTestSupport`` also exposes the app's ``Configuration``, ``Environment`` and the app object itself so that these can be queried by the tests.
@@ -359,12 +371,12 @@ By creating a DropwizardTestSupport instance in your test you can manually start
         public void beforeClass() {
           SUPPORT.before();
         }
-        
+
         @AfterClass
         public void afterClass() {
           SUPPORT.after();
         }
-        
+
         @Test
         public void loginHandlerRedirectsAfterPost() {
             Client client = new JerseyClientBuilder(SUPPORT.getEnvironment()).build("test client");

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResource.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResource.java
@@ -4,14 +4,17 @@ import com.codahale.metrics.annotation.Timed;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.jersey.params.IntParam;
 import io.dropwizard.testing.Person;
+import org.eclipse.jetty.io.EofException;
 
 import javax.validation.constraints.Min;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
+import java.util.Map;
 
 @Path("/person/{name}")
 @Produces(MediaType.APPLICATION_JSON)
@@ -41,5 +44,17 @@ public class PersonResource {
     public Person getPersonWithIndex(@Min(0) @QueryParam("ind") IntParam index,
                                      @PathParam("name") String name) {
         return getPersonList(name).get(index.get());
+    }
+
+    @POST
+    @Path("/runtime-exception")
+    public Person exceptional(Map<String, String> mapper) throws Exception {
+        throw new Exception("I'm an exception!");
+    }
+
+    @GET
+    @Path("/eof-exception")
+    public Person eofException() throws Exception {
+        throw new EofException("I'm an eof exception!");
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResourceExceptionMapperTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResourceExceptionMapperTest.java
@@ -1,0 +1,94 @@
+package io.dropwizard.testing.app;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.google.common.base.Strings;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jersey.validation.JerseyViolationException;
+import io.dropwizard.testing.junit.ResourceTestRule;
+import org.glassfish.jersey.spi.ExtendedExceptionMapper;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class PersonResourceExceptionMapperTest {
+    private static final PeopleStore dao = mock(PeopleStore.class);
+
+    private static final ObjectMapper mapper = Jackson.newObjectMapper()
+        .registerModule(new GuavaModule());
+
+    @ClassRule
+    public static final ResourceTestRule resources = ResourceTestRule.builder()
+        .addResource(new PersonResource(dao))
+        .setRegisterDefaultExceptionMappers(false)
+        .addProvider(new MyJerseyExceptionMapper())
+        .addProvider(new GenericExceptionMapper())
+        .setMapper(mapper)
+        .build();
+
+    @Test
+    public void testDefaultConstraintViolation() {
+        assertThat(resources.client().target("/person/blah/index")
+            .queryParam("ind", -1).request()
+            .get().readEntity(String.class))
+            .isEqualTo("Invalid data");
+    }
+
+    @Test
+    public void testDefaultJsonProcessingMapper() {
+        assertThat(resources.client().target("/person/blah/runtime-exception")
+            .request()
+            .post(Entity.json("{ \"he: \"ho\"}"))
+            .readEntity(String.class))
+            .startsWith("Something went wrong: Unexpected character");
+    }
+
+    @Test
+    public void testDefaultExceptionMapper() {
+        assertThat(resources.client().target("/person/blah/runtime-exception")
+            .request()
+            .post(Entity.json("{}"))
+            .readEntity(String.class))
+            .isEqualTo("Something went wrong: I'm an exception!");
+    }
+
+    @Test
+    public void testDefaultEofExceptionMapper() {
+        assertThat(resources.client().target("/person/blah/eof-exception")
+            .request()
+            .get().readEntity(String.class))
+            .isEqualTo("Something went wrong: I'm an eof exception!");
+    }
+
+    private static class MyJerseyExceptionMapper implements ExceptionMapper<JerseyViolationException> {
+        @Override
+        public Response toResponse(JerseyViolationException exception) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .type(MediaType.TEXT_PLAIN)
+                .entity("Invalid data")
+                .build();
+        }
+    }
+
+    private static class GenericExceptionMapper implements ExtendedExceptionMapper<Throwable> {
+        @Override
+        public boolean isMappable(Throwable throwable) {
+            return !(throwable instanceof JerseyViolationException);
+        }
+
+        @Override
+        public Response toResponse(Throwable exception) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .type(MediaType.TEXT_PLAIN)
+                .entity("Something went wrong: " + Strings.nullToEmpty(exception.getMessage()))
+                .build();
+        }
+    }
+}


### PR DESCRIPTION
This commit makes the default behavior of `ResourceTestRule` to register
all the default exception mappers, much like how the default yaml
configuration will register the default exception mappers.

If a user wants to override the default exception mappers, then they can
call `setRegisterDefaultExceptionMappers(false)` and subsequently register
their custom exception mappers.

Note that this is breaking behavior as those who registered their
exception mappers will now have to call setRegisterDefaultExceptionMappers
and those who wanted the default exception mappers should now remove their
registrations of the default exception mappers.

The  reason behind this pull request is that, in my opinion, it is unreasonable
for someone new to Dropwizard to know all the default exception mappers that
they will need to register in `ResourceTestRule` to get the same behavior as their
app.