### PR TITLE
Lazy initialization of "static" fields should be "synchronized"

### DIFF
--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/jersey/LoggingDBIExceptionMapper.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/jersey/LoggingDBIExceptionMapper.java
@@ -29,7 +29,7 @@ public class LoggingDBIExceptionMapper extends LoggingExceptionMapper<DBIExcepti
     }
 
     @VisibleForTesting
-    static void setLogger(Logger newLogger) {
+    static synchronized void setLogger(Logger newLogger) {
         logger = newLogger;
     }
 }

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/jersey/LoggingSQLExceptionMapper.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/jersey/LoggingSQLExceptionMapper.java
@@ -24,7 +24,7 @@ public class LoggingSQLExceptionMapper extends LoggingExceptionMapper<SQLExcepti
     }
 
     @VisibleForTesting
-    static void setLogger(Logger newLogger) {
+    static synchronized void setLogger(Logger newLogger) {
         logger = newLogger;
     }
 }

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilder.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilder.java
@@ -94,7 +94,7 @@ public class ExecutorServiceBuilder {
     }
 
     @VisibleForTesting
-    static void setLog(Logger newLog) {
+    static synchronized void setLog(Logger newLog) {
        log = newLog;
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2444 - Lazy initialization of "static" fields should be "synchronized"
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2444
Please let me know if you have any questions.
Kirill Vlasov