### PR TITLE
add support for customizing the name of the migrations file

### DIFF
--- a/docs/source/manual/migrations.rst
+++ b/docs/source/manual/migrations.rst
@@ -52,7 +52,8 @@ Defining Migrations
 
 Your database migrations are stored in your Dropwizard project, in
 ``src/main/resources/migrations.xml``. This file will be packaged with your application, allowing you to
-run migrations using your application's command-line interface.
+run migrations using your application's command-line interface. You can change the name of the migrations
+file used by overriding the ``getMigrationsFileName()`` method in ``MigrationsBundle``.
 
 For example, to create a new ``people`` table, you might create an initial ``migrations.xml`` like
 this:

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/AbstractLiquibaseCommand.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/AbstractLiquibaseCommand.java
@@ -19,14 +19,17 @@ import java.sql.SQLException;
 public abstract class AbstractLiquibaseCommand<T extends Configuration> extends ConfiguredCommand<T> {
     private final DatabaseConfiguration<T> strategy;
     private final Class<T> configurationClass;
+    private final String migrationsFileName;
 
     protected AbstractLiquibaseCommand(String name,
                                        String description,
                                        DatabaseConfiguration<T> strategy,
-                                       Class<T> configurationClass) {
+                                       Class<T> configurationClass,
+                                       String migrationsFileName) {
         super(name, description);
         this.strategy = strategy;
         this.configurationClass = configurationClass;
+        this.migrationsFileName = migrationsFileName;
     }
 
     @Override
@@ -72,9 +75,10 @@ public abstract class AbstractLiquibaseCommand<T extends Configuration> extends 
 
         final String migrationsFile = namespace.getString("migrations-file");
         if (migrationsFile == null) {
-            liquibase = new CloseableLiquibase(dataSource);
+            liquibase = new CloseableLiquibaseWithClassPathMigrationsFile(dataSource, migrationsFileName) {
+            };
         } else {
-            liquibase = new CloseableLiquibase(dataSource, migrationsFile);
+            liquibase = new CloseableLiquibaseWithFileSystemMigrationsFile(dataSource, migrationsFile);
         }
 
         final Database database = liquibase.getDatabase();

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibase.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibase.java
@@ -2,28 +2,17 @@ package io.dropwizard.migrations;
 
 import io.dropwizard.db.ManagedDataSource;
 import liquibase.Liquibase;
-import liquibase.database.jvm.JdbcConnection;
+import liquibase.database.DatabaseConnection;
 import liquibase.exception.LiquibaseException;
-import liquibase.resource.ClassLoaderResourceAccessor;
-import liquibase.resource.FileSystemResourceAccessor;
+import liquibase.resource.ResourceAccessor;
 
 import java.sql.SQLException;
 
-public class CloseableLiquibase extends Liquibase implements AutoCloseable {
-    private static final String DEFAULT_MIGRATIONS_FILE = "migrations.xml";
+public abstract class CloseableLiquibase extends Liquibase implements AutoCloseable {
     private final ManagedDataSource dataSource;
 
-    public CloseableLiquibase(ManagedDataSource dataSource) throws LiquibaseException, SQLException {
-        super(DEFAULT_MIGRATIONS_FILE,
-              new ClassLoaderResourceAccessor(),
-              new JdbcConnection(dataSource.getConnection()));
-        this.dataSource = dataSource;
-    }
-
-    public CloseableLiquibase(ManagedDataSource dataSource, String file) throws LiquibaseException, SQLException {
-        super(file,
-              new FileSystemResourceAccessor(),
-              new JdbcConnection(dataSource.getConnection()));
+    public CloseableLiquibase(String changeLogFile, ResourceAccessor resourceAccessor, DatabaseConnection conn, ManagedDataSource dataSource) throws LiquibaseException, SQLException {
+        super(changeLogFile, resourceAccessor, conn);
         this.dataSource = dataSource;
     }
 

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibaseWithClassPathMigrationsFile.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibaseWithClassPathMigrationsFile.java
@@ -1,0 +1,19 @@
+package io.dropwizard.migrations;
+
+import io.dropwizard.db.ManagedDataSource;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.LiquibaseException;
+import liquibase.resource.ClassLoaderResourceAccessor;
+
+import java.sql.SQLException;
+
+public class CloseableLiquibaseWithClassPathMigrationsFile extends CloseableLiquibase implements AutoCloseable {
+
+    public CloseableLiquibaseWithClassPathMigrationsFile(ManagedDataSource dataSource, String file) throws LiquibaseException, SQLException {
+        super(file,
+              new ClassLoaderResourceAccessor(),
+              new JdbcConnection(dataSource.getConnection()),
+              dataSource);
+    }
+
+}

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibaseWithFileSystemMigrationsFile.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibaseWithFileSystemMigrationsFile.java
@@ -1,0 +1,19 @@
+package io.dropwizard.migrations;
+
+import io.dropwizard.db.ManagedDataSource;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.LiquibaseException;
+import liquibase.resource.FileSystemResourceAccessor;
+
+import java.sql.SQLException;
+
+public class CloseableLiquibaseWithFileSystemMigrationsFile extends CloseableLiquibase implements AutoCloseable {
+
+    public CloseableLiquibaseWithFileSystemMigrationsFile(ManagedDataSource dataSource, String file) throws LiquibaseException, SQLException {
+        super(file,
+              new FileSystemResourceAccessor(),
+              new JdbcConnection(dataSource.getConnection()),
+              dataSource);
+    }
+
+}

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbCalculateChecksumCommand.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbCalculateChecksumCommand.java
@@ -12,8 +12,8 @@ import org.slf4j.LoggerFactory;
 public class DbCalculateChecksumCommand<T extends Configuration> extends AbstractLiquibaseCommand<T> {
     private static final Logger LOGGER = LoggerFactory.getLogger("liquibase");
 
-    public DbCalculateChecksumCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass) {
-        super("calculate-checksum", "Calculates and prints a checksum for a change set", strategy, configurationClass);
+    public DbCalculateChecksumCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass, String migrationsFileName) {
+        super("calculate-checksum", "Calculates and prints a checksum for a change set", strategy, configurationClass, migrationsFileName);
     }
 
     @Override

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbClearChecksumsCommand.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbClearChecksumsCommand.java
@@ -6,11 +6,12 @@ import liquibase.Liquibase;
 import net.sourceforge.argparse4j.inf.Namespace;
 
 public class DbClearChecksumsCommand<T extends Configuration> extends AbstractLiquibaseCommand<T> {
-    public DbClearChecksumsCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass) {
+    public DbClearChecksumsCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass, String migrationsFileName) {
         super("clear-checksums",
               "Removes all saved checksums from the database log",
               strategy,
-              configurationClass);
+              configurationClass,
+              migrationsFileName);
     }
 
     @Override

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbCommand.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbCommand.java
@@ -13,22 +13,22 @@ public class DbCommand<T extends Configuration> extends AbstractLiquibaseCommand
     private static final String COMMAND_NAME_ATTR = "subcommand";
     private final SortedMap<String, AbstractLiquibaseCommand<T>> subcommands;
 
-    public DbCommand(String name, DatabaseConfiguration<T> strategy, Class<T> configurationClass) {
-        super(name, "Run database migration tasks", strategy, configurationClass);
+    public DbCommand(String name, DatabaseConfiguration<T> strategy, Class<T> configurationClass, String migrationsFileName) {
+        super(name, "Run database migration tasks", strategy, configurationClass, migrationsFileName);
         this.subcommands = new TreeMap<>();
-        addSubcommand(new DbCalculateChecksumCommand<>(strategy, configurationClass));
-        addSubcommand(new DbClearChecksumsCommand<>(strategy, configurationClass));
-        addSubcommand(new DbDropAllCommand<>(strategy, configurationClass));
-        addSubcommand(new DbDumpCommand<>(strategy, configurationClass));
-        addSubcommand(new DbFastForwardCommand<>(strategy, configurationClass));
-        addSubcommand(new DbGenerateDocsCommand<>(strategy, configurationClass));
-        addSubcommand(new DbLocksCommand<>(strategy, configurationClass));
-        addSubcommand(new DbMigrateCommand<>(strategy, configurationClass));
-        addSubcommand(new DbPrepareRollbackCommand<>(strategy, configurationClass));
-        addSubcommand(new DbRollbackCommand<>(strategy, configurationClass));
-        addSubcommand(new DbStatusCommand<>(strategy, configurationClass));
-        addSubcommand(new DbTagCommand<>(strategy, configurationClass));
-        addSubcommand(new DbTestCommand<>(strategy, configurationClass));
+        addSubcommand(new DbCalculateChecksumCommand<>(strategy, configurationClass, migrationsFileName));
+        addSubcommand(new DbClearChecksumsCommand<>(strategy, configurationClass, migrationsFileName));
+        addSubcommand(new DbDropAllCommand<>(strategy, configurationClass, migrationsFileName));
+        addSubcommand(new DbDumpCommand<>(strategy, configurationClass, migrationsFileName));
+        addSubcommand(new DbFastForwardCommand<>(strategy, configurationClass, migrationsFileName));
+        addSubcommand(new DbGenerateDocsCommand<>(strategy, configurationClass, migrationsFileName));
+        addSubcommand(new DbLocksCommand<>(strategy, configurationClass, migrationsFileName));
+        addSubcommand(new DbMigrateCommand<>(strategy, configurationClass, migrationsFileName));
+        addSubcommand(new DbPrepareRollbackCommand<>(strategy, configurationClass, migrationsFileName));
+        addSubcommand(new DbRollbackCommand<>(strategy, configurationClass, migrationsFileName));
+        addSubcommand(new DbStatusCommand<>(strategy, configurationClass, migrationsFileName));
+        addSubcommand(new DbTagCommand<>(strategy, configurationClass, migrationsFileName));
+        addSubcommand(new DbTestCommand<>(strategy, configurationClass, migrationsFileName));
     }
 
     private void addSubcommand(AbstractLiquibaseCommand<T> subcommand) {

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbDropAllCommand.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbDropAllCommand.java
@@ -8,8 +8,8 @@ import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 
 public class DbDropAllCommand<T extends Configuration> extends AbstractLiquibaseCommand<T> {
-    public DbDropAllCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass) {
-        super("drop-all", "Delete all user-owned objects from the database.", strategy, configurationClass);
+    public DbDropAllCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass, String migrationsFileName) {
+        super("drop-all", "Delete all user-owned objects from the database.", strategy, configurationClass, migrationsFileName);
     }
 
     @Override

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbDumpCommand.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbDumpCommand.java
@@ -48,11 +48,12 @@ public class DbDumpCommand<T extends Configuration> extends AbstractLiquibaseCom
         this.outputStream = outputStream;
     }
 
-    public DbDumpCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass) {
+    public DbDumpCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass, String migrationsFileName) {
         super("dump",
               "Generate a dump of the existing database state.",
               strategy,
-              configurationClass);
+              configurationClass,
+              migrationsFileName);
     }
 
     @Override

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbFastForwardCommand.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbFastForwardCommand.java
@@ -13,11 +13,12 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 public class DbFastForwardCommand<T extends Configuration> extends AbstractLiquibaseCommand<T> {
-    protected DbFastForwardCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass) {
+    protected DbFastForwardCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass, String migrationsFileName) {
         super("fast-forward",
               "Mark the next pending change set as applied without running it",
               strategy,
-              configurationClass);
+              configurationClass,
+              migrationsFileName);
     }
 
     @Override

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbGenerateDocsCommand.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbGenerateDocsCommand.java
@@ -7,8 +7,8 @@ import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 
 public class DbGenerateDocsCommand<T extends Configuration> extends AbstractLiquibaseCommand<T> {
-    public DbGenerateDocsCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass) {
-        super("generate-docs", "Generate documentation about the database state.", strategy, configurationClass);
+    public DbGenerateDocsCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass, String migrationsFileName) {
+        super("generate-docs", "Generate documentation about the database state.", strategy, configurationClass, migrationsFileName);
     }
 
     @Override

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbLocksCommand.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbLocksCommand.java
@@ -8,8 +8,8 @@ import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 
 public class DbLocksCommand<T extends Configuration> extends AbstractLiquibaseCommand<T> {
-    public DbLocksCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass) {
-        super("locks", "Manage database migration locks", strategy, configurationClass);
+    public DbLocksCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass, String migrationsFileName) {
+        super("locks", "Manage database migration locks", strategy, configurationClass, migrationsFileName);
     }
 
     @Override

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbMigrateCommand.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbMigrateCommand.java
@@ -24,8 +24,8 @@ public class DbMigrateCommand<T extends Configuration> extends AbstractLiquibase
         this.outputStream = outputStream;
     }
 
-    public DbMigrateCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass) {
-        super("migrate", "Apply all pending change sets.", strategy, configurationClass);
+    public DbMigrateCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass, String migrationsFileName) {
+        super("migrate", "Apply all pending change sets.", strategy, configurationClass, migrationsFileName);
     }
 
     @Override

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbPrepareRollbackCommand.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbPrepareRollbackCommand.java
@@ -13,8 +13,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 public class DbPrepareRollbackCommand<T extends Configuration> extends AbstractLiquibaseCommand<T> {
-    public DbPrepareRollbackCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass) {
-        super("prepare-rollback", "Generate rollback DDL scripts for pending change sets.", strategy, configurationClass);
+    public DbPrepareRollbackCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass, String migrationsFileName) {
+        super("prepare-rollback", "Generate rollback DDL scripts for pending change sets.", strategy, configurationClass, migrationsFileName);
     }
 
     @Override

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbRollbackCommand.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbRollbackCommand.java
@@ -14,11 +14,12 @@ import java.util.Date;
 import java.util.List;
 
 public class DbRollbackCommand<T extends Configuration> extends AbstractLiquibaseCommand<T> {
-    public DbRollbackCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass) {
+    public DbRollbackCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass, String migrationsFileName) {
         super("rollback",
               "Rollback the database schema to a previous version.",
               strategy,
-              configurationClass);
+              configurationClass,
+              migrationsFileName);
     }
 
     @Override

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbStatusCommand.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbStatusCommand.java
@@ -24,8 +24,8 @@ public class DbStatusCommand<T extends Configuration> extends AbstractLiquibaseC
         this.outputStream = outputStream;
     }
 
-    public DbStatusCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass) {
-        super("status", "Check for pending change sets.", strategy, configurationClass);
+    public DbStatusCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass, String migrationsFileName) {
+        super("status", "Check for pending change sets.", strategy, configurationClass, migrationsFileName);
     }
 
     @Override

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbTagCommand.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbTagCommand.java
@@ -7,8 +7,8 @@ import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 
 public class DbTagCommand<T extends Configuration> extends AbstractLiquibaseCommand<T> {
-    public DbTagCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass) {
-        super("tag", "Tag the database schema.", strategy, configurationClass);
+    public DbTagCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass, String migrationsFileName) {
+        super("tag", "Tag the database schema.", strategy, configurationClass, migrationsFileName);
     }
 
     @Override

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbTestCommand.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbTestCommand.java
@@ -11,8 +11,8 @@ import net.sourceforge.argparse4j.inf.Subparser;
 import java.util.List;
 
 public class DbTestCommand<T extends Configuration> extends AbstractLiquibaseCommand<T> {
-    public DbTestCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass) {
-        super("test", "Apply and rollback pending change sets.", strategy, configurationClass);
+    public DbTestCommand(DatabaseConfiguration<T> strategy, Class<T> configurationClass, String migrationsFileName) {
+        super("test", "Apply and rollback pending change sets.", strategy, configurationClass, migrationsFileName);
     }
 
     @Override

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/MigrationsBundle.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/MigrationsBundle.java
@@ -8,12 +8,17 @@ import io.dropwizard.setup.Environment;
 
 public abstract class MigrationsBundle<T extends Configuration> implements Bundle, DatabaseConfiguration<T> {
     private static final String DEFAULT_NAME = "db";
+    private static final String DEFAULT_MIGRATIONS_FILE = "migrations.xml";
 
     @Override
     @SuppressWarnings("unchecked")
     public final void initialize(Bootstrap<?> bootstrap) {
         final Class<T> klass = (Class<T>) bootstrap.getApplication().getConfigurationClass();
-        bootstrap.addCommand(new DbCommand<>(name(), this, klass));
+        bootstrap.addCommand(new DbCommand<>(name(), this, klass, getMigrationsFileName()));
+    }
+
+    public String getMigrationsFileName() {
+        return DEFAULT_MIGRATIONS_FILE;
     }
 
     public String name() {

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/CloseableLiquibaseTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/CloseableLiquibaseTest.java
@@ -25,7 +25,7 @@ public class CloseableLiquibaseTest {
         factory.setUser("DbTest");
 
         dataSource = (ManagedPooledDataSource) factory.build(new MetricRegistry(), "DbTest");
-        liquibase = new CloseableLiquibase(dataSource);
+        liquibase = new CloseableLiquibaseWithClassPathMigrationsFile(dataSource, "migrations.xml");
     }
 
     @Test

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDumpCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDumpCommandTest.java
@@ -38,7 +38,7 @@ public class DbDumpCommandTest extends AbstractMigrationTest {
     private static List<String> attributeNames;
 
     private final DbDumpCommand<TestMigrationConfiguration> dumpCommand =
-            new DbDumpCommand<>(new TestMigrationDatabaseConfiguration(), TestMigrationConfiguration.class);
+            new DbDumpCommand<>(new TestMigrationDatabaseConfiguration(), TestMigrationConfiguration.class, "migrations.xml");
     private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
     private TestMigrationConfiguration existedDbConf;
 

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCommandTest.java
@@ -1,8 +1,6 @@
 package io.dropwizard.migrations;
 
 import com.google.common.collect.ImmutableMap;
-import io.dropwizard.db.DataSourceFactory;
-import io.dropwizard.db.DatabaseConfiguration;
 import net.jcip.annotations.NotThreadSafe;
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.Namespace;
@@ -22,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class DbMigrateCommandTest extends AbstractMigrationTest {
 
     private DbMigrateCommand<TestMigrationConfiguration> migrateCommand = new DbMigrateCommand<>(
-        TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class);
+        TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations.xml");
     private TestMigrationConfiguration conf;
     private String databaseUrl;
 

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateDifferentFileCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateDifferentFileCommandTest.java
@@ -1,0 +1,39 @@
+package io.dropwizard.migrations;
+
+import com.google.common.collect.ImmutableMap;
+import net.jcip.annotations.NotThreadSafe;
+import net.sourceforge.argparse4j.inf.Namespace;
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@NotThreadSafe
+public class DbMigrateDifferentFileCommandTest extends AbstractMigrationTest {
+
+    private DbMigrateCommand<TestMigrationConfiguration> migrateCommand = new DbMigrateCommand<>(
+        TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations-test.xml");
+    private TestMigrationConfiguration conf;
+    private String databaseUrl;
+
+    @Before
+    public void setUp() throws Exception {
+        databaseUrl = "jdbc:h2:" + createTempFile();
+        conf = createConfiguration(databaseUrl);
+    }
+
+    @Test
+    public void testRun() throws Exception {
+        migrateCommand.run(null, new Namespace(ImmutableMap.<String, Object>of()), conf);
+        try (Handle handle = new DBI(databaseUrl, "sa", "").open()) {
+            final List<Map<String, Object>> rows = handle.select("select * from persons");
+            assertThat(rows).hasSize(0);
+        }
+    }
+
+}

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbStatusCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbStatusCommandTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class DbStatusCommandTest extends AbstractMigrationTest {
 
     private final DbStatusCommand<TestMigrationConfiguration> statusCommand =
-            new DbStatusCommand<>(new TestMigrationDatabaseConfiguration(), TestMigrationConfiguration.class);
+            new DbStatusCommand<>(new TestMigrationDatabaseConfiguration(), TestMigrationConfiguration.class, "migrations.xml");
     private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
     private TestMigrationConfiguration conf;
 

--- a/dropwizard-migrations/src/test/resources/migrations-test.xml
+++ b/dropwizard-migrations/src/test/resources/migrations-test.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="1" author="db_dev">
+        <createTable tableName="persons">
+            <column name="id" type="int" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="name" type="varchar(256)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2" author="db_dev">
+        <addColumn tableName="persons">
+            <column name="email" type="varchar(128)"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
I have a use case where I'd like to run multiple `DropwizardAppRule` instances in an integration test and each DropwizardAppRule is from a different fat jar dependency. Each DropwizardAppRule will need to migrate its own database, however the `migration.xml` files collide because they have the same name. This PR allows the migrations filename to be set in the `MigrationsBundle` by overriding `getMigrationsFileName()`, which defaults to `migrations.xml`.