### PR TITLE
Support access_token query parameter for OAuth

### DIFF
--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/oauth/OAuthProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/oauth/OAuthProviderTest.java
@@ -1,12 +1,17 @@
 package io.dropwizard.auth.oauth;
 
 import com.google.common.collect.ImmutableList;
+
+import org.junit.Test;
+
 import io.dropwizard.auth.AbstractAuthResourceConfig;
 import io.dropwizard.auth.AuthBaseTest;
 import io.dropwizard.auth.AuthFilter;
 import io.dropwizard.auth.AuthResource;
 import io.dropwizard.auth.util.AuthUtil;
 import io.dropwizard.jersey.DropwizardResourceConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class OAuthProviderTest extends AuthBaseTest<OAuthProviderTest.OAuthTestResourceConfig>{
     public static class OAuthTestResourceConfig extends AbstractAuthResourceConfig {
@@ -21,6 +26,15 @@ public class OAuthProviderTest extends AuthBaseTest<OAuthProviderTest.OAuthTestR
                 .setPrefix(BEARER_PREFIX)
                 .buildAuthFilter();
         }
+    }
+
+    @Test
+    public void checksQueryStringAccessTokenIfAuthorizationHeaderMissing() {
+        assertThat(target("/test/profile")
+            .queryParam(OAuthCredentialAuthFilter.OAUTH_ACCESS_TOKEN_PARAM, getOrdinaryGuyValidToken())
+            .request()
+            .get(String.class))
+            .isEqualTo("'" + ORDINARY_USER + "' has user privileges");
     }
 
     @Override


### PR DESCRIPTION
The OAuth Bearer token spec allows to pass the access token not only in the Authorization header with the Bearer prefix, but also as an access_token query parameter.

See https://tools.ietf.org/html/rfc6750#section-2.3

While it's preferred to use the header for increased security, the
token can be helpful at times.

 - biggest advantage is you can avoid CORS pre-flight requests with the query parameter since they are not triggered when no non-simple header is present
 - it can be useful when testing/developing where you can simulate requests in a browser tab without a REST client