### PR TITLE
Add #getUrl() to PooledDataSourceFactory

### DIFF
--- a/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
+++ b/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
@@ -431,6 +431,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
     }
 
     @JsonProperty
+    @Override
     public String getUrl() {
         return url;
     }

--- a/dropwizard-db/src/main/java/io/dropwizard/db/PooledDataSourceFactory.java
+++ b/dropwizard-db/src/main/java/io/dropwizard/db/PooledDataSourceFactory.java
@@ -70,6 +70,13 @@ public interface PooledDataSourceFactory {
     String getDriverClass();
 
     /**
+     * Returns the JDBC connection URL.
+     *
+     * @return the JDBC connection URL as a string
+     */
+    String getUrl();
+
+    /**
      * Configures the pool as a single connection pool.
      * It's useful for tools that use only one database connection,
      * such as database migrations.


### PR DESCRIPTION
Some downstream Dropwizard modules need access to the JDBC
connection URL, which exists on DataSourceFactory but not the
PooledDataSourceFactory interface.  Since this interface is
JDBC-specific (i.e. all connection-pool implementations will
have a connection URL), it won't restrict any implementations.

Fixes #1413.