### PR TITLE
Feature/improve command reuse and inheritability

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/cli/ConfiguredCommand.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/ConfiguredCommand.java
@@ -57,6 +57,11 @@ public abstract class ConfiguredCommand<T extends Configuration> extends Command
         addFileArgument(subparser);
     }
 
+    /**
+     * Adds the configuration file argument for the configured command.
+     * @param subparser The subparser to register the argument on
+     * @return the register argument
+     */
     protected Argument addFileArgument(Subparser subparser) {
         return subparser.addArgument("file")
                         .nargs("?")

--- a/dropwizard-core/src/main/java/io/dropwizard/cli/ConfiguredCommand.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/ConfiguredCommand.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 
 import javax.validation.Validator;
 
+import net.sourceforge.argparse4j.inf.Argument;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 
@@ -53,7 +54,13 @@ public abstract class ConfiguredCommand<T extends Configuration> extends Command
      */
     @Override
     public void configure(Subparser subparser) {
-        subparser.addArgument("file").nargs("?").help("application configuration file");
+        addFileArgument(subparser);
+    }
+
+    protected Argument addFileArgument(Subparser subparser) {
+        return subparser.addArgument("file")
+                        .nargs("?")
+                        .help("application configuration file");
     }
 
     @Override

--- a/dropwizard-core/src/main/java/io/dropwizard/cli/EnvironmentCommand.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/EnvironmentCommand.java
@@ -28,7 +28,7 @@ public abstract class EnvironmentCommand<T extends Configuration> extends Config
     }
 
     @Override
-    protected final void run(Bootstrap<T> bootstrap, Namespace namespace, T configuration) throws Exception {
+    protected void run(Bootstrap<T> bootstrap, Namespace namespace, T configuration) throws Exception {
         final Environment environment = new Environment(bootstrap.getApplication().getName(),
                                                         bootstrap.getObjectMapper(),
                                                         bootstrap.getValidatorFactory().getValidator(),

--- a/dropwizard-core/src/main/java/io/dropwizard/cli/ServerCommand.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/ServerCommand.java
@@ -24,6 +24,12 @@ public class ServerCommand<T extends Configuration> extends EnvironmentCommand<T
         this(application, "server", "Runs the Dropwizard application as an HTTP server");
     }
 
+    /**
+     * A constructor to allow reuse of the server command as a different name
+     * @param application the application using this command
+     * @param name the argument name to invoke this command
+     * @param description a summary of what the command does
+     */
     protected ServerCommand(final Application<T> application, final String name, final String description) {
         super(application, name, description);
         this.configurationClass = application.getConfigurationClass();

--- a/dropwizard-core/src/main/java/io/dropwizard/cli/ServerCommand.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/ServerCommand.java
@@ -21,14 +21,18 @@ public class ServerCommand<T extends Configuration> extends EnvironmentCommand<T
     private final Class<T> configurationClass;
 
     public ServerCommand(Application<T> application) {
-        super(application, "server", "Runs the Dropwizard application as an HTTP server");
+        this(application, "server", "Runs the Dropwizard application as an HTTP server");
+    }
+
+    protected ServerCommand(final Application<T> application, final String name, final String description) {
+        super(application, name, description);
         this.configurationClass = application.getConfigurationClass();
     }
 
     /*
-     * Since we don't subclass ServerCommand, we need a concrete reference to the configuration
-     * class.
-     */
+         * Since we don't subclass ServerCommand, we need a concrete reference to the configuration
+         * class.
+         */
     @Override
     protected Class<T> getConfigurationClass() {
         return configurationClass;

--- a/dropwizard-core/src/test/java/io/dropwizard/cli/InheritedServerCommandTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/cli/InheritedServerCommandTest.java
@@ -1,0 +1,136 @@
+package io.dropwizard.cli;
+
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.configuration.ConfigurationException;
+import io.dropwizard.configuration.ConfigurationFactory;
+import io.dropwizard.configuration.ConfigurationSourceProvider;
+import io.dropwizard.logging.LoggingFactory;
+import io.dropwizard.server.ServerFactory;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.util.JarLocation;
+import net.sourceforge.argparse4j.inf.Argument;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparser;
+import net.sourceforge.argparse4j.internal.ArgumentParserImpl;
+import net.sourceforge.argparse4j.internal.SubparserImpl;
+import org.eclipse.jetty.server.Server;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class InheritedServerCommandTest {
+    private static class ApiCommand extends ServerCommand<Configuration> {
+
+        protected ApiCommand(final Application<Configuration> application) {
+            super(application, "api", "Runs the Dropwizard application as an API HTTP server");
+        }
+    }
+
+    private static class MyApplication extends Application<Configuration> {
+        @Override
+        public void initialize(final Bootstrap<Configuration> bootstrap) {
+            bootstrap.addCommand(new ApiCommand(this));
+            super.initialize(bootstrap);
+        }
+
+        @Override
+        public void run(Configuration configuration, Environment environment) throws Exception {
+        }
+    }
+
+    private final MyApplication application = new MyApplication();
+    private final ApiCommand command = new ApiCommand(application);
+    private final Server server = new Server(0);
+
+    private final Environment environment = mock(Environment.class);
+    private final Namespace namespace = mock(Namespace.class);
+    private final ServerFactory serverFactory = mock(ServerFactory.class);
+    private final Configuration configuration = mock(Configuration.class);
+
+    @Before
+    public void setUp() throws Exception {
+        when(serverFactory.build(environment)).thenReturn(server);
+        when(configuration.getServerFactory()).thenReturn(serverFactory);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+    }
+
+    @Test
+    public void hasAName() throws Exception {
+        assertThat(command.getName())
+                .isEqualTo("api");
+    }
+
+    @Test
+    public void hasADescription() throws Exception {
+        assertThat(command.getDescription())
+                .isEqualTo("Runs the Dropwizard application as an API HTTP server");
+    }
+
+    @Test
+    public void buildsAndRunsAConfiguredServer() throws Exception {
+        command.run(environment, namespace, configuration);
+
+        assertThat(server.isStarted())
+                .isTrue();
+    }
+
+    @Test
+    public void usesDefaultConfigPath() throws Exception {
+
+        class SingletonConfigurationFactory implements ConfigurationFactory{
+            @Override
+            public Object build(final ConfigurationSourceProvider provider, final String path) throws IOException, ConfigurationException {
+                return configuration;
+            }
+
+            @Override
+            public Object build() throws IOException, ConfigurationException {
+                throw new AssertionError("Didn't use the default config path variable");
+            }
+        }
+
+        when(configuration.getLoggingFactory()).thenReturn(mock(LoggingFactory.class));
+
+        final Bootstrap<Configuration> bootstrap = new Bootstrap<>(application);
+
+        bootstrap.setConfigurationFactoryFactory((klass, validator, objectMapper, propertyPrefix) -> new SingletonConfigurationFactory());
+
+        bootstrap.addCommand(new ConfiguredCommand<Configuration>("test", "a test command") {
+
+            @Override
+            protected void run(final Bootstrap<Configuration> bootstrap, final Namespace namespace, final Configuration configuration) throws Exception {
+                assertThat(namespace.getString("file"))
+                        .isNotEmpty()
+                        .isEqualTo("yaml/server.yml");
+            }
+
+            @Override
+            protected Argument addFileArgument(final Subparser subparser) {
+                return super.addFileArgument(subparser)
+                            .setDefault("yaml/server.yml");
+            }
+        });
+
+        final JarLocation location = mock(JarLocation.class);
+
+        when(location.toString()).thenReturn("dw-thing.jar");
+        when(location.getVersion()).thenReturn(Optional.of("1.0.0"));
+
+        Cli cli = new Cli(location, bootstrap, System.out, System.err);
+        cli.run("test");
+    }
+}


### PR DESCRIPTION
Improving command reuse by:

- making `EnvironmentCommand`s  `run` non final, so that inheritors can use the configured bootstrap (instead of having to cast the wildcard bootstrap)
- adding a way to configure the file argument further (like adding a default)
- and adding a protected constructor to the server command to call it differently

Currently at work we end up copying the guts of `ServerCommand` into a new command so that we can override the argument names.