### PR TITLE
Upgrade to Jackson 2.7.1

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -33,7 +33,7 @@ v1.0.0
 * Upgraded to Hibernate 5.0.7 `#1429 <https://github.com/dropwizard/dropwizard/pull/1429>`_
 * Upgraded to Hibernate Validator 5.2.4.Final
 * Upgraded to Jadira Usertype Core 5.0.0.GA
-* Upgraded to Jackson 2.6.5
+* Upgraded to Jackson 2.7.1
 * Upgraded to JDBI 2.71 `#1358 <https://github.com/dropwizard/dropwizard/pull/1358>`_
 * Upgraded to Jersey 2.22.2
 * Upgraded to Jetty 9.3.7.v20160115 `#1330 <https://github.com/dropwizard/dropwizard/pull/1330>`_

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -24,8 +24,8 @@
         <dropwizard.version>${project.version}</dropwizard.version>
         <guava.version>19.0</guava.version>
         <jersey.version>2.22.2</jersey.version>
-        <jackson.api.version>2.6.0</jackson.api.version>
-        <jackson.version>2.6.5</jackson.version>
+        <jackson.api.version>2.7.0</jackson.api.version>
+        <jackson.version>2.7.2</jackson.version>
         <jetty.version>9.3.7.v20160115</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics3.version>3.1.2</metrics3.version>
@@ -295,11 +295,6 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-jdk7</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>

--- a/dropwizard-jackson/pom.xml
+++ b/dropwizard-jackson/pom.xml
@@ -46,10 +46,6 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jdk7</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-guava</artifactId>
         </dependency>
         <dependency>

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
@@ -3,7 +3,6 @@ package io.dropwizard.jackson;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.fasterxml.jackson.datatype.jdk7.Jdk7Module;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -58,7 +57,6 @@ public class Jackson {
         mapper.registerModule(new JodaModule());
         mapper.registerModule(new AfterburnerModule());
         mapper.registerModule(new FuzzyEnumModule());
-        mapper.registerModule(new Jdk7Module());
         mapper.registerModules(new Jdk8Module());
         mapper.registerModules(new JavaTimeModule());
         mapper.setPropertyNamingStrategy(new AnnotationSensitivePropertyNamingStrategy());


### PR DESCRIPTION
This PR upgrades dropwizard-jackson to Jackson 2.7.1.

Release notes: https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.7