### PR TITLE
ExecutorServiceBuilder: Set default maximumPoolSize to 1; corePoolSiz…

### DIFF
--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilder.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilder.java
@@ -31,7 +31,7 @@ public class ExecutorServiceBuilder {
         this.environment = environment;
         this.nameFormat = nameFormat;
         this.corePoolSize = 0;
-        this.maximumPoolSize = Integer.MAX_VALUE;
+        this.maximumPoolSize = 1;
         this.keepAliveTime = Duration.seconds(60);
         this.shutdownTime = Duration.seconds(5);
         this.workQueue = new LinkedBlockingQueue<>();
@@ -75,7 +75,7 @@ public class ExecutorServiceBuilder {
     }
 
     public ExecutorService build() {
-        if (maximumPoolSize != Integer.MAX_VALUE && !isBoundedQueue()) {
+        if (corePoolSize != maximumPoolSize && maximumPoolSize > 1 && !isBoundedQueue()) {
             log.warn("Parameter 'maximumPoolSize' is conflicting with unbounded work queues");
         }
         final ThreadPoolExecutor executor = new ThreadPoolExecutor(corePoolSize,

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
@@ -1,14 +1,16 @@
 package io.dropwizard.lifecycle.setup;
 
+import com.google.common.base.Throwables;
+import io.dropwizard.util.Duration;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.exceptions.verification.WantedButNotInvoked;
 import org.slf4j.Logger;
 
-import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.*;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 public class ExecutorServiceBuilderTest {
 
@@ -20,26 +22,116 @@ public class ExecutorServiceBuilderTest {
     @Before
     public void setUp() throws Exception {
         executorServiceBuilder = new ExecutorServiceBuilder(new LifecycleEnvironment(), "test");
-        executorServiceBuilder.minThreads(4);
-        executorServiceBuilder.maxThreads(8);
-
         log = mock(Logger.class);
         ExecutorServiceBuilder.setLog(log);
     }
 
     @Test
     public void testGiveAWarningAboutMaximumPoolSizeAndUnboundedQueue() {
-        executorServiceBuilder.build();
+        executorServiceBuilder
+            .minThreads(4)
+            .maxThreads(8)
+            .build();
 
         verify(log).warn(WARNING);
     }
 
     @Test
-    public void testGiveNoWarningAboutMaximumPoolSizeAndBoundedQueue() {
-        executorServiceBuilder.workQueue(new ArrayBlockingQueue<>(16));
-
-        executorServiceBuilder.build();
+    public void testGiveNoWarningAboutMaximumPoolSizeAndBoundedQueue() throws InterruptedException {
+        ExecutorService exe = executorServiceBuilder
+            .minThreads(4)
+            .maxThreads(8)
+            .workQueue(new ArrayBlockingQueue<>(16))
+            .build();
 
         verify(log, never()).warn(WARNING);
+        assertCanExecuteAtLeast2ConcurrentTasks(exe);
+    }
+
+    /**
+     * There should be no warning about using a Executors.newSingleThreadExecutor() equivalent
+     * @see java.util.concurrent.Executors#newSingleThreadExecutor()
+     */
+    @Test
+    public void shouldNotWarnWhenSettingUpSingleThreadedPool() {
+        executorServiceBuilder
+            .minThreads(1)
+            .maxThreads(1)
+            .keepAliveTime(Duration.milliseconds(0))
+            .workQueue(new LinkedBlockingQueue<>())
+            .build();
+
+        verify(log, never()).warn(anyString());
+    }
+
+    /**
+     * There should be no warning about using a Executors.newCachedThreadPool() equivalent
+     * @see java.util.concurrent.Executors#newCachedThreadPool()
+     */
+    @Test
+    public void shouldNotWarnWhenSettingUpCachedThreadPool() throws InterruptedException {
+        ExecutorService exe = executorServiceBuilder
+            .minThreads(0)
+            .maxThreads(Integer.MAX_VALUE)
+            .keepAliveTime(Duration.seconds(60))
+            .workQueue(new SynchronousQueue<>())
+            .build();
+
+        verify(log, never()).warn(anyString());
+        assertCanExecuteAtLeast2ConcurrentTasks(exe); // cached thread pools work right?
+    }
+
+    @Test
+    public void shouldNotWarnWhenUsingTheDefaultConfiguration() {
+        executorServiceBuilder.build();
+        verify(log, never()).warn(anyString());
+    }
+
+    /**
+     * Setting large max threads without large min threads is misleading on the default queue implementation
+     * It should warn or work
+     */
+    @Test
+    public void shouldBeAbleToExecute2TasksAtOnceWithLargeMaxThreadsOrBeWarnedOtherwise() {
+        ExecutorService exe = executorServiceBuilder
+            .maxThreads(Integer.MAX_VALUE)
+            .build();
+
+        try { verify(log).warn(anyString()); }
+        catch (WantedButNotInvoked error) {
+            // no warning has been given so we should be able to execute at least 2 things at once
+            assertCanExecuteAtLeast2ConcurrentTasks(exe);
+        }
+    }
+
+    /**
+     * Tries to run 2 tasks that on the executor that rely on each others side-effect to complete. If they fail to
+     * complete within a short time then we can assume they are not running concurrently
+     * @param exe an executor to try to run 2 tasks on
+     */
+    private void assertCanExecuteAtLeast2ConcurrentTasks(Executor exe) {
+        CountDownLatch latch = new CountDownLatch(2);
+        Runnable concurrentLatchCountDownAndWait = new Runnable() {
+            public void run() {
+                latch.countDown();
+                try { latch.await(); }
+                catch (InterruptedException ex) {
+                    Throwables.propagate(ex);
+                }
+            }
+        };
+
+        exe.execute(concurrentLatchCountDownAndWait);
+        exe.execute(concurrentLatchCountDownAndWait);
+
+        try {
+            // 1 second is ages even on a slow VM
+            assertThat(latch.await(1, TimeUnit.SECONDS))
+                .as("2 tasks executed concurrently on " + exe)
+                .isTrue();
+        }
+        catch (InterruptedException ex) {
+            Throwables.propagate(ex);
+        }
     }
 }


### PR DESCRIPTION
This is somewhat related to issue #575 
For unbound queues the current warning triggers when you have a maximumPoolSize of 1, which is actually fine. Howevew, it fails to warn when you have a maximumPoolSize of Integer.MAX_VALUE but this is also misleading. Even worse the default functionality reads like its a Executors.newCachedThreadPool() but actually is limited to a single thread, ie can't run concurrent tasks.

I've added a simple test to prove if a given Executor can run concurrent tasks.

This change improves the warning to trigger in the correct situations.
The change sets the default maximumPoolSize to 1, which is less misleading and won't cause a functionality change. Unless a user had done:
```java
environment.lifecycle().executorService("some-executor")
                .workQueue(new SynchronousQueue<>())
                .build()
```
Before this commit this would result in a unbound cached thread pool, now you'd need to do
```java
environment.lifecycle().executorService("some-executor")
                .maxThreads(Integer.MAX_VALUE)
                .workQueue(new SynchronousQueue<>())
                .build()
```
Though if you're manually setting your BlockingQueue implementation I'd suggest the user probably won't rely on default settings anyway.

--commit-message
> 
ExecutorServiceBuilder: Set default maximumPoolSize to 1; corePoolSize < maximumPoolSize with an unbound work queue has misleading functionality including when the maximumPoolSize is Integer.MAX_VALUE (current default). Note: This is a minor change in functionality as before the default settings would allow only a single threaded pool.
ExecutorServiceBuilder: Creating a Executors.newSingleThreadExecutor() & Executors.newCachedThreadPool() like executor should not cause a warning message
ExecutorServiceBuilder: Simply setting maxThreads to > 1 with an unbound work queue now causes a warning in all cas