### PR TITLE
Allow file appender infinite log files

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -599,7 +599,8 @@ archivedLogFilenamePattern   (none)       Required if ``archive`` is ``true``.
                                           Otherwise rollover is date-based, and the pattern must contain ``%d``, which is replaced with the
                                           date in ``yyyy-MM-dd`` form.
                                           If the pattern ends with ``.gz`` or ``.zip``, files will be compressed as they are archived.
-archivedFileCount            5            The number of archived files to keep. Must be between ``1`` and ``50``.
+archivedFileCount            5            The number of archived files to keep. Must be greater than or equal to ``0``. Zero is a
+                                          special value signifying to keep infinite logs (use with caution)
 maxFileSize                  (unlimited)  The maximum size of the currently active file before a rollover is triggered. The value can be
                                           expressed in bytes, kilobytes, megabytes, gigabytes, and terabytes by appending B, K, MB, GB, or
                                           TB to the numeric value.  Examples include 100MB, 1GB, 1TB.  Sizes can also be spelled out, such

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
@@ -71,7 +71,8 @@ import javax.validation.constraints.NotNull;
  *         <td>{@code archivedFileCount}</td>
  *         <td>{@code 5}</td>
  *         <td>
- *             The number of archived files to keep. Must be greater than {@code 0}.
+ *             The number of archived files to keep. Must be greater than or equal to {@code 0}. Zero is a
+ *             special value signifying to keep infinite logs (use with caution)
  *         </td>
  *     </tr>
  *     <tr>
@@ -111,7 +112,7 @@ public class FileAppenderFactory<E extends DeferredProcessingAware> extends Abst
 
     private String archivedLogFilenamePattern;
 
-    @Min(1)
+    @Min(0)
     private int archivedFileCount = 5;
 
     private Size maxFileSize;

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
@@ -86,6 +86,18 @@ public class FileAppenderFactoryTest {
     }
 
     @Test
+    public void isValidForInfiniteRolledFiles() throws Exception{
+        FileAppenderFactory fileAppenderFactory = new FileAppenderFactory();
+        fileAppenderFactory.setCurrentLogFilename(folder.newFile("logfile.log").toString());
+        fileAppenderFactory.setArchivedFileCount(0);
+        fileAppenderFactory.setArchivedLogFilenamePattern(folder.newFile("example-%d.log.gz").toString());
+        ImmutableList<String> errors =
+            ConstraintViolations.format(validator.validate(fileAppenderFactory));
+        assertThat(errors).isEmpty();
+        assertThat(fileAppenderFactory.buildAppender(new LoggerContext())).isNotNull();
+    }
+
+    @Test
     public void isValidForMaxFileSize() throws Exception{
         FileAppenderFactory fileAppenderFactory = new FileAppenderFactory();
         fileAppenderFactory.setCurrentLogFilename(folder.newFile("logfile.log").toString());


### PR DESCRIPTION
Closes #1491

I think there is no reason not to allow dropwizard users the ability to keep infinite files as long as it is warned and the default remains something sensible.

This also fixes the erroneous description that the number of archived files have a maximum (they don't)