### PR TITLE
Make DropwizardAppRule start and stop app only once, even when called recursively

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
@@ -11,6 +11,7 @@ import io.dropwizard.testing.DropwizardTestSupport;
 import org.junit.rules.ExternalResource;
 
 import javax.annotation.Nullable;
+import java.util.concurrent.atomic.AtomicInteger;
 
 
 /**
@@ -21,11 +22,50 @@ import javax.annotation.Nullable;
  * override the {@link #newApplication()} method to provide your application instance(s).
  * </p>
  *
+ * <p>
+ * Using DropwizardAppRule at the suite level can speed up test runs, as the application is only started and stopped
+ * once for the entire suite:
+ * </p>
+ *
+ * <pre>
+ * @RunWith(Suite.class)
+ * @SuiteClasses({FooTest.class, BarTest.class})
+ * public class MySuite {
+ *   @ClassRule
+ *   public static final DropwizardAppRule&lt;MyConfig> DROPWIZARD = new DropwizardAppRule&lt;>(MyApp.class);
+ * }
+ * </pre>
+ *
+ * <p>
+ * If the same instance of DropwizardAppRule is reused at the suite- and class-level, then the application will be
+ * started and stopped once, regardless of whether the entire suite or a single test is executed.
+ * </p>
+ *
+ * <pre>
+ * public class FooTest {
+ *   @ClassRule public static final DropwizardAppRule&lt;MyConfig> DROPWIZARD = MySuite.DROPWIZARD;
+ *
+ *   public void testFoo() { ... }
+ * }
+ *
+ * public class BarTest {
+ *   @ClassRule public static final DropwizardAppRule&lt;MyConfig> DROPWIZARD = MySuite.DROPWIZARD;
+ *
+ *   public void testBar() { ... }
+ * }
+ * </pre>
+ *
+ * <p>
+ *
+ * </p>
+ *
  * @param <C> the configuration type
  */
 public class DropwizardAppRule<C extends Configuration> extends ExternalResource {
 
     private final DropwizardTestSupport<C> testSupport;
+
+    private final AtomicInteger recursiveCallCount = new AtomicInteger(0);
 
     public DropwizardAppRule(Class<? extends Application<C>> applicationClass) {
         this(applicationClass, (String) null);
@@ -84,12 +124,16 @@ public class DropwizardAppRule<C extends Configuration> extends ExternalResource
 
     @Override
     protected void before() {
-        testSupport.before();
+        if (recursiveCallCount.getAndIncrement() == 0) {
+            testSupport.before();
+        }
     }
 
     @Override
     protected void after() {
-        testSupport.after();
+        if (recursiveCallCount.decrementAndGet() == 0) {
+            testSupport.after();
+        }
     }
 
     public C getConfiguration() {

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
@@ -28,11 +28,11 @@ import java.util.concurrent.atomic.AtomicInteger;
  * </p>
  *
  * <pre>
- * @RunWith(Suite.class)
- * @SuiteClasses({FooTest.class, BarTest.class})
+ * &#064;RunWith(Suite.class)
+ * &#064;SuiteClasses({FooTest.class, BarTest.class})
  * public class MySuite {
- *   @ClassRule
- *   public static final DropwizardAppRule&lt;MyConfig> DROPWIZARD = new DropwizardAppRule&lt;>(MyApp.class);
+ *   &#064;ClassRule
+ *   public static final DropwizardAppRule&lt;MyConfig> DROPWIZARD = new DropwizardAppRule&lt;>(...);
  * }
  * </pre>
  *
@@ -43,13 +43,13 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * <pre>
  * public class FooTest {
- *   @ClassRule public static final DropwizardAppRule&lt;MyConfig> DROPWIZARD = MySuite.DROPWIZARD;
+ *   &#064;ClassRule public static final DropwizardAppRule&lt;MyConfig> DROPWIZARD = MySuite.DROPWIZARD;
  *
  *   public void testFoo() { ... }
  * }
  *
  * public class BarTest {
- *   @ClassRule public static final DropwizardAppRule&lt;MyConfig> DROPWIZARD = MySuite.DROPWIZARD;
+ *   &#064;ClassRule public static final DropwizardAppRule&lt;MyConfig> DROPWIZARD = MySuite.DROPWIZARD;
  *
  *   public void testBar() { ... }
  * }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleReentrantTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleReentrantTest.java
@@ -1,0 +1,46 @@
+package io.dropwizard.testing.junit;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.times;
+
+import io.dropwizard.testing.DropwizardTestSupport;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class DropwizardAppRuleReentrantTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    DropwizardTestSupport<TestConfiguration> testSupport;
+
+    @Mock
+    Statement statement;
+
+    @Mock
+    Description description;
+
+    @Test
+    public void testReentrantRuleStartsApplicationOnlyOnce() throws Throwable {
+        DropwizardAppRule<TestConfiguration> dropwizardAppRule = new DropwizardAppRule<>(testSupport);
+
+        RuleChain.outerRule(dropwizardAppRule)
+            .around(dropwizardAppRule) // recursive
+            .apply(statement, description)
+            .evaluate();
+
+        InOrder inOrder = inOrder(testSupport, statement, description);
+        inOrder.verify(testSupport, times(1)).before();
+        inOrder.verify(statement).evaluate();
+        inOrder.verify(testSupport, times(1)).after();
+        inOrder.verifyNoMoreInteractions();
+    }
+}


### PR DESCRIPTION
We've found on our projects that builds go significantly faster if we use DropwizardAppRule at the suite level.

This however makes it difficult to run individual tests in isolation.

This pull request makes DropwizardAppRule usable in a recursive way, but only starts and stops the application once for the outer call. With this change we are able to run the entire test suite, or a single test in a single class, and the application will be started/stopped once and only once.

There are usage examples in the javadoc changes.