### PR TITLE
Issue 1037

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ sudo: false
 language: java
 jdk:
   - oraclejdk8
-#after_success:
-#  - bash .travis_after_success.sh
+after_success:
+  - bash .travis_after_success.sh
 cache:
   directories:
     - $HOME/.m2
@@ -18,7 +18,7 @@ cache:
 # NOTE: CI_DEPLOY_USERNAME is set to dropwizardci, the username
 # we've set up with Sonatype, which only has permission to push
 # to the snapshot repo.
-#env:
-#  global:
-#    - secure: "EAuz7bCKj4r438IEC2y73WVrFwXirflbXA4HhpwVmAFWNqC9LIIpkWcO5GVp773HsZvJBcJjJriP+aKRkImV8AyMgjCeEUv2dlezvbkIIz38vKyw9MWaPIyZ3uS9RCuL7OwGf5BeJ1DvHFYdMBaspZd+EmCYr7abnHdqs+Tm/W8="
-#    - secure: "RI0QcuKMsij3sgRm+Bjhu3X217U6UslvSzcRv13iLLwrTj73zhGi5PF/+kj8Qh1HMQw0oQRR6M8qPqGy82KcjiGbpgPgSy1rVAvkYg+Yw1k7v4l7Vgyj7TNsAM3pqHyojx2jgRjpQsgw/WXQmiahWV6OCOUzdbhEUwVzIXI+vtk="
+env:
+  global:
+    - secure: "EAuz7bCKj4r438IEC2y73WVrFwXirflbXA4HhpwVmAFWNqC9LIIpkWcO5GVp773HsZvJBcJjJriP+aKRkImV8AyMgjCeEUv2dlezvbkIIz38vKyw9MWaPIyZ3uS9RCuL7OwGf5BeJ1DvHFYdMBaspZd+EmCYr7abnHdqs+Tm/W8="
+    - secure: "RI0QcuKMsij3sgRm+Bjhu3X217U6UslvSzcRv13iLLwrTj73zhGi5PF/+kj8Qh1HMQw0oQRR6M8qPqGy82KcjiGbpgPgSy1rVAvkYg+Yw1k7v4l7Vgyj7TNsAM3pqHyojx2jgRjpQsgw/WXQmiahWV6OCOUzdbhEUwVzIXI+vtk="

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ sudo: false
 language: java
 jdk:
   - oraclejdk8
-after_success:
-  - bash .travis_after_success.sh
+#after_success:
+#  - bash .travis_after_success.sh
 cache:
   directories:
     - $HOME/.m2
@@ -18,7 +18,7 @@ cache:
 # NOTE: CI_DEPLOY_USERNAME is set to dropwizardci, the username
 # we've set up with Sonatype, which only has permission to push
 # to the snapshot repo.
-env:
-  global:
-    - secure: "EAuz7bCKj4r438IEC2y73WVrFwXirflbXA4HhpwVmAFWNqC9LIIpkWcO5GVp773HsZvJBcJjJriP+aKRkImV8AyMgjCeEUv2dlezvbkIIz38vKyw9MWaPIyZ3uS9RCuL7OwGf5BeJ1DvHFYdMBaspZd+EmCYr7abnHdqs+Tm/W8="
-    - secure: "RI0QcuKMsij3sgRm+Bjhu3X217U6UslvSzcRv13iLLwrTj73zhGi5PF/+kj8Qh1HMQw0oQRR6M8qPqGy82KcjiGbpgPgSy1rVAvkYg+Yw1k7v4l7Vgyj7TNsAM3pqHyojx2jgRjpQsgw/WXQmiahWV6OCOUzdbhEUwVzIXI+vtk="
+#env:
+#  global:
+#    - secure: "EAuz7bCKj4r438IEC2y73WVrFwXirflbXA4HhpwVmAFWNqC9LIIpkWcO5GVp773HsZvJBcJjJriP+aKRkImV8AyMgjCeEUv2dlezvbkIIz38vKyw9MWaPIyZ3uS9RCuL7OwGf5BeJ1DvHFYdMBaspZd+EmCYr7abnHdqs+Tm/W8="
+#    - secure: "RI0QcuKMsij3sgRm+Bjhu3X217U6UslvSzcRv13iLLwrTj73zhGi5PF/+kj8Qh1HMQw0oQRR6M8qPqGy82KcjiGbpgPgSy1rVAvkYg+Yw1k7v4l7Vgyj7TNsAM3pqHyojx2jgRjpQsgw/WXQmiahWV6OCOUzdbhEUwVzIXI+vtk="

--- a/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
+++ b/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
@@ -143,7 +143,9 @@ import java.util.concurrent.TimeUnit;
  *         <td>{@code initialSize}</td>
  *         <td>10</td>
  *         <td>
- *             The initial size of the connection pool.
+ *             The initial size of the connection pool. May be zero, which will allow you to start
+ *             the connection pool without requiring the DB to be up. In the latter case the {@link #minSize}
+ *             must also be set to zero.
  *         </td>
  *     </tr>
  *     <tr>
@@ -340,10 +342,10 @@ public class DataSourceFactory implements PooledDataSourceFactory {
 
     private boolean useFairQueue = true;
 
-    @Min(1)
+    @Min(0)
     private int initialSize = 10;
 
-    @Min(1)
+    @Min(0)
     private int minSize = 10;
 
     @Min(1)

--- a/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceConfigurationTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceConfigurationTest.java
@@ -2,16 +2,19 @@ package io.dropwizard.db;
 
 import com.google.common.io.Resources;
 
+import io.dropwizard.configuration.ConfigurationValidationException;
 import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.util.Duration;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.File;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 public class DataSourceConfigurationTest {
 
@@ -106,6 +109,16 @@ public class DataSourceConfigurationTest {
         assertThat(ds.getUrl()).isEqualTo("jdbc:postgresql://db.example.com/db-prod?user=scott&password=tiger");
         assertThat(ds.getUser()).isNull();
         assertThat(ds.getPassword()).isNull();
+    }
+    // Test added for https://github.com/dropwizard/dropwizard/issues/1037
+    @Test
+    public void testInitialSizeZeroIsAllowed() throws Exception {
+        try {
+            DataSourceFactory ds = getDataSourceFactory("yaml/empty_initial_pool.yml");
+            assertThat(ds.getInitialSize()).isEqualTo(0);
+        } catch (ConfigurationValidationException e) {
+            fail();
+        }
     }
 
     private DataSourceFactory getDataSourceFactory(String resourceName) throws Exception {

--- a/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceConfigurationTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceConfigurationTest.java
@@ -7,7 +7,6 @@ import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.util.Duration;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.File;

--- a/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceConfigurationTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceConfigurationTest.java
@@ -117,7 +117,8 @@ public class DataSourceConfigurationTest {
             DataSourceFactory ds = getDataSourceFactory("yaml/empty_initial_pool.yml");
             assertThat(ds.getInitialSize()).isEqualTo(0);
         } catch (ConfigurationValidationException e) {
-            fail();
+            e.printStackTrace();
+            fail(e.getMessage());
         }
     }
 

--- a/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceConfigurationTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceConfigurationTest.java
@@ -109,16 +109,10 @@ public class DataSourceConfigurationTest {
         assertThat(ds.getUser()).isNull();
         assertThat(ds.getPassword()).isNull();
     }
-    // Test added for https://github.com/dropwizard/dropwizard/issues/1037
     @Test
     public void testInitialSizeZeroIsAllowed() throws Exception {
-        try {
-            DataSourceFactory ds = getDataSourceFactory("yaml/empty_initial_pool.yml");
-            assertThat(ds.getInitialSize()).isEqualTo(0);
-        } catch (ConfigurationValidationException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
+        DataSourceFactory ds = getDataSourceFactory("yaml/empty_initial_pool.yml");
+           assertThat(ds.getInitialSize()).isEqualTo(0);
     }
 
     private DataSourceFactory getDataSourceFactory(String resourceName) throws Exception {

--- a/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceFactoryTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceFactoryTest.java
@@ -8,6 +8,7 @@ import io.dropwizard.util.Duration;
 import io.dropwizard.validation.BaseValidator;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -18,8 +19,9 @@ import java.sql.SQLException;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
-public class DataSourceFactoryTest {
+    public class DataSourceFactoryTest {
     private final MetricRegistry metricRegistry = new MetricRegistry();
 
     private DataSourceFactory factory;
@@ -44,6 +46,18 @@ public class DataSourceFactoryTest {
         dataSource = factory.build(metricRegistry, "test");
         dataSource.start();
         return dataSource;
+    }
+
+    @Test
+    public void testInitialSizeIsZero() throws Exception {
+        factory.setUrl("nonsense invalid url");
+        factory.setInitialSize(0);
+        ManagedDataSource dataSource = factory.build(metricRegistry, "test");
+        try {
+            dataSource.start();
+        } catch (Exception e) {
+            fail();
+        }
     }
 
     @Test

--- a/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceFactoryTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceFactoryTest.java
@@ -8,7 +8,6 @@ import io.dropwizard.util.Duration;
 import io.dropwizard.validation.BaseValidator;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -21,7 +20,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
-    public class DataSourceFactoryTest {
+public class DataSourceFactoryTest {
     private final MetricRegistry metricRegistry = new MetricRegistry();
 
     private DataSourceFactory factory;

--- a/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceFactoryTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceFactoryTest.java
@@ -52,11 +52,7 @@ public class DataSourceFactoryTest {
         factory.setUrl("nonsense invalid url");
         factory.setInitialSize(0);
         ManagedDataSource dataSource = factory.build(metricRegistry, "test");
-        try {
-            dataSource.start();
-        } catch (Exception e) {
-            fail();
-        }
+        dataSource.start();
     }
 
     @Test

--- a/dropwizard-db/src/test/resources/yaml/empty_initial_pool.yml
+++ b/dropwizard-db/src/test/resources/yaml/empty_initial_pool.yml
@@ -3,3 +3,4 @@ user: pg-user
 password: iAMs00perSecrEET
 url: jdbc:postgresql://db.example.com/db-prod
 initialSize: 0
+minSize: 0

--- a/dropwizard-db/src/test/resources/yaml/empty_initial_pool.yml
+++ b/dropwizard-db/src/test/resources/yaml/empty_initial_pool.yml
@@ -1,0 +1,5 @@
+driverClass: org.postgresql.Driver
+user: pg-user
+password: iAMs00perSecrEET
+url: jdbc:postgresql://db.example.com/db-prod
+initialSize: 0


### PR DESCRIPTION
#1037 Simple fix to make it possible to instantiate an empty connection pool. For cases where you still want the webapp to load, e.g. you want a service to be able to start and show an error page when a DB isn't available.

Includes tests. Please ignore the changes to `travis.yml`