### PR TITLE
Document using @UnitOfWork outside Jersey resources

### DIFF
--- a/docs/source/manual/hibernate.rst
+++ b/docs/source/manual/hibernate.rst
@@ -149,6 +149,22 @@ back.
                Otherwise, you'll get a ``LazyInitializationException`` thrown in your template (or
                ``null`` values produced by Jackson).
 
+Transactional Resource Methods Outside Jersey Resources
+----------------------------------------------------
+
+Currently creating transactions with the `@UnitOfWork` annotation works out-of-box only for resources
+managed by Jersey. If you want to use it outside Jersey resources, e.g. in authenticators, you should
+instantiate your class with ``UnitOfWorkAwareProxyFactory``.
+
+.. code-block:: java
+
+     SessionDao dao = new SessionDao(hibernateBundle.getSessionFactory());
+     ExampleAuthenticator exampleAuthenticator = new UnitOfWorkAwareProxyFactory(hibernateBundle)
+                    .create(ExampleAuthenticator.class, SessionDao.class, dao);
+
+It will create a proxy of your class, which will open a Hibernate session with a transaction around
+methods with the ``@UnitOfWork`` annotation.
+
 Prepended Comments
 ==================
 


### PR DESCRIPTION
Add a section in the docs about how to use declarative transactions in authenticators.
It's not really obvious and many users expect they will work out of box.

See #1334, #1361.