### PR TITLE
#1278 pull request for FileAppenderFactory

### DIFF
--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
@@ -1,28 +1,28 @@
 package io.dropwizard.logging;
 
+import javax.validation.constraints.Min;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.FileAppender;
 import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
 import ch.qos.logback.core.rolling.DefaultTimeBasedFileNamingAndTriggeringPolicy;
+import ch.qos.logback.core.rolling.FixedWindowRollingPolicy;
 import ch.qos.logback.core.rolling.RollingFileAppender;
 import ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP;
+import ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy;
 import ch.qos.logback.core.rolling.TimeBasedFileNamingAndTriggeringPolicy;
 import ch.qos.logback.core.rolling.TimeBasedRollingPolicy;
-import ch.qos.logback.core.rolling.FixedWindowRollingPolicy;
-import ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy;
 import ch.qos.logback.core.spi.DeferredProcessingAware;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.dropwizard.logging.async.AsyncAppenderFactory;
 import io.dropwizard.logging.filter.LevelFilterFactory;
 import io.dropwizard.logging.layout.LayoutFactory;
 import io.dropwizard.util.Size;
 import io.dropwizard.validation.ValidationMethod;
-
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
 
 /**
  * An {@link AppenderFactory} implementation which provides an appender that writes events to a file, archiving older
@@ -105,8 +105,8 @@ import javax.validation.constraints.NotNull;
  */
 @JsonTypeName("file")
 public class FileAppenderFactory<E extends DeferredProcessingAware> extends AbstractAppenderFactory<E> {
-    @NotNull
-    private String currentLogFilename;
+
+	private String currentLogFilename;
 
     private boolean archive = true;
 
@@ -185,6 +185,12 @@ public class FileAppenderFactory<E extends DeferredProcessingAware> extends Abst
     public boolean isMaxFileSizeSettingSpecified() {
         return !archive || !(archivedLogFilenamePattern != null && archivedLogFilenamePattern.contains("%i")) ||
                 maxFileSize != null;
+    }
+    
+    @JsonIgnore
+    @ValidationMethod(message = "currentLogFilename can only be null when archiving is enabled")
+    public boolean isValidFileConfiguration() {
+    	return archive || currentLogFilename != null;
     }
 
     @Override

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
@@ -106,7 +106,7 @@ import io.dropwizard.validation.ValidationMethod;
 @JsonTypeName("file")
 public class FileAppenderFactory<E extends DeferredProcessingAware> extends AbstractAppenderFactory<E> {
 
-	private String currentLogFilename;
+    private String currentLogFilename;
 
     private boolean archive = true;
 
@@ -190,7 +190,7 @@ public class FileAppenderFactory<E extends DeferredProcessingAware> extends Abst
     @JsonIgnore
     @ValidationMethod(message = "currentLogFilename can only be null when archiving is enabled")
     public boolean isValidFileConfiguration() {
-    	return archive || currentLogFilename != null;
+        return archive || currentLogFilename != null;
     }
 
     @Override

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
@@ -135,8 +135,8 @@ public class FileAppenderFactoryTest {
     
     @Test
     public void testCurrentFileNameErrorWhenArchiveIsNotEnabled() throws Exception {
-    	FileAppenderFactory fileAppenderFactory = new FileAppenderFactory();
-    	fileAppenderFactory.setArchive(false);
+        FileAppenderFactory fileAppenderFactory = new FileAppenderFactory();
+        fileAppenderFactory.setArchive(false);
         ImmutableList<String> errors =
                 ConstraintViolations.format(validator.validate(fileAppenderFactory));
         assertThat(errors)
@@ -148,10 +148,10 @@ public class FileAppenderFactoryTest {
     
     @Test
     public void testCurrentFileNameCanBeNullWhenArchiveIsEnabled() throws Exception {
-    	FileAppenderFactory fileAppenderFactory = new FileAppenderFactory();
-    	fileAppenderFactory.setArchive(true);
-    	fileAppenderFactory.setArchivedLogFilenamePattern("name-to-be-used");
-    	fileAppenderFactory.setCurrentLogFilename(null);
+        FileAppenderFactory fileAppenderFactory = new FileAppenderFactory();
+        fileAppenderFactory.setArchive(true);
+        fileAppenderFactory.setArchivedLogFilenamePattern("name-to-be-used");
+        fileAppenderFactory.setCurrentLogFilename(null);
         ImmutableList<String> errors =
                 ConstraintViolations.format(validator.validate(fileAppenderFactory));
         assertThat(errors).isEmpty();

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
@@ -14,6 +14,7 @@ import org.junit.rules.TemporaryFolder;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.io.Files;
 
 import ch.qos.logback.classic.AsyncAppender;
 import ch.qos.logback.classic.Logger;
@@ -159,17 +160,14 @@ public class FileAppenderFactoryTest {
 
     @Test
     public void testCurrentLogFileNameIsEmptyAndAppenderUsesArchivedNameInstead() throws Exception {
-        final Logger root = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
         final FileAppenderFactory<ILoggingEvent> appenderFactory = new FileAppenderFactory<>();
         appenderFactory.setArchivedLogFilenamePattern(folder.newFile("test-archived-name-%d.log").toString());
-        final Appender<ILoggingEvent> appender = appenderFactory.build(root.getLoggerContext(), "test", new DropwizardLayoutFactory(), new NullLevelFilterFactory<>(), new AsyncLoggingEventAppenderFactory());
+        final FileAppender<ILoggingEvent> rollingAppender = appenderFactory.buildAppender(new LoggerContext());
 
-        RollingFileAppender<ILoggingEvent> rollingAppender = (RollingFileAppender<ILoggingEvent>) ((AsyncAppender) appender).getAppender("file-appender");
-        
-        String file = rollingAppender.getFile();
-        String dateSuffic = LocalDateTime.now().format(DateTimeFormatter.ofPattern("YYYY-MM-dd"));
-        String[] split = file.split("/");
-        Assert.assertEquals("test-archived-name-" + dateSuffic + ".log", split[split.length-1]);
+        final String file = rollingAppender.getFile();
+        final String dateSuffix = LocalDateTime.now().format(DateTimeFormatter.ofPattern("YYYY-MM-dd"));
+        final String name = Files.getNameWithoutExtension(file);
+        Assert.assertEquals("test-archived-name-" + dateSuffix, name);
     }
 
     @Test


### PR DESCRIPTION
Hi,

this pull request is with regards to: 

FileAppenderFactory not valid for null currentLogFilename #1278

First time pull request, let me know if there is something I forgot. 

This fix adds: 
* New validation based on the archived configuration to allow for null currentFileNames in case one wants to use the rolling policies file policy instead 
* Tests to assure that validation works and the rolling policy's filename is used instead. 