### PR TITLE
Fix handling multiple headers with the same name

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardApacheConnector.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardApacheConnector.java
@@ -1,5 +1,6 @@
 package io.dropwizard.client;
 
+import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.MoreExecutors;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -26,7 +27,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Future;
@@ -94,7 +94,7 @@ public class DropwizardApacheConnector implements Connector {
             for (Header header : apacheResponse.getAllHeaders()) {
                 final List<String> headerValues = jerseyResponse.getHeaders().get(header.getName());
                 if (headerValues == null) {
-                    jerseyResponse.getHeaders().put(header.getName(), Collections.singletonList(header.getValue()));
+                    jerseyResponse.getHeaders().put(header.getName(), Lists.newArrayList(header.getValue()));
                 } else {
                     headerValues.add(header.getValue());
                 }


### PR DESCRIPTION
~~As a simple fix, an immutable, single-element list (`Collections.singletonList`) has been wrapped in a mutable one, so it can be extended (if there will be anymore headers with the same name).~~

In this case `Lists.newArrayList` was used to create a mutable `List`, so it can be extended in case of multiple headers with the same name, i.e. `Set-Cookie`.

Fixes #1494 