### PR TITLE
ValidationMethod violation message is itself

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ConstraintMessage.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ConstraintMessage.java
@@ -6,7 +6,6 @@ import com.google.common.base.Strings;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Iterables;
-import io.dropwizard.validation.ConstraintViolations;
 import io.dropwizard.validation.ValidationMethod;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
@@ -68,7 +67,7 @@ public class ConstraintMessage {
         // Take the message specified in a ValidationMethod annotation if it
         // is what caused the violation
         if (isValidationMethod(v)) {
-            return ConstraintViolations.validationMethodFormatted(v);
+            return v.getMessage();
         }
 
         final Optional<String> entity = isRequestEntity(v, invocable);

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/ConstraintViolations.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/ConstraintViolations.java
@@ -1,45 +1,22 @@
 package io.dropwizard.validation;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Ordering;
 
 import javax.validation.ConstraintViolation;
-import javax.validation.ElementKind;
-import javax.validation.Path;
 import java.util.HashSet;
 import java.util.Set;
 
 public class ConstraintViolations {
-    private static final Joiner DOT_JOINER = Joiner.on('.');
-
     private ConstraintViolations() { /* singleton */ }
 
     public static <T> String format(ConstraintViolation<T> v) {
         if (v.getConstraintDescriptor().getAnnotation() instanceof ValidationMethod) {
-            return validationMethodFormatted(v);
+            return v.getMessage();
         } else {
             return String.format("%s %s", v.getPropertyPath(), v.getMessage());
         }
-    }
-
-    public static <T> String validationMethodFormatted(ConstraintViolation<T> v) {
-        final ImmutableList<Path.Node> nodes = ImmutableList.copyOf(v.getPropertyPath());
-
-        // It is possible that a BeanParam may contain a ValidationMethod, and in which case, it has
-        // name that is not client friendly (ie. <function>.<arg index>.<validation method
-        // message>.) This will trim it off.
-        int paramIndex = -1;
-        for (int i = 0; i < nodes.size(); i++) {
-            if (nodes.get(i).getKind() == ElementKind.PARAMETER) {
-                paramIndex = i;
-            }
-        }
-
-        final String usefulNodes = DOT_JOINER.join(nodes.subList(paramIndex + 1, nodes.size() - 1));
-        final String msg = usefulNodes + (v.getMessage().startsWith(".") ? "" : " ") + v.getMessage();
-        return msg.trim();
     }
 
     public static <T> ImmutableList<String> format(Set<ConstraintViolation<T>> violations) {

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/MethodValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/MethodValidatorTest.java
@@ -41,6 +41,6 @@ public class MethodValidatorTest {
 
         assertThat(errors)
                 .containsOnly("must have a false thing",
-                              "subExample also needs something special");
+                              "also needs something special");
     }
 }


### PR DESCRIPTION
Previously, when a ValidationMethod caused a constraint violation and the
violation was caused by a nested object using the `@Valid` annotation, the
message would contain the path of the nested object. This may be
misleading to the client who sees the message because the nested code path
may not have a related field in the JSON they sent (for example, the field
could be a misnomer).

The fix is return the message exactly as it is transcribed in the
`@ValidationMethod` annotation. Thus, it is now the user's responsibility
to create descriptive enough messages, such that the client can discern
the error through any amount of nesting.

This change does break APIs that relied on the message containing the code path
to the object that contained the ValidationMethod violation. ValidationMethods not used
in nested objects are not effected.

This fixes #1237, such that dropwizard doesn't prepend the path of the error in the message