### PR TITLE
Use lambdas and remove redundant type parameters

### DIFF
--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/NoAuthPolymorphicPrincipalEntityTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/NoAuthPolymorphicPrincipalEntityTest.java
@@ -57,15 +57,13 @@ public class NoAuthPolymorphicPrincipalEntityTest extends JerseyTest {
         }
 
         @Override protected ContainerRequestFilter getAuthFilter() {
-            return new ContainerRequestFilter() {
-                @Override public void filter(ContainerRequestContext requestContext) throws IOException {
-                    throw new AssertionError("Authentication must not be performed");
-                }
+            return requestContext -> {
+                throw new AssertionError("Authentication must not be performed");
             };
         }
 
         @Override protected AbstractBinder getAuthBinder() {
-            return new PolymorphicAuthValueFactoryProvider.Binder<PrincipalImpl>(
+            return new PolymorphicAuthValueFactoryProvider.Binder<>(
                 ImmutableSet.of(JsonPrincipal.class, NullPrincipal.class));
         }
 

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/NoAuthPrincipalEntityTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/NoAuthPrincipalEntityTest.java
@@ -54,10 +54,8 @@ public class NoAuthPrincipalEntityTest extends JerseyTest {
         }
 
         @Override protected ContainerRequestFilter getAuthFilter() {
-            return new ContainerRequestFilter() {
-                @Override public void filter(ContainerRequestContext requestContext) throws IOException {
-                    throw new AssertionError("Authentication must not be performed");
-                }
+            return requestContext -> {
+                throw new AssertionError("Authentication must not be performed");
             };
         }
 

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/PolymorphicPrincipalEntityTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/PolymorphicPrincipalEntityTest.java
@@ -64,10 +64,8 @@ public class PolymorphicPrincipalEntityTest extends JerseyTest {
         }
 
         @Override protected ContainerRequestFilter getAuthFilter() {
-            return new ContainerRequestFilter() {
-                @Override public void filter(ContainerRequestContext requestContext) throws IOException {
-                    throw new AssertionError("getAuthFilter result must not be invoked");
-                }
+            return requestContext -> {
+                throw new AssertionError("getAuthFilter result must not be invoked");
             };
         }
 

--- a/dropwizard-benchmarks/src/main/java/io/dropwizard/benchmarks/jersey/ConstraintViolationBenchmark.java
+++ b/dropwizard-benchmarks/src/main/java/io/dropwizard/benchmarks/jersey/ConstraintViolationBenchmark.java
@@ -54,12 +54,7 @@ public class ConstraintViolationBenchmark {
     private ConstraintViolation<ConstraintViolationBenchmark.Resource> paramViolation;
     private ConstraintViolation<ConstraintViolationBenchmark.Resource> objViolation;
 
-    final Invocable invocable = Invocable.create(new Inflector<Request, Object>() {
-        @Override
-        public Object apply(Request request) {
-            return null;
-        }
-    });
+    final Invocable invocable = Invocable.create(request -> null);
 
     @Setup
     public void prepare() {

--- a/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardApacheConnector.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardApacheConnector.java
@@ -190,14 +190,11 @@ public class DropwizardApacheConnector implements Connector {
     @Override
     public Future<?> apply(final ClientRequest request, final AsyncConnectorCallback callback) {
         // Simulate an asynchronous execution
-        return MoreExecutors.newDirectExecutorService().submit(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    callback.response(apply(request));
-                } catch (Exception e) {
-                    callback.failure(e);
-                }
+        return MoreExecutors.newDirectExecutorService().submit((Runnable) () -> {
+            try {
+                callback.response(apply(request));
+            } catch (Exception e) {
+                callback.failure(e);
             }
         });
     }
@@ -266,12 +263,7 @@ public class DropwizardApacheConnector implements Connector {
          */
         @Override
         public void writeTo(final OutputStream outputStream) throws IOException {
-            clientRequest.setStreamProvider(new OutboundMessageContext.StreamProvider() {
-                @Override
-                public OutputStream getOutputStream(int contentLength) throws IOException {
-                    return outputStream;
-                }
-            });
+            clientRequest.setStreamProvider(contentLength -> outputStream);
             clientRequest.writeEntity();
         }
 
@@ -300,12 +292,7 @@ public class DropwizardApacheConnector implements Connector {
 
         private BufferedJerseyRequestHttpEntity(ClientRequest clientRequest) {
             final ByteArrayOutputStream stream = new ByteArrayOutputStream(BUFFER_INITIAL_SIZE);
-            clientRequest.setStreamProvider(new OutboundMessageContext.StreamProvider() {
-                @Override
-                public OutputStream getOutputStream(int contentLength) throws IOException {
-                    return stream;
-                }
-            });
+            clientRequest.setStreamProvider(contentLength -> stream);
             try {
                 clientRequest.writeEntity();
             } catch (IOException e) {

--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
@@ -56,12 +56,7 @@ import java.util.List;
  * </p>
  */
 public class HttpClientBuilder {
-    private static final HttpRequestRetryHandler NO_RETRIES = new HttpRequestRetryHandler() {
-        @Override
-        public boolean retryRequest(IOException exception, int executionCount, HttpContext context) {
-            return false;
-        }
-    };
+    private static final HttpRequestRetryHandler NO_RETRIES = (exception, executionCount, context) -> false;
 
     private final MetricRegistry metricRegistry;
     private String environmentName;

--- a/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
@@ -296,7 +296,7 @@ public class JerseyClientBuilder {
                     .executorService("jersey-client-" + name + "-%d")
                     .minThreads(configuration.getMinThreads())
                     .maxThreads(configuration.getMaxThreads())
-                    .workQueue(new ArrayBlockingQueue<Runnable>(configuration.getWorkQueueSize()))
+                    .workQueue(new ArrayBlockingQueue<>(configuration.getWorkQueueSize()))
                     .build();
         }
 
@@ -366,15 +366,10 @@ public class JerseyClientBuilder {
         if (connectorProvider == null) {
             final ConfiguredCloseableHttpClient apacheHttpClient =
                     apacheHttpClientBuilder.buildWithDefaultRequestConfiguration(name);
-            connectorProvider = new ConnectorProvider() {
-                @Override
-                public Connector getConnector(Client client, Configuration runtimeConfig) {
-                    return new DropwizardApacheConnector(
-                            apacheHttpClient.getClient(),
-                            apacheHttpClient.getDefaultRequestConfig(),
-                            configuration.isChunkedEncodingEnabled());
-                }
-            };
+            connectorProvider = (client, runtimeConfig) -> new DropwizardApacheConnector(
+                    apacheHttpClient.getClient(),
+                    apacheHttpClient.getDefaultRequestConfig(),
+                    configuration.isChunkedEncodingEnabled());
         }
         config.connectorProvider(connectorProvider);
 

--- a/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
@@ -299,12 +299,7 @@ public class HttpClientBuilderTest {
 
     @Test
     public void usesACustomHttpRequestRetryHandler() throws Exception {
-        final HttpRequestRetryHandler customHandler = new HttpRequestRetryHandler() {
-            @Override
-            public boolean retryRequest(IOException exception, int executionCount, HttpContext context) {
-                return false;
-            }
-        };
+        final HttpRequestRetryHandler customHandler = (exception, executionCount, context) -> false;
 
         configuration.setRetries(1);
         assertThat(builder.using(configuration).using(customHandler)

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientIntegrationTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientIntegrationTest.java
@@ -64,20 +64,17 @@ public class JerseyClientIntegrationTest {
 
     @Test
     public void testChunkedGzipPost() throws Exception {
-        httpServer.createContext("/register", new HttpHandler() {
-            @Override
-            public void handle(HttpExchange httpExchange) throws IOException {
-                try {
-                    Headers requestHeaders = httpExchange.getRequestHeaders();
-                    assertThat(requestHeaders.get(TRANSFER_ENCODING)).containsExactly(CHUNKED);
-                    assertThat(requestHeaders.get(HttpHeaders.CONTENT_LENGTH)).isNull();
-                    assertThat(requestHeaders.get(HttpHeaders.CONTENT_ENCODING)).containsExactly(GZIP);
-                    assertThat(requestHeaders.get(HttpHeaders.ACCEPT_ENCODING)).containsExactly(GZIP_DEFLATE);
-                    checkBody(httpExchange, true);
-                    postResponse(httpExchange);
-                } finally {
-                    httpExchange.close();
-                }
+        httpServer.createContext("/register", httpExchange -> {
+            try {
+                Headers requestHeaders = httpExchange.getRequestHeaders();
+                assertThat(requestHeaders.get(TRANSFER_ENCODING)).containsExactly(CHUNKED);
+                assertThat(requestHeaders.get(HttpHeaders.CONTENT_LENGTH)).isNull();
+                assertThat(requestHeaders.get(HttpHeaders.CONTENT_ENCODING)).containsExactly(GZIP);
+                assertThat(requestHeaders.get(HttpHeaders.ACCEPT_ENCODING)).containsExactly(GZIP_DEFLATE);
+                checkBody(httpExchange, true);
+                postResponse(httpExchange);
+            } finally {
+                httpExchange.close();
             }
         });
         httpServer.start();
@@ -87,22 +84,19 @@ public class JerseyClientIntegrationTest {
 
     @Test
     public void testBufferedGzipPost() {
-        httpServer.createContext("/register", new HttpHandler() {
-            @Override
-            public void handle(HttpExchange httpExchange) throws IOException {
-                try {
-                    Headers requestHeaders = httpExchange.getRequestHeaders();
+        httpServer.createContext("/register", httpExchange -> {
+            try {
+                Headers requestHeaders = httpExchange.getRequestHeaders();
 
-                    assertThat(requestHeaders.get(HttpHeaders.CONTENT_LENGTH)).containsExactly("58");
-                    assertThat(requestHeaders.get(TRANSFER_ENCODING)).isNull();
-                    assertThat(requestHeaders.get(HttpHeaders.CONTENT_ENCODING)).containsExactly(GZIP);
-                    assertThat(requestHeaders.get(HttpHeaders.ACCEPT_ENCODING));
+                assertThat(requestHeaders.get(HttpHeaders.CONTENT_LENGTH)).containsExactly("58");
+                assertThat(requestHeaders.get(TRANSFER_ENCODING)).isNull();
+                assertThat(requestHeaders.get(HttpHeaders.CONTENT_ENCODING)).containsExactly(GZIP);
+                assertThat(requestHeaders.get(HttpHeaders.ACCEPT_ENCODING));
 
-                    checkBody(httpExchange, true);
-                    postResponse(httpExchange);
-                } finally {
-                    httpExchange.close();
-                }
+                checkBody(httpExchange, true);
+                postResponse(httpExchange);
+            } finally {
+                httpExchange.close();
             }
         });
         httpServer.start();
@@ -114,21 +108,18 @@ public class JerseyClientIntegrationTest {
 
     @Test
     public void testChunkedPost() throws Exception {
-        httpServer.createContext("/register", new HttpHandler() {
-            @Override
-            public void handle(HttpExchange httpExchange) throws IOException {
-                try {
-                    Headers requestHeaders = httpExchange.getRequestHeaders();
-                    assertThat(requestHeaders.get(TRANSFER_ENCODING)).containsExactly(CHUNKED);
-                    assertThat(requestHeaders.get(HttpHeaders.CONTENT_LENGTH)).isNull();
-                    assertThat(requestHeaders.get(HttpHeaders.CONTENT_ENCODING)).isNull();
-                    assertThat(requestHeaders.get(HttpHeaders.ACCEPT_ENCODING)).containsExactly(GZIP_DEFLATE);
+        httpServer.createContext("/register", httpExchange -> {
+            try {
+                Headers requestHeaders = httpExchange.getRequestHeaders();
+                assertThat(requestHeaders.get(TRANSFER_ENCODING)).containsExactly(CHUNKED);
+                assertThat(requestHeaders.get(HttpHeaders.CONTENT_LENGTH)).isNull();
+                assertThat(requestHeaders.get(HttpHeaders.CONTENT_ENCODING)).isNull();
+                assertThat(requestHeaders.get(HttpHeaders.ACCEPT_ENCODING)).containsExactly(GZIP_DEFLATE);
 
-                    checkBody(httpExchange, false);
-                    postResponse(httpExchange);
-                } finally {
-                    httpExchange.close();
-                }
+                checkBody(httpExchange, false);
+                postResponse(httpExchange);
+            } finally {
+                httpExchange.close();
             }
         });
         httpServer.start();
@@ -140,25 +131,22 @@ public class JerseyClientIntegrationTest {
 
     @Test
     public void testChunkedPostWithoutGzip() throws Exception {
-        httpServer.createContext("/register", new HttpHandler() {
-            @Override
-            public void handle(HttpExchange httpExchange) throws IOException {
-                try {
-                    Headers requestHeaders = httpExchange.getRequestHeaders();
-                    assertThat(requestHeaders.get(TRANSFER_ENCODING)).containsExactly(CHUNKED);
-                    assertThat(requestHeaders.get(HttpHeaders.CONTENT_LENGTH)).isNull();
-                    assertThat(requestHeaders.get(HttpHeaders.CONTENT_ENCODING)).isNull();
-                    assertThat(requestHeaders.get(HttpHeaders.ACCEPT_ENCODING)).isNull();
+        httpServer.createContext("/register", httpExchange -> {
+            try {
+                Headers requestHeaders = httpExchange.getRequestHeaders();
+                assertThat(requestHeaders.get(TRANSFER_ENCODING)).containsExactly(CHUNKED);
+                assertThat(requestHeaders.get(HttpHeaders.CONTENT_LENGTH)).isNull();
+                assertThat(requestHeaders.get(HttpHeaders.CONTENT_ENCODING)).isNull();
+                assertThat(requestHeaders.get(HttpHeaders.ACCEPT_ENCODING)).isNull();
 
-                    checkBody(httpExchange, false);
+                checkBody(httpExchange, false);
 
-                    httpExchange.getResponseHeaders().add(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON);
-                    httpExchange.sendResponseHeaders(200, 0);
-                    httpExchange.getResponseBody().write(JSON_TOKEN.getBytes(StandardCharsets.UTF_8));
-                    httpExchange.getResponseBody().close();
-                } finally {
-                    httpExchange.close();
-                }
+                httpExchange.getResponseHeaders().add(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON);
+                httpExchange.sendResponseHeaders(200, 0);
+                httpExchange.getResponseBody().write(JSON_TOKEN.getBytes(StandardCharsets.UTF_8));
+                httpExchange.getResponseBody().close();
+            } finally {
+                httpExchange.close();
             }
         });
         httpServer.start();
@@ -216,21 +204,18 @@ public class JerseyClientIntegrationTest {
 
     @Test
     public void testGet() {
-        httpServer.createContext("/player", new HttpHandler() {
-            @Override
-            public void handle(HttpExchange httpExchange) throws IOException {
-                try {
-                    assertThat(httpExchange.getRequestURI().getQuery()).isEqualTo("id=21");
+        httpServer.createContext("/player", httpExchange -> {
+            try {
+                assertThat(httpExchange.getRequestURI().getQuery()).isEqualTo("id=21");
 
-                    httpExchange.getResponseHeaders().add(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON);
-                    httpExchange.sendResponseHeaders(200, 0);
-                    httpExchange.getResponseBody().write(JSON_MAPPER.createObjectNode()
-                            .put("email", "john@doe.me")
-                            .put("name", "John Doe")
-                            .toString().getBytes(StandardCharsets.UTF_8));
-                } finally {
-                    httpExchange.close();
-                }
+                httpExchange.getResponseHeaders().add(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON);
+                httpExchange.sendResponseHeaders(200, 0);
+                httpExchange.getResponseBody().write(JSON_MAPPER.createObjectNode()
+                        .put("email", "john@doe.me")
+                        .put("name", "John Doe")
+                        .toString().getBytes(StandardCharsets.UTF_8));
+            } finally {
+                httpExchange.close();
             }
         });
         httpServer.start();
@@ -258,17 +243,14 @@ public class JerseyClientIntegrationTest {
 
     @Test
     public void testSetUserAgent() {
-        httpServer.createContext("/test", new HttpHandler() {
-            @Override
-            public void handle(HttpExchange httpExchange) throws IOException {
-                try {
-                    assertThat(httpExchange.getRequestHeaders().get(HttpHeaders.USER_AGENT))
-                            .containsExactly("Custom user-agent");
-                    httpExchange.sendResponseHeaders(200, 0);
-                    httpExchange.getResponseBody().write("Hello World!".getBytes(StandardCharsets.UTF_8));
-                } finally {
-                    httpExchange.close();
-                }
+        httpServer.createContext("/test", httpExchange -> {
+            try {
+                assertThat(httpExchange.getRequestHeaders().get(HttpHeaders.USER_AGENT))
+                        .containsExactly("Custom user-agent");
+                httpExchange.sendResponseHeaders(200, 0);
+                httpExchange.getResponseBody().write("Hello World!".getBytes(StandardCharsets.UTF_8));
+            } finally {
+                httpExchange.close();
             }
         });
         httpServer.start();
@@ -297,16 +279,13 @@ public class JerseyClientIntegrationTest {
      */
     @Test
     public void testFilterOnAWebTarget() {
-        httpServer.createContext("/test", new HttpHandler() {
-            @Override
-            public void handle(HttpExchange httpExchange) throws IOException {
-                try {
-                    httpExchange.getResponseHeaders().add(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN);
-                    httpExchange.sendResponseHeaders(200, 0);
-                    httpExchange.getResponseBody().write("Hello World!".getBytes(StandardCharsets.UTF_8));
-                } finally {
-                    httpExchange.close();
-                }
+        httpServer.createContext("/test", httpExchange -> {
+            try {
+                httpExchange.getResponseHeaders().add(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN);
+                httpExchange.sendResponseHeaders(200, 0);
+                httpExchange.getResponseBody().write("Hello World!".getBytes(StandardCharsets.UTF_8));
+            } finally {
+                httpExchange.close();
             }
         });
         httpServer.start();

--- a/dropwizard-client/src/test/java/io/dropwizard/client/ssl/DropwizardSSLConnectionSocketFactoryTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/ssl/DropwizardSSLConnectionSocketFactoryTest.java
@@ -53,7 +53,7 @@ public class DropwizardSSLConnectionSocketFactoryTest {
     }
 
     @ClassRule
-    public static DropwizardAppRule<Configuration> TLS_APP_RULE = new DropwizardAppRule<Configuration>(TlsTestApplication.class,
+    public static DropwizardAppRule<Configuration> TLS_APP_RULE = new DropwizardAppRule<>(TlsTestApplication.class,
             ResourceHelpers.resourceFilePath("yaml/ssl_connection_socket_factory_test.yml"),
             Optional.of("tls"),
             ConfigOverride.config("tls", "server.applicationConnectors[0].keyStorePath", ResourceHelpers.resourceFilePath("stores/server/keycert.p12")),

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryFactoryTest.java
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConfigurationFactoryFactoryTest {
 
-    private final ConfigurationFactoryFactory<Example> factoryFactory = new DefaultConfigurationFactoryFactory<Example>();
+    private final ConfigurationFactoryFactory<Example> factoryFactory = new DefaultConfigurationFactoryFactory<>();
     private final Validator validator = BaseValidator.newValidator();
     private File validFile;
 

--- a/dropwizard-core/src/main/java/io/dropwizard/setup/Bootstrap.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/Bootstrap.java
@@ -67,7 +67,7 @@ public class Bootstrap<T extends Configuration> {
         this.metricRegistry = new MetricRegistry();
         this.configurationSourceProvider = new FileConfigurationSourceProvider();
         this.classLoader = Thread.currentThread().getContextClassLoader();
-        this.configurationFactoryFactory = new DefaultConfigurationFactoryFactory<T>();
+        this.configurationFactoryFactory = new DefaultConfigurationFactoryFactory<>();
     }
 
     /**

--- a/dropwizard-core/src/main/java/io/dropwizard/setup/Environment.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/Environment.java
@@ -78,7 +78,7 @@ public class Environment {
 
 
         this.healthCheckExecutorService = this.lifecycle().executorService("TimeBoundHealthCheck-pool-%d")
-                .workQueue(new ArrayBlockingQueue<Runnable>(1))
+                .workQueue(new ArrayBlockingQueue<>(1))
                 .minThreads(1)
                 .maxThreads(4)
                 .threadFactory(new ThreadFactoryBuilder().setDaemon(true).build())

--- a/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
@@ -151,15 +151,12 @@ public class DefaultServerFactoryTest {
 
         ((AbstractNetworkConnector)server.getConnectors()[0]).setPort(0);
 
-        ScheduledFuture<Void> cleanup = executor.schedule(new Callable<Void>() {
-            @Override
-            public Void call() throws Exception {
-                if (!server.isStopped()) {
-                    server.stop();
-                }
-                executor.shutdownNow();
-                return null;
+        ScheduledFuture<Void> cleanup = executor.schedule((Callable<Void>) () -> {
+            if (!server.isStopped()) {
+                server.stop();
             }
+            executor.shutdownNow();
+            return null;
         }, 5, TimeUnit.SECONDS);
 
 
@@ -167,24 +164,18 @@ public class DefaultServerFactoryTest {
 
         final int port = ((AbstractNetworkConnector) server.getConnectors()[0]).getLocalPort();
 
-        Future<String> futureResult = executor.submit(new Callable<String>() {
-            @Override
-            public String call() throws Exception {
-                URL url = new URL("http://localhost:" + port + "/app/test");
-                URLConnection connection = url.openConnection();
-                connection.connect();
-                return CharStreams.toString(new InputStreamReader(connection.getInputStream()));
-            }
+        Future<String> futureResult = executor.submit(() -> {
+            URL url = new URL("http://localhost:" + port + "/app/test");
+            URLConnection connection = url.openConnection();
+            connection.connect();
+            return CharStreams.toString(new InputStreamReader(connection.getInputStream()));
         });
 
         requestReceived.await();
 
-        Future<Void> serverStopped = executor.submit(new Callable<Void>() {
-            @Override
-            public Void call() throws Exception {
-                server.stop();
-                return null;
-            }
+        Future<Void> serverStopped = executor.submit((Callable<Void>) () -> {
+            server.stop();
+            return null;
         });
 
         Connector[] connectors = server.getConnectors();

--- a/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
+++ b/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
@@ -518,7 +518,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
     @Deprecated
     @JsonProperty
     public void setDefaultReadOnly(boolean defaultReadOnly) {
-        readOnlyByDefault = Boolean.valueOf(defaultReadOnly);
+        readOnlyByDefault = defaultReadOnly;
     }
 
     @JsonIgnore

--- a/dropwizard-db/src/main/java/io/dropwizard/db/ManagedPooledDataSource.java
+++ b/dropwizard-db/src/main/java/io/dropwizard/db/ManagedPooledDataSource.java
@@ -37,37 +37,16 @@ public class ManagedPooledDataSource extends DataSourceProxy implements ManagedD
     public void start() throws Exception {
         final ConnectionPool connectionPool = createPool();
         metricRegistry.register(name(getClass(), connectionPool.getName(), "active"),
-                new Gauge<Integer>() {
-                    @Override
-                    public Integer getValue() {
-                        return connectionPool.getActive();
-                    }
-                });
+            (Gauge<Integer>) connectionPool::getActive);
 
         metricRegistry.register(name(getClass(), connectionPool.getName(), "idle"),
-                new Gauge<Integer>() {
-
-                    @Override
-                    public Integer getValue() {
-                        return connectionPool.getIdle();
-                    }
-                });
+            (Gauge<Integer>) connectionPool::getIdle);
 
         metricRegistry.register(name(getClass(), connectionPool.getName(), "waiting"),
-                new Gauge<Integer>() {
-                    @Override
-                    public Integer getValue() {
-                        return connectionPool.getWaitCount();
-                    }
-                });
+            (Gauge<Integer>) connectionPool::getWaitCount);
 
         metricRegistry.register(name(getClass(), connectionPool.getName(), "size"),
-                new Gauge<Integer>() {
-                    @Override
-                    public Integer getValue() {
-                        return connectionPool.getSize();
-                    }
-                });
+            (Gauge<Integer>) connectionPool::getSize);
     }
 
     @Override

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkApplicationListenerTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkApplicationListenerTest.java
@@ -88,13 +88,10 @@ public class UnitOfWorkApplicationListenerTest {
 
     @Test
     public void bindsAndUnbindsTheSessionToTheManagedContext() throws Exception {
-        doAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                assertThat(ManagedSessionContext.hasBind(sessionFactory))
-                        .isTrue();
-                return null;
-            }
+        doAnswer(invocation -> {
+            assertThat(ManagedSessionContext.hasBind(sessionFactory))
+                    .isTrue();
+            return null;
         }).when(session).beginTransaction();
 
         execute();

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/DBIHealthCheck.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/DBIHealthCheck.java
@@ -27,13 +27,10 @@ public class DBIHealthCheck extends HealthCheck {
 
     @Override
     protected Result check() throws Exception {
-        return timeBoundHealthCheck.check(new Callable<Result>() {
-            @Override
-            public Result call() throws Exception {
-                try (Handle handle = dbi.open()) {
-                    handle.execute(validationQuery);
-                    return Result.healthy();
-                }
+        return timeBoundHealthCheck.check(() -> {
+            try (Handle handle = dbi.open()) {
+                handle.execute(validationQuery);
+                return Result.healthy();
             }
         });
     }

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/DBIHealthCheckTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/DBIHealthCheckTest.java
@@ -26,17 +26,14 @@ public class DBIHealthCheckTest {
         DBI dbi = mock(DBI.class);
         Handle handle = mock(Handle.class);
         when(dbi.open()).thenReturn(handle);
-        Mockito.doAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                try {
-                    TimeUnit.SECONDS.sleep(10);
-                } catch (Exception ignored) {
-                }
-                return null;
+        Mockito.doAnswer(invocation -> {
+            try {
+                TimeUnit.SECONDS.sleep(10);
+            } catch (Exception ignored) {
             }
+            return null;
         }).when(handle).execute(validationQuery);
-        
+
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         DBIHealthCheck dbiHealthCheck = new DBIHealthCheck(executorService,
                 Duration.milliseconds(5),

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/JerseyViolationExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/JerseyViolationExceptionMapper.java
@@ -18,12 +18,7 @@ public class JerseyViolationExceptionMapper implements ExceptionMapper<JerseyVio
         final Set<ConstraintViolation<?>> violations = exception.getConstraintViolations();
         final Invocable invocable = exception.getInvocable();
         final ImmutableList<String> errors = FluentIterable.from(exception.getConstraintViolations())
-                .transform(new Function<ConstraintViolation<?>, String>() {
-                    @Override
-                    public String apply(ConstraintViolation<?> constraintViolation) {
-                        return ConstraintMessage.getMessage(constraintViolation, invocable);
-                    }
-                }).toList();
+                .transform(violation -> ConstraintMessage.getMessage(violation, invocable)).toList();
 
         final int status = ConstraintMessage.determineStatus(violations, invocable);
         return Response.status(status)

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/gzip/ConfiguredGZipEncoderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/gzip/ConfiguredGZipEncoderTest.java
@@ -29,7 +29,7 @@ public class ConfiguredGZipEncoderTest {
     @Test
     public void gzipParametersSpec() throws IOException {
         ClientRequestContext context = mock(ClientRequestContext.class);
-        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<String, Object>();
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         when(context.getHeaders()).thenReturn(headers);
         headers.put(HttpHeaders.CONTENT_ENCODING, null);
         when(context.hasEntity()).thenReturn(true);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProviderTest.java
@@ -155,7 +155,7 @@ public class JacksonMessageBodyProviderTest {
                                              Example.class,
                                              NONE,
                                              MediaType.APPLICATION_JSON_TYPE,
-                                             new MultivaluedHashMap<String,String>(),
+                                             new MultivaluedHashMap<>(),
                                              entity);
 
         assertThat(obj)
@@ -178,7 +178,7 @@ public class JacksonMessageBodyProviderTest {
             PartialExample.class,
             new Annotation[]{valid},
             MediaType.APPLICATION_JSON_TYPE,
-            new MultivaluedHashMap<String,String>(),
+            new MultivaluedHashMap<>(),
             entity);
 
         assertThat(obj)
@@ -201,7 +201,7 @@ public class JacksonMessageBodyProviderTest {
             PartialExample.class,
             new Annotation[]{valid},
             MediaType.APPLICATION_JSON_TYPE,
-            new MultivaluedHashMap<String,String>(),
+            new MultivaluedHashMap<>(),
             entity);
 
         assertThat(obj)
@@ -221,7 +221,7 @@ public class JacksonMessageBodyProviderTest {
                               Example.class,
                               NONE,
                               MediaType.APPLICATION_JSON_TYPE,
-                              new MultivaluedHashMap<String,String>(),
+                              new MultivaluedHashMap<>(),
                               entity);
             failBecauseExceptionWasNotThrown(WebApplicationException.class);
         } catch (JsonProcessingException e) {
@@ -243,7 +243,7 @@ public class JacksonMessageBodyProviderTest {
                          Example.class,
                          NONE,
                          MediaType.APPLICATION_JSON_TYPE,
-                         new MultivaluedHashMap<String,Object>(),
+                         new MultivaluedHashMap<>(),
                          output);
 
         assertThat(output.toString())
@@ -278,7 +278,7 @@ public class JacksonMessageBodyProviderTest {
                 type,
                 new Annotation[]{ valid },
                 MediaType.APPLICATION_JSON_TYPE,
-                new MultivaluedHashMap<String, String>(),
+                new MultivaluedHashMap<>(),
                 entity);
 
         assertThat(obj)

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
@@ -109,11 +109,6 @@ public class HttpsConnectorFactoryTest {
     }
 
     private <T> Collection<String> getViolationProperties(Set<ConstraintViolation<T>> violations) {
-        return Collections2.transform(violations, new Function<ConstraintViolation<T>, String>() {
-            @Override
-            public String apply(ConstraintViolation<T> input) {
-                return input.getPropertyPath().toString();
-            }
-        });
+        return Collections2.transform(violations, input -> input.getPropertyPath().toString());
     }
 }

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
@@ -36,7 +36,7 @@ public class ExecutorServiceBuilderTest {
 
     @Test
     public void testGiveNoWarningAboutMaximumPoolSizeAndBoundedQueue() {
-        executorServiceBuilder.workQueue(new ArrayBlockingQueue<Runnable>(16));
+        executorServiceBuilder.workQueue(new ArrayBlockingQueue<>(16));
 
         executorServiceBuilder.build();
 

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/LifecycleEnvironmentTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/LifecycleEnvironmentTest.java
@@ -51,12 +51,7 @@ public class LifecycleEnvironmentTest {
     @Test
     public void scheduledExecutorServiceBuildsDaemonThreads() throws ExecutionException, InterruptedException {
         final ScheduledExecutorService executorService = environment.scheduledExecutorService("daemon-%d", true).build();
-        final Future<Boolean> isDaemon = executorService.submit(new Callable<Boolean>() {
-            @Override
-            public Boolean call() throws Exception {
-                return Thread.currentThread().isDaemon();
-            }
-        });
+        final Future<Boolean> isDaemon = executorService.submit(() -> Thread.currentThread().isDaemon());
 
         assertThat(isDaemon.get()).isTrue();
     }
@@ -64,12 +59,7 @@ public class LifecycleEnvironmentTest {
     @Test
     public void scheduledExecutorServiceBuildsUserThreadsByDefault() throws ExecutionException, InterruptedException {
         final ScheduledExecutorService executorService = environment.scheduledExecutorService("user-%d").build();
-        final Future<Boolean> isDaemon = executorService.submit(new Callable<Boolean>() {
-            @Override
-            public Boolean call() throws Exception {
-                return Thread.currentThread().isDaemon();
-            }
-        });
+        final Future<Boolean> isDaemon = executorService.submit(() -> Thread.currentThread().isDaemon());
 
         assertThat(isDaemon.get()).isFalse();
     }

--- a/dropwizard-metrics/src/main/java/io/dropwizard/metrics/BaseReporterFactory.java
+++ b/dropwizard-metrics/src/main/java/io/dropwizard/metrics/BaseReporterFactory.java
@@ -180,14 +180,11 @@ public abstract class BaseReporterFactory implements ReporterFactory {
         final StringMatchingStrategy stringMatchingStrategy = getUseRegexFilters() ?
                 REGEX_STRING_MATCHING_STRATEGY : DEFAULT_STRING_MATCHING_STRATEGY;
 
-        return new MetricFilter() {
-            @Override
-            public boolean matches(final String name, final Metric metric) {
-                // Include the metric if its name is not excluded and its name is included
-                // Where, by default, with no includes setting, all names are included.
-                return !stringMatchingStrategy.containsMatch(getExcludes(), name) &&
-                        (getIncludes().isEmpty() || stringMatchingStrategy.containsMatch(getIncludes(), name));
-            }
+        return (name, metric) -> {
+            // Include the metric if its name is not excluded and its name is included
+            // Where, by default, with no includes setting, all names are included.
+            return !stringMatchingStrategy.containsMatch(getExcludes(), name) &&
+                    (getIncludes().isEmpty() || stringMatchingStrategy.containsMatch(getIncludes(), name));
         };
     }
 

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbRollbackCommand.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbRollbackCommand.java
@@ -50,7 +50,7 @@ public class DbRollbackCommand<T extends Configuration> extends AbstractLiquibas
     public void run(Namespace namespace, Liquibase liquibase) throws Exception {
         final String tag = namespace.getString("tag");
         final Integer count = namespace.getInt("count");
-        final Date date = (Date) namespace.get("date");
+        final Date date = namespace.get("date");
         final Boolean dryRun = namespace.getBoolean("dry-run");
         final String context = getContext(namespace);
 

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCommandTest.java
@@ -22,12 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class DbMigrateCommandTest extends AbstractMigrationTest {
 
     private DbMigrateCommand<TestMigrationConfiguration> migrateCommand = new DbMigrateCommand<>(
-            new DatabaseConfiguration<TestMigrationConfiguration>() {
-                @Override
-                public DataSourceFactory getDataSourceFactory(TestMigrationConfiguration configuration) {
-                    return configuration.getDataSource();
-                }
-            }, TestMigrationConfiguration.class);
+        TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class);
     private TestMigrationConfiguration conf;
     private String databaseUrl;
 

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
@@ -164,12 +164,7 @@ public class DropwizardTestSupport<C extends Configuration> {
             final Bootstrap<C> bootstrap = new Bootstrap<C>(application) {
                 @Override
                 public void run(C configuration, Environment environment) throws Exception {
-                    environment.lifecycle().addServerLifecycleListener(new ServerLifecycleListener() {
-                        @Override
-                        public void serverStarted(Server server) {
-                            jettyServer = server;
-                        }
-                    });
+                    environment.lifecycle().addServerLifecycleListener(server -> jettyServer = server);
                     DropwizardTestSupport.this.configuration = configuration;
                     DropwizardTestSupport.this.environment = environment;
                     super.run(configuration, environment);
@@ -183,21 +178,11 @@ public class DropwizardTestSupport<C extends Configuration> {
                 }
             };
             if (explicitConfig) {
-                bootstrap.setConfigurationFactoryFactory(new ConfigurationFactoryFactory<C>() {
-                    @Override
-                    public ConfigurationFactory<C> create(Class<C> klass, Validator validator,
-                                                          ObjectMapper objectMapper, String propertyPrefix) {
-                        return new POJOConfigurationFactory<>(configuration);
-                    }
-                });
+                bootstrap.setConfigurationFactoryFactory((klass, validator, objectMapper, propertyPrefix) ->
+                    new POJOConfigurationFactory<>(configuration));
             } else if (customPropertyPrefix.isPresent()) {
-                bootstrap.setConfigurationFactoryFactory(new ConfigurationFactoryFactory<C>() {
-                    @Override
-                    public ConfigurationFactory<C> create(Class<C> klass, Validator validator,
-                                                          ObjectMapper objectMapper, String propertyPrefix) {
-                        return new ConfigurationFactory<>(klass, validator, objectMapper, customPropertyPrefix.get());
-                    }
-                });
+                bootstrap.setConfigurationFactoryFactory((klass, validator, objectMapper, propertyPrefix) ->
+                    new ConfigurationFactory<>(klass, validator, objectMapper, customPropertyPrefix.get()));
             }
 
             application.initialize(bootstrap);

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleWithExplicitTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleWithExplicitTest.java
@@ -36,7 +36,7 @@ public class DropwizardAppRuleWithExplicitTest {
         DefaultServerFactory sf = (DefaultServerFactory) config.getServerFactory();
         ((HttpConnectorFactory) sf.getApplicationConnectors().get(0)).setPort(0);
         ((HttpConnectorFactory) sf.getAdminConnectors().get(0)).setPort(0);
-        RULE = new DropwizardAppRule<TestConfiguration>(TestApplication.class, config);
+        RULE = new DropwizardAppRule<>(TestApplication.class, config);
     }
 
     Client client = ClientBuilder.newClient();

--- a/dropwizard-views/src/test/java/io/dropwizard/views/ViewBundleTest.java
+++ b/dropwizard-views/src/test/java/io/dropwizard/views/ViewBundleTest.java
@@ -59,7 +59,7 @@ public class ViewBundleTest {
 
     @Test
     public void addsTheViewMessageBodyWriterToTheEnvironment() throws Exception {
-        new ViewBundle<Configuration>().run(null, environment);
+        new ViewBundle<>().run(null, environment);
 
         verify(jerseyEnvironment).register(any(ViewMessageBodyWriter.class));
     }


### PR DESCRIPTION
Since we're java 8 now, I figured I'd pick up some low hanging fruit by replacing explicit anonymous classes with lambdas and removing. I've opted to not convert code to use the Streams API because I know some find that more controversial.

The downside is that it may make backporting fixes to 0.{8,9}.x more difficult, but I'm optimistic it won't become a significant issue.