### PR TITLE
Dependency updates

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -43,7 +43,7 @@ v1.0.0
 * Upgraded to Jackson 2.7.4
 * Upgraded to JDBI 2.73 `#1358 <https://github.com/dropwizard/dropwizard/pull/1358>`_
 * Upgraded to Jersey 2.23
-* Upgraded to Jetty 9.3.8.v20160314 `#1330 <https://github.com/dropwizard/dropwizard/pull/1330>`_
+* Upgraded to Jetty 9.3.9.v20160517 `#1330 <https://github.com/dropwizard/dropwizard/pull/1330>`_
 * Upgraded to Joda-Time 2.9.3
 * Upgraded to Liquibase 3.5.0
 * Upgraded to liquibase-slf4j 2.0.0

--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -45,7 +45,7 @@ v1.0.0
 * Upgraded to Jersey 2.23
 * Upgraded to Jetty 9.3.9.v20160517 `#1330 <https://github.com/dropwizard/dropwizard/pull/1330>`_
 * Upgraded to Joda-Time 2.9.3
-* Upgraded to Liquibase 3.5.0
+* Upgraded to Liquibase 3.5.1
 * Upgraded to liquibase-slf4j 2.0.0
 * Upgraded to Logback 1.1.7
 * Upgraded to Mustache 0.9.1

--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -52,7 +52,7 @@ v1.0.0
 * Upgraded to Logback 1.1.7
 * Upgraded to Mustache 0.9.1
 * Upgraded to SLF4J 1.7.21
-* Upgraded to tomcat-jdbc 8.0.33
+* Upgraded to tomcat-jdbc 8.5.2
 * Upgraded to Objenesis 2.3
 * Upgraded to AssertJ 3.4.1
 

--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -37,7 +37,7 @@ v1.0.0
 * Upgraded to argparse4j 0.7.0
 * Upgraded to Guava 19.0
 * Upgraded to H2 1.4.191
-* Upgraded to Hibernate 5.0.7 `#1429 <https://github.com/dropwizard/dropwizard/pull/1429>`_
+* Upgraded to Hibernate 5.1.0 `#1429 <https://github.com/dropwizard/dropwizard/pull/1429>`_
 * Upgraded to Hibernate Validator 5.2.4.Final
 * Upgraded to HSQLDB 2.3.4
 * Upgraded to Jadira Usertype Core 5.0.0.GA

--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -42,7 +42,7 @@ v1.0.0
 * Upgraded to Jadira Usertype Core 5.0.0.GA
 * Upgraded to Jackson 2.7.4
 * Upgraded to JDBI 2.73 `#1358 <https://github.com/dropwizard/dropwizard/pull/1358>`_
-* Upgraded to Jersey 2.22.2
+* Upgraded to Jersey 2.23
 * Upgraded to Jetty 9.3.8.v20160314 `#1330 <https://github.com/dropwizard/dropwizard/pull/1330>`_
 * Upgraded to Joda-Time 2.9.3
 * Upgraded to Liquibase 3.5.0

--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -51,6 +51,7 @@ v1.0.0
 * Upgraded to Mustache 0.9.1
 * Upgraded to SLF4J 1.7.21
 * Upgraded to tomcat-jdbc 8.0.33
+* Upgraded to Objenesis 2.3
 * Upgraded to AssertJ 3.4.1
 
 .. _rel-0.9.2:

--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -39,6 +39,7 @@ v1.0.0
 * Upgraded to H2 1.4.191
 * Upgraded to Hibernate 5.0.7 `#1429 <https://github.com/dropwizard/dropwizard/pull/1429>`_
 * Upgraded to Hibernate Validator 5.2.4.Final
+* Upgraded to HSQLDB 2.3.4
 * Upgraded to Jadira Usertype Core 5.0.0.GA
 * Upgraded to Jackson 2.7.4
 * Upgraded to JDBI 2.73 `#1358 <https://github.com/dropwizard/dropwizard/pull/1358>`_

--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -45,6 +45,7 @@ v1.0.0
 * Upgraded to JDBI 2.73 `#1358 <https://github.com/dropwizard/dropwizard/pull/1358>`_
 * Upgraded to Jersey 2.23
 * Upgraded to Jetty 9.3.9.v20160517 `#1330 <https://github.com/dropwizard/dropwizard/pull/1330>`_
+* Upgraded to JMH 1.12
 * Upgraded to Joda-Time 2.9.3
 * Upgraded to Liquibase 3.5.1
 * Upgraded to liquibase-slf4j 2.0.0

--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -55,6 +55,7 @@ v1.0.0
 * Upgraded to tomcat-jdbc 8.5.2
 * Upgraded to Objenesis 2.3
 * Upgraded to AssertJ 3.4.1
+* Upgraded to Mockito 2.0.53-beta
 
 .. _rel-0.9.2:
 

--- a/dropwizard-benchmarks/pom.xml
+++ b/dropwizard-benchmarks/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <!-- see https://issues.apache.org/jira/browse/MCOMPILER-235 -->
         <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
-        <jmh.version>1.11.3</jmh.version>
+        <jmh.version>1.12</jmh.version>
         <!-- Skip deployment of this sub-module -->
         <source.skip>true</source.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -95,7 +95,7 @@
             <dependency>
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-jdbc</artifactId>
-                <version>8.0.33</version>
+                <version>8.5.2</version>
             </dependency>
             <dependency>
                 <groupId>com.h2database</groupId>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>org.objenesis</groupId>
                 <artifactId>objenesis</artifactId>
-                <version>2.2</version>
+                <version>2.3</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -23,7 +23,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <dropwizard.version>${project.version}</dropwizard.version>
         <guava.version>19.0</guava.version>
-        <jersey.version>2.22.2</jersey.version>
+        <jersey.version>2.23</jersey.version>
         <jackson.api.version>2.7.4</jackson.api.version>
         <jackson.version>2.7.4</jackson.version>
         <jetty.version>9.3.8.v20160314</jetty.version>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -26,7 +26,7 @@
         <jersey.version>2.23</jersey.version>
         <jackson.api.version>2.7.4</jackson.api.version>
         <jackson.version>2.7.4</jackson.version>
-        <jetty.version>9.3.8.v20160314</jetty.version>
+        <jetty.version>9.3.9.v20160517</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics3.version>3.1.2</metrics3.version>
         <slf4j.version>1.7.21</slf4j.version>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -140,7 +140,7 @@
             <dependency>
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-core</artifactId>
-                <version>3.5.0</version>
+                <version>3.5.1</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.yaml</groupId>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -135,7 +135,7 @@
             <dependency>
                 <groupId>org.hsqldb</groupId>
                 <artifactId>hsqldb</artifactId>
-                <version>2.3.3</version>
+                <version>2.3.4</version>
             </dependency>
             <dependency>
                 <groupId>org.liquibase</groupId>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -124,13 +124,23 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-core</artifactId>
-                <version>5.0.7.Final</version>
+                <version>5.1.0.Final</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jboss.logging</groupId>
                         <artifactId>jboss-logging</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.javassist</groupId>
+                <artifactId>javassist</artifactId>
+                <version>3.20.0-GA</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml</groupId>
+                <artifactId>classmate</artifactId>
+                <version>1.3.0</version>
             </dependency>
             <dependency>
                 <groupId>org.hsqldb</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <maven.site.deploy.skip>true</maven.site.deploy.skip>
         <junit.version>4.12</junit.version>
         <assertj.version>3.4.1</assertj.version>
-        <mockito.version>1.10.19</mockito.version>
+        <mockito.version>2.0.53-beta</mockito.version>
     </properties>
 
     <developers>


### PR DESCRIPTION
* Upgrade to Hibernate 5.1.0
* Upgrade to Mockito 2.0.53-beta
* Upgrade to tomcat-jdbc 8.5.2
* Upgrade to JMH 1.12
* Upgrade to HSQLDB 2.3.4
* Upgrade to Objenesis 2.3
* Upgrade to Liquibase 3.5.1
* Upgrade to Jetty 9.3.9.v20160517
* Upgrade to Jersey 2.23