### PR TITLE
Improve Support for Optional{Double,Int,Long} in Jersey

### DIFF
--- a/dropwizard-core/src/test/java/io/dropwizard/setup/BootstrapTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/setup/BootstrapTest.java
@@ -12,6 +12,9 @@ import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.validation.NonEmptyStringParamUnwrapper;
 import io.dropwizard.jersey.validation.ParamValidatorUnwrapper;
 import io.dropwizard.validation.valuehandling.GuavaOptionalValidatedValueUnwrapper;
+import io.dropwizard.validation.valuehandling.OptionalDoubleValidatedValueUnwrapper;
+import io.dropwizard.validation.valuehandling.OptionalIntValidatedValueUnwrapper;
+import io.dropwizard.validation.valuehandling.OptionalLongValidatedValueUnwrapper;
 import io.dropwizard.validation.valuehandling.OptionalValidatedValueUnwrapper;
 import org.hibernate.validator.HibernateValidator;
 import org.hibernate.validator.internal.engine.ValidatorFactoryImpl;
@@ -105,6 +108,9 @@ public class BootstrapTest {
                 .extractingResultOf("getClass")
                 .containsSubsequence(GuavaOptionalValidatedValueUnwrapper.class,
                                      OptionalValidatedValueUnwrapper.class,
+                                     OptionalDoubleValidatedValueUnwrapper.class,
+                                     OptionalIntValidatedValueUnwrapper.class,
+                                     OptionalLongValidatedValueUnwrapper.class,
                                      NonEmptyStringParamUnwrapper.class,
                                      ParamValidatorUnwrapper.class);
     }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -62,6 +62,9 @@ public class DropwizardResourceConfig extends ResourceConfig {
         register(io.dropwizard.jersey.guava.OptionalMessageBodyWriter.class);
         register(io.dropwizard.jersey.guava.OptionalParamFeature.class);
         register(io.dropwizard.jersey.optional.OptionalMessageBodyWriter.class);
+        register(io.dropwizard.jersey.optional.OptionalDoubleMessageBodyWriter.class);
+        register(io.dropwizard.jersey.optional.OptionalIntMessageBodyWriter.class);
+        register(io.dropwizard.jersey.optional.OptionalLongMessageBodyWriter.class);
         register(io.dropwizard.jersey.optional.OptionalParamFeature.class);
         register(NonEmptyStringParamFeature.class);
         register(new SessionFactoryProvider.Binder());

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalDoubleMessageBodyWriter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalDoubleMessageBodyWriter.java
@@ -1,0 +1,45 @@
+package io.dropwizard.jersey.optional;
+
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.OptionalDouble;
+
+@Provider
+@Produces(MediaType.WILDCARD)
+public class OptionalDoubleMessageBodyWriter implements MessageBodyWriter<OptionalDouble> {
+    // Jersey ignores this
+    @Override
+    public long getSize(OptionalDouble entity, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return -1;
+    }
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return (OptionalDouble.class.isAssignableFrom(type));
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Override
+    public void writeTo(OptionalDouble entity,
+                        Class<?> type,
+                        Type genericType,
+                        Annotation[] annotations,
+                        MediaType mediaType,
+                        MultivaluedMap<String, Object> httpHeaders,
+                        OutputStream entityStream) throws IOException {
+        if (!entity.isPresent()) {
+            throw new NotFoundException();
+        }
+
+        entityStream.write(Double.toString(entity.getAsDouble()).getBytes(StandardCharsets.US_ASCII));
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalDoubleParamConverterProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalDoubleParamConverterProvider.java
@@ -1,0 +1,46 @@
+package io.dropwizard.jersey.optional;
+
+import javax.inject.Singleton;
+import javax.ws.rs.ext.ParamConverter;
+import javax.ws.rs.ext.ParamConverterProvider;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.OptionalDouble;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+@Singleton
+public class OptionalDoubleParamConverterProvider implements ParamConverterProvider {
+    private final OptionalDoubleParamConverter paramConverter = new OptionalDoubleParamConverter();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> ParamConverter<T> getConverter(final Class<T> rawType, final Type genericType,
+                                              final Annotation[] annotations) {
+        return OptionalDouble.class.equals(rawType) ? (ParamConverter<T>) paramConverter : null;
+    }
+
+    public static class OptionalDoubleParamConverter implements ParamConverter<OptionalDouble> {
+        @Override
+        public OptionalDouble fromString(final String value) {
+            if (value == null) {
+                return OptionalDouble.empty();
+            }
+
+            try {
+                return OptionalDouble.of(Double.parseDouble(value));
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException(e);
+            }
+        }
+
+        @Override
+        public String toString(final OptionalDouble value) {
+            checkArgument(value != null);
+            return value.isPresent() ? Double.toString(value.getAsDouble()) : "";
+        }
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalIntMessageBodyWriter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalIntMessageBodyWriter.java
@@ -1,0 +1,45 @@
+package io.dropwizard.jersey.optional;
+
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.OptionalInt;
+
+@Provider
+@Produces(MediaType.WILDCARD)
+public class OptionalIntMessageBodyWriter implements MessageBodyWriter<OptionalInt> {
+    // Jersey ignores this
+    @Override
+    public long getSize(OptionalInt entity, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return -1;
+    }
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return (OptionalInt.class.isAssignableFrom(type));
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Override
+    public void writeTo(OptionalInt entity,
+                        Class<?> type,
+                        Type genericType,
+                        Annotation[] annotations,
+                        MediaType mediaType,
+                        MultivaluedMap<String, Object> httpHeaders,
+                        OutputStream entityStream) throws IOException {
+        if (!entity.isPresent()) {
+            throw new NotFoundException();
+        }
+
+        entityStream.write(Integer.toString(entity.getAsInt()).getBytes(StandardCharsets.US_ASCII));
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalIntParamConverterProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalIntParamConverterProvider.java
@@ -1,0 +1,46 @@
+package io.dropwizard.jersey.optional;
+
+import javax.inject.Singleton;
+import javax.ws.rs.ext.ParamConverter;
+import javax.ws.rs.ext.ParamConverterProvider;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.OptionalInt;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+@Singleton
+public class OptionalIntParamConverterProvider implements ParamConverterProvider {
+    private final OptionalIntParamConverter paramConverter = new OptionalIntParamConverter();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> ParamConverter<T> getConverter(final Class<T> rawType, final Type genericType,
+                                              final Annotation[] annotations) {
+        return OptionalInt.class.equals(rawType) ? (ParamConverter<T>) paramConverter : null;
+    }
+
+    public static class OptionalIntParamConverter implements ParamConverter<OptionalInt> {
+        @Override
+        public OptionalInt fromString(final String value) {
+            if (value == null) {
+                return OptionalInt.empty();
+            }
+
+            try {
+                return OptionalInt.of(Integer.parseInt(value));
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException(e);
+            }
+        }
+
+        @Override
+        public String toString(final OptionalInt value) {
+            checkArgument(value != null);
+            return value.isPresent() ? Integer.toString(value.getAsInt()) : "";
+        }
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalLongMessageBodyWriter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalLongMessageBodyWriter.java
@@ -1,0 +1,44 @@
+package io.dropwizard.jersey.optional;
+
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.OptionalLong;
+
+@Provider
+@Produces(MediaType.WILDCARD)
+public class OptionalLongMessageBodyWriter implements MessageBodyWriter<OptionalLong> {
+    // Jersey ignores this
+    @Override
+    public long getSize(OptionalLong entity, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return -1;
+    }
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return (OptionalLong.class.isAssignableFrom(type));
+    }
+
+    @Override
+    public void writeTo(OptionalLong entity,
+                        Class<?> type,
+                        Type genericType,
+                        Annotation[] annotations,
+                        MediaType mediaType,
+                        MultivaluedMap<String, Object> httpHeaders,
+                        OutputStream entityStream) throws IOException {
+        if (!entity.isPresent()) {
+            throw new NotFoundException();
+        }
+
+        entityStream.write(Long.toString(entity.getAsLong()).getBytes(StandardCharsets.US_ASCII));
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalLongParamConverterProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalLongParamConverterProvider.java
@@ -1,0 +1,46 @@
+package io.dropwizard.jersey.optional;
+
+import javax.inject.Singleton;
+import javax.ws.rs.ext.ParamConverter;
+import javax.ws.rs.ext.ParamConverterProvider;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.OptionalLong;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+@Singleton
+public class OptionalLongParamConverterProvider implements ParamConverterProvider {
+    private OptionalLongParamConverter paramConverter = new OptionalLongParamConverter();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> ParamConverter<T> getConverter(final Class<T> rawType, final Type genericType,
+                                              final Annotation[] annotations) {
+        return OptionalLong.class.equals(rawType) ? (ParamConverter<T>) paramConverter : null;
+    }
+
+    public static class OptionalLongParamConverter implements ParamConverter<OptionalLong> {
+        @Override
+        public OptionalLong fromString(final String value) {
+            if (value == null) {
+                return OptionalLong.empty();
+            }
+
+            try {
+                return OptionalLong.of(Long.parseLong(value));
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException(e);
+            }
+        }
+
+        @Override
+        public String toString(final OptionalLong value) {
+            checkArgument(value != null);
+            return value.isPresent() ? Long.toString(value.getAsLong()) : "";
+        }
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalParamBinder.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalParamBinder.java
@@ -10,5 +10,8 @@ final class OptionalParamBinder extends AbstractBinder {
     protected void configure() {
         // Param converter providers
         bind(OptionalParamConverterProvider.class).to(ParamConverterProvider.class).in(Singleton.class);
+        bind(OptionalDoubleParamConverterProvider.class).to(ParamConverterProvider.class).in(Singleton.class);
+        bind(OptionalIntParamConverterProvider.class).to(ParamConverterProvider.class).in(Singleton.class);
+        bind(OptionalLongParamConverterProvider.class).to(ParamConverterProvider.class).in(Singleton.class);
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalCookieParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalCookieParamResourceTest.java
@@ -28,7 +28,6 @@ public class OptionalCookieParamResourceTest extends JerseyTest {
     protected Application configure() {
         forceSet(TestProperties.CONTAINER_PORT, "0");
         return DropwizardResourceConfig.forTesting(new MetricRegistry())
-                .register(OptionalParamFeature.class)
                 .register(OptionalCookieParamResource.class)
                 .register(MyMessageParamConverterProvider.class);
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalDoubleMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalDoubleMessageBodyWriterTest.java
@@ -17,12 +17,12 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.util.Optional;
+import java.util.OptionalDouble;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
-public class OptionalMessageBodyWriterTest extends JerseyTest {
+public class OptionalDoubleMessageBodyWriterTest extends JerseyTest {
     static {
         BootstrapLogging.bootstrap();
     }
@@ -31,53 +31,52 @@ public class OptionalMessageBodyWriterTest extends JerseyTest {
     protected Application configure() {
         forceSet(TestProperties.CONTAINER_PORT, "0");
         return DropwizardResourceConfig.forTesting(new MetricRegistry())
-                .register(OptionalReturnResource.class);
+                .register(OptionalDoubleReturnResource.class);
     }
 
     @Test
     public void presentOptionalsReturnTheirValue() throws Exception {
         assertThat(target("optional-return")
-                .queryParam("id", "woo").request()
-                .get(String.class))
-                .isEqualTo("woo");
+                .queryParam("id", "1").request()
+                .get(Double.class))
+                .isEqualTo(1);
     }
 
     @Test
     public void presentOptionalsReturnTheirValueWithResponse() throws Exception {
         assertThat(target("optional-return/response-wrapped")
-                .queryParam("id", "woo").request()
-                .get(String.class))
-                .isEqualTo("woo");
+                .queryParam("id", "1").request()
+                .get(Double.class))
+                .isEqualTo(1);
     }
 
     @Test
     public void absentOptionalsThrowANotFound() throws Exception {
         try {
-            target("optional-return").request().get(String.class);
+            target("optional-return").request().get(Double.class);
             failBecauseExceptionWasNotThrown(WebApplicationException.class);
         } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus())
-                    .isEqualTo(404);
+            assertThat(e.getResponse().getStatus()).isEqualTo(404);
         }
     }
 
     @Path("optional-return")
     @Produces(MediaType.TEXT_PLAIN)
-    public static class OptionalReturnResource {
+    public static class OptionalDoubleReturnResource {
         @GET
-        public Optional<String> showWithQueryParam(@QueryParam("id") String id) {
-            return Optional.ofNullable(id);
+        public OptionalDouble showWithQueryParam(@QueryParam("id") OptionalDouble id) {
+            return id;
         }
 
         @POST
-        public Optional<String> showWithFormParam(@FormParam("id") String id) {
-            return Optional.ofNullable(id);
+        public OptionalDouble showWithFormParam(@FormParam("id") OptionalDouble id) {
+            return id;
         }
 
         @Path("response-wrapped")
         @GET
-        public Response showWithQueryParamResponse(@QueryParam("id") String id) {
-            return Response.ok(Optional.ofNullable(id)).build();
+        public Response showWithQueryParamResponse(@QueryParam("id") OptionalDouble id) {
+            return Response.ok(id).build();
         }
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalFormParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalFormParamResourceTest.java
@@ -32,7 +32,6 @@ public class OptionalFormParamResourceTest extends JerseyTest {
     protected Application configure() {
         forceSet(TestProperties.CONTAINER_PORT, "0");
         return DropwizardResourceConfig.forTesting(new MetricRegistry())
-                .register(OptionalParamFeature.class)
                 .register(OptionalFormParamResource.class)
                 .register(MyMessageParamConverterProvider.class);
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalHeaderParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalHeaderParamResourceTest.java
@@ -28,7 +28,6 @@ public class OptionalHeaderParamResourceTest extends JerseyTest {
     protected Application configure() {
         forceSet(TestProperties.CONTAINER_PORT, "0");
         return DropwizardResourceConfig.forTesting(new MetricRegistry())
-                .register(OptionalParamFeature.class)
                 .register(OptionalHeaderParamResource.class)
                 .register(MyMessageParamConverterProvider.class);
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalIntMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalIntMessageBodyWriterTest.java
@@ -17,12 +17,12 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.util.Optional;
+import java.util.OptionalInt;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
-public class OptionalMessageBodyWriterTest extends JerseyTest {
+public class OptionalIntMessageBodyWriterTest extends JerseyTest {
     static {
         BootstrapLogging.bootstrap();
     }
@@ -31,53 +31,52 @@ public class OptionalMessageBodyWriterTest extends JerseyTest {
     protected Application configure() {
         forceSet(TestProperties.CONTAINER_PORT, "0");
         return DropwizardResourceConfig.forTesting(new MetricRegistry())
-                .register(OptionalReturnResource.class);
+                .register(OptionalIntReturnResource.class);
     }
 
     @Test
     public void presentOptionalsReturnTheirValue() throws Exception {
         assertThat(target("optional-return")
-                .queryParam("id", "woo").request()
-                .get(String.class))
-                .isEqualTo("woo");
+                .queryParam("id", "1").request()
+                .get(Integer.class))
+                .isEqualTo(1);
     }
 
     @Test
     public void presentOptionalsReturnTheirValueWithResponse() throws Exception {
         assertThat(target("optional-return/response-wrapped")
-                .queryParam("id", "woo").request()
-                .get(String.class))
-                .isEqualTo("woo");
+                .queryParam("id", "1").request()
+                .get(Integer.class))
+                .isEqualTo(1);
     }
 
     @Test
     public void absentOptionalsThrowANotFound() throws Exception {
         try {
-            target("optional-return").request().get(String.class);
+            target("optional-return").request().get(Integer.class);
             failBecauseExceptionWasNotThrown(WebApplicationException.class);
         } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus())
-                    .isEqualTo(404);
+            assertThat(e.getResponse().getStatus()).isEqualTo(404);
         }
     }
 
     @Path("optional-return")
     @Produces(MediaType.TEXT_PLAIN)
-    public static class OptionalReturnResource {
+    public static class OptionalIntReturnResource {
         @GET
-        public Optional<String> showWithQueryParam(@QueryParam("id") String id) {
-            return Optional.ofNullable(id);
+        public OptionalInt showWithQueryParam(@QueryParam("id") OptionalInt id) {
+            return id;
         }
 
         @POST
-        public Optional<String> showWithFormParam(@FormParam("id") String id) {
-            return Optional.ofNullable(id);
+        public OptionalInt showWithFormParam(@FormParam("id") OptionalInt id) {
+            return id;
         }
 
         @Path("response-wrapped")
         @GET
-        public Response showWithQueryParamResponse(@QueryParam("id") String id) {
-            return Response.ok(Optional.ofNullable(id)).build();
+        public Response showWithQueryParamResponse(@QueryParam("id") OptionalInt id) {
+            return Response.ok(id).build();
         }
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalLongMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalLongMessageBodyWriterTest.java
@@ -17,12 +17,12 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.util.Optional;
+import java.util.OptionalLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
-public class OptionalMessageBodyWriterTest extends JerseyTest {
+public class OptionalLongMessageBodyWriterTest extends JerseyTest {
     static {
         BootstrapLogging.bootstrap();
     }
@@ -31,53 +31,52 @@ public class OptionalMessageBodyWriterTest extends JerseyTest {
     protected Application configure() {
         forceSet(TestProperties.CONTAINER_PORT, "0");
         return DropwizardResourceConfig.forTesting(new MetricRegistry())
-                .register(OptionalReturnResource.class);
+                .register(OptionalLongReturnResource.class);
     }
 
     @Test
     public void presentOptionalsReturnTheirValue() throws Exception {
         assertThat(target("optional-return")
-                .queryParam("id", "woo").request()
-                .get(String.class))
-                .isEqualTo("woo");
+                .queryParam("id", "1").request()
+                .get(Long.class))
+                .isEqualTo(1L);
     }
 
     @Test
     public void presentOptionalsReturnTheirValueWithResponse() throws Exception {
         assertThat(target("optional-return/response-wrapped")
-                .queryParam("id", "woo").request()
-                .get(String.class))
-                .isEqualTo("woo");
+                .queryParam("id", "1").request()
+                .get(Long.class))
+                .isEqualTo(1L);
     }
 
     @Test
     public void absentOptionalsThrowANotFound() throws Exception {
         try {
-            target("optional-return").request().get(String.class);
+            target("optional-return").request().get(Long.class);
             failBecauseExceptionWasNotThrown(WebApplicationException.class);
         } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus())
-                    .isEqualTo(404);
+            assertThat(e.getResponse().getStatus()).isEqualTo(404);
         }
     }
 
     @Path("optional-return")
     @Produces(MediaType.TEXT_PLAIN)
-    public static class OptionalReturnResource {
+    public static class OptionalLongReturnResource {
         @GET
-        public Optional<String> showWithQueryParam(@QueryParam("id") String id) {
-            return Optional.ofNullable(id);
+        public OptionalLong showWithQueryParam(@QueryParam("id") OptionalLong id) {
+            return id;
         }
 
         @POST
-        public Optional<String> showWithFormParam(@FormParam("id") String id) {
-            return Optional.ofNullable(id);
+        public OptionalLong showWithFormParam(@FormParam("id") OptionalLong id) {
+            return id;
         }
 
         @Path("response-wrapped")
         @GET
-        public Response showWithQueryParamResponse(@QueryParam("id") String id) {
-            return Response.ok(Optional.ofNullable(id)).build();
+        public Response showWithQueryParamResponse(@QueryParam("id") OptionalLong id) {
+            return Response.ok(id).build();
         }
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalQueryParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalQueryParamResourceTest.java
@@ -28,7 +28,6 @@ public class OptionalQueryParamResourceTest extends JerseyTest {
     protected Application configure() {
         forceSet(TestProperties.CONTAINER_PORT, "0");
         return DropwizardResourceConfig.forTesting(new MetricRegistry())
-                .register(OptionalParamFeature.class)
                 .register(OptionalQueryParamResource.class)
                 .register(MyMessageParamConverterProvider.class);
     }

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/BaseValidator.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/BaseValidator.java
@@ -1,6 +1,9 @@
 package io.dropwizard.validation;
 
 import io.dropwizard.validation.valuehandling.GuavaOptionalValidatedValueUnwrapper;
+import io.dropwizard.validation.valuehandling.OptionalDoubleValidatedValueUnwrapper;
+import io.dropwizard.validation.valuehandling.OptionalIntValidatedValueUnwrapper;
+import io.dropwizard.validation.valuehandling.OptionalLongValidatedValueUnwrapper;
 import io.dropwizard.validation.valuehandling.OptionalValidatedValueUnwrapper;
 import org.hibernate.validator.HibernateValidator;
 import org.hibernate.validator.HibernateValidatorConfiguration;
@@ -28,6 +31,9 @@ public class BaseValidator {
             .byProvider(HibernateValidator.class)
             .configure()
             .addValidatedValueHandler(new GuavaOptionalValidatedValueUnwrapper())
-            .addValidatedValueHandler(new OptionalValidatedValueUnwrapper());
+            .addValidatedValueHandler(new OptionalValidatedValueUnwrapper())
+            .addValidatedValueHandler(new OptionalDoubleValidatedValueUnwrapper())
+            .addValidatedValueHandler(new OptionalIntValidatedValueUnwrapper())
+            .addValidatedValueHandler(new OptionalLongValidatedValueUnwrapper());
     }
 }

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/valuehandling/OptionalDoubleValidatedValueUnwrapper.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/valuehandling/OptionalDoubleValidatedValueUnwrapper.java
@@ -1,0 +1,23 @@
+package io.dropwizard.validation.valuehandling;
+
+import org.hibernate.validator.spi.valuehandling.ValidatedValueUnwrapper;
+
+import java.lang.reflect.Type;
+import java.util.OptionalDouble;
+
+/**
+ * A {@link ValidatedValueUnwrapper} for {@link OptionalDouble}.
+ *
+ * Extracts the value contained by the {@link OptionalDouble} for validation, or produces {@code null}.
+ */
+public class OptionalDoubleValidatedValueUnwrapper extends ValidatedValueUnwrapper<OptionalDouble> {
+    @Override
+    public Object handleValidatedValue(final OptionalDouble optional) {
+        return optional.isPresent() ? optional.getAsDouble() : null;
+    }
+
+    @Override
+    public Type getValidatedValueType(final Type type) {
+        return Double.class;
+    }
+}

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/valuehandling/OptionalIntValidatedValueUnwrapper.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/valuehandling/OptionalIntValidatedValueUnwrapper.java
@@ -1,0 +1,23 @@
+package io.dropwizard.validation.valuehandling;
+
+import org.hibernate.validator.spi.valuehandling.ValidatedValueUnwrapper;
+
+import java.lang.reflect.Type;
+import java.util.OptionalInt;
+
+/**
+ * A {@link ValidatedValueUnwrapper} for {@link OptionalInt}.
+ *
+ * Extracts the value contained by the {@link OptionalInt} for validation, or produces {@code null}.
+ */
+public class OptionalIntValidatedValueUnwrapper extends ValidatedValueUnwrapper<OptionalInt> {
+    @Override
+    public Object handleValidatedValue(final OptionalInt optional) {
+        return optional.isPresent() ? optional.getAsInt() : null;
+    }
+
+    @Override
+    public Type getValidatedValueType(final Type type) {
+        return Integer.class;
+    }
+}

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/valuehandling/OptionalLongValidatedValueUnwrapper.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/valuehandling/OptionalLongValidatedValueUnwrapper.java
@@ -1,0 +1,23 @@
+package io.dropwizard.validation.valuehandling;
+
+import org.hibernate.validator.spi.valuehandling.ValidatedValueUnwrapper;
+
+import java.lang.reflect.Type;
+import java.util.OptionalLong;
+
+/**
+ * A {@link ValidatedValueUnwrapper} for {@link OptionalLong}.
+ *
+ * Extracts the value contained by the {@link OptionalLong} for validation, or produces {@code null}.
+ */
+public class OptionalLongValidatedValueUnwrapper extends ValidatedValueUnwrapper<OptionalLong> {
+    @Override
+    public Object handleValidatedValue(final OptionalLong optional) {
+        return optional.isPresent() ? optional.getAsLong() : null;
+    }
+
+    @Override
+    public Type getValidatedValueType(final Type type) {
+        return Long.class;
+    }
+}

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/valuehandling/OptionalDoubleValidatedValueUnwrapperTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/valuehandling/OptionalDoubleValidatedValueUnwrapperTest.java
@@ -1,0 +1,67 @@
+package io.dropwizard.validation.valuehandling;
+
+import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.valuehandling.UnwrapValidatedValue;
+import org.junit.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OptionalDoubleValidatedValueUnwrapperTest {
+
+    public static class Example {
+        @Min(3)
+        @UnwrapValidatedValue
+        public OptionalDouble three = OptionalDouble.empty();
+
+        @NotNull
+        @UnwrapValidatedValue
+        public OptionalDouble notNull = OptionalDouble.of(123.456D);
+    }
+
+    private final Validator validator = Validation
+        .byProvider(HibernateValidator.class)
+        .configure()
+        .addValidatedValueHandler(new OptionalDoubleValidatedValueUnwrapper())
+        .buildValidatorFactory()
+        .getValidator();
+
+    @Test
+    public void succeedsWhenAbsent() {
+        Example example = new Example();
+        Set<ConstraintViolation<Example>> violations = validator.validate(example);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void failsWhenFailingConstraint() {
+        Example example = new Example();
+        example.three = OptionalDouble.of(2);
+        Set<ConstraintViolation<Example>> violations = validator.validate(example);
+        assertThat(violations).hasSize(1);
+    }
+
+    @Test
+    public void succeedsWhenConstraintsMet() {
+        Example example = new Example();
+        example.three = OptionalDouble.of(10);
+        Set<ConstraintViolation<Example>> violations = validator.validate(example);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void notNullFailsWhenAbsent() {
+        Example example = new Example();
+        example.notNull = OptionalDouble.empty();
+        Set<ConstraintViolation<Example>> violations = validator.validate(example);
+        assertThat(violations).hasSize(1);
+    }
+}

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/valuehandling/OptionalIntValidatedValueUnwrapperTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/valuehandling/OptionalIntValidatedValueUnwrapperTest.java
@@ -1,0 +1,66 @@
+package io.dropwizard.validation.valuehandling;
+
+import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.valuehandling.UnwrapValidatedValue;
+import org.junit.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import java.util.OptionalInt;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OptionalIntValidatedValueUnwrapperTest {
+
+    public static class Example {
+        @Min(3)
+        @UnwrapValidatedValue
+        public OptionalInt three = OptionalInt.empty();
+
+        @NotNull
+        @UnwrapValidatedValue
+        public OptionalInt notNull = OptionalInt.of(123);
+    }
+
+    private final Validator validator = Validation
+        .byProvider(HibernateValidator.class)
+        .configure()
+        .addValidatedValueHandler(new OptionalIntValidatedValueUnwrapper())
+        .buildValidatorFactory()
+        .getValidator();
+
+    @Test
+    public void succeedsWhenAbsent() {
+        Example example = new Example();
+        Set<ConstraintViolation<Example>> violations = validator.validate(example);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void failsWhenFailingConstraint() {
+        Example example = new Example();
+        example.three = OptionalInt.of(2);
+        Set<ConstraintViolation<Example>> violations = validator.validate(example);
+        assertThat(violations).hasSize(1);
+    }
+
+    @Test
+    public void succeedsWhenConstraintsMet() {
+        Example example = new Example();
+        example.three = OptionalInt.of(10);
+        Set<ConstraintViolation<Example>> violations = validator.validate(example);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void notNullFailsWhenAbsent() {
+        Example example = new Example();
+        example.notNull = OptionalInt.empty();
+        Set<ConstraintViolation<Example>> violations = validator.validate(example);
+        assertThat(violations).hasSize(1);
+    }
+}

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/valuehandling/OptionalLongValidatedValueUnwrapperTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/valuehandling/OptionalLongValidatedValueUnwrapperTest.java
@@ -1,0 +1,66 @@
+package io.dropwizard.validation.valuehandling;
+
+import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.valuehandling.UnwrapValidatedValue;
+import org.junit.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import java.util.OptionalLong;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OptionalLongValidatedValueUnwrapperTest {
+
+    public static class Example {
+        @Min(3)
+        @UnwrapValidatedValue
+        public OptionalLong three = OptionalLong.empty();
+
+        @NotNull
+        @UnwrapValidatedValue
+        public OptionalLong notNull = OptionalLong.of(123456789L);
+    }
+
+    private final Validator validator = Validation
+        .byProvider(HibernateValidator.class)
+        .configure()
+        .addValidatedValueHandler(new OptionalLongValidatedValueUnwrapper())
+        .buildValidatorFactory()
+        .getValidator();
+
+    @Test
+    public void succeedsWhenAbsent() {
+        Example example = new Example();
+        Set<ConstraintViolation<Example>> violations = validator.validate(example);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void failsWhenFailingConstraint() {
+        Example example = new Example();
+        example.three = OptionalLong.of(2);
+        Set<ConstraintViolation<Example>> violations = validator.validate(example);
+        assertThat(violations).hasSize(1);
+    }
+
+    @Test
+    public void succeedsWhenConstraintsMet() {
+        Example example = new Example();
+        example.three = OptionalLong.of(10);
+        Set<ConstraintViolation<Example>> violations = validator.validate(example);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void notNullFailsWhenAbsent() {
+        Example example = new Example();
+        example.notNull = OptionalLong.empty();
+        Set<ConstraintViolation<Example>> violations = validator.validate(example);
+        assertThat(violations).hasSize(1);
+    }
+}


### PR DESCRIPTION
This PR adds `ValidatedValueUnwrapper`, `ParamConverter`, and `MessageBodyWriter` implementations for `OptionalDouble`, `OptionalInt`, and `OptionalLong` to be consistent with the already existing `GuavaOptionalValidatedValueUnwrapper` and `OptionalValidatedValueUnwrapper` classes.

Fixes #1447