### PR TITLE
Add helper functions for getting listening ports and IP addresses

### DIFF
--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/LocalIpFilter.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/LocalIpFilter.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.dropwizard.jetty;
+
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+
+/**
+ * @see https://github.com/apache/curator/blob/master/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/LocalIpFilter.java
+ */
+public interface LocalIpFilter {
+
+    public boolean use(NetworkInterface networkInterface,
+                       InetAddress address) throws SocketException;
+}

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/LocalIpFilter.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/LocalIpFilter.java
@@ -1,19 +1,16 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright 2013-2014 The Apache Software Foundation (Curator Project)
+ *
+ * The Apache Software Foundation licenses this file to you under the Apache
+ * License, version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at:
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
  * under the License.
  */
 package io.dropwizard.jetty;

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/NetUtil.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/NetUtil.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2012 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
@@ -13,29 +13,40 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.dropwizard.jetty;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
-
 import java.io.File;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * This class is taken from the Netty project, and all credit goes to them.
  * It has been modified, to remove dependencies on other classes, and to convert to methods, rather than a
  * static value.
+ * 
+ * The {@link #getAllLocalIPs()} method was taken from the Apache Curator project
+ * which is also under the Apache 2.0 license.
  */
 public class NetUtil {
     public static final int DEFAULT_TCP_BACKLOG_WINDOWS = 200;
     public static final int DEFAULT_TCP_BACKLOG_LINUX = 128;
     public static final String TCP_BACKLOG_SETTING_LOCATION = "/proc/sys/net/core/somaxconn";
 
-
+    private static final AtomicReference<LocalIpFilter> localIpFilter = new AtomicReference<LocalIpFilter>((nif, adr) ->
+        (adr != null) && !adr.isLoopbackAddress() && (nif.isPointToPoint() || !adr.isLinkLocalAddress())
+    );
 
     /**
      * The SOMAXCONN value of the current machine.  If failed to get the value,  {@code 200}  is used as a
@@ -64,7 +75,7 @@ public class NetUtil {
                 // - Linux and Mac OS X: 128
                 int somaxconn = tcpBacklog;
                 try {
-                    String setting = Files.toString(new File(TCP_BACKLOG_SETTING_LOCATION), Charsets.UTF_8);
+                    String setting = Files.toString(new File(TCP_BACKLOG_SETTING_LOCATION), StandardCharsets.UTF_8);
                     somaxconn = Integer.parseInt(setting.trim());
                 } catch (SecurityException | IOException | NumberFormatException | NullPointerException e) {
                     // file.exists() may throw a SecurityException, in this
@@ -78,11 +89,71 @@ public class NetUtil {
     }
 
     public static boolean isWindows() {
-        boolean windows = System.getProperty("os.name", "").toLowerCase(Locale.US).contains("win");
+        final boolean windows = System.getProperty("os.name", "").toLowerCase(Locale.US).contains("win");
         return windows;
     }
 
     public static int getDefaultTcpBacklog() {
         return isWindows() ? DEFAULT_TCP_BACKLOG_WINDOWS : DEFAULT_TCP_BACKLOG_LINUX;
+    }
+
+    /**
+     * Replace the default local ip filter used by {@link #getAllLocalIPs()}
+     *
+     * @param newLocalIpFilter the new local ip filter
+     */
+    public static void setLocalIpFilter(LocalIpFilter newLocalIpFilter) {
+        localIpFilter.set(newLocalIpFilter);
+    }
+
+    /**
+     * Return the current local ip filter used by {@link #getAllLocalIPs()}
+     *
+     * @return ip filter
+     */
+    public static LocalIpFilter getLocalIpFilter() {
+        return localIpFilter.get();
+    }
+
+    /**
+     * based on http://pastebin.com/5X073pUc
+     * <p>
+     *
+     * Returns all available IP addresses.
+     * <p>
+     * In error case or if no network connection is established, we return
+     * an empty list here.
+     * <p>
+     * Loopback addresses are excluded - so 127.0.0.1 will not be never
+     * returned.
+     * <p>
+     * The "primary" IP might not be the first one in the returned list.
+     *
+     * @return  Returns all IP addresses (can be an empty list in error case
+     *          or if network connection is missing).
+     * @see http://pastebin.com/5X073pUc
+     * @see https://github.com/apache/curator/blob/master/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/ServiceInstanceBuilder.java
+     * @throws SocketException errors
+     */
+    public static Collection<InetAddress> getAllLocalIPs() throws SocketException {
+        final List<InetAddress> listAdr = new ArrayList<>();
+        final Enumeration<NetworkInterface> nifs = NetworkInterface.getNetworkInterfaces();
+        if (nifs == null) {
+            return listAdr;
+        }
+
+        while (nifs.hasMoreElements()) {
+            final NetworkInterface nif = nifs.nextElement();
+            // We ignore subinterfaces - as not yet needed.
+
+            final Enumeration<InetAddress> adrs = nif.getInetAddresses();
+            while (adrs.hasMoreElements()) {
+                final InetAddress adr = adrs.nextElement();
+                if (localIpFilter.get().use(nif, adr)) {
+                    listAdr.add(adr);
+                }
+            }
+        }
+        return listAdr;
     }
 }

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NetUtilTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NetUtilTest.java
@@ -1,11 +1,12 @@
 package io.dropwizard.jetty;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
-
 import java.io.File;
+import java.net.InetAddress;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-
+import java.util.Collection;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
@@ -34,7 +35,6 @@ public class NetUtilTest {
         assumeThat(System.getProperty(OS_NAME_PROPERTY), containsString("Mac OS X"));
         assumeThat(isTcpBacklogSettingReadable(),is(false));
         assertEquals(NetUtil.DEFAULT_TCP_BACKLOG_LINUX, NetUtil.getTcpBacklog());
-
     }
 
     /**
@@ -56,7 +56,20 @@ public class NetUtilTest {
         assumeThat(isTcpBacklogSettingReadable(),is(true));
         assertNotEquals(-1, NetUtil.getTcpBacklog(-1));
     }
-
+    
+    @Test
+    public void testAllLocalIps() throws Exception {
+        final Collection<InetAddress> addresses = NetUtil.getAllLocalIPs();
+        assertThat(addresses.size()).isGreaterThan(0);
+    }
+    
+    @Test
+    public void testLocalIpsWithLocalFilter() throws Exception {
+        NetUtil.setLocalIpFilter((inf, adr) -> adr != null);
+        final Collection<InetAddress> addresses = NetUtil.getAllLocalIPs();
+        assertThat(addresses.size()).isGreaterThan(0);
+        assertThat(addresses).contains(InetAddress.getLocalHost());
+    }
 
     public boolean isTcpBacklogSettingReadable() {
         return AccessController.doPrivileged(new PrivilegedAction<Boolean>() {

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NetUtilTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NetUtilTest.java
@@ -59,8 +59,11 @@ public class NetUtilTest {
     
     @Test
     public void testAllLocalIps() throws Exception {
+        NetUtil.setLocalIpFilter((nif, adr) ->
+            (adr != null) && !adr.isLoopbackAddress() && (nif.isPointToPoint() || !adr.isLinkLocalAddress()));
         final Collection<InetAddress> addresses = NetUtil.getAllLocalIPs();
         assertThat(addresses.size()).isGreaterThan(0);
+        assertThat(addresses).doesNotContain(InetAddress.getLoopbackAddress());
     }
     
     @Test
@@ -68,7 +71,7 @@ public class NetUtilTest {
         NetUtil.setLocalIpFilter((inf, adr) -> adr != null);
         final Collection<InetAddress> addresses = NetUtil.getAllLocalIPs();
         assertThat(addresses.size()).isGreaterThan(0);
-        assertThat(addresses).contains(InetAddress.getLocalHost());
+        assertThat(addresses).contains(InetAddress.getLoopbackAddress());
     }
 
     public boolean isTcpBacklogSettingReadable() {

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/ServerLifecycleListener.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/ServerLifecycleListener.java
@@ -1,9 +1,19 @@
 package io.dropwizard.lifecycle;
 
+import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
-
+import org.eclipse.jetty.server.ServerConnector;
 import java.util.EventListener;
 
 public interface ServerLifecycleListener extends EventListener {
     void serverStarted(Server server);
+
+    default int getLocalPort(Server server) {
+        return ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+    }
+
+    default int getAdminPort(Server server) {
+        final Connector[] connectors = server.getConnectors();
+        return ((ServerConnector) connectors[connectors.length -1]).getLocalPort();
+    }
 }

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/ServerLifecycleListener.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/ServerLifecycleListener.java
@@ -6,12 +6,28 @@ import org.eclipse.jetty.server.ServerConnector;
 import java.util.EventListener;
 
 public interface ServerLifecycleListener extends EventListener {
+
     void serverStarted(Server server);
 
+    /**
+     * Return the local port of the first {@link ServerConnector} in the
+     * provided {@link Server} instance.
+     *
+     * @param server Server instance to use
+     * @return First local port of the server instance
+     */
     default int getLocalPort(Server server) {
         return ((ServerConnector) server.getConnectors()[0]).getLocalPort();
     }
 
+    /**
+     * Return the local port of the last {@link ServerConnector} in the
+     * provided {@link Server} instance. This may be the same value as returned
+     * by {@link #getLocalPort(Server)} if using the "simple" server configuration.
+     *
+     * @param server Server instance to use
+     * @return Last local port or the server instance
+     */
     default int getAdminPort(Server server) {
         final Connector[] connectors = server.getConnectors();
         return ((ServerConnector) connectors[connectors.length -1]).getLocalPort();


### PR DESCRIPTION
I've had to do this a few times now in [dropwizard-consul](https://github.com/smoketurner/dropwizard-consul/blob/master/consul-core/src/main/java/com/smoketurner/dropwizard/consul/core/ConsulServiceListener.java#L46) and [dropwizard-discovery](https://github.com/dropwizard/dropwizard-discovery/blob/master/src/main/java/io/dropwizard/discovery/core/CuratorAdvertisementListener.java#L41) and we provide this in [DropwizardTestSupport](https://github.com/dropwizard/dropwizard/blob/master/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java#L204), so I figured we could add these helper methods to the `ServerLifecycleListener` directly.