### PR TITLE
configures the environment with the context paths before the application.run()

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/cli/EnvironmentCommand.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/EnvironmentCommand.java
@@ -36,6 +36,8 @@ public abstract class EnvironmentCommand<T extends Configuration> extends Config
                                                         bootstrap.getClassLoader());
         configuration.getMetricsFactory().configure(environment.lifecycle(),
                                                     bootstrap.getMetricRegistry());
+        configuration.getServerFactory().configure(environment);
+
         bootstrap.run(configuration, environment);
         application.run(configuration, environment);
         run(environment, namespace, configuration);

--- a/dropwizard-core/src/main/java/io/dropwizard/server/DefaultServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/DefaultServerFactory.java
@@ -155,9 +155,6 @@ public class DefaultServerFactory extends AbstractServerFactory {
         printBanner(environment.getName());
         final ThreadPool threadPool = createThreadPool(environment.metrics());
         final Server server = buildServer(environment.lifecycle(), threadPool);
-
-        LOGGER.info("Registering jersey handler with root path prefix: {}", applicationContextPath);
-        environment.getApplicationContext().setContextPath(applicationContextPath);
         final Handler applicationHandler = createAppServlet(server,
                                                             environment.jersey(),
                                                             environment.getObjectMapper(),
@@ -166,8 +163,7 @@ public class DefaultServerFactory extends AbstractServerFactory {
                                                             environment.getJerseyServletContainer(),
                                                             environment.metrics());
 
-        LOGGER.info("Registering admin handler with root path prefix: {}", adminContextPath);
-        environment.getAdminContext().setContextPath(adminContextPath);
+
         final Handler adminHandler = createAdminServlet(server,
                                                         environment.getAdminContext(),
                                                         environment.metrics(),
@@ -179,6 +175,15 @@ public class DefaultServerFactory extends AbstractServerFactory {
         final Handler gzipHandler = buildGzipHandler(routingHandler);
         server.setHandler(addStatsHandler(addRequestLog(server, gzipHandler, environment.getName())));
         return server;
+    }
+
+    @Override
+    public void configure(Environment environment) {
+        LOGGER.info("Registering jersey handler with root path prefix: {}", applicationContextPath);
+        environment.getApplicationContext().setContextPath(applicationContextPath);
+
+        LOGGER.info("Registering admin handler with root path prefix: {}", adminContextPath);
+        environment.getAdminContext().setContextPath(adminContextPath);
     }
 
     private RoutingHandler buildRoutingHandler(MetricRegistry metricRegistry,

--- a/dropwizard-core/src/main/java/io/dropwizard/server/ServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/ServerFactory.java
@@ -19,4 +19,11 @@ public interface ServerFactory extends Discoverable {
      * @return a {@link Server} running the Dropwizard application
      */
     Server build(Environment environment);
+
+    /**
+     * Configures the given environment with context paths defined in the factory for the application.
+     *
+     * @param environment the application's environment
+     */
+    void configure(Environment environment);
 }

--- a/dropwizard-core/src/main/java/io/dropwizard/server/SimpleServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/SimpleServerFactory.java
@@ -103,8 +103,6 @@ public class SimpleServerFactory extends AbstractServerFactory {
         final ThreadPool threadPool = createThreadPool(environment.metrics());
         final Server server = buildServer(environment.lifecycle(), threadPool);
 
-        LOGGER.info("Registering jersey handler with root path prefix: {}", applicationContextPath);
-        environment.getApplicationContext().setContextPath(applicationContextPath);
         final Handler applicationHandler = createAppServlet(server,
                                                             environment.jersey(),
                                                             environment.getObjectMapper(),
@@ -113,8 +111,6 @@ public class SimpleServerFactory extends AbstractServerFactory {
                                                             environment.getJerseyServletContainer(),
                                                             environment.metrics());
 
-        LOGGER.info("Registering admin handler with root path prefix: {}", adminContextPath);
-        environment.getAdminContext().setContextPath(adminContextPath);
         final Handler adminHandler = createAdminServlet(server,
                                                         environment.getAdminContext(),
                                                         environment.metrics(),
@@ -135,5 +131,14 @@ public class SimpleServerFactory extends AbstractServerFactory {
         server.setHandler(addStatsHandler(addRequestLog(server, gzipHandler, environment.getName())));
 
         return server;
+    }
+
+    @Override
+    public void configure(Environment environment) {
+        LOGGER.info("Registering jersey handler with root path prefix: {}", applicationContextPath);
+        environment.getApplicationContext().setContextPath(applicationContextPath);
+
+        LOGGER.info("Registering admin handler with root path prefix: {}", adminContextPath);
+        environment.getAdminContext().setContextPath(adminContextPath);
     }
 }

--- a/dropwizard-core/src/test/java/io/dropwizard/server/AbstractServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/AbstractServerFactoryTest.java
@@ -85,5 +85,10 @@ public class AbstractServerFactoryTest {
                                   environment.metrics());
             return server;
         }
+
+		@Override
+		public void configure(Environment environment) {
+			// left blank intentionally
+		}
     }
 }

--- a/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
@@ -26,7 +26,6 @@ import org.eclipse.jetty.server.Server;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.validation.Validator;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -45,12 +44,17 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 public class DefaultServerFactoryTest {
+	private Environment environment = new Environment("test", Jackson.newObjectMapper(),
+            Validators.newValidator(), new MetricRegistry(),
+            ClassLoader.getSystemClassLoader());
     private DefaultServerFactory http;
 
     @Before
     public void setUp() throws Exception {
+
         final ObjectMapper objectMapper = Jackson.newObjectMapper();
         objectMapper.getSubtypeResolver().registerSubtypes(ConsoleAppenderFactory.class,
                                                            FileAppenderFactory.class,
@@ -108,9 +112,7 @@ public class DefaultServerFactoryTest {
     @Test
     public void registersDefaultExceptionMappers() throws Exception {
         assertThat(http.getRegisterDefaultExceptionMappers()).isTrue();
-        Environment environment = new Environment("test", Jackson.newObjectMapper(),
-                Validators.newValidator(), new MetricRegistry(),
-                ClassLoader.getSystemClassLoader());
+
         http.build(environment);
         Set<Object> singletons = environment.jersey().getResourceConfig().getSingletons();
         assertThat(singletons).hasAtLeastOneElementOfType(LoggingExceptionMapper.class);
@@ -135,12 +137,6 @@ public class DefaultServerFactoryTest {
 
     @Test
     public void testGracefulShutdown() throws Exception {
-        ObjectMapper objectMapper = Jackson.newObjectMapper();
-        Validator validator = Validators.newValidator();
-        MetricRegistry metricRegistry = new MetricRegistry();
-        Environment environment = new Environment("test", objectMapper, validator, metricRegistry,
-                ClassLoader.getSystemClassLoader());
-
         CountDownLatch requestReceived = new CountDownLatch(1);
         CountDownLatch shutdownInvoked = new CountDownLatch(1);
 
@@ -200,6 +196,14 @@ public class DefaultServerFactoryTest {
         // cancel the cleanup future since everything succeeded
         cleanup.cancel(false);
         executor.shutdownNow();
+    }
+
+    @Test
+    public void testConfiguredEnvironment() {
+    	http.configure(environment);
+
+    	assertEquals(http.getAdminContextPath(), environment.getAdminContext().getContextPath());
+    	assertEquals(http.getApplicationContextPath(), environment.getApplicationContext().getContextPath());
     }
 
     @Path("/test")

--- a/dropwizard-core/src/test/java/io/dropwizard/server/SimpleServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/SimpleServerFactoryTest.java
@@ -31,12 +31,15 @@ import java.io.PrintWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 public class SimpleServerFactoryTest {
 
     private SimpleServerFactory http;
     private final ObjectMapper objectMapper = Jackson.newObjectMapper();
     private Validator validator = BaseValidator.newValidator();
+    private Environment environment = new Environment("testEnvironment", objectMapper, validator, new MetricRegistry(),
+            ClassLoader.getSystemClassLoader());
 
     @Before
     public void setUp() throws Exception {
@@ -70,8 +73,6 @@ public class SimpleServerFactoryTest {
 
     @Test
     public void testBuild() throws Exception {
-        final Environment environment = new Environment("testEnvironment", objectMapper, validator, new MetricRegistry(),
-                ClassLoader.getSystemClassLoader());
         environment.jersey().register(new TestResource());
         environment.admin().addTask(new TestTask());
 
@@ -85,6 +86,14 @@ public class SimpleServerFactoryTest {
                 .isEqualTo("Hello, test_user!");
 
         server.stop();
+    }
+
+    @Test
+    public void testConfiguredEnvironment() {
+    	http.configure(environment);
+
+    	assertEquals(http.getAdminContextPath(), environment.getAdminContext().getContextPath());
+    	assertEquals(http.getApplicationContextPath(), environment.getApplicationContext().getContextPath());
     }
 
     private static String httpRequest(String requestMethod, String url) throws Exception {


### PR DESCRIPTION
This commit configures the context paths for the application before the
application `run()` instead of setting it prior to starting the server.
This allows applications to obtain the context paths during the run
method.

This shouldn't break any changes to the users, but note that
ServerFactory now needs to call `configure` explicitly to set the
context paths in the environment