### PR TITLE
Null pointers should not be dereferenced

### DIFF
--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/TaskServlet.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/TaskServlet.java
@@ -209,9 +209,11 @@ public class TaskServlet extends HttpServlet {
             try {
                 underlying.executeTask(params, output);
             } catch (Exception e) {
-                if (exceptionMeter != null && exceptionClass.isAssignableFrom(e.getClass()) ||
-                        (e.getCause() != null && exceptionClass.isAssignableFrom(e.getCause().getClass()))) {
-                    exceptionMeter.mark();
+                if (exceptionMeter != null) {
+                    if (exceptionClass.isAssignableFrom(e.getClass()) ||
+                            (e.getCause() != null && exceptionClass.isAssignableFrom(e.getCause().getClass()))) {
+                        exceptionMeter.mark();
+                    }
                 }
 
                 throw e;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2259 - Null pointers should not be dereferenced
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2259
Please let me know if you have any questions.
Kirill Vlasov