### PR TITLE
Register the default MetricRegistry as the "default"

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/setup/Environment.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/Environment.java
@@ -1,6 +1,7 @@
 package io.dropwizard.setup;
 
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SharedMetricRegistries;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -84,6 +85,8 @@ public class Environment {
                 .threadFactory(new ThreadFactoryBuilder().setDaemon(true).build())
                 .rejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy())
                 .build();
+
+        SharedMetricRegistries.add("default", metricRegistry);
     }
 
     /**


### PR DESCRIPTION
I end up doing this a lot in my code so I can reference the `MetricRegistry` throughout my app.