### PR TITLE
Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
@@ -291,7 +291,7 @@ public class JerseyClientBuilder {
                     "an executor service and an object mapper");
         }
 
-        if (executorService == null && environment != null) {
+        if (executorService == null) {
             executorService = environment.lifecycle()
                     .executorService("jersey-client-" + name + "-%d")
                     .minThreads(configuration.getMinThreads())
@@ -300,7 +300,7 @@ public class JerseyClientBuilder {
                     .build();
         }
 
-        if (objectMapper == null && environment != null) {
+        if (objectMapper == null) {
             objectMapper = environment.getObjectMapper();
         }
 

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ResourceTestRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ResourceTestRule.java
@@ -223,9 +223,7 @@ public class ResourceTestRule implements TestRule {
                     base.evaluate();
                 } finally {
                     ResourceTestResourceConfig.RULE_ID_TO_RULE.remove(ruleId);
-                    if (test != null) {
-                        test.tearDown();
-                    }
+                    test.tearDown();
                 }
             }
         };


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2583 - Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2583
Please let me know if you have any questions.
Kirill Vlasov