### PR TITLE
Added naming to migration bundles

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -26,6 +26,7 @@ v1.0.0
 * Support for authentication by polymorphic principals `#1392 <https://github.com/dropwizard/dropwizard/pull/1392>`_
 * Support for configuring Jetty's ``inheritedChannel`` option `#1410 <https://github.com/dropwizard/dropwizard/pull/1410>`_
 * Support for using ``DropwizardAppRule`` at the suite level `#1411 <https://github.com/dropwizard/dropwizard/pull/1411>`_
+* Support for adding multiple ``MigrationBundles`` `#1430 <https://github.com/dropwizard/dropwizard/pull/1430>`_
 * Upgraded to argparse4j 0.7.0
 * Upgraded to Guava 19.0
 * Upgraded to Jackson 2.6.4

--- a/docs/source/manual/migrations.rst
+++ b/docs/source/manual/migrations.rst
@@ -209,10 +209,10 @@ To mark a pending changeset as applied (e.g., after having backfilled your ``mig
 This will mark the next pending changeset as applied. You can also use the ``--all`` flag to mark
 all pending changesets as applied.
 
-Support for adding multiple migration bundles
+Support For Adding Multiple Migration Bundles
 =============================================
 
-Assuming migrations need to be done for two different databases, you would need to have two differnet data source factories:
+Assuming migrations need to be done for two different databases, you would need to have two different data source factories:
 
 .. code-block:: java
 
@@ -267,7 +267,7 @@ Now multiple migration bundles can be added with unique names like so:
         });
     }
 
-Now to migrate your schema:
+To migrate your schema:
 
 .. code-block:: text
 
@@ -281,8 +281,8 @@ and
 
 .. note::
 
-    Do note that whenever you add a name to a migration bundle as defined above, this name becomes the command that
-    needs to be run at the command line. eg: To check the state of your database, use the ``status`` command:
+    Whenever a name is added to a migration bundle, it becomes the command that needs to be run at the command line.
+    eg: To check the state of your database, use the ``status`` command:
 
 .. code-block:: text
 
@@ -294,10 +294,10 @@ or
 
     java -jar hello-world.jar db2 status helloworld.yml
 
-By default the migration bundle uses the "db" command. By overriding as above you can customize it to provide any name you want
+By default the migration bundle uses the "db" command. By overriding you can customize it to provide any name you want
 and have multiple migration bundles. Wherever the "db" command was being used, this custom name can be used.
 
-There will also be a need to provide different change log files as well. This can be done as
+There will also be a need to provide different change log migration files as well. This can be done as
 
 .. code-block:: text
 

--- a/docs/source/manual/migrations.rst
+++ b/docs/source/manual/migrations.rst
@@ -209,6 +209,104 @@ To mark a pending changeset as applied (e.g., after having backfilled your ``mig
 This will mark the next pending changeset as applied. You can also use the ``--all`` flag to mark
 all pending changesets as applied.
 
+Support for adding multiple migration bundles
+=============================================
+
+Assuming migrations need to be done for two different databases, you would need to have two differnet data source factories:
+
+.. code-block:: java
+
+    public class ExampleConfiguration extends Configuration {
+        @Valid
+        @NotNull
+        private DataSourceFactory database1 = new DataSourceFactory();
+
+        @Valid
+        @NotNull
+        private DataSourceFactory database2 = new DataSourceFactory();
+
+        @JsonProperty("database1")
+        public DataSourceFactory getDb1DataSourceFactory() {
+            return database1;
+        }
+
+        @JsonProperty("database2")
+        public DataSourceFactory getDb2DataSourceFactory() {
+            return database2;
+        }
+    }
+
+Now multiple migration bundles can be added with unique names like so:
+
+.. code-block:: java
+
+    @Override
+    public void initialize(Bootstrap<ExampleConfiguration> bootstrap) {
+        bootstrap.addBundle(new MigrationsBundle<ExampleConfiguration>() {
+            @Override
+            public DataSourceFactory getDataSourceFactory(ExampleConfiguration configuration) {
+                return configuration.getDb1DataSourceFactory();
+            }
+
+            @Override
+            public String name() {
+                return "db1";
+            }
+        });
+
+        bootstrap.addBundle(new MigrationsBundle<ExampleConfiguration>() {
+            @Override
+            public DataSourceFactory getDataSourceFactory(ExampleConfiguration configuration) {
+                return configuration.getDb2DataSourceFactory();
+            }
+
+            @Override
+            public String name() {
+                return "db2";
+            }
+        });
+    }
+
+Now to migrate your schema:
+
+.. code-block:: text
+
+    java -jar hello-world.jar db1 migrate helloworld.yml
+
+and
+
+.. code-block:: text
+
+    java -jar hello-world.jar db2 migrate helloworld.yml
+
+.. note::
+
+    Do note that whenever you add a name to a migration bundle as defined above, this name becomes the command that
+    needs to be run at the command line. eg: To check the state of your database, use the ``status`` command:
+
+.. code-block:: text
+
+    java -jar hello-world.jar db1 status helloworld.yml
+
+or
+
+.. code-block:: text
+
+    java -jar hello-world.jar db2 status helloworld.yml
+
+By default the migration bundle uses the "db" command. By overriding as above you can customize it to provide any name you want
+and have multiple migration bundles. Wherever the "db" command was being used, this custom name can be used.
+
+There will also be a need to provide different change log files as well. This can be done as
+
+.. code-block:: text
+
+    java -jar hello-world.jar db1 migrate helloworld.yml --migrations <path_to_db1_migrations.xml>
+
+.. code-block:: text
+
+    java -jar hello-world.jar db2 migrate helloworld.yml --migrations <path_to_db2_migrations.xml>
+
 More Information
 ================
 

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbCommand.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbCommand.java
@@ -13,8 +13,8 @@ public class DbCommand<T extends Configuration> extends AbstractLiquibaseCommand
     private static final String COMMAND_NAME_ATTR = "subcommand";
     private final SortedMap<String, AbstractLiquibaseCommand<T>> subcommands;
 
-    public DbCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass) {
-        super("db", "Run database migration tasks", strategy, configurationClass);
+    public DbCommand(String name, DatabaseConfiguration<T> strategy, Class<T> configurationClass) {
+        super(name, "Run database migration tasks", strategy, configurationClass);
         this.subcommands = new TreeMap<>();
         addSubcommand(new DbCalculateChecksumCommand<>(strategy, configurationClass));
         addSubcommand(new DbClearChecksumsCommand<>(strategy, configurationClass));

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/MigrationsBundle.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/MigrationsBundle.java
@@ -7,7 +7,7 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 
 public abstract class MigrationsBundle<T extends Configuration> implements Bundle, DatabaseConfiguration<T> {
-    public static final String DEFAULT_NAME = "db";
+    private static final String DEFAULT_NAME = "db";
 
     @Override
     @SuppressWarnings("unchecked")
@@ -16,7 +16,7 @@ public abstract class MigrationsBundle<T extends Configuration> implements Bundl
         bootstrap.addCommand(new DbCommand<>(name(), this, klass));
     }
 
-    protected String name() {
+    public String name() {
         return DEFAULT_NAME;
     }
 

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/MigrationsBundle.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/MigrationsBundle.java
@@ -7,11 +7,17 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 
 public abstract class MigrationsBundle<T extends Configuration> implements Bundle, DatabaseConfiguration<T> {
+    public static final String DEFAULT_NAME = "db";
+
     @Override
     @SuppressWarnings("unchecked")
     public final void initialize(Bootstrap<?> bootstrap) {
         final Class<T> klass = (Class<T>) bootstrap.getApplication().getConfigurationClass();
-        bootstrap.addCommand(new DbCommand<>(this, klass));
+        bootstrap.addCommand(new DbCommand<>(name(), this, klass));
+    }
+
+    protected String name() {
+        return DEFAULT_NAME;
     }
 
     @Override


### PR DESCRIPTION
In similar lines to HibernateBundles, having the possibility of unique names. This PR attempts to do the same for MigrationBundles, so that multiple migration bundles can be provided for.