### PR TITLE
Add Maven profiles for selecting alpn-boot version

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -290,12 +290,6 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            <dependency>
-                <groupId>org.mortbay.jetty.alpn</groupId>
-                <artifactId>alpn-boot</artifactId>
-                <version>8.1.3.v20150130</version>
-                <scope>test</scope>
-            </dependency>
 
             <!-- Jackson -->
             <dependency>

--- a/dropwizard-http2/pom.xml
+++ b/dropwizard-http2/pom.xml
@@ -11,13 +11,18 @@
     <artifactId>dropwizard-http2</artifactId>
     <name>Dropwizard HTTP/2 Support</name>
 
+    <properties>
+        <!-- Default alpn-boot version. See <profiles> for specific profiles. -->
+        <alpn-boot.version>8.1.3.v20150130</alpn-boot.version>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/8.1.3.v20150130/alpn-boot-8.1.3.v20150130.jar
+                    <argLine>-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar
                              -Duser.language=en -Duser.region=US</argLine>
                     <parallel>classes</parallel>
                     <threadCount>2</threadCount>
@@ -80,13 +85,190 @@
         </dependency>
 
         <!-- This needs to be on your JVM's bootpath for HTTP2 to work with ALPN protocol
-            -Xbootclasspath/p:/<path_to_alpn_boot_jar>/alpn-boot-8.1.3.v20150130.jar
+            -Xbootclasspath/p:/<path_to_alpn_boot_jar>/alpn-boot-${alpn-boot.version}.jar
              The correct version depends on the specific JVM version.
              Consult http://www.eclipse.org/jetty/documentation/current/alpn-chapter.html for the reference -->
         <dependency>
             <groupId>org.mortbay.jetty.alpn</groupId>
             <artifactId>alpn-boot</artifactId>
+            <version>${alpn-boot.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <!-- Profiles for selecting the correct version of alpn-boot for each JDK.
+         see http://www.eclipse.org/jetty/documentation/current/alpn-chapter.html for reference. -->
+    <profiles>
+        <profile>
+            <id>jdk-1.8.0</id>
+            <activation>
+                <jdk>1.8.0</jdk>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.0.v20141016</alpn-boot.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_05</id>
+            <activation>
+                <jdk>1.8.0_05</jdk>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.0.v20141016</alpn-boot.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_11</id>
+            <activation>
+                <jdk>1.8.0_11</jdk>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.0.v20141016</alpn-boot.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_20</id>
+            <activation>
+                <jdk>1.8.0_20</jdk>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.0.v20141016</alpn-boot.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_25</id>
+            <activation>
+                <jdk>1.8.0_25</jdk>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.2.v20141202</alpn-boot.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_31</id>
+            <activation>
+                <jdk>1.8.0_31</jdk>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.3.v20150130</alpn-boot.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_40</id>
+            <activation>
+                <jdk>1.8.0_40</jdk>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.3.v20150130</alpn-boot.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_45</id>
+            <activation>
+                <jdk>1.8.0_45</jdk>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.3.v20150130</alpn-boot.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_51</id>
+            <activation>
+                <jdk>1.8.0_51</jdk>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.4.v20150727</alpn-boot.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_60</id>
+            <activation>
+                <jdk>1.8.0_60</jdk>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.5.v20150921</alpn-boot.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_65</id>
+            <activation>
+                <jdk>1.8.0_65</jdk>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.6.v20151105</alpn-boot.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_66</id>
+            <activation>
+                <jdk>1.8.0_66</jdk>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.6.v20151105</alpn-boot.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_71</id>
+            <activation>
+                <jdk>1.8.0_71</jdk>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.7.v20160121</alpn-boot.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_72</id>
+            <activation>
+                <jdk>1.8.0_72</jdk>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.7.v20160121</alpn-boot.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_73</id>
+            <activation>
+                <jdk>1.8.0_73</jdk>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.7.v20160121</alpn-boot.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_74</id>
+            <activation>
+                <jdk>1.8.0_74</jdk>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.7.v20160121</alpn-boot.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_77</id>
+            <activation>
+                <jdk>1.8.0_77</jdk>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.7.v20160121</alpn-boot.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_91</id>
+            <activation>
+                <jdk>1.8.0_91</jdk>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.7.v20160121</alpn-boot.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_92</id>
+            <activation>
+                <jdk>1.8.0_92</jdk>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.8.v20160420</alpn-boot.version>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
The version of `alpn-boot` is dependent on the version of the JVM being used, otherwise the build will fail.

Since not everyone is using the same version of the JVM, this PR adds profiles to `dropwizard-http2` for selecting the correct version of `alpn-boot`.

This is only required for running tests locally and on Travis CI.