### PR TITLE
Remove a first sync call workaround in HTTP2 integration tests

### DIFF
--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2CIntegrationTest.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2CIntegrationTest.java
@@ -62,9 +62,6 @@ public class Http2CIntegrationTest  extends AbstractHttp2Test {
 
     @Test
     public void testHttp2cManyRequests() throws Exception {
-        // For some reason the library requires to perform the first request synchronously with HTTP/2
-        testHttp2c();
-
         performManyAsyncRequests(client, "http://localhost:" + appRule.getLocalPort() + "/api/test");
     }
 }

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2IntegrationTest.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2IntegrationTest.java
@@ -74,9 +74,6 @@ public class Http2IntegrationTest extends AbstractHttp2Test {
 
     @Test
     public void testHttp2ManyRequests() throws Exception {
-        // For some reason the library requires to perform the first request synchronously with HTTP/2
-        testHttp2();
-
         performManyAsyncRequests(client, "https://localhost:" + appRule.getLocalPort() + "/api/test");
     }
 }


### PR DESCRIPTION
It looks like that the latest versions of Jetty fixed the bug which the inability to perform the first call asynchronously. Let's remove the workaround for this bug and keep tests more simple.