### PR TITLE
Unused local variables should be removed

### DIFF
--- a/dropwizard-client/src/test/java/io/dropwizard/client/ssl/DropwizardSSLConnectionSocketFactoryTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/ssl/DropwizardSSLConnectionSocketFactoryTest.java
@@ -91,7 +91,7 @@ public class DropwizardSSLConnectionSocketFactoryTest {
         tlsConfiguration.setTrustStorePath(new File(ResourceHelpers.resourceFilePath("stores/server/other_cert_truststore.ts")));
         final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).build("tls_broken_client");
         try {
-            final Response response = client.target(String.format("https://localhost:%d", TLS_APP_RULE.getLocalPort())).request().get();
+            client.target(String.format("https://localhost:%d", TLS_APP_RULE.getLocalPort())).request().get();
             fail("expected ProcessingException");
         } catch(ProcessingException e) {
            assertThat(e.getCause()).isInstanceOf(SSLHandshakeException.class);
@@ -110,7 +110,7 @@ public class DropwizardSSLConnectionSocketFactoryTest {
     public void shouldErrorIfServerCertSelfSignedAndSelfSignedCertsNotAllowed() throws Exception {
         final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).build("self_sign_failure");
         try {
-            final ClientResponse response = client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(1))).request().get(ClientResponse.class);
+            client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(1))).request().get(ClientResponse.class);
             fail("expected ProcessingException");
         } catch(ProcessingException e) {
             assertThat(e.getCause()).isInstanceOf(SSLHandshakeException.class);
@@ -134,7 +134,7 @@ public class DropwizardSSLConnectionSocketFactoryTest {
         tlsConfiguration.setKeyStoreType("PKCS12");
         final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).build("client_auth_broken");
         try {
-            final Response response = client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(2))).request().get();
+            client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(2))).request().get();
             fail("expected ProcessingException");
         } catch(ProcessingException e) {
             assertThat(e.getCause()).isInstanceOfAny(SocketException.class, SSLHandshakeException.class);
@@ -145,7 +145,7 @@ public class DropwizardSSLConnectionSocketFactoryTest {
     public void shouldErrorIfHostnameVerificationOnAndServerHostnameDoesntMatch() throws Exception {
         final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).build("bad_host_broken");
         try {
-            final Response response = client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(3))).request().get();
+            client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(3))).request().get();
             fail("Expected ProcessingException");
         } catch (ProcessingException e) {
             assertThat(e.getCause()).isExactlyInstanceOf(SSLPeerUnverifiedException.class);
@@ -166,7 +166,7 @@ public class DropwizardSSLConnectionSocketFactoryTest {
         tlsConfiguration.setSupportedProtocols(asList("TLSv1.2"));
         final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).build("reject_non_supported");
         try {
-            final Response response = client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(4))).request().get();
+            client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(4))).request().get();
             fail("expected ProcessingException");
         } catch (ProcessingException e) {
             assertThat(e.getCause()).isInstanceOfAny(SocketException.class, SSLHandshakeException.class);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapperTest.java
@@ -34,7 +34,6 @@ public class JsonProcessingExceptionMapperTest extends JerseyTest {
 
     @Override
     protected void configureClient(ClientConfig config) {
-        final Validator validator = Validators.newValidator();
         final ObjectMapper mapper = new ObjectMapper();
         final JacksonMessageBodyProvider provider = new JacksonMessageBodyProvider(mapper);
         config.register(provider);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1481 - Unused local variables should be removed
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1481
Please let me know if you have any questions.
Kirill Vlasov