### PR TITLE
fix link to issue in release notes

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -13,7 +13,7 @@ v1.0.0
 * ``dropwizard-java8`` bundle merged into mainline `#1365 <https://github.com/dropwizard/dropwizard/issues/1365>`_
 * HTTP/2 and server push support `#1349 <https://github.com/dropwizard/dropwizard/issues/1349>`_
 * ``dropwizard-spdy`` module is removed in favor of ``dropwizard-http2`` `#1330 <https://github.com/dropwizard/dropwizard/pull/1330>`_
-* Switching to ``logback-access`` for HTTP request logging `#1415 <https://github.com/dropwizard/dropwizard/pull/1415>`
+* Switching to ``logback-access`` for HTTP request logging `#1415 <https://github.com/dropwizard/dropwizard/pull/1415>`_
 * Support for validating return values in JAX-RS resources `#1251 <https://github.com/dropwizard/dropwizard/pull/1251>`_
 * Consistent handling null entities in JAX-RS resources `#1251 <https://github.com/dropwizard/dropwizard/pull/1251>`_
 * Returning an HTTP 500 error for entities that can't be serialized `#1347 <https://github.com/dropwizard/dropwizard/pull/1347>`_


### PR DESCRIPTION
Just a small formatting fix I found while looking at the release notes for v1.0.0. 

Here's the before and after:
![image 2016-04-20 at 11 07 28 am](https://cloud.githubusercontent.com/assets/28044/14679511/309f26e2-06e8-11e6-80b6-9dab400633e4.png)
