### PR TITLE
Handle redirect in WebApplicationException response

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/LoggingExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/LoggingExceptionMapper.java
@@ -21,7 +21,11 @@ public abstract class LoggingExceptionMapper<E extends Throwable> implements Exc
 
         if (exception instanceof WebApplicationException) {
             final Response response = ((WebApplicationException) exception).getResponse();
-            if (response.getStatusInfo().getFamily().equals(Response.Status.Family.SERVER_ERROR)) {
+            Response.Status.Family family = response.getStatusInfo().getFamily();
+            if (family.equals(Response.Status.Family.REDIRECTION)) {
+                return response;
+            }
+            if (family.equals(Response.Status.Family.SERVER_ERROR)) {
                 logException(exception);
             }
             status = response.getStatus();

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/ExceptionResource.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/ExceptionResource.java
@@ -8,7 +8,9 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
 import java.io.IOException;
+import java.net.URI;
 
 @Path("/exception/")
 @Produces(MediaType.APPLICATION_JSON)
@@ -28,5 +30,18 @@ public class ExceptionResource {
     @Path("web-application-exception")
     public void webApplicationException() throws WebApplicationException {
         throw new WebApplicationException("KAPOW", Response.Status.BAD_REQUEST);
+    }
+
+    @GET
+    @Path("web-application-exception-with-redirect")
+    public void webApplicationExceptionWithRedirect() throws WebApplicationException {
+        URI redirectPath = UriBuilder.fromPath("/exception/redirect-target").build();
+        throw new WebApplicationException(Response.seeOther(redirectPath).build());
+    }
+
+    @GET
+    @Path("redirect-target")
+    public Response redirectTarget() {
+        return Response.ok().entity("{\"status\":\"OK\"}").build();
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/LoggingExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/LoggingExceptionMapperTest.java
@@ -69,4 +69,12 @@ public class LoggingExceptionMapperTest extends JerseyTest {
             assertThat(response.readEntity(String.class)).isEqualTo("{\"code\":400,\"message\":\"KAPOW\"}");
         }
     }
+
+    @Test
+    public void handlesRedirectInWebApplicationException() {
+        String responseText = target("/exception/web-application-exception-with-redirect")
+            .request(MediaType.APPLICATION_JSON)
+            .get(String.class);
+        assertThat(responseText).isEqualTo("{\"status\":\"OK\"}");
+    }
 }


### PR DESCRIPTION
The change to "[Format WebApplicationException](https://github.com/dropwizard/dropwizard/commit/930443a5bc5760c3319bedf7b36e13810bf0dd8e#diff-235351c1b64afb2dba6188b2bd0c5386)" introduced a regression: namely, if the response contained within the WebApplicationException is a redirect, the redirect no longer works. Instead, a JSON entity is returned instead.

This change restores the previous behaviour for redirects in the WebApplicationException response.