### PR TITLE
Allow selection of `TCP` or `UDP` for Graphite Reporter

### DIFF
--- a/dropwizard-metrics-graphite/src/test/java/io/dropwizard/metrics/graphite/GraphiteReporterFactoryTest.java
+++ b/dropwizard-metrics-graphite/src/test/java/io/dropwizard/metrics/graphite/GraphiteReporterFactoryTest.java
@@ -3,6 +3,7 @@ package io.dropwizard.metrics.graphite;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.graphite.Graphite;
 import com.codahale.metrics.graphite.GraphiteReporter;
+import com.codahale.metrics.graphite.GraphiteUDP;
 import com.google.common.base.Optional;
 import io.dropwizard.configuration.ConfigurationFactory;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
@@ -17,6 +18,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public class GraphiteReporterFactoryTest {
+
+    private final GraphiteReporter.Builder builderSpy = mock(GraphiteReporter.Builder.class);
+
+    private GraphiteReporterFactory graphiteReporterFactory = new GraphiteReporterFactory() {
+        @Override
+        protected GraphiteReporter.Builder builder(MetricRegistry registry) {
+            return builderSpy;
+        }
+    };
 
     @Test
     public void isDiscoverable() throws Exception {
@@ -34,13 +44,7 @@ public class GraphiteReporterFactoryTest {
 
     @Test
     public void testNoAddressResolutionForGraphite() throws Exception {
-        final GraphiteReporter.Builder builderSpy = mock(GraphiteReporter.Builder.class);
-        new GraphiteReporterFactory() {
-            @Override
-            protected GraphiteReporter.Builder builder(MetricRegistry registry) {
-                return builderSpy;
-            }
-        }.build(new MetricRegistry());
+        graphiteReporterFactory.build(new MetricRegistry());
 
         final ArgumentCaptor<Graphite> argument = ArgumentCaptor.forClass(Graphite.class);
         verify(builderSpy).build(argument.capture());
@@ -49,6 +53,28 @@ public class GraphiteReporterFactoryTest {
         assertThat(getField(graphite, "hostname")).isEqualTo("localhost");
         assertThat(getField(graphite, "port")).isEqualTo(8080);
         assertThat(getField(graphite, "address")).isNull();
+    }
+
+    @Test
+    public void testCorrectTransportForGraphiteUDP() throws Exception {
+        graphiteReporterFactory.setTransport("udp");
+        graphiteReporterFactory.build(new MetricRegistry());
+
+        final ArgumentCaptor<GraphiteUDP> argument = ArgumentCaptor.forClass(GraphiteUDP.class);
+        verify(builderSpy).build(argument.capture());
+
+        final GraphiteUDP graphite = argument.getValue();
+        assertThat(getField(graphite, "hostname")).isEqualTo("localhost");
+        assertThat(getField(graphite, "port")).isEqualTo(8080);
+        assertThat(getField(graphite, "address")).isNull();
+    }
+
+    private static Object getField(GraphiteUDP graphite, String name) {
+        try {
+            return FieldUtils.getDeclaredField(GraphiteUDP.class, name, true).get(graphite);
+        } catch (IllegalAccessException e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     private static Object getField(Graphite graphite, String name) {


### PR DESCRIPTION
 - allows usage of TCP or UDP graphite reporter from metrics lib

Welcome to feedback. I only tackled the UDP/TCP variant to start. Likely, other graphite reports (pickle, rabbitmq) would be separate reporter factory/config options