### PR TITLE
Register RequestLogFactory as Discoverable

### DIFF
--- a/dropwizard-jetty/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
+++ b/dropwizard-jetty/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
@@ -1,1 +1,2 @@
 io.dropwizard.jetty.ConnectorFactory
+io.dropwizard.jetty.RequestLogFactory


### PR DESCRIPTION
Last missing piece for #1290 (as verified by external implementation, sorry for the scattered dot connection). Also included in #1415 by this is a much smaller change.