### PR TITLE
Fix configuration factory test on windows

### DIFF
--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryTest.java
@@ -426,13 +426,13 @@ public class ConfigurationFactoryTest {
             fail("Should print a detailed error on a malformed YAML file");
         } catch (Exception e) {
             assertThat(e.getMessage()).isEqualTo(resourceFileName + " has an error:" + NEWLINE +
-                    "  * Malformed YAML at line: 2, column: 21; while parsing a flow sequence" + NEWLINE +
-                    " in 'reader', line 2, column 7:" + NEWLINE +
-                    "    type: [ coder,wizard" + NEWLINE +
-                    "          ^" + NEWLINE +
-                    "expected ',' or ']', but got StreamEnd" + NEWLINE +
-                    " in 'reader', line 2, column 21:" + NEWLINE +
-                    "    wizard" + NEWLINE +
+                    "  * Malformed YAML at line: 2, column: 21; while parsing a flow sequence\n" +
+                    " in 'reader', line 2, column 7:\n" +
+                    "    type: [ coder,wizard\n" +
+                    "          ^\n" +
+                    "expected ',' or ']', but got StreamEnd\n" +
+                    " in 'reader', line 2, column 21:\n" +
+                    "    wizard\n" +
                     "          ^" + NEWLINE);
         }
     }


### PR DESCRIPTION
Looks like the exception message contains newlines, so this test failed on Windows. Not sure if this is the desired behavior, because as of now there is a mix of line endings -- I just got the test to pass.