### PR TITLE
Deal correctly with nested JAR resources

### DIFF
--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/assets/ResourceURL.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/assets/ResourceURL.java
@@ -45,7 +45,7 @@ public class ResourceURL {
 
                     final String fileName = resourceURL.getFile();
                     // leaves just the relative file path inside the jar
-                    final String relativeFilePath = fileName.substring(fileName.indexOf('!') + 2);
+                    final String relativeFilePath = fileName.substring(fileName.lastIndexOf('!') + 2);
                     final JarFile jarFile = jarConnection.getJarFile();
                     final ZipEntry zipEntry = jarFile.getEntry(relativeFilePath);
                     final InputStream inputStream = jarFile.getInputStream(zipEntry);


### PR DESCRIPTION
I have a project JAR (call it lib) containing a Bundle that exposes resources via the AssetsServlet. The resources live inside that JAR also. I am including this JAR as a dependency in another project (call it app) that uses the maven-spring-boot-plugin to create a self-contained, runnable JAR. When the asset servlet is hit, the code in lib attempts to load the resource. It fails in io.dropwizard.servlets.assets.ResourceUrl#isDirectory at this point:

```
                String filename = resourceURL.getFile();
                filename = filename.substring(filename.indexOf('!') + 2);
                JarFile jarFile = e.getJarFile();
                ZipEntry zipEntry = jarFile.getEntry(filename);
                InputStream inputStream = jarFile.getInputStream(zipEntry);
```

filename starts out as: ```jar:file:app.jar!/lib/lib.jar!/resource/file.txt```

The code converts it to: ```lib/lib.jar!/resource/file.txt```

jarFile is set (correctly I think) to: ```app.jar!/lib/lib.jar```

The call to ```jarFile.getEntry``` fails with the modified filename.

This PR uses ```lastIndexOf('!')``` to work around this problem and we end up with a call to get the entry ```resource/file.txt``` from the embedded JAR. Of course, this fix makes it impossible to correctly load a resource file with an ! in its name, so it might be better to use ```lastIndexOf('.jar!')``` instead to limit the damage.

Looking for alternative suggestions and ideas on how best to unit test this.