### PR TITLE
Updated to Hibernate 5.0.7

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -105,7 +105,7 @@
             <dependency>
                 <groupId>org.jadira.usertype</groupId>
                 <artifactId>usertype.core</artifactId>
-                <version>4.0.0.GA</version>
+                <version>5.0.0.GA</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.hibernate</groupId>
@@ -124,7 +124,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-core</artifactId>
-                <version>4.3.11.Final</version>
+                <version>5.0.7.Final</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jboss.logging</groupId>
@@ -325,7 +325,7 @@
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-hibernate4</artifactId>
+                <artifactId>jackson-datatype-hibernate5</artifactId>
                 <version>${jackson.version}</version>
                 <exclusions>
                     <exclusion>

--- a/dropwizard-hibernate/pom.xml
+++ b/dropwizard-hibernate/pom.xml
@@ -1,55 +1,57 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>io.dropwizard</groupId>
-        <artifactId>dropwizard-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-    </parent>
+	<parent>
+		<groupId>io.dropwizard</groupId>
+		<artifactId>dropwizard-parent</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
 
-    <artifactId>dropwizard-hibernate</artifactId>
-    <name>Dropwizard Hibernate Support</name>
+	<artifactId>dropwizard-hibernate</artifactId>
+	<name>Dropwizard Hibernate Support</name>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.dropwizard</groupId>
-                <artifactId>dropwizard-bom</artifactId>
-                <version>${project.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>io.dropwizard</groupId>
+				<artifactId>dropwizard-bom</artifactId>
+				<version>${project.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
-    <dependencies>
-        <dependency>
-            <groupId>io.dropwizard</groupId>
-            <artifactId>dropwizard-db</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-hibernate4</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jadira.usertype</groupId>
-            <artifactId>usertype.core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-core</artifactId>
-        </dependency>
-        <!-- we need HSQL because it handles time zones, H2 totally doesn't -->
-        <dependency>
-            <groupId>org.hsqldb</groupId>
-            <artifactId>hsqldb</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-            <artifactId>jersey-test-framework-provider-inmemory</artifactId>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+	<dependencies>
+		<dependency>
+			<groupId>io.dropwizard</groupId>
+			<artifactId>dropwizard-db</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-hibernate5</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jadira.usertype</groupId>
+			<artifactId>usertype.core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-core</artifactId>
+		</dependency>
+
+		<!-- we need HSQL because it handles time zones, H2 totally doesn't -->
+		<dependency>
+			<groupId>org.hsqldb</groupId>
+			<artifactId>hsqldb</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jersey.test-framework.providers</groupId>
+			<artifactId>jersey-test-framework-provider-inmemory</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 </project>

--- a/dropwizard-hibernate/pom.xml
+++ b/dropwizard-hibernate/pom.xml
@@ -1,57 +1,56 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>io.dropwizard</groupId>
-		<artifactId>dropwizard-parent</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
-	</parent>
+    <parent>
+        <groupId>io.dropwizard</groupId>
+        <artifactId>dropwizard-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
 
-	<artifactId>dropwizard-hibernate</artifactId>
-	<name>Dropwizard Hibernate Support</name>
+    <artifactId>dropwizard-hibernate</artifactId>
+    <name>Dropwizard Hibernate Support</name>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>io.dropwizard</groupId>
-				<artifactId>dropwizard-bom</artifactId>
-				<version>${project.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.dropwizard</groupId>
+                <artifactId>dropwizard-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
-	<dependencies>
-		<dependency>
-			<groupId>io.dropwizard</groupId>
-			<artifactId>dropwizard-db</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.datatype</groupId>
-			<artifactId>jackson-datatype-hibernate5</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.jadira.usertype</groupId>
-			<artifactId>usertype.core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-core</artifactId>
-		</dependency>
+    <dependencies>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-db</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-hibernate5</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jadira.usertype</groupId>
+            <artifactId>usertype.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+        </dependency>
 
-		<!-- we need HSQL because it handles time zones, H2 totally doesn't -->
-		<dependency>
-			<groupId>org.hsqldb</groupId>
-			<artifactId>hsqldb</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.glassfish.jersey.test-framework.providers</groupId>
-			<artifactId>jersey-test-framework-provider-inmemory</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+        <!-- we need HSQL because it handles time zones, H2 totally doesn't -->
+        <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
+            <artifactId>jersey-test-framework-provider-inmemory</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/HibernateBundle.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/HibernateBundle.java
@@ -1,6 +1,6 @@
 package io.dropwizard.hibernate;
 
-import com.fasterxml.jackson.datatype.hibernate4.Hibernate4Module;
+import com.fasterxml.jackson.datatype.hibernate5.Hibernate5Module;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.Configuration;
 import io.dropwizard.ConfiguredBundle;
@@ -32,14 +32,14 @@ public abstract class HibernateBundle<T extends Configuration> implements Config
 
     @Override
     public final void initialize(Bootstrap<?> bootstrap) {
-        bootstrap.getObjectMapper().registerModule(createHibernate4Module());
+        bootstrap.getObjectMapper().registerModule(createHibernate5Module());
     }
 
     /**
      * Override to configure the {@link Hibernate4Module}.
      */
-    protected Hibernate4Module createHibernate4Module() {
-        return new Hibernate4Module();
+    protected Hibernate5Module createHibernate5Module() {
+        return new Hibernate5Module();
     }
 
     /**

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/HibernateBundle.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/HibernateBundle.java
@@ -36,7 +36,7 @@ public abstract class HibernateBundle<T extends Configuration> implements Config
     }
 
     /**
-     * Override to configure the {@link Hibernate4Module}.
+     * Override to configure the {@link Hibernate5Module}.
      */
     protected Hibernate5Module createHibernate5Module() {
         return new Hibernate5Module();

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryFactory.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryFactory.java
@@ -88,7 +88,7 @@ public class SessionFactoryFactory {
 
         final ServiceRegistry registry = new StandardServiceRegistryBuilder()
                 .addService(ConnectionProvider.class, connectionProvider)
-                .applySettings(properties)
+                .applySettings(configuration.getProperties())
                 .build();
 
         configure(configuration, registry);

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryHealthCheck.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryHealthCheck.java
@@ -1,5 +1,7 @@
 package io.dropwizard.hibernate;
 
+import static org.hibernate.resource.transaction.spi.TransactionStatus.*;
+
 import com.codahale.metrics.health.HealthCheck;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.dropwizard.db.TimeBoundHealthCheck;
@@ -8,7 +10,6 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 
 public class SessionFactoryHealthCheck extends HealthCheck {
@@ -49,7 +50,7 @@ public class SessionFactoryHealthCheck extends HealthCheck {
                     session.createSQLQuery(validationQuery).list();
                     txn.commit();
                 } catch (Exception e) {
-                    if (txn.isActive()) {
+                    if (txn.getStatus() == ACTIVE || txn.getStatus() == MARKED_ROLLBACK) {
                         txn.rollback();
                     }
                     throw e;

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryHealthCheck.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryHealthCheck.java
@@ -1,7 +1,5 @@
 package io.dropwizard.hibernate;
 
-import static org.hibernate.resource.transaction.spi.TransactionStatus.*;
-
 import com.codahale.metrics.health.HealthCheck;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.dropwizard.db.TimeBoundHealthCheck;
@@ -50,7 +48,7 @@ public class SessionFactoryHealthCheck extends HealthCheck {
                     session.createSQLQuery(validationQuery).list();
                     txn.commit();
                 } catch (Exception e) {
-                    if (txn.getStatus() == ACTIVE || txn.getStatus() == MARKED_ROLLBACK) {
+                    if (txn.getStatus().canRollback()) {
                         txn.rollback();
                     }
                     throw e;

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAspect.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAspect.java
@@ -5,9 +5,6 @@ import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.hibernate.context.internal.ManagedSessionContext;
 
-import static org.hibernate.resource.transaction.spi.TransactionStatus.ACTIVE;
-import static org.hibernate.resource.transaction.spi.TransactionStatus.MARKED_ROLLBACK;
-
 import java.util.Map;
 
 /**
@@ -107,7 +104,7 @@ class UnitOfWorkAspect {
             return;
         }
         final Transaction txn = session.getTransaction();
-        if (txn != null && (txn.getStatus() == ACTIVE || txn.getStatus() == MARKED_ROLLBACK)) {
+        if (txn != null && txn.getStatus().canRollback()) {
             txn.rollback();
         }
     }
@@ -117,7 +114,7 @@ class UnitOfWorkAspect {
             return;
         }
         final Transaction txn = session.getTransaction();
-        if (txn != null && (txn.getStatus() == ACTIVE || txn.getStatus() == MARKED_ROLLBACK)) {
+        if (txn != null && txn.getStatus().canRollback()) {
             txn.commit();
         }
     }

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAspect.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAspect.java
@@ -5,6 +5,9 @@ import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.hibernate.context.internal.ManagedSessionContext;
 
+import static org.hibernate.resource.transaction.spi.TransactionStatus.ACTIVE;
+import static org.hibernate.resource.transaction.spi.TransactionStatus.MARKED_ROLLBACK;
+
 import java.util.Map;
 
 /**
@@ -104,7 +107,7 @@ class UnitOfWorkAspect {
             return;
         }
         final Transaction txn = session.getTransaction();
-        if (txn != null && txn.isActive()) {
+        if (txn != null && (txn.getStatus() == ACTIVE || txn.getStatus() == MARKED_ROLLBACK)) {
             txn.rollback();
         }
     }
@@ -114,7 +117,7 @@ class UnitOfWorkAspect {
             return;
         }
         final Transaction txn = session.getTransaction();
-        if (txn != null && txn.isActive()) {
+        if (txn != null && (txn.getStatus() == ACTIVE || txn.getStatus() == MARKED_ROLLBACK)) {
             txn.commit();
         }
     }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/HibernateBundleTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/HibernateBundleTest.java
@@ -3,7 +3,7 @@ package io.dropwizard.hibernate;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.hibernate4.Hibernate4Module;
+import com.fasterxml.jackson.datatype.hibernate5.Hibernate5Module;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.Configuration;
 import io.dropwizard.db.DataSourceFactory;
@@ -62,7 +62,7 @@ public class HibernateBundleTest {
         final ArgumentCaptor<Module> captor = ArgumentCaptor.forClass(Module.class);
         verify(objectMapperFactory).registerModule(captor.capture());
 
-        assertThat(captor.getValue()).isInstanceOf(Hibernate4Module.class);
+        assertThat(captor.getValue()).isInstanceOf(Hibernate5Module.class);
     }
 
     @Test

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryFactoryTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryFactoryTest.java
@@ -18,6 +18,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import java.util.HashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
@@ -50,6 +51,11 @@ public class SessionFactoryFactoryTest {
         config.setUser("sa");
         config.setDriverClass("org.hsqldb.jdbcDriver");
         config.setValidationQuery("SELECT 1 FROM INFORMATION_SCHEMA.SYSTEM_USERS");
+        
+        HashMap<String, String> props = new HashMap<>();
+        props.put("hibernate.show_sql", "true");
+        props.put("hibernate.dialect", "org.hibernate.dialect.HSQLDialect");
+        config.setProperties(props);
     }
 
     @After
@@ -101,7 +107,7 @@ public class SessionFactoryFactoryTest {
         final Session session = sessionFactory.openSession();
         try {
             session.createSQLQuery("DROP TABLE people IF EXISTS").executeUpdate();
-            session.createSQLQuery("CREATE TABLE people (name varchar(100) primary key, email varchar(100), birthday timestamp)").executeUpdate();
+            session.createSQLQuery("CREATE TABLE people (name varchar(100) primary key, email varchar(100), birthday timestamp(0))").executeUpdate();
             session.createSQLQuery("INSERT INTO people VALUES ('Coda', 'coda@example.com', '1979-01-02 00:22:00')").executeUpdate();
 
             final Person entity = (Person) session.get(Person.class, "Coda");

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryFactoryTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryFactoryTest.java
@@ -2,6 +2,8 @@ package io.dropwizard.hibernate;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.db.ManagedPooledDataSource;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
@@ -18,7 +20,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import java.util.HashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
@@ -52,10 +53,10 @@ public class SessionFactoryFactoryTest {
         config.setDriverClass("org.hsqldb.jdbcDriver");
         config.setValidationQuery("SELECT 1 FROM INFORMATION_SCHEMA.SYSTEM_USERS");
         
-        HashMap<String, String> props = new HashMap<>();
-        props.put("hibernate.show_sql", "true");
-        props.put("hibernate.dialect", "org.hibernate.dialect.HSQLDialect");
-        config.setProperties(props);
+        config.setProperties(ImmutableMap.<String, String>builder().
+                put("hibernate.show_sql", "true").
+                put("hibernate.dialect", "org.hibernate.dialect.HSQLDialect").
+                build());
     }
 
     @After

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryHealthCheckTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryHealthCheckTest.java
@@ -9,6 +9,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 
+import static org.hibernate.resource.transaction.spi.TransactionStatus.ACTIVE;
+
 @SuppressWarnings("HibernateResourceOpenedButNotSafelyClosed")
 public class SessionFactoryHealthCheckTest {
     private final SessionFactory factory = mock(SessionFactory.class);
@@ -57,7 +59,7 @@ public class SessionFactoryHealthCheckTest {
 
         final Transaction transaction = mock(Transaction.class);
         when(session.beginTransaction()).thenReturn(transaction);
-        when(transaction.isActive()).thenReturn(true);
+        when(transaction.getStatus()).thenReturn(ACTIVE);
 
         final SQLQuery query = mock(SQLQuery.class);
         when(session.createSQLQuery(anyString())).thenReturn(query);

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkApplicationListenerTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkApplicationListenerTest.java
@@ -17,10 +17,10 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import java.lang.reflect.Method;
+
+import static org.hibernate.resource.transaction.spi.TransactionStatus.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doAnswer;
@@ -58,13 +58,13 @@ public class UnitOfWorkApplicationListenerTest {
         when(session.getSessionFactory()).thenReturn(sessionFactory);
         when(session.beginTransaction()).thenReturn(transaction);
         when(session.getTransaction()).thenReturn(transaction);
-        when(transaction.isActive()).thenReturn(true);
+        when(transaction.getStatus()).thenReturn(ACTIVE);
 
         when(analyticsSessionFactory.openSession()).thenReturn(analyticsSession);
         when(analyticsSession.getSessionFactory()).thenReturn(analyticsSessionFactory);
         when(analyticsSession.beginTransaction()).thenReturn(analyticsTransaction);
         when(analyticsSession.getTransaction()).thenReturn(analyticsTransaction);
-        when(analyticsTransaction.isActive()).thenReturn(true);
+        when(analyticsTransaction.getStatus()).thenReturn(ACTIVE);
 
         when(appEvent.getType()).thenReturn(ApplicationEvent.Type.INITIALIZATION_APP_FINISHED);
         when(requestMethodStartEvent.getType()).thenReturn(RequestEvent.Type.RESOURCE_METHOD_START);
@@ -191,7 +191,7 @@ public class UnitOfWorkApplicationListenerTest {
 
     @Test
     public void doesNotCommitAnInactiveTransaction() throws Exception {
-        when(transaction.isActive()).thenReturn(false);
+        when(transaction.getStatus()).thenReturn(NOT_ACTIVE);
 
         execute();
 
@@ -209,7 +209,7 @@ public class UnitOfWorkApplicationListenerTest {
 
     @Test
     public void doesNotRollbackAnInactiveTransaction() throws Exception {
-        when(transaction.isActive()).thenReturn(false);
+        when(transaction.getStatus()).thenReturn(NOT_ACTIVE);
 
         executeWithException();
 


### PR DESCRIPTION
Hibernate 5 has been out for a while; there are a few patch releases and it seems fairly stable, so I updated the dropwizard-hibernate module to use Hibernate 5.

This is a big advantage to people who want to use Java 8 time classes such as Instant, because they won't have to include extra Jadira jars to make hibernate persist the new types.  I'm not aware of any downside since those not using Java 8 can still use the Jadira support for Joda time etc. as before.