### PR TITLE
Support importing and overriding multiple configuration files

### DIFF
--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryTest.java
@@ -130,6 +130,7 @@ public class ConfigurationFactoryTest {
     private File emptyFile;
     private File invalidFile;
     private File validFile;
+    private File importingFile;
 
     private static File resourceFileName(String resourceName) throws URISyntaxException {
         return new File(Resources.getResource(resourceName).toURI());
@@ -151,6 +152,7 @@ public class ConfigurationFactoryTest {
         this.emptyFile = resourceFileName("factory-test-empty.yml");
         this.invalidFile = resourceFileName("factory-test-invalid.yml");
         this.validFile = resourceFileName("factory-test-valid.yml");
+        this.importingFile = resourceFileName("factory-test-importing.yml");
     }
 
     @Test
@@ -372,6 +374,13 @@ public class ConfigurationFactoryTest {
         assertThat(example.servers.get(0).getPort()).isEqualTo(8080);
         assertThat(example.servers.get(1).getPort()).isEqualTo(8081);
         assertThat(example.servers.get(2).getPort()).isEqualTo(8082);
+    }
+
+    @Test
+    public void importConfigurationFile() throws Exception {
+        final Example example = factory.build(importingFile);
+
+        assertThat(example.getName()).isEqualTo("Coda Hale");
     }
 
     @Test

--- a/dropwizard-configuration/src/test/resources/factory-test-importing.yml
+++ b/dropwizard-configuration/src/test/resources/factory-test-importing.yml
@@ -1,0 +1,4 @@
+imports:
+ - factory-test-valid.yml
+
+name: "Importing Coda Hale"

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/JsonUtil.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/JsonUtil.java
@@ -1,0 +1,35 @@
+package io.dropwizard.jackson;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.util.Iterator;
+
+public class JsonUtil {
+
+    private JsonUtil() {
+        // Static helper class
+    }
+
+    public static JsonNode merge(JsonNode extendedNode, JsonNode mergedNode) {
+        Iterator<String> fieldNames = mergedNode.fieldNames();
+        while (fieldNames.hasNext()) {
+            String fieldName = fieldNames.next();
+            JsonNode jsonNode = extendedNode.get(fieldName);
+
+            // if field exists and is an embedded object
+            if (jsonNode != null && jsonNode.isObject()) {
+                merge(jsonNode, mergedNode.get(fieldName));
+            } else {
+                if (extendedNode instanceof ObjectNode) {
+                    // Overwrite field
+                    JsonNode value = mergedNode.get(fieldName);
+                    ((ObjectNode) extendedNode).replace(fieldName, value);
+                }
+            }
+
+        }
+
+        return extendedNode;
+    }
+}


### PR DESCRIPTION
Hi,

this is a quick PoC implementation of https://github.com/dropwizard/dropwizard/issues/125
The issue was closed, but I think the feature could be introduced without adding too much complexity. I deliberately ignored some details such as other paths then files in the quick prototype, but those could be added by specifying the type of the import.

The merging of the configs is done early on the JsonNode level, with same semantics as implementations of extending objects like `$.extends`.

Stuff to add:
- [ ] Circular deps check
- [ ] Different resource path types (URL, resource, file path)
- [ ] Test coverage

Would this feature be considered to be accepted? I'll gladly put in more work on it.


The use case would be:

`base.yml`:
```yml
database:
    driverClass: org.postgresql.Driver
    logValidationErrors: true
```

`dev.yml`:
```yml
import:
   - base.yml

database:
   user: postgres
```

`prod.yml`:
```yml
imports:
   - base.yml

database:
   user: ${PROD_DB_USER}
   logValidationErrors: false
```

Running the app with `prod.yml` would result in configuration loaded as:
```yml
database:
    driverClass: org.postgresql.Driver
    user: ${PROD_DB_USER}
    logValidationErrors: false # Overridden the value from base
```