### PR TITLE
Fix newline comparison for windows test

### DIFF
--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryTest.java
@@ -433,7 +433,7 @@ public class ConfigurationFactoryTest {
                     "expected ',' or ']', but got StreamEnd\n" +
                     " in 'reader', line 2, column 21:\n" +
                     "    wizard\n" +
-                    "          ^" + NEWLINE);
+                    "          ^\n");
         }
     }
 }


### PR DESCRIPTION
May have been a change in the recent Jackson version, but this fixes the test on windows.