### PR TITLE
Fixed broken or outdated links

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -83,7 +83,7 @@ you ship more quickly and with fewer regrets.
 * Guava_, which, in addition to highly optimized immutable data structures, provides a growing
   number of classes to speed up development in Java.
 * Logback_ and slf4j_ for performant and flexible logging.
-* `Hibernate Validator`_, the `JSR-349`_ reference implementation, provides an easy, declarative
+* `Hibernate Validator`_, the `JSR 349`_ reference implementation, provides an easy, declarative
   framework for validating user input and generating helpful and i18n-friendly error messages.
 * The `Apache HttpClient`_ and Jersey_ client libraries allow for both low- and high-level
   interaction with other web services.
@@ -93,11 +93,11 @@ you ship more quickly and with fewer regrets.
 * Freemarker_ and Mustache_ are simple templating systems for more user-facing applications.
 * `Joda Time`_ is a very complete, sane library for handling dates and times.
 
-.. _Guava: http://code.google.com/p/guava-libraries/
+.. _Guava: https://github.com/google/guava
 .. _Logback: http://logback.qos.ch/
 .. _slf4j: http://www.slf4j.org/
 .. _Hibernate Validator: http://www.hibernate.org/subprojects/validator.html
-.. _JSR-349: http://jcp.org/en/jsr/detail?id=349
+.. _JSR 349: http://jcp.org/en/jsr/detail?id=349
 .. _Apache HttpClient: http://hc.apache.org/httpcomponents-client-ga/index.html
 .. _JDBI: http://www.jdbi.org
 .. _Liquibase: http://www.liquibase.org
@@ -123,7 +123,7 @@ we go through this example application. If you have any questions about how Mave
 .. _Buildr: http://buildr.apache.org/
 .. _Gradle: http://www.gradle.org/
 .. _SBT: https://github.com/harrah/xsbt/wiki
-.. _Gant: http://gant.codehaus.org/
+.. _Gant: https://github.com/Gant/Gant
 .. _Leiningen: https://github.com/technomancy/leiningen
 .. __: http://www.sonatype.com/books/mvnref-book/reference/
 


### PR DESCRIPTION
- link to JSR 349 did not render correctly, removed hyphen (which seems
  to be the official variant anyway)
- fixed broken link to Gant (codehaus shut down)
- use updated link to Guava (Google Code shut down)