### PR TITLE
Add a test for building the HTTPS connector

### DIFF
--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
@@ -1,5 +1,6 @@
 package io.dropwizard.jetty;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
@@ -8,7 +9,19 @@ import io.dropwizard.jackson.DiscoverableSubtypeResolver;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.validation.BaseValidator;
 import org.apache.commons.lang3.SystemUtils;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.ConnectionFactory;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SslConnectionFactory;
+import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
+import org.eclipse.jetty.util.thread.ThreadPool;
 import org.junit.Test;
 
 import javax.validation.ConstraintViolation;
@@ -21,6 +34,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
+import static org.apache.commons.lang3.reflect.FieldUtils.getField;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assume.assumeFalse;
@@ -131,6 +145,104 @@ public class HttpsConnectorFactoryTest {
         factory.setKeyStoreType(WINDOWS_MY_KEYSTORE_NAME);
         factory.buildSslContextFactory();
     }
+
+    @Test
+    public void testBuild() throws Exception {
+        final HttpsConnectorFactory https = new HttpsConnectorFactory();
+        https.setBindHost("127.0.0.1");
+        https.setPort(8443);
+
+        https.setKeyStorePath("/etc/app/server.ks");
+        https.setKeyStoreType("JKS");
+        https.setKeyStorePassword("correct_horse");
+        https.setKeyStoreProvider("BC");
+        https.setTrustStorePath("/etc/app/server.ts");
+        https.setTrustStoreType("JKS");
+        https.setTrustStorePassword("battery_staple");
+        https.setTrustStoreProvider("BC");
+
+        https.setKeyManagerPassword("new_overlords");
+        https.setNeedClientAuth(true);
+        https.setWantClientAuth(true);
+        https.setCertAlias("alt_server");
+        https.setCrlPath(new File("/etc/ctr_list.txt"));
+        https.setEnableCRLDP(true);
+        https.setEnableOCSP(true);
+        https.setMaxCertPathLength(4);
+        https.setOcspResponderUrl(new URI("http://windc1/ocsp"));
+        https.setJceProvider("BC");
+        https.setAllowRenegotiation(false);
+        https.setEndpointIdentificationAlgorithm("HTTPS");
+        https.setValidateCerts(true);
+        https.setValidatePeers(true);
+        https.setSupportedProtocols(ImmutableList.of("TLSv1.1", "TLSv1.2"));
+        https.setSupportedCipherSuites(ImmutableList.of("TLS_DHE_RSA.*", "TLS_ECDHE.*"));
+
+        final Server server = new Server();
+        final MetricRegistry metrics = new MetricRegistry();
+        final ThreadPool threadPool = new QueuedThreadPool();
+        final Connector connector = https.build(server, metrics, "test-https-connector", threadPool);
+        assertThat(connector).isInstanceOf(ServerConnector.class);
+
+        final ServerConnector serverConnector = (ServerConnector) connector;
+        assertThat(serverConnector.getPort()).isEqualTo(8443);
+        assertThat(serverConnector.getHost()).isEqualTo("127.0.0.1");
+        assertThat(serverConnector.getName()).isEqualTo("test-https-connector");
+        assertThat(serverConnector.getServer()).isSameAs(server);
+        assertThat(serverConnector.getScheduler()).isInstanceOf(ScheduledExecutorScheduler.class);
+        assertThat(serverConnector.getExecutor()).isSameAs(threadPool);
+
+        final Jetty93InstrumentedConnectionFactory jetty93SslConnectionFacttory =
+            (Jetty93InstrumentedConnectionFactory) serverConnector.getConnectionFactory("ssl");
+        assertThat(jetty93SslConnectionFacttory).isInstanceOf(Jetty93InstrumentedConnectionFactory.class);
+        assertThat(jetty93SslConnectionFacttory.getTimer()).isSameAs(
+            metrics.timer("org.eclipse.jetty.server.HttpConnectionFactory.127.0.0.1.8443.connections"));
+        final SslContextFactory sslContextFactory = ((SslConnectionFactory) jetty93SslConnectionFacttory
+            .getConnectionFactory()).getSslContextFactory();
+
+        assertThat(getField(SslContextFactory.class, "_keyStoreResource", true).get(sslContextFactory))
+            .isEqualTo(Resource.newResource("/etc/app/server.ks"));
+        assertThat(sslContextFactory.getKeyStoreType()).isEqualTo("JKS");
+        assertThat(getField(SslContextFactory.class, "_keyStorePassword", true).get(sslContextFactory).toString())
+            .isEqualTo("correct_horse");
+        assertThat(sslContextFactory.getKeyStoreProvider()).isEqualTo("BC");
+        assertThat(getField(SslContextFactory.class, "_trustStoreResource", true).get(sslContextFactory))
+            .isEqualTo(Resource.newResource("/etc/app/server.ts"));
+        assertThat(sslContextFactory.getKeyStoreType()).isEqualTo("JKS");
+        assertThat(getField(SslContextFactory.class, "_trustStorePassword", true).get(sslContextFactory).toString())
+            .isEqualTo("battery_staple");
+        assertThat(sslContextFactory.getKeyStoreProvider()).isEqualTo("BC");
+        assertThat(getField(SslContextFactory.class, "_keyManagerPassword", true).get(sslContextFactory).toString())
+            .isEqualTo("new_overlords");
+        assertThat(sslContextFactory.getNeedClientAuth()).isTrue();
+        assertThat(sslContextFactory.getWantClientAuth()).isTrue();
+        assertThat(sslContextFactory.getCertAlias()).isEqualTo("alt_server");
+        assertThat(sslContextFactory.getCrlPath()).isEqualTo("/etc/ctr_list.txt");
+        assertThat(sslContextFactory.isEnableCRLDP()).isTrue();
+        assertThat(sslContextFactory.isEnableOCSP()).isTrue();
+        assertThat(sslContextFactory.getMaxCertPathLength()).isEqualTo(4);
+        assertThat(sslContextFactory.getOcspResponderURL()).isEqualTo("http://windc1/ocsp");
+        assertThat(sslContextFactory.getProvider()).isEqualTo("BC");
+        assertThat(sslContextFactory.isRenegotiationAllowed()).isFalse();
+        assertThat(getField(SslContextFactory.class, "_endpointIdentificationAlgorithm", true).get(sslContextFactory))
+            .isEqualTo("HTTPS");
+        assertThat(sslContextFactory.isValidateCerts()).isTrue();
+        assertThat(sslContextFactory.isValidatePeerCerts()).isTrue();
+        assertThat(sslContextFactory.getIncludeProtocols()).containsOnly("TLSv1.1", "TLSv1.2");
+        assertThat(sslContextFactory.getIncludeCipherSuites()).containsOnly("TLS_DHE_RSA.*", "TLS_ECDHE.*");
+
+        final ConnectionFactory httpConnectionFactory = serverConnector.getConnectionFactory("http/1.1");
+        assertThat(httpConnectionFactory).isInstanceOf(HttpConnectionFactory.class);
+        final HttpConfiguration httpConfiguration = ((HttpConnectionFactory) httpConnectionFactory)
+            .getHttpConfiguration();
+        assertThat(httpConfiguration.getSecureScheme()).isEqualTo("https");
+        assertThat(httpConfiguration.getSecurePort()).isEqualTo(8443);
+        assertThat(httpConfiguration.getCustomizers()).hasAtLeastOneElementOfType(SecureRequestCustomizer.class);
+
+        connector.stop();
+        server.stop();
+    }
+
 
     private boolean canAccessWindowsKeyStore() {
         if (SystemUtils.IS_OS_WINDOWS) {

--- a/dropwizard-jetty/src/test/resources/logback-test.xml
+++ b/dropwizard-jetty/src/test/resources/logback-test.xml
@@ -5,6 +5,9 @@
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
+
+    <logger level="info" name="io.dropwizard.jetty.HttpsConnectorFactory"/>
+
     <root level="off">
         <appender-ref ref="STDOUT"/>
     </root>


### PR DESCRIPTION
I noticed that we don't have a test for building the HTTPS connector in `HttpsConnectionFactory`.
There is a lot of things are going on during this process (building a SSL context factory, logging
supported ciphers, setting metric names, using correct instrumented connectors and so on),
so it makes sense to test it independently from other components. I think it would be great to
have a test which verifies that we correctly configure Jetty on the SSL side.

As a result, this should allow to spot possible bugs earlier during future Jetty updates.