### PR TITLE
Fix tests affected by the DST change

### DIFF
--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OffsetDateTimeArgumentTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OffsetDateTimeArgumentTest.java
@@ -7,8 +7,9 @@ import org.skife.jdbi.v2.StatementContext;
 import java.sql.PreparedStatement;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.time.Instant;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.util.Optional;
 
 public class OffsetDateTimeArgumentTest {
@@ -18,12 +19,12 @@ public class OffsetDateTimeArgumentTest {
 
     @Test
     public void apply() throws Exception {
-        final ZoneOffset localOffset = ZoneOffset.from(OffsetDateTime.now());
-        OffsetDateTime dateTime = OffsetDateTime.of(2007, 12, 3, 10, 15, 30, 375_000_000, localOffset);
+        final Instant now = OffsetDateTime.now().toInstant();
+        final OffsetDateTime dateTime = OffsetDateTime.ofInstant(now, ZoneId.systemDefault());
 
         new OffsetDateTimeArgument(dateTime, Optional.empty()).apply(1, statement, context);
 
-        Mockito.verify(statement).setTimestamp(1, Timestamp.valueOf("2007-12-03 10:15:30.375"));
+        Mockito.verify(statement).setTimestamp(1, Timestamp.from(now));
     }
 
     @Test

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OffsetDateTimeMapperTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OffsetDateTimeMapperTest.java
@@ -5,8 +5,9 @@ import org.mockito.Mockito;
 
 import java.sql.ResultSet;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -17,12 +18,13 @@ public class OffsetDateTimeMapperTest {
 
     @Test
     public void mapColumnByName() throws Exception {
-        when(resultSet.getTimestamp("name")).thenReturn(Timestamp.valueOf("2007-12-03 10:15:30.375"));
+        final Instant now = OffsetDateTime.now().toInstant();
+
+        when(resultSet.getTimestamp("name")).thenReturn(Timestamp.from(now));
 
         OffsetDateTime actual = new OffsetDateTimeMapper().mapColumn(resultSet, "name", null);
 
-        final ZoneOffset localOffset = ZoneOffset.from(OffsetDateTime.now());
-        assertThat(actual).isEqualTo(OffsetDateTime.of(2007, 12, 3, 10, 15, 30, 375_000_000, localOffset));
+        assertThat(actual).isEqualTo(OffsetDateTime.ofInstant(now, ZoneId.systemDefault()));
     }
 
     @Test
@@ -36,12 +38,13 @@ public class OffsetDateTimeMapperTest {
 
     @Test
     public void mapColumnByIndex() throws Exception {
-        when(resultSet.getTimestamp(1)).thenReturn(Timestamp.valueOf("2007-12-03 10:15:30.375"));
+        final Instant now = OffsetDateTime.now().toInstant();
+
+        when(resultSet.getTimestamp(1)).thenReturn(Timestamp.from(now));
 
         OffsetDateTime actual = new OffsetDateTimeMapper().mapColumn(resultSet, 1, null);
 
-        final ZoneOffset localOffset = ZoneOffset.from(OffsetDateTime.now());
-        assertThat(actual).isEqualTo(OffsetDateTime.of(2007, 12, 3, 10, 15, 30, 375_000_000, localOffset));
+        assertThat(actual).isEqualTo(OffsetDateTime.ofInstant(now, ZoneId.systemDefault()));
     }
 
     @Test


### PR DESCRIPTION
The problems with these three tests were caused by the fact, that the date used in them has been forcing
non-DST timezone (i.e. `+01:00` in most of the Europe), but then it was compared to the same date, but in current (that is DST) timezone (i.e. `+02:00`).