### PR TITLE
Revise code example in docs for testing non-junit

### DIFF
--- a/docs/source/manual/testing.rst
+++ b/docs/source/manual/testing.rst
@@ -382,7 +382,7 @@ By creating a DropwizardTestSupport instance in your test you can manually start
 
         @Test
         public void loginHandlerRedirectsAfterPost() {
-            Client client = new JerseyClientBuilder(SUPPORT.getEnvironment()).build("test client");
+            Client client = new JerseyClientBuilder().build();
 
             Response response = client.target(
                      String.format("http://localhost:%d/login", SUPPORT.getLocalPort()))

--- a/docs/source/manual/testing.rst
+++ b/docs/source/manual/testing.rst
@@ -326,7 +326,10 @@ The ``DropwizardClientRule`` takes care of:
 Integration Testing
 ===================
 
-It can be useful to start up your entire app and hit it with real HTTP requests during testing.
+It can be useful to start up your entire application and hit it with real HTTP requests during testing.
+The ``dropwizard-testing`` module offers helper classes for your easily doing so.
+The optional ``dropwizard-client`` module offers more helpers, e.g. a custom JerseyClientBuilder,
+which is aware of your application's environment.
 
 JUnit
 -----
@@ -367,7 +370,7 @@ By creating a DropwizardTestSupport instance in your test you can manually start
         public static final DropwizardTestSupport<TestConfiguration> SUPPORT =
                 new DropwizardTestSupport<TestConfiguration>(MyApp.class,
                     ResourceHelpers.resourceFilePath("my-app-config.yaml"),
-                    ConfigOverride.config("server.applicationConnectors[0].port", "0") // create random port
+                    ConfigOverride.config("server.applicationConnectors[0].port", "0") // Optional, if not using a separate testing-specific configuration file, use a randomly selected port
                 );
 
         @BeforeClass
@@ -382,7 +385,7 @@ By creating a DropwizardTestSupport instance in your test you can manually start
 
         @Test
         public void loginHandlerRedirectsAfterPost() {
-            Client client = new JerseyClientBuilder().build();
+            Client client = new JerseyClientBuilder(SUPPORT.getEnvironment()).build("test client");
 
             Response response = client.target(
                      String.format("http://localhost:%d/login", SUPPORT.getLocalPort()))

--- a/docs/source/manual/testing.rst
+++ b/docs/source/manual/testing.rst
@@ -365,16 +365,19 @@ By creating a DropwizardTestSupport instance in your test you can manually start
     public class LoginAcceptanceTest {
 
         public static final DropwizardTestSupport<TestConfiguration> SUPPORT =
-                new DropwizardTestSupport<TestConfiguration>(MyApp.class, ResourceHelpers.resourceFilePath("my-app-config.yaml"));
+                new DropwizardTestSupport<TestConfiguration>(MyApp.class,
+                    ResourceHelpers.resourceFilePath("my-app-config.yaml"),
+                    ConfigOverride.config("server.applicationConnectors[0].port", "0") // create random port
+                );
 
         @BeforeClass
         public void beforeClass() {
-          SUPPORT.before();
+            SUPPORT.before();
         }
 
         @AfterClass
         public void afterClass() {
-          SUPPORT.after();
+            SUPPORT.after();
         }
 
         @Test
@@ -382,7 +385,7 @@ By creating a DropwizardTestSupport instance in your test you can manually start
             Client client = new JerseyClientBuilder(SUPPORT.getEnvironment()).build("test client");
 
             Response response = client.target(
-                     String.format("http://localhost:%d/login", RULE.getLocalPort()))
+                     String.format("http://localhost:%d/login", SUPPORT.getLocalPort()))
                     .request()
                     .post(Entity.json(loginForm()));
 


### PR DESCRIPTION
Hi,

after reading the docs of 0.9.2, I've tried the given example for non-junit tests.
In my case I'm using TestNG.
Unfortunately the give code doesn't compile and there where 'BindException'
because port 8080 was already in use.

So I've added an overriding config to get a random port and I fixed the wrong var-name.
Additionally I removed the parameter from JerseyClientBuilder,
because 'environment' and 'test-name' aren't supported.
My tests are running fine without them, but I have to admit,
that I'm not using any "special" Jackson mappings.

Feedback is always welcome.

Kind regards
Martin