### PR TITLE
Add CacheBuilderSpecSerializer

### DIFF
--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryTest.java
@@ -1,6 +1,7 @@
 package io.dropwizard.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.cache.CacheBuilderSpec;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
@@ -12,6 +13,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.validation.Valid;
 import javax.validation.Validator;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
@@ -111,6 +113,10 @@ public class ConfigurationFactoryTest {
         @JsonProperty
         List<ExampleServer> servers = ImmutableList.of(
                 ExampleServer.create(8080), ExampleServer.create(8081), ExampleServer.create(8082));
+
+        @JsonProperty
+        @Valid
+        CacheBuilderSpec cacheBuilderSpec = CacheBuilderSpec.disableCaching();
     }
 
     static class NonInsatiableExample {
@@ -151,6 +157,17 @@ public class ConfigurationFactoryTest {
         this.emptyFile = resourceFileName("factory-test-empty.yml");
         this.invalidFile = resourceFileName("factory-test-invalid.yml");
         this.validFile = resourceFileName("factory-test-valid.yml");
+    }
+
+    @Test
+    public void usesDefaultedCacheBuilderSpec() throws Exception {
+        final ExampleWithDefaults example =
+            new YamlConfigurationFactory<>(ExampleWithDefaults.class, validator, Jackson.newObjectMapper(), "dw")
+                .build();
+        assertThat(example.cacheBuilderSpec)
+            .isNotNull();
+        assertThat(example.cacheBuilderSpec)
+            .isEqualTo(CacheBuilderSpec.disableCaching());
     }
 
     @Test

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/GuavaExtrasModule.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/GuavaExtrasModule.java
@@ -1,6 +1,8 @@
 package io.dropwizard.jackson;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.BeanDescription;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -8,8 +10,12 @@ import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.deser.Deserializers;
+import com.fasterxml.jackson.databind.ser.Serializers;
 import com.google.common.cache.CacheBuilderSpec;
 
 import java.io.IOException;
@@ -27,6 +33,13 @@ public class GuavaExtrasModule extends Module {
         }
     }
 
+    private static class CacheBuilderSpecSerializer extends JsonSerializer<CacheBuilderSpec> {
+        @Override
+        public void serialize(CacheBuilderSpec value, JsonGenerator gen, SerializerProvider serializers) throws IOException, JsonProcessingException {
+            gen.writeString(value.toParsableString());
+        }
+    }
+
     private static class GuavaExtrasDeserializers extends Deserializers.Base {
         @Override
         public JsonDeserializer<?> findBeanDeserializer(JavaType type,
@@ -37,6 +50,17 @@ public class GuavaExtrasModule extends Module {
             }
 
             return super.findBeanDeserializer(type, config, beanDesc);
+        }
+    }
+
+    private static class GuavaExtrasSerializers extends Serializers.Base {
+        @Override
+        public JsonSerializer<?> findSerializer(SerializationConfig config, JavaType type, BeanDescription beanDesc) {
+            if (CacheBuilderSpec.class.isAssignableFrom(type.getRawClass())) {
+                return new CacheBuilderSpecSerializer();
+            }
+
+            return super.findSerializer(config, type, beanDesc);
         }
     }
 
@@ -53,5 +77,6 @@ public class GuavaExtrasModule extends Module {
     @Override
     public void setupModule(SetupContext context) {
         context.addDeserializers(new GuavaExtrasDeserializers());
+        context.addSerializers(new GuavaExtrasSerializers());
     }
 }

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/GuavaExtrasModuleTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/GuavaExtrasModuleTest.java
@@ -32,6 +32,12 @@ public class GuavaExtrasModuleTest {
     }
 
     @Test
+    public void canSerializeCacheBuilderSpecs() throws Exception {
+        assertThat(mapper.writeValueAsString(CacheBuilderSpec.disableCaching()))
+            .isEqualTo("\"maximumSize=0\"");
+    }
+
+    @Test
     public void canDeserializeAbsentOptions() throws Exception {
         assertThat(mapper.readValue("null", Optional.class))
                 .isEqualTo(Optional.absent());


### PR DESCRIPTION
If a configuration has a default value for a CacheBuilderSpec (e.g. `CacheBuilderSpec cacheBuilderSpec = CacheBuilderSpec.disableCaching();`) and the value is not overridden in the configuration file, we need to serialize the object before parsing the configuration so that it can be properly instantiated in the `Configuration` class. 