### PR TITLE
Added ability to set the Jersey URL pattern in Application.run()

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
@@ -489,14 +489,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
         serverPush.addFilter(handler);
         if (jerseyContainer != null) {
             if (jerseyRootPath.isPresent()) {
-                String urlPattern = jerseyRootPath.get();
-                if (!urlPattern.endsWith("*") && !urlPattern.endsWith("/")) {
-                    urlPattern += "/";
-                }
-                if (!urlPattern.endsWith("*")) {
-                    urlPattern += "*";
-                }
-                jersey.setUrlPattern(urlPattern);
+                jersey.setUrlPattern(jerseyRootPath.get());
             }
             jersey.register(new JacksonMessageBodyProvider(objectMapper));
             jersey.register(new HibernateValidationFeature(validator));

--- a/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
 import com.google.common.io.Resources;
 import io.dropwizard.jersey.errors.EarlyEofExceptionMapper;
 import io.dropwizard.jersey.errors.LoggingExceptionMapper;
@@ -40,7 +41,6 @@ import org.eclipse.jetty.setuid.RLimit;
 import org.eclipse.jetty.setuid.SetUIDListener;
 import org.eclipse.jetty.util.BlockingArrayQueue;
 import org.eclipse.jetty.util.thread.ThreadPool;
-import org.hibernate.validator.constraints.NotEmpty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -193,7 +193,7 @@ import java.util.regex.Pattern;
  *     </tr>
  *     <tr>
  *         <td>{@code rootPath}</td>
- *         <td>/</td>
+ *         <td>/*</td>
  *         <td>
  *           The URL pattern relative to {@code applicationContextPath} from which the JAX-RS resources will be served.
  *         </td>
@@ -255,8 +255,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
     @NotNull
     private Set<String> allowedMethods = AllowedMethodsFilter.DEFAULT_ALLOWED_METHODS;
 
-    @NotEmpty
-    private String jerseyRootPath = "/";
+    private Optional<String> jerseyRootPath = Optional.absent();
 
     @JsonIgnore
     @ValidationMethod(message = "must have a smaller minThreads than maxThreads")
@@ -443,13 +442,13 @@ public abstract class AbstractServerFactory implements ServerFactory {
     }
 
     @JsonProperty("rootPath")
-    public String getJerseyRootPath() {
+    public Optional<String> getJerseyRootPath() {
         return jerseyRootPath;
     }
 
     @JsonProperty("rootPath")
     public void setJerseyRootPath(String jerseyRootPath) {
-        this.jerseyRootPath = jerseyRootPath;
+        this.jerseyRootPath = Optional.fromNullable(jerseyRootPath);
     }
 
     protected Handler createAdminServlet(Server server,
@@ -489,14 +488,16 @@ public abstract class AbstractServerFactory implements ServerFactory {
         handler.addFilter(ThreadNameFilter.class, "/*", EnumSet.of(DispatcherType.REQUEST));
         serverPush.addFilter(handler);
         if (jerseyContainer != null) {
-            String urlPattern = jerseyRootPath;
-            if (!urlPattern.endsWith("*") && !urlPattern.endsWith("/")) {
-                urlPattern += "/";
+            if (jerseyRootPath.isPresent()) {
+                String urlPattern = jerseyRootPath.get();
+                if (!urlPattern.endsWith("*") && !urlPattern.endsWith("/")) {
+                    urlPattern += "/";
+                }
+                if (!urlPattern.endsWith("*")) {
+                    urlPattern += "*";
+                }
+                jersey.setUrlPattern(urlPattern);
             }
-            if (!urlPattern.endsWith("*")) {
-                urlPattern += "*";
-            }
-            jersey.setUrlPattern(urlPattern);
             jersey.register(new JacksonMessageBodyProvider(objectMapper));
             jersey.register(new HibernateValidationFeature(validator));
             if (registerDefaultExceptionMappers == null || registerDefaultExceptionMappers) {

--- a/dropwizard-core/src/test/java/io/dropwizard/server/AbstractServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/AbstractServerFactoryTest.java
@@ -1,0 +1,103 @@
+package io.dropwizard.server;
+
+import io.dropwizard.Configuration;
+import io.dropwizard.jersey.DropwizardResourceConfig;
+import io.dropwizard.jersey.setup.JerseyContainerHolder;
+import io.dropwizard.jersey.setup.JerseyEnvironment;
+import io.dropwizard.setup.Environment;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.thread.ThreadPool;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests that the {@link JerseyEnvironment#getUrlPattern()} is set by the following priority order:
+ * <ol>
+ *     <li>YAML defined value</li>
+ *     <li>{@link io.dropwizard.Application#run(Configuration, Environment)} defined value</li>
+ *     <li>Default value defined by {@link DropwizardResourceConfig#urlPattern}</li>
+ * </ol>
+ */
+public class AbstractServerFactoryTest {
+
+    private final JerseyContainerHolder holder = mock(JerseyContainerHolder.class);
+    private final DropwizardResourceConfig config = new DropwizardResourceConfig();
+    private final JerseyEnvironment jerseyEnvironment = new JerseyEnvironment(holder, config);
+    private final Environment environment = mock(Environment.class, RETURNS_DEEP_STUBS);
+    private final TestServerFactory serverFactory = new TestServerFactory();
+
+    private static final String DEFAULT_PATTERN = "/*";
+    private static final String RUN_SET_PATTERN = "/set/from/run/*";
+    private static final String YAML_SET_PATTERN = "/set/from/yaml/*";
+
+    @Before
+    public void before() {
+        when(this.environment.jersey()).thenReturn(this.jerseyEnvironment);
+    }
+
+    @Test
+    public void usesYamlDefinedPattern() {
+        this.serverFactory.setJerseyRootPath(YAML_SET_PATTERN);
+        this.jerseyEnvironment.setUrlPattern(RUN_SET_PATTERN);
+
+        this.serverFactory.build(this.environment);
+
+        assertThat(this.jerseyEnvironment.getUrlPattern()).isEqualTo(YAML_SET_PATTERN);
+    }
+
+    @Test
+    public void usesRunDefinedPatternWhenNoYaml() {
+        this.jerseyEnvironment.setUrlPattern(RUN_SET_PATTERN);
+
+        this.serverFactory.build(this.environment);
+
+        assertThat(this.jerseyEnvironment.getUrlPattern()).isEqualTo(RUN_SET_PATTERN);
+    }
+
+    @Test
+    public void usesDefaultPatternWhenNoneSet() {
+        this.serverFactory.build(this.environment);
+
+        assertThat(this.jerseyEnvironment.getUrlPattern()).isEqualTo(DEFAULT_PATTERN);
+    }
+
+    @Test
+    public void yamlPatternEndsWithSlashStar() {
+        assertPatternEndsWithSlashStar("/missing/slash/star");
+    }
+
+    @Test
+    public void yamlPatternEndsWithStar() {
+        assertPatternEndsWithSlashStar("/missing/star/");
+    }
+
+    private void assertPatternEndsWithSlashStar(String jerseyRootPath) {
+        this.serverFactory.setJerseyRootPath(jerseyRootPath);
+        this.serverFactory.build(this.environment);
+        assertThat(this.jerseyEnvironment.getUrlPattern()).endsWith("/*");
+    }
+
+    /**
+     * Test implementation of {@link AbstractServerFactory} used to run {@link #createAppServlet}, which triggers the
+     * setting of {@link JerseyEnvironment#setUrlPattern(String)}.
+     */
+    public static class TestServerFactory extends AbstractServerFactory {
+        @Override
+        public Server build(Environment environment) {
+            // mimics the current default + simple server factory build() methods
+            ThreadPool threadPool = createThreadPool(environment.metrics());
+            Server server = buildServer(environment.lifecycle(), threadPool);
+            this.createAppServlet(server,
+                                  environment.jersey(),
+                                  environment.getObjectMapper(),
+                                  environment.getValidator(),
+                                  environment.getApplicationContext(),
+                                  environment.getJerseyServletContainer(),
+                                  environment.metrics());
+            return server;
+        }
+    }
+}

--- a/dropwizard-core/src/test/java/io/dropwizard/server/AbstractServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/AbstractServerFactoryTest.java
@@ -35,49 +35,33 @@ public class AbstractServerFactoryTest {
 
     @Before
     public void before() {
-        when(this.environment.jersey()).thenReturn(this.jerseyEnvironment);
+        when(environment.jersey()).thenReturn(jerseyEnvironment);
     }
 
     @Test
     public void usesYamlDefinedPattern() {
-        this.serverFactory.setJerseyRootPath(YAML_SET_PATTERN);
-        this.jerseyEnvironment.setUrlPattern(RUN_SET_PATTERN);
+        serverFactory.setJerseyRootPath(YAML_SET_PATTERN);
+        jerseyEnvironment.setUrlPattern(RUN_SET_PATTERN);
 
-        this.serverFactory.build(this.environment);
+        serverFactory.build(environment);
 
-        assertThat(this.jerseyEnvironment.getUrlPattern()).isEqualTo(YAML_SET_PATTERN);
+        assertThat(jerseyEnvironment.getUrlPattern()).isEqualTo(YAML_SET_PATTERN);
     }
 
     @Test
     public void usesRunDefinedPatternWhenNoYaml() {
-        this.jerseyEnvironment.setUrlPattern(RUN_SET_PATTERN);
+        jerseyEnvironment.setUrlPattern(RUN_SET_PATTERN);
 
-        this.serverFactory.build(this.environment);
+        serverFactory.build(environment);
 
-        assertThat(this.jerseyEnvironment.getUrlPattern()).isEqualTo(RUN_SET_PATTERN);
+        assertThat(jerseyEnvironment.getUrlPattern()).isEqualTo(RUN_SET_PATTERN);
     }
 
     @Test
     public void usesDefaultPatternWhenNoneSet() {
-        this.serverFactory.build(this.environment);
+        serverFactory.build(environment);
 
-        assertThat(this.jerseyEnvironment.getUrlPattern()).isEqualTo(DEFAULT_PATTERN);
-    }
-
-    @Test
-    public void yamlPatternEndsWithSlashStar() {
-        assertPatternEndsWithSlashStar("/missing/slash/star");
-    }
-
-    @Test
-    public void yamlPatternEndsWithStar() {
-        assertPatternEndsWithSlashStar("/missing/star/");
-    }
-
-    private void assertPatternEndsWithSlashStar(String jerseyRootPath) {
-        this.serverFactory.setJerseyRootPath(jerseyRootPath);
-        this.serverFactory.build(this.environment);
-        assertThat(this.jerseyEnvironment.getUrlPattern()).endsWith("/*");
+        assertThat(jerseyEnvironment.getUrlPattern()).isEqualTo(DEFAULT_PATTERN);
     }
 
     /**
@@ -90,7 +74,7 @@ public class AbstractServerFactoryTest {
             // mimics the current default + simple server factory build() methods
             ThreadPool threadPool = createThreadPool(environment.metrics());
             Server server = buildServer(environment.lifecycle(), threadPool);
-            this.createAppServlet(server,
+            createAppServlet(server,
                                   environment.jersey(),
                                   environment.getObjectMapper(),
                                   environment.getValidator(),

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/setup/JerseyEnvironment.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/setup/JerseyEnvironment.java
@@ -103,7 +103,14 @@ public class JerseyEnvironment {
     }
 
     public void setUrlPattern(String urlPattern) {
-        config.setUrlPattern(urlPattern);
+        String normalizedUrlPattern = urlPattern;
+        if (!normalizedUrlPattern.endsWith("*") && !normalizedUrlPattern.endsWith("/")) {
+            normalizedUrlPattern += "/";
+        }
+        if (!normalizedUrlPattern.endsWith("*")) {
+            normalizedUrlPattern+= "*";
+        }
+        config.setUrlPattern(normalizedUrlPattern);
     }
 
     public DropwizardResourceConfig getResourceConfig() {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/setup/JerseyEnvironmentTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/setup/JerseyEnvironmentTest.java
@@ -1,0 +1,36 @@
+package io.dropwizard.jersey.setup;
+
+import io.dropwizard.jersey.DropwizardResourceConfig;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class JerseyEnvironmentTest {
+
+    private final JerseyContainerHolder holder = mock(JerseyContainerHolder.class);
+    private final DropwizardResourceConfig config = new DropwizardResourceConfig();
+    private final JerseyEnvironment jerseyEnvironment = new JerseyEnvironment(holder, config);
+
+    @Test
+    public void urlPatternEndsWithSlashStar() {
+        assertPatternEndsWithSlashStar("/missing/slash/star");
+    }
+
+    @Test
+    public void urlPatternEndsWithStar() {
+        assertPatternEndsWithSlashStar("/missing/star/");
+    }
+
+    @Test
+    public void urlPatternSuffixNoop() {
+        String slashStarPath = "/slash/star/*";
+        jerseyEnvironment.setUrlPattern(slashStarPath);
+        assertThat(jerseyEnvironment.getUrlPattern()).isEqualTo(slashStarPath);
+    }
+
+    private void assertPatternEndsWithSlashStar(String jerseyRootPath) {
+        jerseyEnvironment.setUrlPattern(jerseyRootPath);
+        assertThat(jerseyEnvironment.getUrlPattern()).endsWith("/*");
+    }
+}


### PR DESCRIPTION
Before this commit, the only way to set the Jersey URL pattern was to
add it in the YAML configuration, under `rootpath`. This commit now
allows the following priority order for the Jersey URL pattern:

1. the YAML config
2. the value set in the applications `run()` block
3. the default value from `DropwizardResourceConfig`, which is `/*`

with this priority order, there should be no breaking changes for users
who have set the value in the YAML. it will now allow applications
to have this value hardcoded, making the YAML file simpler

fixes #1408