### PR TITLE
Use h2 and h2c as the HTTP/2 connector names

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -434,7 +434,7 @@ This connector extends the attributes that are available to the :ref:`HTTPS conn
 
     server:
       applicationConnectors:
-        - type: http2
+        - type: h2
           port: 8445
           maxConcurrentStreams: 1024
           initialStreamSendWindow: 65535
@@ -472,7 +472,7 @@ This connector extends the attributes that are available to the :ref:`HTTP conne
 
     server:
       applicationConnectors:
-        - type: http2c
+        - type: h2c
           port: 8446
           maxConcurrentStreams: 1024
           initialStreamSendWindow: 65535

--- a/dropwizard-example/example.yml
+++ b/dropwizard-example/example.yml
@@ -37,7 +37,7 @@ server:
       validateCerts: false
       validatePeers: false
     #this requires the alpn-boot library on the JVM's boot classpath
-    #- type: http2
+    #- type: h2
     #  port: 8445
     #  keyStorePath: example.keystore
     #  keyStorePassword: example

--- a/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2CConnectorFactory.java
+++ b/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2CConnectorFactory.java
@@ -49,7 +49,7 @@ import javax.validation.constraints.Min;
  * For more configuration parameters, see {@link HttpsConnectorFactory}.
  * @see HttpConnectorFactory
  */
-@JsonTypeName("http2c")
+@JsonTypeName("h2c")
 public class Http2CConnectorFactory extends HttpConnectorFactory {
 
     @Min(100)

--- a/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2ConnectorFactory.java
+++ b/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2ConnectorFactory.java
@@ -17,7 +17,7 @@ import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 
 /**
- * Builds HTTP/2 over TLS connectors.
+ * Builds HTTP/2 over TLS (h2) connectors.
  * <p/>
  * <b>Configuration Parameters:</b>
  * <table>
@@ -48,7 +48,7 @@ import javax.validation.constraints.Min;
  *
  * @see HttpsConnectorFactory
  */
-@JsonTypeName("http2")
+@JsonTypeName("h2")
 public class Http2ConnectorFactory extends HttpsConnectorFactory {
 
     /**

--- a/dropwizard-http2/src/test/resources/test-http2.yml
+++ b/dropwizard-http2/src/test/resources/test-http2.yml
@@ -1,7 +1,7 @@
 server:
   type: simple
   connector:
-    type: http2
+    type: h2
     port: 0
     keyStorePassword: http2_server
     validateCerts: false

--- a/dropwizard-http2/src/test/resources/test-http2c.yml
+++ b/dropwizard-http2/src/test/resources/test-http2c.yml
@@ -1,7 +1,7 @@
 server:
   type: simple
   connector:
-    type: http2c
+    type: h2c
     port: 0
   applicationContextPath: /api
   adminContextPath: /admin


### PR DESCRIPTION
`h2` and `h2c` are official identificators for the HTTP/2 over TLS and HTTP/2 clear text protocols. It would be more consistent with the spec and less confusing for users, if we used these them instead `http2` and `http2c`.

See [HTTP/2 implementation list](https://github.com/http2/http2-spec/wiki/Implementations) for the reference.