### PR TITLE
+ take the tcp backlog from OS

### DIFF
--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
@@ -490,7 +490,15 @@ public class HttpConnectorFactory implements ConnectorFactory {
         connector.setInheritChannel(inheritChannel);
         if (acceptQueueSize != null) {
             connector.setAcceptQueueSize(acceptQueueSize);
+        } else {
+            // if we do not set the acceptQueueSize, when jetty
+            // creates the ServerSocket, it uses the default backlog of 50, and
+            // not the value from the OS.  Therefore we set to the value
+            // obtained from NetUtil, which will attempt to read the value from the OS.
+            // somaxconn setting
+            connector.setAcceptQueueSize(NetUtil.getTcpBacklog());
         }
+
         connector.setReuseAddress(reuseAddress);
         if (soLingerTime != null) {
             connector.setSoLingerTime((int) soLingerTime.toSeconds());

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/NetUtil.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/NetUtil.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.dropwizard.jetty;
+
+import java.io.*;
+import java.nio.charset.Charset;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Locale;
+
+/**
+ * This class is taken from the Netty project, and all credit goes to them.
+ * It has been modified, to remove dependencies on other classes, and to convert to methods, rather than a
+ * static value.
+ */
+public class NetUtil {
+    public static final int DEFAULT_TCP_BACKLOG_WINDOWS = 200;
+    public static final int DEFAULT_TCP_BACKLOG_LINUX = 128;
+    public static final String TCP_BACKLOG_SETTING_LOCATION = "/proc/sys/net/core/somaxconn";
+
+
+
+    /**
+     * The SOMAXCONN value of the current machine.  If failed to get the value,  {@code 200}  is used as a
+     * default value for Windows or {@code 128} for others.
+     */
+    public static int getTcpBacklog() {
+        return getTcpBacklog(getDefaultTcpBacklog());
+    }
+
+    /**
+     * The SOMAXCONN value of the current machine.  If failed to get the value, <code>defaultBacklog</code> argument is
+     * used
+     */
+    public static int getTcpBacklog(int tcpBacklog) {
+        // Taken from netty.
+
+        // As a SecurityManager may prevent reading the somaxconn file we wrap this in a privileged block.
+        //
+        // See https://github.com/netty/netty/issues/3680
+        return AccessController.doPrivileged(new PrivilegedAction<Integer>() {
+            @Override
+            public Integer run() {
+                // Determine the default somaxconn (server socket backlog) value of the platform.
+                // The known defaults:
+                // - Windows NT Server 4.0+: 200
+                // - Linux and Mac OS X: 128
+                int somaxconn = tcpBacklog;
+                File file = new File(TCP_BACKLOG_SETTING_LOCATION);
+                BufferedReader in = null;
+                try {
+                    // file.exists() may throw a SecurityException if a SecurityManager is used, so execute it in the
+                    // try / catch block.
+                    // See https://github.com/netty/netty/issues/4936
+                    if (file.exists()) {
+                        in = new BufferedReader(new InputStreamReader(new FileInputStream(file), Charset.forName("UTF-8")));
+                        somaxconn = Integer.parseInt(in.readLine());
+                    }
+                } catch (SecurityException | IOException | NumberFormatException e) {
+                    // file.exists() may throw a SecurityException, in this
+                    // case we are just returning the default somaxconn that was passed in.
+                } finally {
+                    if (in != null) {
+                        try {
+                            in.close();
+                        } catch (Exception e) {
+                            // Ignored.
+                        }
+                    }
+                }
+                return somaxconn;
+            }
+        });
+
+    }
+
+    public static boolean isWindows() {
+        boolean windows = System.getProperty("os.name", "").toLowerCase(Locale.US).contains("win");
+        return windows;
+    }
+
+    public static int getDefaultTcpBacklog() {
+        return isWindows() ? DEFAULT_TCP_BACKLOG_WINDOWS : DEFAULT_TCP_BACKLOG_LINUX;
+    }
+}

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/NetUtil.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/NetUtil.java
@@ -16,8 +16,11 @@
 
 package io.dropwizard.jetty;
 
-import java.io.*;
-import java.nio.charset.Charset;
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
+
+import java.io.File;
+import java.io.IOException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Locale;
@@ -60,29 +63,15 @@ public class NetUtil {
                 // - Windows NT Server 4.0+: 200
                 // - Linux and Mac OS X: 128
                 int somaxconn = tcpBacklog;
-                File file = new File(TCP_BACKLOG_SETTING_LOCATION);
-                BufferedReader in = null;
                 try {
-                    // file.exists() may throw a SecurityException if a SecurityManager is used, so execute it in the
-                    // try / catch block.
-                    // See https://github.com/netty/netty/issues/4936
-                    if (file.exists()) {
-                        in = new BufferedReader(new InputStreamReader(new FileInputStream(file), Charset.forName("UTF-8")));
-                        somaxconn = Integer.parseInt(in.readLine());
-                    }
-                } catch (SecurityException | IOException | NumberFormatException e) {
+                    String setting = Files.toString(new File(TCP_BACKLOG_SETTING_LOCATION), Charsets.UTF_8);
+                    somaxconn = Integer.parseInt(setting.trim());
+                } catch (SecurityException | IOException | NumberFormatException | NullPointerException e) {
                     // file.exists() may throw a SecurityException, in this
                     // case we are just returning the default somaxconn that was passed in.
                 } finally {
-                    if (in != null) {
-                        try {
-                            in.close();
-                        } catch (Exception e) {
-                            // Ignored.
-                        }
-                    }
+                    return somaxconn;
                 }
-                return somaxconn;
             }
         });
 

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
@@ -178,6 +178,7 @@ public class HttpConnectorFactoryTest {
         ServerConnector connector = (ServerConnector) http.build(server, metrics, "test-http-connector", threadPool);
         assertThat(connector.getAcceptQueueSize()).isEqualTo(NetUtil.getTcpBacklog());
 
+        connector.stop();
     }
 
 }

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
@@ -162,4 +162,22 @@ public class HttpConnectorFactoryTest {
         connector.stop();
         server.stop();
     }
+
+    @Test
+    public void testDefaultAcceptQueueSize() throws Exception {
+        HttpConnectorFactory http = new HttpConnectorFactory();
+        http.setBindHost("127.0.0.1");
+        http.setAcceptorThreads(1);
+        http.setSelectorThreads(2);
+        http.setSoLingerTime(Duration.seconds(30));
+
+        Server server = new Server();
+        MetricRegistry metrics = new MetricRegistry();
+        ThreadPool threadPool = new QueuedThreadPool();
+
+        ServerConnector connector = (ServerConnector) http.build(server, metrics, "test-http-connector", threadPool);
+        assertThat(connector.getAcceptQueueSize()).isEqualTo(NetUtil.getTcpBacklog());
+
+    }
+
 }

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NetUtilTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NetUtilTest.java
@@ -1,66 +1,60 @@
 package io.dropwizard.jetty;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assume.assumeThat;
 
 public class NetUtilTest {
 
     private static final String OS_NAME_PROPERTY = "os.name";
-    public String osName;
 
-    @Before
-    public void setup() {
-        osName = System.getProperty(OS_NAME_PROPERTY);
-    }
-
-    @After
-    public void tearDown() {
-        if (osName == null) {
-            System.clearProperty(OS_NAME_PROPERTY);
-        } else {
-            System.setProperty(OS_NAME_PROPERTY, osName);
-        }
-    }
-
+    /**
+     * Assuming Windows
+     */
     @Test
     public void testDefaultTcpBacklogForWindows() {
-        System.setProperty(OS_NAME_PROPERTY, "win");
-        if (NetUtil.isWindows() && !isTcpBacklogSettingReadable()) {
-            assertEquals(NetUtil.DEFAULT_TCP_BACKLOG_WINDOWS, NetUtil.getTcpBacklog());
-        }
+        assumeThat(System.getProperty(OS_NAME_PROPERTY),containsString("win"));
+        assumeThat(isTcpBacklogSettingReadable(),is(false));
+        assertEquals(NetUtil.DEFAULT_TCP_BACKLOG_WINDOWS, NetUtil.getTcpBacklog());
     }
 
+    /**
+     * Assuming Mac (which does not have /proc)
+     */
     @Test
     public void testNonWindowsDefaultTcpBacklog() {
-        System.setProperty(OS_NAME_PROPERTY, "lin");
+        assumeThat(System.getProperty(OS_NAME_PROPERTY), containsString("Mac OS X"));
+        assumeThat(isTcpBacklogSettingReadable(),is(false));
+        assertEquals(NetUtil.DEFAULT_TCP_BACKLOG_LINUX, NetUtil.getTcpBacklog());
 
-        if (!NetUtil.isWindows() && !isTcpBacklogSettingReadable()) {
-            assertEquals(NetUtil.DEFAULT_TCP_BACKLOG_LINUX, NetUtil.getTcpBacklog());
-        }
     }
 
+    /**
+     * Assuming Mac (which does not have /proc)
+     */
     @Test
     public void testNonWindowsSpecifiedTcpBacklog() {
-        System.setProperty(OS_NAME_PROPERTY, "lin");
-
-        if (!NetUtil.isWindows() && !isTcpBacklogSettingReadable()) {
-            assertEquals(100, NetUtil.getTcpBacklog(100));
-        }
+        assumeThat(System.getProperty(OS_NAME_PROPERTY), containsString("Mac OS X"));
+        assumeThat(isTcpBacklogSettingReadable(),is(false));
+        assertEquals(100, NetUtil.getTcpBacklog(100));
     }
 
+    /**
+     * Assuming Linux (which has /proc)
+     */
     @Test
     public void testOsSetting() {
-        if(!NetUtil.isWindows() && isTcpBacklogSettingReadable()) {
-            assertNotEquals(-1, NetUtil.getTcpBacklog(-1));
-        }
+        assumeThat(System.getProperty(OS_NAME_PROPERTY),containsString("Linux"));
+        assumeThat(isTcpBacklogSettingReadable(),is(true));
+        assertNotEquals(-1, NetUtil.getTcpBacklog(-1));
     }
 
 

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NetUtilTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NetUtilTest.java
@@ -1,0 +1,81 @@
+package io.dropwizard.jetty;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class NetUtilTest {
+
+    private static final String OS_NAME_PROPERTY = "os.name";
+    public String osName;
+
+    @Before
+    public void setup() {
+        osName = System.getProperty(OS_NAME_PROPERTY);
+    }
+
+    @After
+    public void tearDown() {
+        if (osName == null) {
+            System.clearProperty(OS_NAME_PROPERTY);
+        } else {
+            System.setProperty(OS_NAME_PROPERTY, osName);
+        }
+    }
+
+    @Test
+    public void testDefaultTcpBacklogForWindows() {
+        System.setProperty(OS_NAME_PROPERTY, "win");
+        if (NetUtil.isWindows() && !isTcpBacklogSettingReadable()) {
+            assertEquals(NetUtil.DEFAULT_TCP_BACKLOG_WINDOWS, NetUtil.getTcpBacklog());
+        }
+    }
+
+    @Test
+    public void testNonWindowsDefaultTcpBacklog() {
+        System.setProperty(OS_NAME_PROPERTY, "lin");
+
+        if (!NetUtil.isWindows() && !isTcpBacklogSettingReadable()) {
+            assertEquals(NetUtil.DEFAULT_TCP_BACKLOG_LINUX, NetUtil.getTcpBacklog());
+        }
+    }
+
+    @Test
+    public void testNonWindowsSpecifiedTcpBacklog() {
+        System.setProperty(OS_NAME_PROPERTY, "lin");
+
+        if (!NetUtil.isWindows() && !isTcpBacklogSettingReadable()) {
+            assertEquals(100, NetUtil.getTcpBacklog(100));
+        }
+    }
+
+    @Test
+    public void testOsSetting() {
+        if(!NetUtil.isWindows() && isTcpBacklogSettingReadable()) {
+            assertNotEquals(-1, NetUtil.getTcpBacklog(-1));
+        }
+    }
+
+
+    public boolean isTcpBacklogSettingReadable() {
+        return AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
+            @Override
+            public Boolean run() {
+                try {
+                    File f = new File(NetUtil.TCP_BACKLOG_SETTING_LOCATION);
+                    return (f.exists() && f.canRead());
+                } catch (Exception e) {
+                    return false;
+                }
+
+            }
+        });
+    }
+}


### PR DESCRIPTION
Hi there.  

I've noticed that the acceptQueueSize of the http connector, does not take the OS setting as detailed in the documentation:

http://www.dropwizard.io/0.9.2/docs/manual/configuration.html
````
acceptQueueSize	(OS default)	The size of the TCP/IP accept queue for the listening socket.
````

Meaning that the tcp backlog on the socket isn't that of the OS setting (somaxcon).

When you do not specify the `acceptQueueSize` on the `ServerConnector`, Jetty is reverting to the default JDK setting as set in the `java.net.ServerSocket`, example (jdk8 - I check jdk6 has the same default of 50):
````
    public ServerSocket(int port, int backlog, InetAddress bindAddr) throws IOException {
        setImpl();
        if (port < 0 || port > 0xFFFF)
            throw new IllegalArgumentException(
                       "Port value out of range: " + port);
        if (backlog < 1)
          backlog = 50;
        try {
            bind(new InetSocketAddress(bindAddr, port), backlog);
        } catch(SecurityException e) {
            close();
            throw e;
        } catch(IOException e) {
            close();
            throw e;
        }
    }

````

This is currently the case for our dropwizard apps in production (I performed an strace to 100% check this was the case - `strace -e trace=network -f `  - an `ss -lt` will also show it you)

````
[pid  9831] bind(56, {sa_family=AF_INET6, sin6_port=htons(6000), inet_pton(AF_INET6, "::", &sin6_addr), sin6_flowinfo=0, sin6_scope_id=0}, 28) = 0
[pid  9831] listen(56, 50) 
````

This pull requests uses the same logic that Netty uses, to read the somaxconn setting from the environment, and set the `acceptQueueSize` to the OS value if readable.  or the defaults of 128 for *nix systems and 200 for windows.


Let me know if you need more information.
thanks
/dom
