### PR TITLE
Refactor ResourceTestRule

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardTestResourceConfig.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardTestResourceConfig.java
@@ -1,0 +1,61 @@
+package io.dropwizard.testing.junit;
+
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.jersey.DropwizardResourceConfig;
+import io.dropwizard.jersey.errors.EarlyEofExceptionMapper;
+import io.dropwizard.jersey.errors.LoggingExceptionMapper;
+import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
+import io.dropwizard.jersey.jackson.JsonProcessingExceptionMapper;
+import io.dropwizard.jersey.validation.HibernateValidationFeature;
+import io.dropwizard.jersey.validation.JerseyViolationExceptionMapper;
+import org.glassfish.jersey.server.ServerProperties;
+
+import javax.servlet.ServletConfig;
+import javax.ws.rs.core.Context;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A configuration of a Jersey web application by {@link ResourceTestJerseyConfiguration} with
+ * support of injecting a configuration from a {@link ServletConfig}. It allows to use it along
+ * with the Grizzly web test container.
+ */
+class DropwizardTestResourceConfig extends DropwizardResourceConfig {
+
+    /**
+     * A registry of passed configuration objects. It's used for obtaining the current configuration
+     * via a servlet context.
+     */
+    static final Map<String, ResourceTestJerseyConfiguration> CONFIGURATION_REGISTRY = new ConcurrentHashMap<>();
+    static final String CONFIGURATION_ID = "io.dropwizard.testing.junit.resourceTestJerseyConfigurationId";
+
+    DropwizardTestResourceConfig(ResourceTestJerseyConfiguration configuration) {
+        super(true, new MetricRegistry());
+
+        if (configuration.registerDefaultExceptionMappers) {
+            register(new LoggingExceptionMapper<Throwable>() {
+            });
+            register(new JerseyViolationExceptionMapper());
+            register(new JsonProcessingExceptionMapper());
+            register(new EarlyEofExceptionMapper());
+        }
+        for (Class<?> provider : configuration.providers) {
+            register(provider);
+        }
+        property(ServerProperties.RESPONSE_SET_STATUS_OVER_SEND_ERROR, "true");
+        for (Map.Entry<String, Object> property : configuration.properties.entrySet()) {
+            property(property.getKey(), property.getValue());
+        }
+        register(new JacksonMessageBodyProvider(configuration.mapper));
+        register(new HibernateValidationFeature(configuration.validator));
+        for (Object singleton : configuration.singletons) {
+            register(singleton);
+        }
+    }
+
+    DropwizardTestResourceConfig(@Context ServletConfig servletConfig) {
+        this(CONFIGURATION_REGISTRY.get(requireNonNull(servletConfig.getInitParameter(CONFIGURATION_ID))));
+    }
+}

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ResourceTestJerseyConfiguration.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ResourceTestJerseyConfiguration.java
@@ -1,0 +1,40 @@
+package io.dropwizard.testing.junit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
+
+import javax.validation.Validator;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A configuration of a Jersey testing environment.
+ * Encapsulates data required to configure a {@link ResourceTestRule}.
+ * Primarily accessed via {@link DropwizardTestResourceConfig}.
+ */
+class ResourceTestJerseyConfiguration {
+
+    final Set<Object> singletons;
+    final Set<Class<?>> providers;
+    final Map<String, Object> properties;
+    final ObjectMapper mapper;
+    final Validator validator;
+    final TestContainerFactory testContainerFactory;
+    final boolean registerDefaultExceptionMappers;
+
+    ResourceTestJerseyConfiguration(Set<Object> singletons, Set<Class<?>> providers, Map<String, Object> properties,
+                                    ObjectMapper mapper, Validator validator, TestContainerFactory testContainerFactory,
+                                    boolean registerDefaultExceptionMappers) {
+        this.singletons = singletons;
+        this.providers = providers;
+        this.properties = properties;
+        this.mapper = mapper;
+        this.validator = validator;
+        this.testContainerFactory = testContainerFactory;
+        this.registerDefaultExceptionMappers = registerDefaultExceptionMappers;
+    }
+
+    String getId() {
+        return String.valueOf(hashCode());
+    }
+}

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ResourceTestRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ResourceTestRule.java
@@ -1,20 +1,11 @@
 package io.dropwizard.testing.junit;
 
-import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import io.dropwizard.jackson.Jackson;
-import io.dropwizard.jersey.DropwizardResourceConfig;
-import io.dropwizard.jersey.errors.EarlyEofExceptionMapper;
-import io.dropwizard.jersey.errors.LoggingExceptionMapper;
-import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
-import io.dropwizard.jersey.jackson.JsonProcessingExceptionMapper;
-import io.dropwizard.jersey.validation.HibernateValidationFeature;
-import io.dropwizard.jersey.validation.JerseyViolationExceptionMapper;
 import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.logging.BootstrapLogging;
 import org.glassfish.jersey.client.ClientConfig;
-import org.glassfish.jersey.server.ServerProperties;
 import org.glassfish.jersey.servlet.ServletProperties;
 import org.glassfish.jersey.test.DeploymentContext;
 import org.glassfish.jersey.test.JerseyTest;
@@ -25,16 +16,12 @@ import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
-import javax.servlet.ServletConfig;
 import javax.validation.Validator;
 import javax.ws.rs.client.Client;
-import javax.ws.rs.core.Context;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * A JUnit {@link TestRule} for testing Jersey resources.
@@ -45,6 +32,9 @@ public class ResourceTestRule implements TestRule {
         BootstrapLogging.bootstrap();
     }
 
+    /**
+     * A {@link ResourceTestRule} builder which enables configuration of a Jersey testing environment.
+     */
     public static class Builder {
 
         private final Set<Object> singletons = new HashSet<>();
@@ -95,47 +85,39 @@ public class ResourceTestRule implements TestRule {
             return this;
         }
 
+        /**
+         * Builds a {@link ResourceTestRule} with a configured Jersey testing environment.
+         *
+         * @return a new {@link ResourceTestRule}
+         */
         public ResourceTestRule build() {
-            return new ResourceTestRule(singletons, providers, properties, mapper, validator, testContainerFactory, registerDefaultExceptionMappers);
+            return new ResourceTestRule(new ResourceTestJerseyConfiguration(singletons, providers, properties, mapper, validator,
+                    testContainerFactory, registerDefaultExceptionMappers));
         }
     }
 
+    /**
+     * Creates a new Jersey testing environment builder for {@link ResourceTestRule}
+     *
+     * @return a new {@link Builder}
+     */
     public static Builder builder() {
         return new Builder();
     }
 
-    private final Set<Object> singletons;
-    private final Set<Class<?>> providers;
-    private final Map<String, Object> properties;
-    private final ObjectMapper mapper;
-    private final Validator validator;
-    private final TestContainerFactory testContainerFactory;
-    private final boolean registerDefaultExceptionMappers;
-
+    private ResourceTestJerseyConfiguration configuration;
     private JerseyTest test;
 
-    private ResourceTestRule(Set<Object> singletons,
-                             Set<Class<?>> providers,
-                             Map<String, Object> properties,
-                             ObjectMapper mapper,
-                             Validator validator,
-                             TestContainerFactory testContainerFactory,
-                             boolean registerDefaultExceptionMappers) {
-        this.singletons = singletons;
-        this.providers = providers;
-        this.properties = properties;
-        this.mapper = mapper;
-        this.validator = validator;
-        this.testContainerFactory = testContainerFactory;
-        this.registerDefaultExceptionMappers = registerDefaultExceptionMappers;
+    private ResourceTestRule(ResourceTestJerseyConfiguration configuration) {
+        this.configuration = configuration;
     }
 
     public Validator getValidator() {
-        return validator;
+        return configuration.validator;
     }
 
     public ObjectMapper getObjectMapper() {
-        return mapper;
+        return configuration.mapper;
     }
 
     public Client client() {
@@ -146,83 +128,39 @@ public class ResourceTestRule implements TestRule {
         return test;
     }
 
-    public static class ResourceTestResourceConfig extends DropwizardResourceConfig {
-        private static final String RULE_ID = "io.dropwizard.testing.junit.resourceTestRuleId";
-        private static final Map<String, ResourceTestRule> RULE_ID_TO_RULE = new HashMap<>();
-
-        public ResourceTestResourceConfig(final String ruleId, final ResourceTestRule resourceTestRule) {
-            super(true, new MetricRegistry());
-            RULE_ID_TO_RULE.put(ruleId, resourceTestRule);
-            configure(resourceTestRule);
-        }
-
-        public ResourceTestResourceConfig(@Context ServletConfig servletConfig) {
-            super(true, new MetricRegistry());
-            final String ruleId = servletConfig.getInitParameter(RULE_ID);
-            requireNonNull(ruleId);
-
-            final ResourceTestRule resourceTestRule = RULE_ID_TO_RULE.get(ruleId);
-            requireNonNull(resourceTestRule);
-            configure(resourceTestRule);
-        }
-
-        private void configure(final ResourceTestRule resourceTestRule) {
-            if (resourceTestRule.registerDefaultExceptionMappers) {
-                register(new LoggingExceptionMapper<Throwable>() {
-                });
-                register(new JerseyViolationExceptionMapper());
-                register(new JsonProcessingExceptionMapper());
-                register(new EarlyEofExceptionMapper());
-            }
-            for (Class<?> provider : resourceTestRule.providers) {
-                register(provider);
-            }
-            property(ServerProperties.RESPONSE_SET_STATUS_OVER_SEND_ERROR, "true");
-            for (Map.Entry<String, Object> property : resourceTestRule.properties.entrySet()) {
-                property(property.getKey(), property.getValue());
-            }
-            register(new JacksonMessageBodyProvider(resourceTestRule.mapper));
-            register(new HibernateValidationFeature(resourceTestRule.validator));
-            for (Object singleton : resourceTestRule.singletons) {
-                register(singleton);
-            }
-        }
-    }
-
     @Override
-    public Statement apply(final Statement base, Description description) {
-        final ResourceTestRule rule = this;
-        final String ruleId = String.valueOf(rule.hashCode());
+    public Statement apply(Statement base, Description description) {
         return new Statement() {
             @Override
             public void evaluate() throws Throwable {
+                DropwizardTestResourceConfig.CONFIGURATION_REGISTRY.put(configuration.getId(), configuration);
                 try {
                     test = new JerseyTest() {
                         @Override
                         protected TestContainerFactory getTestContainerFactory() {
-                            return testContainerFactory;
+                            return configuration.testContainerFactory;
                         }
 
                         @Override
                         protected DeploymentContext configureDeployment() {
-                            return ServletDeploymentContext.builder(new ResourceTestResourceConfig(ruleId, rule))
+                            return ServletDeploymentContext.builder(new DropwizardTestResourceConfig(configuration))
                                     .initParam(ServletProperties.JAXRS_APPLICATION_CLASS,
-                                            ResourceTestResourceConfig.class.getName())
-                                    .initParam(ResourceTestResourceConfig.RULE_ID, ruleId)
+                                            DropwizardTestResourceConfig.class.getName())
+                                    .initParam(DropwizardTestResourceConfig.CONFIGURATION_ID, configuration.getId())
                                     .build();
                         }
 
                         @Override
-                        protected void configureClient(final ClientConfig config) {
+                        protected void configureClient(ClientConfig config) {
                             final JacksonJsonProvider jsonProvider = new JacksonJsonProvider();
-                            jsonProvider.setMapper(mapper);
+                            jsonProvider.setMapper(configuration.mapper);
                             config.register(jsonProvider);
                         }
                     };
                     test.setUp();
                     base.evaluate();
                 } finally {
-                    ResourceTestResourceConfig.RULE_ID_TO_RULE.remove(ruleId);
+                    DropwizardTestResourceConfig.CONFIGURATION_REGISTRY.remove(configuration.getId());
                     test.tearDown();
                 }
             }


### PR DESCRIPTION
Currently the `ResourceTestResourceConfig` class is kind of a mess. It uses several inner classes, a static map of test rules, and doesn't have any comments. It's hard to see what's going on there.

This change:
* moves the inner class `ResourceTestResourceConfig` to a separate class named `DropwizardTestResourceConfig`. This name is more meaningful and suitable in my opinion;
* introduces the class `ResourceTestJerseyConfiguration` which contains a configuration passed by a user via `ResourceTest.Builder`. It allows to decouple `DropwizardTestResourceConfig` from `ResourceTestRule`.
* this class is also used for passing the current `ResourceConfig` configuration via a servlet context instead of the `ResourceTestRule` class in a Grizzly web test container. This removes additinal responsibility from the `ResourceTestRule` class.
* adds a minimal documentation for every class, describing their goals.

As a result, this change should make easier to make future improvements to the `ResourceTestRule` class, because of separation of concerns, better class names and added documentation.