### PR TITLE
dropwizard-testing: Add Jersey Client configurability to ResourceTestRule

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ResourceTestJerseyConfiguration.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ResourceTestJerseyConfiguration.java
@@ -1,11 +1,13 @@
 package io.dropwizard.testing.junit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
 
 import javax.validation.Validator;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 
 /**
  * A configuration of a Jersey testing environment.
@@ -19,17 +21,19 @@ class ResourceTestJerseyConfiguration {
     final Map<String, Object> properties;
     final ObjectMapper mapper;
     final Validator validator;
+    final Consumer<ClientConfig> clientConfigurator;
     final TestContainerFactory testContainerFactory;
     final boolean registerDefaultExceptionMappers;
 
     ResourceTestJerseyConfiguration(Set<Object> singletons, Set<Class<?>> providers, Map<String, Object> properties,
-                                    ObjectMapper mapper, Validator validator, TestContainerFactory testContainerFactory,
-                                    boolean registerDefaultExceptionMappers) {
+                                    ObjectMapper mapper, Validator validator, Consumer<ClientConfig> clientConfigurator,
+                                    TestContainerFactory testContainerFactory, boolean registerDefaultExceptionMappers) {
         this.singletons = singletons;
         this.providers = providers;
         this.properties = properties;
         this.mapper = mapper;
         this.validator = validator;
+        this.clientConfigurator = clientConfigurator;
         this.testContainerFactory = testContainerFactory;
         this.registerDefaultExceptionMappers = registerDefaultExceptionMappers;
     }


### PR DESCRIPTION
Addresses #1416.

Adds a `setClientConfigurator` method to the `ResourceTestRule.Builder` class which allows configuration of the Jersey Clients used in test rules. Adds a test to `PersonResourceTest` which ensures that custom providers installed by this new builder method are reflected in the produced clients.