### PR TITLE
Fix: allow validation of Param nullable instances

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ParamValidatorUnwrapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ParamValidatorUnwrapper.java
@@ -17,7 +17,7 @@ public class ParamValidatorUnwrapper extends ValidatedValueUnwrapper<AbstractPar
 
     @Override
     public Object handleValidatedValue(final AbstractParam<?> abstractParam) {
-        return abstractParam.get();
+        return abstractParam == null ? null : abstractParam.get();
     }
 
     @Override

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
@@ -27,9 +27,9 @@ public class ConstraintViolationExceptionMapperTest extends JerseyTest {
     static {
         BootstrapLogging.bootstrap();
     }
-    
+
     private static final Locale DEFAULT_LOCALE = Locale.getDefault();
-    
+
     @Override
     protected Application configure() {
         forceSet(TestProperties.CONTAINER_PORT, "0");
@@ -48,8 +48,7 @@ public class ConstraintViolationExceptionMapperTest extends JerseyTest {
     public static void shutdown() {
         Locale.setDefault(DEFAULT_LOCALE);
     }
-    
-    
+
     @Test
     public void postInvalidEntityIs422() throws Exception {
         assumeThat(Locale.getDefault().getLanguage(), is("en"));
@@ -312,6 +311,19 @@ public class ConstraintViolationExceptionMapperTest extends JerseyTest {
                 .request().get();
         String ret2 = "{\"errors\":[\"query param cheese may not be null\"]}";
         assertThat(response2.readEntity(String.class)).isEqualTo(ret2);
+    }
+
+    @Test
+    public void paramsCanBeValidatedWhenNull() {
+        assertThat(target("/valid/nullable-int-param")
+            .request().get().readEntity(String.class)).isEqualTo("I was null");
+    }
+
+    @Test
+    public void paramsCanBeUnwrappedAndValidated() {
+        assertThat(target("/valid/nullable-int-param").queryParam("num", 4)
+            .request().get().readEntity(String.class))
+            .containsOnlyOnce("[\"query param num must be less than or equal to 3\"]");
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
@@ -1,5 +1,6 @@
 package io.dropwizard.jersey.validation;
 
+import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 
 import io.dropwizard.jersey.jackson.JacksonMessageBodyProviderTest.PartialExample;
@@ -154,6 +155,12 @@ public class ValidatingResource {
     @Path("headCopy")
     public String heads(@QueryParam("cheese") @NotNull @UnwrapValidatedValue(false) IntParam secretSauce) {
         return secretSauce.get().toString();
+    }
+
+    @GET
+    @Path("nullable-int-param")
+    public String nullableIntParam(@QueryParam("num") @Max(3) IntParam secretSauce) {
+        return secretSauce == null ? "I was null" : secretSauce.get().toString();
     }
 
     @GET


### PR DESCRIPTION
Before if you had a resource that was like:

```java
@GET
@Path("nullable-int-param")
public String nullableIntParam(@QueryParam("num") @Max(3) IntParam secretSauce) {
    return secretSauce == null ? "I was null" : secretSauce.get().toString();
}
```

And you passed in `null`, the validator will fail due to an null
dereference in the unwrapper class.

This fixes the behavior by checking if the param is null before attempting
to unwrap