### PR TITLE
Allow Validated to annotate non-entity objects

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/DropwizardConfiguredValidator.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/DropwizardConfiguredValidator.java
@@ -1,5 +1,6 @@
 package io.dropwizard.jersey.validation;
 
+import com.google.common.collect.ImmutableList;
 import io.dropwizard.validation.ConstraintViolations;
 import io.dropwizard.validation.Validated;
 import org.glassfish.jersey.server.internal.inject.ConfiguredValidator;
@@ -14,6 +15,8 @@ import javax.validation.Validator;
 import javax.validation.executable.ExecutableValidator;
 import javax.validation.groups.Default;
 import javax.validation.metadata.BeanDescriptor;
+import javax.ws.rs.WebApplicationException;
+import java.util.Arrays;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
@@ -44,14 +47,37 @@ public class DropwizardConfiguredValidator implements ConfiguredValidator {
      * {@link Default} group
      */
     private Class<?>[] getGroup(Invocable invocable) {
+        final ImmutableList.Builder<Class<?>[]> builder = ImmutableList.builder();
         for (Parameter parameter : invocable.getParameters()) {
-            if (parameter.getSource().equals(Parameter.Source.UNKNOWN)) {
-                if (parameter.isAnnotationPresent(Validated.class)) {
-                    return parameter.getAnnotation(Validated.class).value();
-                }
+            if (parameter.isAnnotationPresent(Validated.class)) {
+                builder.add(parameter.getAnnotation(Validated.class).value());
             }
         }
-        return new Class<?>[] {Default.class};
+
+        final ImmutableList<Class<?>[]> groups = builder.build();
+        switch (groups.size()) {
+            // No parameters were annotated with Validated, so validate under the default group
+            case 0: return new Class<?>[] {Default.class};
+
+            // A single parameter was annotated with Validated, so use their group
+            case 1: return groups.get(0);
+
+            // Multiple parameters were annotated with Validated, so we must check if
+            // all groups are equal to each other, if not, throw an exception because
+            // the validator is unable to handle parameters validated under different
+            // groups. If the parameters have the same group, we can grab the first
+            // group.
+            default:
+                for (int i = 0; i < groups.size(); i++) {
+                    for (int j = i; j < groups.size(); j++) {
+                        if (!Arrays.deepEquals(groups.get(i), groups.get(j))) {
+                            throw new WebApplicationException("Parameters must have the same validation groups in " +
+                                invocable.getHandlingMethod().getName(), 500);
+                        }
+                    }
+                }
+                return groups.get(0);
+        }
     }
 
     @Override

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
@@ -198,6 +198,31 @@ public class ConstraintViolationExceptionMapperTest extends JerseyTest {
     }
 
     @Test
+    public void getGroupSubBeanParamsIs400() throws Exception {
+        final Response response = target("/valid/sub-group-zoo")
+            .queryParam("address", "42 WALLABY WAY")
+            .queryParam("name", "Coda")
+            .request().get();
+        assertThat(response.getStatus()).isEqualTo(400);
+
+        assertThat(response.readEntity(String.class))
+            .containsOnlyOnce("[\"address must not be uppercase\"]");
+    }
+
+    @Test
+    public void postValidGroupsIs400() throws Exception {
+        final Response response = target("/valid/sub-valid-group-zoo")
+            .queryParam("address", "42 WALLABY WAY")
+            .queryParam("name", "Coda")
+            .request()
+            .post(Entity.json("{}"));
+        assertThat(response.getStatus()).isEqualTo(400);
+
+        assertThat(response.readEntity(String.class))
+            .containsOnlyOnce("[\"address must not be uppercase\"]");
+    }
+
+    @Test
     public void getInvalidatedBeanParamsIs400() throws Exception {
         // bean parameter is too short and so will fail validation
         final Response response = target("/valid/zoo2")

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/SubBeanParameter.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/SubBeanParameter.java
@@ -1,5 +1,8 @@
 package io.dropwizard.jersey.validation;
 
+import io.dropwizard.jersey.jackson.JacksonMessageBodyProviderTest;
+import io.dropwizard.validation.ValidationMethod;
+import org.assertj.core.util.Strings;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.ws.rs.QueryParam;
@@ -8,6 +11,13 @@ public class SubBeanParameter extends BeanParameter {
     @QueryParam("address")
     @NotEmpty
     private String address;
+
+
+    @ValidationMethod(message="address must not be uppercase",
+        groups = JacksonMessageBodyProviderTest.Partial1.class)
+    public boolean isAddressNotUppercase() {
+        return Strings.isNullOrEmpty(address) || (!address.toUpperCase().equals(address));
+    }
 
     public String getAddress() {
         return address;

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
@@ -140,6 +140,20 @@ public class ValidatingResource {
     }
 
     @GET
+    @Path("sub-group-zoo")
+    public String subGroupBlazer(@Valid @Validated(Partial1.class) @BeanParam SubBeanParameter params) {
+        return params.getName() + " " + params.getAddress();
+    }
+
+    @POST
+    @Path("sub-valid-group-zoo")
+    public String subValidGroupBlazer(
+        @Valid @Validated(Partial1.class) @BeanParam SubBeanParameter params,
+        @Valid @Validated(Partial1.class) ValidRepresentation entity) {
+        return params.getName() + " " + params.getAddress() + " " + entity.getName();
+    }
+
+    @GET
     @Path("zoo2")
     public String blazerValidated(@Validated @Valid @BeanParam BeanParameter params) {
         return params.getName();

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResource.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResource.java
@@ -4,9 +4,13 @@ import com.codahale.metrics.annotation.Timed;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.jersey.params.IntParam;
 import io.dropwizard.testing.Person;
+import io.dropwizard.validation.Validated;
 import org.eclipse.jetty.io.EofException;
 
+import javax.validation.Valid;
 import javax.validation.constraints.Min;
+import javax.validation.groups.Default;
+import javax.ws.rs.BeanParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -56,5 +60,19 @@ public class PersonResource {
     @Path("/eof-exception")
     public Person eofException() throws Exception {
         throw new EofException("I'm an eof exception!");
+    }
+
+    @POST
+    @Path("/validation-groups-exception")
+    public String validationGroupsException(
+        @Valid @Validated(Partial1.class) @BeanParam BeanParameter params,
+        @Valid @Validated(Default.class) byte[] entity) {
+        return params.age.toString() + entity.length;
+    }
+
+    public interface Partial1 { }
+    public static class BeanParameter {
+        @QueryParam("age")
+        public Integer age;
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResourceTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResourceTest.java
@@ -112,6 +112,17 @@ public class PersonResourceTest {
     }
 
     @Test
+    public void testValidationGroupsException() {
+        final Response resp = resources.client().target("/person/blah/validation-groups-exception")
+            .request()
+            .post(Entity.json("{}"));
+        assertThat(resp.getStatus()).isEqualTo(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+        assertThat(resp.readEntity(String.class))
+            .isEqualTo("{\"code\":500,\"message\":\"Parameters must have the same" +
+                " validation groups in validationGroupsException\"}");
+    }
+
+    @Test
     public void testCustomClientConfiguration() {
         assertThat(resources.client().getConfiguration().isRegistered(DummyExceptionMapper.class)).isTrue();
     }


### PR DESCRIPTION
This is a fix for #1433.

Previously, the `Validated` annotation would only be allowed on entity parameters of a resource, even though a `BeanParam` could be validated. This created a problem where one would want to specify a validation group on an endpoint that only accepted a `BeanParam`, as they would be forced to annotate a dummy request entity with `Validated`.

This pull request also handles the situation when the user supplies two or more entities with `Validated`. These annotations must be equivalent (and thus redundant), else an exception will be thrown as the underlying validator cannot validate parameters under different validation groups.

I would like critiques of the implementation because as of right now, a `WebApplicationException` is thrown, as a `RuntimeException` will result in Jersey interpreting it as a `ProcessingException`, and `WebApplicationException` works around it. Alternatively, we could define a new exception type but that would require adding a new exception mapper as well, which I feel like is more code bloat than I care for.

As a side note, it should definitely be documented (looking at me) that a single parameter annotated with `Validated` will be effect how the rest of the parameters are validated with the same group. Some would find the following surprising:

```java
@PUT
public FooBar putFoo(@Validated(Group.class) @Valid @BeanParam MyParams params,
                     @Valid @NotNull FooBar entity) {
    // ...
}
```

In this case, both `params` and `entity` are validated under the `Group` class. The same would apply if `entity` was annotated and `params` wasn't.