### PR TITLE
Add Resource Bean Validation

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ConstraintMessage.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ConstraintMessage.java
@@ -94,7 +94,10 @@ public class ConstraintMessage {
      * friendly string representation of where the error occurred (eg. "patient.name")
      */
     public static Optional<String> isRequestEntity(ConstraintViolation<?> violation, Invocable invocable) {
-        final Path.Node parent = Iterables.get(violation.getPropertyPath(), 1);
+        final Path.Node parent = Iterables.get(violation.getPropertyPath(), 1, null);
+        if (parent == null) {
+            return Optional.empty();
+        }
         final List<Parameter> parameters = invocable.getParameters();
 
         switch (parent.getKind()) {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
@@ -533,4 +533,16 @@ public class ConstraintViolationExceptionMapperTest extends JerseyTest {
         assertThat(response.readEntity(String.class))
                 .containsOnlyOnce("examples may not be empty");
     }
+
+    @Test
+    public void testInvalidFieldQueryParam() {
+        final Response response = target("/valid/bar")
+            .queryParam("sort", "foo")
+            .request()
+            .get();
+
+        assertThat(response.getStatus()).isEqualTo(422);
+        assertThat(response.readEntity(String.class))
+            .containsOnlyOnce("sortParam must match \\\"^(asc|desc)$\\\"");
+    }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
@@ -18,6 +18,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.CookieParam;
@@ -41,6 +42,11 @@ import java.util.Set;
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class ValidatingResource {
+
+    @QueryParam("sort")
+    @Pattern(regexp = "^(asc|desc)$")
+    private String sortParam;
+
     @POST
     @Path("foo")
     @Valid


### PR DESCRIPTION
Update ConstraintMessage.isRequestEntity to be resilient against
exceptions by using the `Iterables.get` method which accepts a default
value. This is required in case the property path contains fewer than 2
items.