### PR TITLE
Allow for supplying Filters to Logging Appenders

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -542,6 +542,8 @@ Console
           timeZone: UTC
           target: stdout
           logFormat: # TODO
+          filterFactories:
+            - type: URI
 
 
 ====================== ===========  ===========
@@ -554,6 +556,8 @@ target                 stdout       The name of the standard stream to which eve
                                     Can be ``stdout`` or ``stderr``.
 logFormat              default      The Logback pattern with which events will be formatted. See
                                     the Logback_ documentation for details.
+filterFactories        (none)       The list of filters to apply to the appender, in order, after
+                                    the thresold.
 ====================== ===========  ===========
 
 .. _Logback: http://logback.qos.ch/manual/layouts.html#conversionWord
@@ -577,6 +581,8 @@ File
           archivedFileCount: 5
           timeZone: UTC
           logFormat: # TODO
+          filterFactories:
+            - type: URI
 
 
 ============================ ===========  ==================================================================================================
@@ -594,6 +600,8 @@ archivedFileCount            5            The number of archived files to keep. 
 timeZone                     UTC          The time zone to which event timestamps will be converted.
 logFormat                    default      The Logback pattern with which events will be formatted. See
                                           the Logback_ documentation for details.
+filterFactories              (none)       The list of filters to apply to the appender, in order, after
+                                          the thresold.
 ============================ ===========  ==================================================================================================
 
 
@@ -614,6 +622,8 @@ Syslog
           threshold: ALL
           stackTracePrefix: \t
           logFormat: # TODO
+          filterFactories:
+            - type: URI
 
 
 ============================ ===========  ==================================================================================================
@@ -631,8 +641,31 @@ logFormat                    default      The Logback pattern with which events 
                                           the Logback_ documentation for details.
 stackTracePrefix             \t           The prefix to use when writing stack trace lines (these are sent
                                           to the syslog server separately from the main message)
+filterFactories              (none)       The list of filters to apply to the appender, in order, after
+                                          the thresold.
 ============================ ===========  ==================================================================================================
 
+
+.. _man-configuration-logging-filter-factories:
+
+FilterFactories
+---------------
+
+.. code-block:: yaml
+
+    logging:
+      level: INFO
+      appenders:
+        - type: console
+          filterFactories:
+            - type: URI
+
+
+====================== ===========  ================
+Name                   Default      Description
+====================== ===========  ================
+type                   REQUIRED     The filter type.
+====================== ===========  ================
 
 .. _man-configuration-metrics:
 

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/AbstractAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/AbstractAppenderFactory.java
@@ -10,12 +10,15 @@ import ch.qos.logback.core.pattern.PatternLayoutBase;
 import ch.qos.logback.core.spi.DeferredProcessingAware;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import io.dropwizard.logging.async.AsyncAppenderFactory;
+import io.dropwizard.logging.filter.FilterFactory;
 import io.dropwizard.logging.layout.LayoutFactory;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+import java.util.List;
 import java.util.TimeZone;
 
 /**
@@ -68,6 +71,14 @@ import java.util.TimeZone;
  *             events of level WARN and ERROR. To keep all events, set discardingThreshold to 0.
  *         </td>
  *     </tr>
+ *     <tr>
+ *         <td>{@code filterFactories}</td>
+ *         <td>(none)</td>
+ *         <td>
+ *             A list of {@link FilterFactory filters} to apply to the appender, in order,
+ *             after the {@code threshold}.
+ *         </td>
+ *     </tr>
  * </table>
  */
 public abstract class AbstractAppenderFactory<E extends DeferredProcessingAware> implements AppenderFactory<E> {
@@ -87,6 +98,8 @@ public abstract class AbstractAppenderFactory<E extends DeferredProcessingAware>
     private int discardingThreshold = -1;
 
     private boolean includeCallerData = false;
+
+    private ImmutableList<FilterFactory<E>> filterFactories = ImmutableList.of();
 
     @JsonProperty
     public int getQueueSize() {
@@ -146,6 +159,16 @@ public abstract class AbstractAppenderFactory<E extends DeferredProcessingAware>
     @JsonProperty
     public void setIncludeCallerData(boolean includeCallerData) {
         this.includeCallerData = includeCallerData;
+    }
+
+    @JsonProperty
+    public ImmutableList<FilterFactory<E>> getFilterFactories() {
+        return filterFactories;
+    }
+
+    @JsonProperty
+    public void setFilterFactories(List<FilterFactory<E>> appenders) {
+        this.filterFactories = ImmutableList.copyOf(appenders);
     }
 
     protected Appender<E> wrapAsync(Appender<E> appender, AsyncAppenderFactory<E> asyncAppenderFactory) {

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/ConsoleAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/ConsoleAppenderFactory.java
@@ -103,6 +103,7 @@ public class ConsoleAppenderFactory<E extends DeferredProcessingAware> extends A
         appender.setEncoder(layoutEncoder);
 
         appender.addFilter(levelFilterFactory.build(threshold));
+        getFilterFactories().stream().forEach(f -> appender.addFilter(f.build()));
         appender.start();
 
         return wrapAsync(appender, asyncAppenderFactory);

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
@@ -198,6 +198,7 @@ public class FileAppenderFactory<E extends DeferredProcessingAware> extends Abst
 
         appender.setPrudent(false);
         appender.addFilter(levelFilterFactory.build(threshold));
+        getFilterFactories().stream().forEach(f -> appender.addFilter(f.build()));
         appender.stop();
         appender.start();
 

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/SyslogAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/SyslogAppenderFactory.java
@@ -216,6 +216,7 @@ public class SyslogAppenderFactory extends AbstractAppenderFactory<ILoggingEvent
         appender.setThrowableExcluded(!includeStackTrace);
         appender.setStackTracePattern(stackTracePrefix);
         appender.addFilter(levelFilterFactory.build(threshold));
+        getFilterFactories().stream().forEach(f -> appender.addFilter(f.build()));
         appender.start();
         return wrapAsync(appender, asyncAppenderFactory);
     }

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/filter/FilterFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/filter/FilterFactory.java
@@ -1,0 +1,23 @@
+package io.dropwizard.logging.filter;
+
+import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.core.spi.DeferredProcessingAware;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.dropwizard.jackson.Discoverable;
+
+/**
+ * A service provider interface for creating Logback {@link Filter} instances.
+ * <p/>
+ * To create your own, just:
+ * <ol>
+ * <li>Create a class which implements {@link FilterFactory}.</li>
+ * <li>Annotate it with {@code @JsonTypeName} and give it a unique type name.</li>
+ * <li>add a {@code META-INF/services/io.dropwizard.logging.filter.FilterFactory} file with your
+ * implementation's full class name to the class path.</li>
+ * </ol>
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+public interface FilterFactory<E extends DeferredProcessingAware> extends Discoverable {
+
+    Filter<E> build();
+}

--- a/dropwizard-logging/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
+++ b/dropwizard-logging/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
@@ -1,2 +1,3 @@
 io.dropwizard.logging.AppenderFactory
 io.dropwizard.logging.LoggingFactory
+io.dropwizard.logging.filter.FilterFactory

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/DefaultLoggingFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/DefaultLoggingFactoryTest.java
@@ -71,6 +71,7 @@ public class DefaultLoggingFactoryTest {
         assertThat(fileAppenderFactory.getCurrentLogFilename()).isEqualTo("${new_app}.log");
         assertThat(fileAppenderFactory.getArchivedLogFilenamePattern()).isEqualTo("${new_app}-%d.log.gz");
         assertThat(fileAppenderFactory.getArchivedFileCount()).isEqualTo(5);
+        assertThat(fileAppenderFactory.getFilterFactories()).containsExactly(new TestFilterFactory(), new SecondTestFilterFactory());
 
         final JsonNode legacyApp = config.getLoggers().get("com.example.legacyApp");
         assertThat(legacyApp).isNotNull();
@@ -119,4 +120,5 @@ public class DefaultLoggingFactoryTest {
                 "DEBUG com.example.notAdditive: Not additive application debug log",
                 "INFO  com.example.notAdditive: Not additive application info log");
     }
+
 }

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/SecondTestFilterFactory.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/SecondTestFilterFactory.java
@@ -1,0 +1,32 @@
+package io.dropwizard.logging;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.core.spi.FilterReply;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.dropwizard.logging.filter.FilterFactory;
+
+@JsonTypeName("second-test-filter-factory")
+public class SecondTestFilterFactory implements FilterFactory<ILoggingEvent> {
+
+    @Override
+    public Filter<ILoggingEvent> build() {
+        return new Filter<ILoggingEvent>() {
+            @Override
+            public FilterReply decide(ILoggingEvent event) {
+                return FilterReply.NEUTRAL;
+            }
+        };
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof SecondTestFilterFactory;
+    }
+}

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/SecondTestFilterFactory.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/SecondTestFilterFactory.java
@@ -19,14 +19,4 @@ public class SecondTestFilterFactory implements FilterFactory<ILoggingEvent> {
             }
         };
     }
-
-    @Override
-    public int hashCode() {
-        return super.hashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        return obj instanceof SecondTestFilterFactory;
-    }
 }

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/TestFilterFactory.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/TestFilterFactory.java
@@ -1,0 +1,32 @@
+package io.dropwizard.logging;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.core.spi.FilterReply;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.dropwizard.logging.filter.FilterFactory;
+
+@JsonTypeName("test-filter-factory")
+public class TestFilterFactory implements FilterFactory<ILoggingEvent> {
+
+    @Override
+    public Filter<ILoggingEvent> build() {
+        return new Filter<ILoggingEvent>() {
+            @Override
+            public FilterReply decide(ILoggingEvent event) {
+                return FilterReply.NEUTRAL;
+            }
+        };
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof TestFilterFactory;
+    }
+}

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/TestFilterFactory.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/TestFilterFactory.java
@@ -19,14 +19,4 @@ public class TestFilterFactory implements FilterFactory<ILoggingEvent> {
             }
         };
     }
-
-    @Override
-    public int hashCode() {
-        return super.hashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        return obj instanceof TestFilterFactory;
-    }
 }

--- a/dropwizard-logging/src/test/resources/META-INF/services/io.dropwizard.logging.filter.FilterFactory
+++ b/dropwizard-logging/src/test/resources/META-INF/services/io.dropwizard.logging.filter.FilterFactory
@@ -1,0 +1,2 @@
+io.dropwizard.logging.TestFilterFactory
+io.dropwizard.logging.SecondTestFilterFactory

--- a/dropwizard-logging/src/test/resources/yaml/logging_advanced.yml
+++ b/dropwizard-logging/src/test/resources/yaml/logging_advanced.yml
@@ -5,6 +5,9 @@ loggers:
     level: DEBUG
     appenders:
       - type: file
+        filterFactories:
+          - type: test-filter-factory
+          - type: second-test-filter-factory
         currentLogFilename: '${new_app}.log'
         archivedLogFilenamePattern: '${new_app}-%d.log.gz'
         logFormat: "%-5level %logger: %msg%n"


### PR DESCRIPTION
This change adds a seam to allow consumers to supply Logback Filters to apply to logging Appenders. These filters will be applied, in order, after the threshold filter. This allows for further refinement of what will be logged. For example, I have an endpoint that is called on a schedule to check availability that I would like to exclude from the access logs by supplying a filter for this URI.

You could also add appenders with the following:
* A filter that will only log failures based on status code.
* A filter that will log requests with slow responses.
* A filter that will log large requests/responses.