### PR TITLE
Rename JDBI argument factories to match class names

### DIFF
--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/DBIFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/DBIFactory.java
@@ -35,8 +35,8 @@ import io.dropwizard.jdbi.args.OptionalLocalDateArgumentFactory;
 import io.dropwizard.jdbi.args.OptionalLocalDateTimeArgumentFactory;
 import io.dropwizard.jdbi.args.OptionalLongArgumentFactory;
 import io.dropwizard.jdbi.args.OptionalLongMapper;
-import io.dropwizard.jdbi.args.OptionalOffsetTimeArgumentFactory;
-import io.dropwizard.jdbi.args.OptionalZonedTimeArgumentFactory;
+import io.dropwizard.jdbi.args.OptionalOffsetDateTimeArgumentFactory;
+import io.dropwizard.jdbi.args.OptionalZonedDateTimeArgumentFactory;
 import io.dropwizard.jdbi.args.ZonedDateTimeArgumentFactory;
 import io.dropwizard.jdbi.args.ZonedDateTimeMapper;
 import io.dropwizard.jdbi.logging.LogbackLog;
@@ -142,8 +142,8 @@ public class DBIFactory {
         dbi.registerArgumentFactory(new OptionalLocalDateArgumentFactory());
         dbi.registerArgumentFactory(new OptionalLocalDateTimeArgumentFactory());
         dbi.registerArgumentFactory(new OptionalInstantArgumentFactory(timeZone));
-        dbi.registerArgumentFactory(new OptionalOffsetTimeArgumentFactory(timeZone));
-        dbi.registerArgumentFactory(new OptionalZonedTimeArgumentFactory(timeZone));
+        dbi.registerArgumentFactory(new OptionalOffsetDateTimeArgumentFactory(timeZone));
+        dbi.registerArgumentFactory(new OptionalZonedDateTimeArgumentFactory(timeZone));
 
         dbi.registerColumnMapper(new JodaDateTimeMapper(timeZone));
         dbi.registerColumnMapper(new InstantMapper(timeZone));

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalOffsetDateTimeArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalOffsetDateTimeArgumentFactory.java
@@ -13,15 +13,15 @@ import java.util.TimeZone;
 /**
  * An {@link ArgumentFactory} for {@link OffsetDateTime} arguments wrapped by {@link Optional}.
  */
-public class OptionalOffsetTimeArgumentFactory implements ArgumentFactory<Optional<OffsetDateTime>> {
+public class OptionalOffsetDateTimeArgumentFactory implements ArgumentFactory<Optional<OffsetDateTime>> {
 
     private final Optional<Calendar> calendar;
 
-    public OptionalOffsetTimeArgumentFactory() {
+    public OptionalOffsetDateTimeArgumentFactory() {
         calendar = Optional.empty();
     }
 
-    public OptionalOffsetTimeArgumentFactory(Optional<TimeZone> timeZone) {
+    public OptionalOffsetDateTimeArgumentFactory(Optional<TimeZone> timeZone) {
         calendar = timeZone.map(GregorianCalendar::new);
     }
 
@@ -30,7 +30,7 @@ public class OptionalOffsetTimeArgumentFactory implements ArgumentFactory<Option
         if (value instanceof Optional) {
             final Optional<?> optionalValue = (Optional<?>) value;
             // Fall through to OptionalArgumentFactory if absent.
-            // Fall through to OptionalArgumentFactory if present, but not DateTime.
+            // Fall through to OptionalArgumentFactory if present, but not OffsetDateTime.
             return optionalValue.isPresent() && optionalValue.get() instanceof OffsetDateTime;
         }
         return false;

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalZonedDateTimeArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalZonedDateTimeArgumentFactory.java
@@ -13,15 +13,15 @@ import java.util.TimeZone;
 /**
  * An {@link ArgumentFactory} for {@link ZonedDateTime} arguments wrapped by {@link Optional}.
  */
-public class OptionalZonedTimeArgumentFactory implements ArgumentFactory<Optional<ZonedDateTime>> {
+public class OptionalZonedDateTimeArgumentFactory implements ArgumentFactory<Optional<ZonedDateTime>> {
 
     private final Optional<Calendar> calendar;
 
-    public OptionalZonedTimeArgumentFactory() {
+    public OptionalZonedDateTimeArgumentFactory() {
         calendar = Optional.empty();
     }
 
-    public OptionalZonedTimeArgumentFactory(Optional<TimeZone> timeZone) {
+    public OptionalZonedDateTimeArgumentFactory(Optional<TimeZone> timeZone) {
         calendar = timeZone.map(GregorianCalendar::new);
     }
 
@@ -30,7 +30,7 @@ public class OptionalZonedTimeArgumentFactory implements ArgumentFactory<Optiona
         if (value instanceof Optional) {
             final Optional<?> optionalValue = (Optional<?>) value;
             // Fall through to OptionalArgumentFactory if absent.
-            // Fall through to OptionalArgumentFactory if present, but not DateTime.
+            // Fall through to OptionalArgumentFactory if present, but not ZonedDateTime.
             return optionalValue.isPresent() && optionalValue.get() instanceof ZonedDateTime;
         }
         return false;


### PR DESCRIPTION
* Renamed `OptionalOffsetTimeArgumentFactory` to `OptionalOffsetDateTimeArgumentFactory`
* Renamed `OptionalZonedTimeArgumentFactory` to `OptionalZonedDateTimeArgumentFactory`

Fixes https://github.com/dropwizard/dropwizard/issues/1382