### PR TITLE
Upgrade to Jackson 2.7.3

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -24,8 +24,8 @@
         <dropwizard.version>${project.version}</dropwizard.version>
         <guava.version>19.0</guava.version>
         <jersey.version>2.22.2</jersey.version>
-        <jackson.api.version>2.6.0</jackson.api.version>
-        <jackson.version>2.6.5</jackson.version>
+        <jackson.api.version>2.7.3</jackson.api.version>
+        <jackson.version>2.7.3</jackson.version>
         <jetty.version>9.3.7.v20160115</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics3.version>3.1.2</metrics3.version>

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryTest.java
@@ -425,8 +425,8 @@ public class ConfigurationFactoryTest {
             factory.build(resourceFileName);
             fail("Should print a detailed error on a malformed YAML file");
         } catch (Exception e) {
-            assertThat(e.getMessage()).isEqualTo(resourceFileName + " has an error:" + NEWLINE +
-                    "  * Malformed YAML at line: 2, column: 21; while parsing a flow sequence\n" +
+            assertThat(e.getMessage()).isEqualTo(
+                    "YAML decoding problem: while parsing a flow sequence\n" +
                     " in 'reader', line 2, column 7:\n" +
                     "    type: [ coder,wizard\n" +
                     "          ^\n" +

--- a/dropwizard-jackson/pom.xml
+++ b/dropwizard-jackson/pom.xml
@@ -46,10 +46,6 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jdk7</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-guava</artifactId>
         </dependency>
         <dependency>

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/AnnotationSensitivePropertyNamingStrategy.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/AnnotationSensitivePropertyNamingStrategy.java
@@ -15,11 +15,11 @@ import com.fasterxml.jackson.databind.introspect.AnnotatedParameter;
 public class AnnotationSensitivePropertyNamingStrategy extends PropertyNamingStrategy {
     private static final long serialVersionUID = -1372862028366311230L;
 
-    private final LowerCaseWithUnderscoresStrategy snakeCase;
+    private final SnakeCaseStrategy snakeCase;
 
     public AnnotationSensitivePropertyNamingStrategy() {
         super();
-        this.snakeCase = new LowerCaseWithUnderscoresStrategy();
+        this.snakeCase = new SnakeCaseStrategy();
     }
 
     @Override

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
@@ -3,7 +3,6 @@ package io.dropwizard.jackson;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.fasterxml.jackson.datatype.jdk7.Jdk7Module;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -58,7 +57,6 @@ public class Jackson {
         mapper.registerModule(new JodaModule());
         mapper.registerModule(new AfterburnerModule());
         mapper.registerModule(new FuzzyEnumModule());
-        mapper.registerModule(new Jdk7Module());
         mapper.registerModules(new Jdk8Module());
         mapper.registerModules(new JavaTimeModule());
         mapper.setPropertyNamingStrategy(new AnnotationSensitivePropertyNamingStrategy());

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonTest.java
@@ -5,6 +5,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class JacksonTest
@@ -24,5 +28,18 @@ public class JacksonTest
 
         assertThat(mapper.getFactory()).isNotNull();
     }
+
+    @Test
+    public void objectMapperCanDeserializeJdk7Types() throws IOException {
+        final LogMetadata metadata = Jackson.newObjectMapper()
+            .readValue("{\"path\": \"/var/log/app/server.log\"}", LogMetadata.class);
+        assertThat(metadata).isNotNull();
+        assertThat(metadata.path).isEqualTo(Paths.get("/var/log/app/server.log"));
+    }
+
+     static class LogMetadata {
+
+         public Path path;
+     }
 
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/ExceptionResource.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/ExceptionResource.java
@@ -10,6 +10,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import java.io.IOException;
+import java.io.StringReader;
 import java.net.URI;
 
 @Path("/exception/")
@@ -23,7 +24,7 @@ public class ExceptionResource {
     @GET
     @Path("json-mapping-exception")
     public void jsonMappingException() throws JsonMappingException {
-        throw new JsonMappingException("BOOM");
+        throw new JsonMappingException(new StringReader(""), "BOOM");
     }
 
     @GET


### PR DESCRIPTION
* Upgrade to the latest Jackson version that correctly handle subtyping
* Remove JDK7 module, because it has been merged to jackson-databind
* Upgrade deprecated API
* Fix the test for printing a detailed YAML parsing error

See the discussion of the previous update attempt in issue #1449.