### PR TITLE
Allow periods in keys to be escaped in ConfigOverrides

### DIFF
--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/YamlConfigurationFactory.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/YamlConfigurationFactory.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.dataformat.yaml.snakeyaml.error.MarkedYAMLException
 import com.fasterxml.jackson.dataformat.yaml.snakeyaml.error.YAMLException;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
-import com.google.common.collect.Iterables;
+import com.google.common.collect.FluentIterable;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
@@ -40,7 +40,8 @@ public class YamlConfigurationFactory<T> implements ConfigurationFactory<T> {
 
     private static final Pattern ESCAPED_COMMA_PATTERN = Pattern.compile("\\\\,");
     private static final Splitter ESCAPED_COMMA_SPLITTER = Splitter.on(Pattern.compile("(?<!\\\\),")).trimResults();
-    private static final Splitter DOT_SPLITTER = Splitter.on('.').trimResults();
+    private static final Pattern ESCAPED_DOT_PATTERN = Pattern.compile("\\\\\\.");
+    private static final Splitter ESCAPED_DOT_SPLITTER = Splitter.on(Pattern.compile("(?<!\\\\)\\.")).trimResults();
 
     private final Class<T> klass;
     private final String propertyPrefix;
@@ -157,7 +158,9 @@ public class YamlConfigurationFactory<T> implements ConfigurationFactory<T> {
 
     protected void addOverride(JsonNode root, String name, String value) {
         JsonNode node = root;
-        final String[] parts = Iterables.toArray(DOT_SPLITTER.split(name), String.class);
+        final String[] parts = FluentIterable.from(ESCAPED_DOT_SPLITTER.split(name))
+                .transform(key -> ESCAPED_DOT_PATTERN.matcher(key).replaceAll("."))
+                .toArray(String.class);
         for (int i = 0; i < parts.length; i++) {
             final String key = parts[i];
 

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryTest.java
@@ -72,6 +72,9 @@ public class ConfigurationFactoryTest {
 
         private boolean admin;
 
+        @JsonProperty("my.logger")
+        private Map<String, String> logger = new LinkedHashMap<>();
+
         public String getName() {
             return name;
         }
@@ -94,6 +97,10 @@ public class ConfigurationFactoryTest {
 
         public void setAdmin(boolean admin) {
             this.admin = admin;
+        }
+
+        public Map<String, String> getLogger() {
+            return logger;
         }
     }
 
@@ -199,6 +206,22 @@ public class ConfigurationFactoryTest {
         final Example example = factory.build(validFile);
         assertThat(example.getName())
             .isEqualTo("Coda Hale Overridden");
+    }
+
+    @Test
+    public void handlesExistingOverrideWithPeriod() throws Exception {
+        System.setProperty("dw.my\\.logger.level", "debug");
+        final Example example = factory.build(validFile);
+        assertThat(example.getLogger().get("level"))
+            .isEqualTo("debug");
+    }
+
+    @Test
+    public void handlesNewOverrideWithPeriod() throws Exception {
+        System.setProperty("dw.my\\.logger.com\\.example", "error");
+        final Example example = factory.build(validFile);
+        assertThat(example.getLogger().get("com.example"))
+            .isEqualTo("error");
     }
 
     @Test
@@ -419,7 +442,7 @@ public class ConfigurationFactoryTest {
                     "      - type" + NEWLINE +
                     "      - name" + NEWLINE +
                     "      - age" + NEWLINE +
-                    "        [1 more]" + NEWLINE);
+                    "        [2 more]" + NEWLINE);
         }
     }
 

--- a/dropwizard-configuration/src/test/resources/factory-test-valid.yml
+++ b/dropwizard-configuration/src/test/resources/factory-test-valid.yml
@@ -9,3 +9,5 @@ servers:
   - port: 8080
   - port: 8081
   - port: 8082
+my.logger:
+  level: info

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/ConfigOverride.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/ConfigOverride.java
@@ -2,6 +2,36 @@ package io.dropwizard.testing;
 
 import java.util.function.Supplier;
 
+/**
+ * An override for a field in dropwizard configuration intended for use with
+ * {@link DropwizardAppRule}.
+ * <p>
+ * Given a configuration file containing
+ * <pre>
+ * ---
+ * server:
+ *   applicationConnectors:
+ *     - type: http
+ *       port: 8000
+ *   adminConnectors:
+ *     - type: http
+ *       port: 8001
+ *
+ * logging:
+ *   loggers:
+ *     com.example.foo: INFO
+ * </pre>
+ * <ul>
+ * <li><code>ConfigOverride.config("debug", "true")</code> will add a top level
+ * field named "debug" mapped to the string "true".</li>
+ * <li><code>ConfigOverride.config("server.applicationConnectors[0].type",
+ * "https")</code> will change the sole application connector to have type
+ * "https" instead of type "http".
+ * <li><code>ConfigOverride.config("logging.loggers.com\\.example\\.bar",
+ * "DEBUG")</code> will add a logger with the name "com.example.bar" configured
+ * for debug logging.</li>
+ * </ul>
+ */
 public class ConfigOverride {
 
     public static final String DEFAULT_PREFIX = "dw.";


### PR DESCRIPTION
This in particular makes it possible to configure loggers (whose names frequently contain periods) with config overrides.