### PR TITLE
"private" methods that don't access instance data should be "static"

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactory.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactory.java
@@ -90,7 +90,7 @@ public class DropwizardSSLConnectionSocketFactory {
         sslContextBuilder.loadTrustMaterial(trustStore, trustStrategy);
     }
 
-    private KeyStore loadKeyStore(String type, File path, String password) throws Exception {
+    private static KeyStore loadKeyStore(String type, File path, String password) throws Exception {
         final KeyStore keyStore = KeyStore.getInstance(type);
         try (InputStream inputStream = new FileInputStream(path)) {
             keyStore.load(inputStream, password.toCharArray());

--- a/dropwizard-core/src/main/java/io/dropwizard/cli/Cli.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/Cli.java
@@ -89,7 +89,7 @@ public class Cli {
         }
     }
 
-    private boolean isFlag(String[][] flags, String[] arguments) {
+    private static boolean isFlag(String[][] flags, String[] arguments) {
         for (String[] cmd : flags) {
             if (Arrays.equals(arguments, cmd)) {
                 return true;

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkApplicationListenerTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkApplicationListenerTest.java
@@ -271,7 +271,7 @@ public class UnitOfWorkApplicationListenerTest {
         when(uriInfo.getMatchedResourceMethod()).thenReturn(resourceMethod);
     }
 
-    private boolean methodDefinedOnInterface(String methodName, Method[] methods) {
+    private static boolean methodDefinedOnInterface(String methodName, Method[] methods) {
         for (Method method : methods) {
             if (method.getName().equals(methodName)) {
                 return true;

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -189,7 +189,7 @@ public class DropwizardResourceConfig extends ResourceConfig {
             }
         }
 
-        private String normalizePath(String basePath, String path) {
+        private static String normalizePath(String basePath, String path) {
             if (path == null) {
                 return basePath;
             }

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/PrefixedRootCauseFirstThrowableProxyConverterTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/PrefixedRootCauseFirstThrowableProxyConverterTest.java
@@ -33,7 +33,7 @@ public class PrefixedRootCauseFirstThrowableProxyConverterTest {
         return null; // unpossible, tell the type-system
     }
 
-    private void throwRoot() throws SocketTimeoutException {
+    private static void throwRoot() throws SocketTimeoutException {
         throw new SocketTimeoutException("Timed-out reading from socket");
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2325 - "private" methods that don't access instance data should be "static"
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325
Please let me know if you have any questions.
Kirill Vlasov