### PR TITLE
Allow Dropwizard constraints to be applied to type

### DIFF
--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/DurationRange.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/DurationRange.java
@@ -14,6 +14,7 @@ import static java.lang.annotation.ElementType.CONSTRUCTOR;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
@@ -22,7 +23,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Constraint(validatedBy = { })
-@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
 @Retention(RUNTIME)
 @MinDuration(0)
 @MaxDuration(value = Long.MAX_VALUE, unit = TimeUnit.DAYS)

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/MaxDuration.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/MaxDuration.java
@@ -12,6 +12,7 @@ import static java.lang.annotation.ElementType.CONSTRUCTOR;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
@@ -20,7 +21,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * <p/>
  * <code>null</code> elements are considered valid
  */
-@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
 @Retention(RUNTIME)
 @Documented
 @Constraint(validatedBy = MaxDurationValidator.class)

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/MaxSize.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/MaxSize.java
@@ -13,6 +13,7 @@ import static java.lang.annotation.ElementType.CONSTRUCTOR;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
@@ -21,7 +22,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * <p/>
  * <code>null</code> elements are considered valid
  */
-@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
 @Retention(RUNTIME)
 @Documented
 @Constraint(validatedBy = MaxSizeValidator.class)

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/MinDuration.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/MinDuration.java
@@ -12,6 +12,7 @@ import static java.lang.annotation.ElementType.CONSTRUCTOR;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
@@ -20,7 +21,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * <p/>
  * <code>null</code> elements are considered valid
  */
-@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
 @Retention(RUNTIME)
 @Documented
 @Constraint(validatedBy = MinDurationValidator.class)

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/MinSize.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/MinSize.java
@@ -13,6 +13,7 @@ import static java.lang.annotation.ElementType.CONSTRUCTOR;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
@@ -21,7 +22,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * <p/>
  * <code>null</code> elements are considered valid
  */
-@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
 @Retention(RUNTIME)
 @Documented
 @Constraint(validatedBy = MinSizeValidator.class)

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/OneOf.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/OneOf.java
@@ -11,12 +11,13 @@ import static java.lang.annotation.ElementType.CONSTRUCTOR;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Checks to see that the value is one of a set of elements.
  */
-@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER})
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
 @Retention(RUNTIME)
 @Documented
 @Constraint(validatedBy = OneOfValidator.class)

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/PortRange.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/PortRange.java
@@ -9,6 +9,7 @@ import java.lang.annotation.Target;
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
@@ -16,7 +17,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * indicate dynamically allocated ports.
  *
  */
-@Target({ METHOD, FIELD, ANNOTATION_TYPE })
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, TYPE_USE })
 @Retention(RUNTIME)
 @Constraint(validatedBy = PortRangeValidator.class)
 @Documented

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/SizeRange.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/SizeRange.java
@@ -51,7 +51,7 @@ public @interface SizeRange {
     /**
      * Defines several {@code @SizeRange} annotations on the same element.
      */
-    @Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
+    @Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
     @Retention(RUNTIME)
     @Documented
     public @interface List {

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/SizeRange.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/SizeRange.java
@@ -15,6 +15,7 @@ import static java.lang.annotation.ElementType.CONSTRUCTOR;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
@@ -23,7 +24,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Constraint(validatedBy = { })
-@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
 @Retention(RUNTIME)
 @MinSize(0)
 @MaxSize(value = Long.MAX_VALUE, unit = SizeUnit.TERABYTES)

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/DurationValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/DurationValidatorTest.java
@@ -4,7 +4,9 @@ import com.google.common.collect.ImmutableList;
 import io.dropwizard.util.Duration;
 import org.junit.Test;
 
+import javax.validation.Valid;
 import javax.validation.Validator;
+import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
@@ -22,6 +24,18 @@ public class DurationValidatorTest {
         @DurationRange(min = 10, max = 30, unit = TimeUnit.MINUTES)
         private Duration outOfRange = Duration.minutes(60);
 
+        @Valid
+        private List<@MaxDuration(value = 30, unit = TimeUnit.SECONDS) Duration> maxDurs =
+            ImmutableList.of(Duration.minutes(10));
+
+        @Valid
+        private List<@MinDuration(value = 30, unit = TimeUnit.SECONDS) Duration> minDurs =
+            ImmutableList.of(Duration.milliseconds(100));
+
+        @Valid
+        private List<@DurationRange(min = 10, max = 30, unit = TimeUnit.MINUTES) Duration> rangeDurs =
+            ImmutableList.of(Duration.minutes(60));
+
         public void setTooBig(Duration tooBig) {
             this.tooBig = tooBig;
         }
@@ -30,6 +44,15 @@ public class DurationValidatorTest {
         }
         public void setOutOfRange(Duration outOfRange) {
             this.outOfRange = outOfRange;
+        }
+        public void setMaxDurs(List<Duration> maxDurs) {
+            this.maxDurs = maxDurs;
+        }
+        public void setMinDurs(List<Duration> minDurs) {
+            this.minDurs = minDurs;
+        }
+        public void setRangeDurs(List<Duration> rangeDurs) {
+            this.rangeDurs = rangeDurs;
         }
     }
 
@@ -45,7 +68,10 @@ public class DurationValidatorTest {
                     .containsOnly(
                             "outOfRange must be between 10 MINUTES and 30 MINUTES",
                             "tooBig must be less than or equal to 30 SECONDS",
-                            "tooSmall must be greater than or equal to 30 SECONDS");
+                            "tooSmall must be greater than or equal to 30 SECONDS",
+                            "maxDurs[0] must be less than or equal to 30 SECONDS",
+                            "minDurs[0] must be greater than or equal to 30 SECONDS",
+                            "rangeDurs[0] must be between 10 MINUTES and 30 MINUTES");
         }
     }
 
@@ -55,6 +81,9 @@ public class DurationValidatorTest {
         example.setTooBig(Duration.seconds(10));
         example.setTooSmall(Duration.seconds(100));
         example.setOutOfRange(Duration.minutes(15));
+        example.setMaxDurs(ImmutableList.of(Duration.seconds(10)));
+        example.setMinDurs(ImmutableList.of(Duration.seconds(100)));
+        example.setRangeDurs(ImmutableList.of(Duration.minutes(15)));
 
         assertThat(validator.validate(example))
                 .isEmpty();

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/OneOfValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/OneOfValidatorTest.java
@@ -1,8 +1,11 @@
 package io.dropwizard.validation;
 
+import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 
+import javax.validation.Valid;
 import javax.validation.Validator;
+import java.util.List;
 import java.util.Locale;
 
 import static io.dropwizard.validation.ConstraintViolations.format;
@@ -20,6 +23,9 @@ public class OneOfValidatorTest {
 
         @OneOf(value = {"one", "two", "three"}, ignoreWhitespace = true)
         private String whitespaceInsensitive = "one";
+
+        @Valid
+        private List<@OneOf({"one", "two", "three"}) String> basicList = ImmutableList.of("one");
     }
 
     private final Validator validator = BaseValidator.newValidator();
@@ -39,6 +45,15 @@ public class OneOfValidatorTest {
 
         assertThat(format(validator.validate(example)))
                 .containsOnly("basic must be one of [one, two, three]");
+    }
+
+    @Test
+    public void doesNotAllowBadElementsInList() {
+        final Example example = new Example();
+        example.basicList = ImmutableList.of("four");
+
+        assertThat(format(validator.validate(example)))
+            .containsOnly("basicList[0] must be one of [one, two, three]");
     }
 
     @Test

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/PortRangeValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/PortRangeValidatorTest.java
@@ -1,9 +1,12 @@
 package io.dropwizard.validation;
 
+import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.validation.Valid;
 import javax.validation.Validator;
+import java.util.List;
 import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -18,6 +21,9 @@ public class PortRangeValidatorTest {
 
         @PortRange(min = 10000, max = 15000)
         public int otherPort = 10001;
+
+        @Valid
+        List<@PortRange Integer> ports = ImmutableList.of();
     }
 
 
@@ -67,5 +73,12 @@ public class PortRangeValidatorTest {
 
         assertThat(ConstraintViolations.format(validator.validate(example)))
                 .containsOnly("otherPort must be between 10000 and 15000");
+    }
+
+    @Test
+    public void rejectsInvalidPortsInList() {
+        example.ports = ImmutableList.of(-1);
+        assertThat(ConstraintViolations.format(validator.validate(example)))
+            .containsOnly("ports[0] must be between 1 and 65535");
     }
 }

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/SizeValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/SizeValidatorTest.java
@@ -1,10 +1,13 @@
 package io.dropwizard.validation;
 
+import com.google.common.collect.ImmutableList;
 import io.dropwizard.util.Size;
 import io.dropwizard.util.SizeUnit;
 import org.junit.Test;
 
+import javax.validation.Valid;
 import javax.validation.Validator;
+import java.util.List;
 import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -21,6 +24,18 @@ public class SizeValidatorTest {
         @SizeRange(min = 10, max = 100, unit = SizeUnit.KILOBYTES)
         private Size outOfRange = Size.megabytes(2);
 
+        @Valid
+        private List<@MaxSize(value = 30, unit = SizeUnit.KILOBYTES) Size> maxSize =
+            ImmutableList.of(Size.gigabytes(2));
+
+        @Valid
+        private List<@MinSize(value = 30, unit = SizeUnit.KILOBYTES) Size> minSize =
+            ImmutableList.of(Size.bytes(100));
+
+        @Valid
+        private List<@SizeRange(min = 10, max = 100, unit = SizeUnit.KILOBYTES) Size> rangeSize =
+            ImmutableList.of(Size.megabytes(2));
+
         public void setTooBig(Size tooBig) {
             this.tooBig = tooBig;
         }
@@ -29,6 +44,15 @@ public class SizeValidatorTest {
         }
         public void setOutOfRange(Size outOfRange) {
             this.outOfRange = outOfRange;
+        }
+        public void setMaxSize(List<Size> maxSize) {
+            this.maxSize = maxSize;
+        }
+        public void setMinSize(List<Size> minSize) {
+            this.minSize = minSize;
+        }
+        public void setRangeSize(List<Size> rangeSize) {
+            this.rangeSize = rangeSize;
         }
     }
 
@@ -40,7 +64,10 @@ public class SizeValidatorTest {
             assertThat(ConstraintViolations.format(validator.validate(new Example())))
                     .containsOnly("outOfRange must be between 10 KILOBYTES and 100 KILOBYTES",
                                   "tooBig must be less than or equal to 30 KILOBYTES",
-                                  "tooSmall must be greater than or equal to 30 KILOBYTES");
+                                  "tooSmall must be greater than or equal to 30 KILOBYTES",
+                                   "maxSize[0] must be less than or equal to 30 KILOBYTES",
+                                   "minSize[0] must be greater than or equal to 30 KILOBYTES",
+                                   "rangeSize[0] must be between 10 KILOBYTES and 100 KILOBYTES");
         }
     }
 
@@ -50,6 +77,9 @@ public class SizeValidatorTest {
         example.setTooBig(Size.bytes(10));
         example.setTooSmall(Size.megabytes(10));
         example.setOutOfRange(Size.kilobytes(64));
+        example.setMaxSize(ImmutableList.of(Size.bytes(10)));
+        example.setMinSize(ImmutableList.of(Size.megabytes(10)));
+        example.setRangeSize(ImmutableList.of(Size.kilobytes(64)));
 
         assertThat(validator.validate(example))
                 .isEmpty();


### PR DESCRIPTION
Java 8 allows the following code to be valid:

```java
@Valid
List<@OneOf({"one", "two", "three"}) String> bar;
```

But as the annotations are defined know, they will fail to compile. The
fix is simple, add `TYPE_USE` to the constraint annotation.