### PR TITLE
Treat Jackson ObjectMapper#readValue failures as a 400

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProvider.java
@@ -5,6 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
 
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
@@ -36,6 +39,20 @@ public class JacksonMessageBodyProvider extends JacksonJaxbJsonProvider {
                                Annotation[] annotations,
                                MediaType mediaType) {
         return isProvidable(type) && super.isWriteable(type, genericType, annotations, mediaType);
+    }
+
+    @Override
+    public Object readFrom(Class<Object> type,
+                           Type genericType,
+                           Annotation[] annotations,
+                           MediaType mediaType,
+                           MultivaluedMap<String, String> httpHeaders,
+                           InputStream entityStream) throws IOException {
+        try {
+            return super.readFrom(type, genericType, annotations, mediaType, httpHeaders, entityStream);
+        } catch (Throwable cause) {
+            throw new WrappedJsonProcessingException(cause);
+        }
     }
 
     private boolean isProvidable(Class<?> type) {

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/WrappedJsonProcessingException.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/WrappedJsonProcessingException.java
@@ -1,0 +1,11 @@
+package io.dropwizard.jersey.jackson;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public class WrappedJsonProcessingException extends JsonProcessingException {
+
+    WrappedJsonProcessingException(Throwable cause) {
+        super(cause.getMessage(), cause);
+    }
+
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapperTest.java
@@ -5,14 +5,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.jersey.DropwizardResourceConfig;
-import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.logging.BootstrapLogging;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.TestProperties;
 import org.junit.Test;
 
-import javax.validation.Validator;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
@@ -40,10 +38,10 @@ public class JsonProcessingExceptionMapperTest extends JerseyTest {
     }
 
     @Test
-    public void returnsA500ForNonDeserializableRepresentationClasses() throws Exception {
+    public void returnsA400ForNonDeserializableRepresentationClasses() throws Exception {
         Response response = target("/json/broken").request(MediaType.APPLICATION_JSON)
                 .post(Entity.entity(new BrokenRepresentation(ImmutableList.of("whee")), MediaType.APPLICATION_JSON));
-        assertThat(response.getStatus()).isEqualTo(500);
+        isA400ForNonDeserializableRequest(response);
     }
 
     @Test
@@ -56,8 +54,11 @@ public class JsonProcessingExceptionMapperTest extends JerseyTest {
     public void returnsA400ForNonDeserializableRequestEntities() throws Exception {
         Response response = target("/json/ok").request(MediaType.APPLICATION_JSON)
                 .post(Entity.entity(new UnknownRepresentation(100), MediaType.APPLICATION_JSON));
-        assertThat(response.getStatus()).isEqualTo(400);
+        isA400ForNonDeserializableRequest(response);
+    }
 
+    private static void isA400ForNonDeserializableRequest(Response response) {
+        assertThat(response.getStatus()).isEqualTo(400);
         JsonNode errorMessage = response.readEntity(JsonNode.class);
         assertThat(errorMessage.get("code").asInt()).isEqualTo(400);
         assertThat(errorMessage.get("message").asText()).isEqualTo("Unable to process JSON");


### PR DESCRIPTION
See #1539 for the related issue.