### PR TITLE
Upgrade to Jetty 9.3.10.v20160621

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -26,7 +26,7 @@
         <jersey.version>2.23.1</jersey.version>
         <jackson.api.version>2.7.4</jackson.api.version>
         <jackson.version>2.7.4</jackson.version>
-        <jetty.version>9.3.9.v20160517</jetty.version>
+        <jetty.version>9.3.10.v20160621</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics3.version>3.1.2</metrics3.version>
         <slf4j.version>1.7.21</slf4j.version>

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/BiDiGzipHandlerTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/BiDiGzipHandlerTest.java
@@ -38,6 +38,8 @@ public class BiDiGzipHandlerTest {
 
     @Before
     public void setUp() throws Exception {
+        request.setHeader(HttpHeaders.HOST, "localhost");
+
         gzipHandler.setExcludedAgentPatterns();
         gzipHandler.addIncludedMethods("POST");
 


### PR DESCRIPTION
For some reason, our tests fail during upgrade to Jetty 9.3.10.v20160621. We should investigate a reason for it.