### PR TITLE
Fix invalid JSON reporting server errors

### DIFF
--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonResource.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonResource.java
@@ -8,6 +8,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import java.net.URL;
 import java.util.List;
 
 @Path("/json/")
@@ -36,5 +37,28 @@ public class JsonResource {
     @Path("/brokenList")
     public List<Integer> ok(List<BrokenRepresentation> rep) {
         return ImmutableList.of(rep.size());
+    }
+
+    @POST
+    @Path("/url")
+    public void url(URL url) {
+    }
+
+    @POST
+    @Path("/urlList")
+    public void urlList(List<URL> url) {
+    }
+
+    @POST
+    @Path("/interface")
+    public void face(IInterface inter) {
+    }
+
+    @POST
+    @Path("/interfaceList")
+    public void face(List<IInterface> inter) {
+    }
+
+    private interface IInterface {
     }
 }


### PR DESCRIPTION
As a follow up to #1527

This PR does a couple things:

- Entities that throw an `IOException` on deserialization will now map to a client error on invalid input instead of being handled by the logging exception handler
- New implementation determining whether a Jackson exception is due to the server (programmer's) or client's fault. New implementation was needed because the new tests that were written exposed flaws. After scratching my head for far too long, the best solution was peeking at the exception message. Not cleanest, but the tests will show if the error messages change in a future version.
- Clean up the tests a tad

Closes #1539, #1540