### PR TITLE
Permit override of default failed command behavior

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/Application.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/Application.java
@@ -78,7 +78,7 @@ public abstract class Application<T extends Configuration> {
         final Cli cli = new Cli(new JarLocation(getClass()), bootstrap, System.out, System.err);
         if (!cli.run(arguments)) {
             // only exit if there's an error running the command
-            System.exit(1);
+            onFatalError();
         }
     }
 
@@ -92,4 +92,13 @@ public abstract class Application<T extends Configuration> {
         bootstrap.addCommand(new CheckCommand<>(this));
     }
 
+    /**
+     * Called by {@link #run(String...)} to indicate there was a fatal error running the requested command.
+     *
+     * The default implementation calls {@link System#exit(int)} with a non-zero status code to terminate the
+     * application.
+     */
+    protected void onFatalError() {
+        System.exit(1);
+    }
 }

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -10,7 +10,7 @@
     <!-- kind of hard to use exit codes without System.exit -->
     <Match>
         <Class name="io.dropwizard.Application"/>
-        <Method name="run"/>
+        <Method name="onFatalError"/>
         <Bug pattern="DM_EXIT"/>
     </Match>
 


### PR DESCRIPTION
The current behavior of configuration errors etc. in `Application.run(String...)` is to call `System.exit(1)`. This can play havoc with things like integration tests, such that a hard exit will terminate the testing process.

This change allows folks to override the default behavior to do something other than the `System.exit(1)` call.