### PR TITLE
Add ConfigurationParsingException tests

### DIFF
--- a/dropwizard-configuration/src/test/resources/factory-test-malformed-advanced.yml
+++ b/dropwizard-configuration/src/test/resources/factory-test-malformed-advanced.yml
@@ -1,0 +1,2 @@
+name: Mighty Wizard
+type: [ coder,wizard

--- a/dropwizard-configuration/src/test/resources/factory-test-typo.yml
+++ b/dropwizard-configuration/src/test/resources/factory-test-typo.yml
@@ -1,0 +1,7 @@
+name: Migty Wizard
+type:
+    - wizard
+propertis:
+  admin: true
+servers:
+  - port: 8080

--- a/dropwizard-configuration/src/test/resources/factory-test-wrong-type.yml
+++ b/dropwizard-configuration/src/test/resources/factory-test-wrong-type.yml
@@ -1,0 +1,2 @@
+name: Mighty Wizard
+age: one hundred and two


### PR DESCRIPTION
I found out that we currently don't have tests for handling errors during parsing and binding YAML configuration files. This changes fixes this by adding several tests:

* A test that we print the `Did you mean?` suggestions on an unrecognized field in the configuration class. The suggestions are sorted based on an edit distance from the input. The limit is 5 suggestions.
* A test that we print a detailed error message, when there are type data type errors during binding a YAML tree to the configuration class.
* A test that we print a line number, a position of an error, and a parser error message, if a YAML file is malformed.

As a result, this provides the ability to catch regressions during Jackson and SnakeYAML updates.