### PR TITLE
Fix deprecation notices in http2 servers

### DIFF
--- a/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2CConnectorFactory.java
+++ b/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2CConnectorFactory.java
@@ -88,7 +88,7 @@ public class Http2CConnectorFactory extends HttpConnectorFactory {
         final HttpConnectionFactory http11 = buildHttpConnectionFactory(httpConfig);
         final HTTP2ServerConnectionFactory http2c = new HTTP2CServerConnectionFactory(httpConfig);
         http2c.setMaxConcurrentStreams(maxConcurrentStreams);
-        http2c.setInitialStreamSendWindow(initialStreamSendWindow);
+        http2c.setInitialStreamRecvWindow(initialStreamSendWindow);
 
         // The server connector should use HTTP/1.1 by default. It affords to the server to stay compatible
         // with old clients. New clients which want to use HTTP/2, however, will make an HTTP/1.1 OPTIONS

--- a/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2ConnectorFactory.java
+++ b/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2ConnectorFactory.java
@@ -100,7 +100,7 @@ public class Http2ConnectorFactory extends HttpsConnectorFactory {
         final HttpConnectionFactory http1 = buildHttpConnectionFactory(httpConfig);
         final HTTP2ServerConnectionFactory http2 = new HTTP2ServerConnectionFactory(httpConfig);
         http2.setMaxConcurrentStreams(maxConcurrentStreams);
-        http2.setInitialStreamSendWindow(initialStreamSendWindow);
+        http2.setInitialStreamRecvWindow(initialStreamSendWindow);
 
         final NegotiatingServerConnectionFactory alpn = new ALPNServerConnectionFactory(H2, H2_17);
         alpn.setDefaultProtocol(HTTP_1_1); // Speak HTTP 1.1 over TLS if negotiation fails


### PR DESCRIPTION
The latest bump in jetty [deprecated some functions](https://github.com/eclipse/jetty.project/blob/c99c02e2f59cc4c65cc9b893710e48eeeb3bef0b/jetty-http2/http2-server/src/main/java/org/eclipse/jetty/http2/server/AbstractHTTP2ServerConnectionFactory.java#L109-L117)