### PR TITLE
Update on README.md in dropwizard-archetypes

### DIFF
--- a/dropwizard-archetypes/README.md
+++ b/dropwizard-archetypes/README.md
@@ -7,4 +7,4 @@ How to create project using dropwizard archetype (interactive mode)
 mvn archetype:generate -DarchetypeGroupId=io.dropwizard.archetypes -DarchetypeArtifactId=java-simple -DarchetypeVersion=[REPLACE ME WITH A VALID DROPWIZARD VERSION]
 ```
 
-(when asked for $name during project creation via maven, make sure to use a camel case word such as HelloWorld as it is used to generate Configuration and Application classess such as HelloWorldConfiguration.java and HelloWorldApplication.java. Furthermore, do not include any blank space for the same reason!)
+(when asked for **$name** during project creation via maven, make sure to use a camel case word such as **HelloWorld** as it is used to generate Configuration and Application classess such as **HelloWorldConfiguration.java** and **HelloWorldApplication.java**. Furthermore, do not include any blank space for the same reason!)

--- a/dropwizard-archetypes/README.md
+++ b/dropwizard-archetypes/README.md
@@ -1,8 +1,10 @@
 # Dropwizard Archetypes
 
-How to create project using dropwizard archetype
+How to create project using dropwizard archetype (interactive mode)
 ---
 
 ```
-mvn archetype:generate -DarchetypeGroupId=io.dropwizard.archetypes -DarchetypeArtifactId=java-simple -DarchetypeVersion=0.9.1
+mvn archetype:generate -DarchetypeGroupId=io.dropwizard.archetypes -DarchetypeArtifactId=java-simple -DarchetypeVersion=[REPLACE ME WITH A VALID DROPWIZARD VERSION]
 ```
+
+(when asked for $name during project creation via maven, make sure to use a camel case word such as HelloWorld as it is used to generate Configuration and Application classess such as HelloWorldConfiguration.java and HelloWorldApplication.java. Furthermore, do not include any blank space for the same reason!)


### PR DESCRIPTION
Given that $name is used to generate Configuration and Application classes, it is vital for new users not to inappropriately name it during maven interactive mode. 

Also the hard-coded 0.9.1 archetype version is replaced with a place holder (there might be a better solution to have a token put in that is value-replaced by release version?). 