### PR TITLE
fix for metrics library url at getting started section

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -70,7 +70,7 @@ Metrics for metrics
 The Metrics_ library rounds things out, providing you with unparalleled insight into your code's
 behavior in your production environment.
 
-.. _Metrics: http://metrics.codahale.com
+.. _Metrics: http://metrics.dropwizard.io/
 
 .. _gs-and-friends:
 


### PR DESCRIPTION
[Metrics for metrics](http://www.dropwizard.io/0.9.2/docs/getting-started.html#metrics-for-metrics)

Metrics project url `http://metrics.codahale.com/` does not point to valid url, how about pointing to `http://metrics.dropwizard.io/`?