### PR TITLE
Commit a database transaction in the `RESP_FILTERS_START` stage

### DIFF
--- a/dropwizard-hibernate/pom.xml
+++ b/dropwizard-hibernate/pom.xml
@@ -41,6 +41,11 @@
             <artifactId>hibernate-core</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- we need HSQL because it handles time zones, H2 totally doesn't -->
         <dependency>
             <groupId>org.hsqldb</groupId>

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkApplicationListener.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkApplicationListener.java
@@ -69,18 +69,21 @@ public class UnitOfWorkApplicationListener implements ApplicationEventListener {
 
         @Override
         public void onEvent(RequestEvent event) {
-            if (event.getType() == RequestEvent.Type.RESOURCE_METHOD_START) {
+            final RequestEvent.Type eventType = event.getType();
+            if (eventType == RequestEvent.Type.RESOURCE_METHOD_START) {
                 UnitOfWork unitOfWork = methodMap.get(event.getUriInfo()
                         .getMatchedResourceMethod().getInvocable().getDefinitionMethod());
                 unitOfWorkAspect.beforeStart(unitOfWork);
-            } else if (event.getType() == RequestEvent.Type.FINISHED) {
+            } else if (eventType == RequestEvent.Type.RESP_FILTERS_START) {
                 try {
                     unitOfWorkAspect.afterEnd();
                 } catch (Exception e) {
                     throw new MappableException(e);
                 }
-            } else if (event.getType() == RequestEvent.Type.ON_EXCEPTION) {
+            } else if (eventType == RequestEvent.Type.ON_EXCEPTION) {
                 unitOfWorkAspect.onError();
+            } else if (eventType == RequestEvent.Type.FINISHED) {
+                unitOfWorkAspect.onFinish();
             }
         }
     }

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactory.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactory.java
@@ -87,6 +87,8 @@ public class UnitOfWorkAwareProxyFactory {
                 } catch (Exception e) {
                     unitOfWorkAspect.onError();
                     throw e;
+                } finally {
+                    unitOfWorkAspect.onFinish();
                 }
             });
             return (T) proxy;

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/LazyLoadingTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/LazyLoadingTest.java
@@ -1,23 +1,23 @@
 package io.dropwizard.hibernate;
 
-import com.codahale.metrics.MetricRegistry;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Optional;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.db.DataSourceFactory;
-import io.dropwizard.jackson.Jackson;
-import io.dropwizard.jersey.DropwizardResourceConfig;
-import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
-import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
-import io.dropwizard.logging.BootstrapLogging;
+import io.dropwizard.db.PooledDataSourceFactory;
+import io.dropwizard.jersey.errors.ErrorMessage;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
-import org.glassfish.jersey.client.ClientConfig;
-import org.glassfish.jersey.test.JerseyTest;
-import org.glassfish.jersey.test.TestProperties;
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.DropwizardTestSupport;
+import io.dropwizard.testing.ResourceHelpers;
+import org.glassfish.jersey.client.JerseyClientBuilder;
+import org.hibernate.FlushMode;
+import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.exception.ConstraintViolationException;
 import org.junit.After;
 import org.junit.Test;
 
@@ -25,29 +25,93 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Application;
+import javax.ws.rs.PUT;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import java.util.Optional;
 
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-public class LazyLoadingTest extends JerseyTest {
+public class LazyLoadingTest {
 
-    private Bootstrap<?> bootstrap;
-    private HibernateBundle<Configuration> bundle;
+    public static class TestConfiguration extends Configuration {
 
-    static {
-        BootstrapLogging.bootstrap();
+        DataSourceFactory dataSource = new DataSourceFactory();
+
+        TestConfiguration(@JsonProperty("dataSource") DataSourceFactory dataSource) {
+            this.dataSource = dataSource;
+        }
+    }
+
+    public static class TestApplication extends io.dropwizard.Application<TestConfiguration> {
+        final HibernateBundle<TestConfiguration> hibernate = new HibernateBundle<TestConfiguration>(
+            ImmutableList.of(Person.class, Dog.class), new SessionFactoryFactory()) {
+            @Override
+            public PooledDataSourceFactory getDataSourceFactory(TestConfiguration configuration) {
+                return configuration.dataSource;
+            }
+        };
+
+        @Override
+        public void initialize(Bootstrap<TestConfiguration> bootstrap) {
+            bootstrap.addBundle(hibernate);
+        }
+
+        @Override
+        public void run(TestConfiguration configuration, Environment environment) throws Exception {
+
+            final SessionFactory sessionFactory = hibernate.getSessionFactory();
+            initDatabase(sessionFactory);
+
+            environment.jersey().register(new UnitOfWorkApplicationListener("hr-db", sessionFactory));
+            environment.jersey().register(new DogResource(new DogDAO(sessionFactory)));
+            environment.jersey().register(new ConstraintViolationExceptionMapper());
+        }
+
+        private void initDatabase(SessionFactory sessionFactory) {
+            try (Session session = sessionFactory.openSession()) {
+                session.createSQLQuery(
+                    "CREATE TABLE people (name varchar(100) primary key, email varchar(16), birthday timestamp with time zone)")
+                    .executeUpdate();
+                session.createSQLQuery(
+                    "INSERT INTO people VALUES ('Coda', 'coda@example.com', '1979-01-02 00:22:00+0:00')")
+                    .executeUpdate();
+                session.createSQLQuery(
+                    "CREATE TABLE dogs (name varchar(100) primary key, owner varchar(100), CONSTRAINT fk_owner FOREIGN KEY (owner) REFERENCES people(name))")
+                    .executeUpdate();
+                session.createSQLQuery(
+                    "INSERT INTO dogs VALUES ('Raf', 'Coda')")
+                    .executeUpdate();
+            }
+        }
+    }
+
+    public static class TestApplicationWithDisabledLazyLoading extends TestApplication {
+        @Override
+        public void initialize(Bootstrap<TestConfiguration> bootstrap) {
+            hibernate.setLazyLoadingEnabled(false);
+            bootstrap.addBundle(hibernate);
+        }
     }
 
     public static class DogDAO extends AbstractDAO<Dog> {
-        public DogDAO(SessionFactory sessionFactory) {
+        DogDAO(SessionFactory sessionFactory) {
             super(sessionFactory);
         }
 
-        public Optional<Dog> findByName(String name) {
-            return Optional.fromNullable(get(name));
+        Optional<Dog> findByName(String name) {
+            return Optional.ofNullable(get(name));
+        }
+
+        Dog create(Dog dog) throws HibernateException {
+            currentSession().setFlushMode(FlushMode.COMMIT);
+            currentSession().save(requireNonNull(dog));
+            return dog;
         }
     }
 
@@ -56,7 +120,7 @@ public class LazyLoadingTest extends JerseyTest {
     public static class DogResource {
         private final DogDAO dao;
 
-        public DogResource(DogDAO dao) {
+        DogResource(DogDAO dao) {
             this.dao = dao;
         }
 
@@ -65,111 +129,82 @@ public class LazyLoadingTest extends JerseyTest {
         public Optional<Dog> find(@PathParam("name") String name) {
             return dao.findByName(name);
         }
+
+        @PUT
+        @UnitOfWork
+        public void create(Dog dog) {
+            dao.create(dog);
+        }
     }
 
-    private SessionFactory sessionFactory;
+    public static class ConstraintViolationExceptionMapper implements ExceptionMapper<ConstraintViolationException> {
+        @Override
+        public Response toResponse(ConstraintViolationException e) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity(new ErrorMessage(Response.Status.BAD_REQUEST.getStatusCode(), e.getCause().getMessage()))
+                .build();
+        }
+    }
 
-    @Override
+    private DropwizardTestSupport dropwizardTestSupport;
+    private Client client = new JerseyClientBuilder().build();
+
+    public void setup(Class<? extends Application<TestConfiguration>> applicationClass) {
+        dropwizardTestSupport = new DropwizardTestSupport<>(applicationClass, ResourceHelpers.resourceFilePath("hibernate-integration-test.yaml"),
+            ConfigOverride.config("dataSource.url", "jdbc:hsqldb:mem:DbTest" + System.nanoTime() + "?hsqldb.translate_dti_types=false"));
+        dropwizardTestSupport.before();
+    }
+
     @After
-    public void tearDown() throws Exception {
-        super.tearDown();
-
-        if (sessionFactory != null) {
-            sessionFactory.close();
-        }
+    public void tearDown() {
+        dropwizardTestSupport.after();
+        client.close();
     }
 
-    @Override
-    protected Application configure() {
-        forceSet(TestProperties.CONTAINER_PORT, "0");
-
-        final MetricRegistry metricRegistry = new MetricRegistry();
-        final SessionFactoryFactory factory = new SessionFactoryFactory();
-        final DataSourceFactory dbConfig = new DataSourceFactory();
-        final Environment environment = mock(Environment.class);
-        final LifecycleEnvironment lifecycleEnvironment = mock(LifecycleEnvironment.class);
-        when(environment.lifecycle()).thenReturn(lifecycleEnvironment);
-        when(environment.metrics()).thenReturn(metricRegistry);
-        bundle = new HibernateBundle<Configuration>(null, factory) {
-            @Override
-            public DataSourceFactory getDataSourceFactory(Configuration configuration) {
-                return dbConfig;
-            }
-        };
-
-        dbConfig.setUrl("jdbc:hsqldb:mem:DbTest-" + System.nanoTime()+"?hsqldb.translate_dti_types=false");
-        dbConfig.setUser("sa");
-        dbConfig.setDriverClass("org.hsqldb.jdbcDriver");
-        dbConfig.setValidationQuery("SELECT 1 FROM INFORMATION_SCHEMA.SYSTEM_USERS");
-
-        this.sessionFactory = factory.build(bundle,
-                                            environment,
-                                            dbConfig,
-                                            ImmutableList.of(Person.class, Dog.class));
-
-        try (Session session = sessionFactory.openSession()) {
-            session.createSQLQuery("DROP TABLE people IF EXISTS").executeUpdate();
-            session.createSQLQuery(
-                "CREATE TABLE people (name varchar(100) primary key, email varchar(16), birthday timestamp with time zone)")
-                .executeUpdate();
-            session.createSQLQuery(
-                "INSERT INTO people VALUES ('Coda', 'coda@example.com', '1979-01-02 00:22:00+0:00')")
-                .executeUpdate();
-            session.createSQLQuery("DROP TABLE dogs IF EXISTS").executeUpdate();
-            session.createSQLQuery(
-                "CREATE TABLE dogs (name varchar(100) primary key, owner varchar(100), CONSTRAINT fk_owner FOREIGN KEY (owner) REFERENCES people(name))")
-                .executeUpdate();
-            session.createSQLQuery(
-                "INSERT INTO dogs VALUES ('Raf', 'Coda')")
-                .executeUpdate();
-        }
-
-        bootstrap = mock(Bootstrap.class);
-        final ObjectMapper objMapper = Jackson.newObjectMapper();
-        when(bootstrap.getObjectMapper()).thenReturn(objMapper);
-        // Bundle is initialised at start of actual test methods to allow lazy loading to be enabled or disabled.
-
-        final DropwizardResourceConfig config = DropwizardResourceConfig.forTesting(metricRegistry);
-        config.register(new UnitOfWorkApplicationListener("hr-db", sessionFactory));
-        config.register(new DogResource(new DogDAO(sessionFactory)));
-        config.register(new JacksonMessageBodyProvider(objMapper));
-        config.register(new DataExceptionMapper());
-
-        return config;
-    }
-
-    @Override
-    protected void configureClient(ClientConfig config) {
-        config.register(new JacksonMessageBodyProvider(Jackson.newObjectMapper()));
+    private String getUrlPrefix() {
+        return "http://localhost:" + dropwizardTestSupport.getLocalPort();
     }
 
     @Test
     public void serialisesLazyObjectWhenEnabled() throws Exception {
-        bundle.initialize(bootstrap);
+        setup(TestApplication.class);
 
-        final Dog raf = target("/dogs/Raf").request(MediaType.APPLICATION_JSON).get(Dog.class);
+        final Dog raf = client.target(getUrlPrefix() + "/dogs/Raf").request(MediaType.APPLICATION_JSON).get(Dog.class);
 
         assertThat(raf.getName())
-                .isEqualTo("Raf");
+            .isEqualTo("Raf");
 
         assertThat(raf.getOwner())
-                .isNotNull();
+            .isNotNull();
 
         assertThat(raf.getOwner().getName())
-                .isEqualTo("Coda");
+            .isEqualTo("Coda");
     }
 
     @Test
     public void sendsNullWhenDisabled() throws Exception {
-        bundle.setLazyLoadingEnabled(false);
-        bundle.initialize(bootstrap);
+        setup(TestApplicationWithDisabledLazyLoading.class);
 
-        final Dog raf = target("/dogs/Raf").request(MediaType.APPLICATION_JSON).get(Dog.class);
+        final Dog raf = client.target(getUrlPrefix() + "/dogs/Raf").request(MediaType.APPLICATION_JSON).get(Dog.class);
 
         assertThat(raf.getName())
-                .isEqualTo("Raf");
+            .isEqualTo("Raf");
 
         assertThat(raf.getOwner())
-                .isNull();
+            .isNull();
+    }
+
+    @Test
+    public void returnsErrorsWhenEnabled() throws Exception {
+        setup(TestApplication.class);
+
+        final Dog raf = new Dog();
+        raf.setName("Raf");
+
+        // Raf already exists so this should cause a primary key constraint violation
+        final Response response = client.target(getUrlPrefix() + "/dogs/Raf").request().put(Entity.entity(raf, MediaType.APPLICATION_JSON));
+        assertThat(response.getStatusInfo()).isEqualTo(Response.Status.BAD_REQUEST);
+        assertThat(response.getHeaderString(HttpHeaders.CONTENT_TYPE)).isEqualTo(MediaType.APPLICATION_JSON);
+        assertThat(response.readEntity(ErrorMessage.class).getMessage()).contains("unique constraint", "table: DOGS");
     }
 }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkApplicationListenerTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkApplicationListenerTest.java
@@ -41,6 +41,7 @@ public class UnitOfWorkApplicationListenerTest {
 
     private final RequestEvent requestStartEvent = mock(RequestEvent.class);
     private final RequestEvent requestMethodStartEvent = mock(RequestEvent.class);
+    private final RequestEvent responseFiltersStartEvent = mock(RequestEvent.class);
     private final RequestEvent responseFinishedEvent = mock(RequestEvent.class);
     private final RequestEvent requestMethodExceptionEvent = mock(RequestEvent.class);
     private final Session session = mock(Session.class);
@@ -70,6 +71,7 @@ public class UnitOfWorkApplicationListenerTest {
         when(requestMethodStartEvent.getType()).thenReturn(RequestEvent.Type.RESOURCE_METHOD_START);
         when(responseFinishedEvent.getType()).thenReturn(RequestEvent.Type.FINISHED);
         when(requestMethodExceptionEvent.getType()).thenReturn(RequestEvent.Type.ON_EXCEPTION);
+        when(responseFiltersStartEvent.getType()).thenReturn(RequestEvent.Type.RESP_FILTERS_START);
         when(requestMethodStartEvent.getUriInfo()).thenReturn(uriInfo);
         when(responseFinishedEvent.getUriInfo()).thenReturn(uriInfo);
         when(requestMethodExceptionEvent.getUriInfo()).thenReturn(uriInfo);
@@ -281,6 +283,7 @@ public class UnitOfWorkApplicationListenerTest {
         listener.onEvent(appEvent);
         RequestEventListener requestListener = listener.onRequest(requestStartEvent);
         requestListener.onEvent(requestMethodStartEvent);
+        requestListener.onEvent(responseFiltersStartEvent);
         requestListener.onEvent(responseFinishedEvent);
     }
 
@@ -288,7 +291,9 @@ public class UnitOfWorkApplicationListenerTest {
         listener.onEvent(appEvent);
         RequestEventListener requestListener = listener.onRequest(requestStartEvent);
         requestListener.onEvent(requestMethodStartEvent);
+        requestListener.onEvent(responseFiltersStartEvent);
         requestListener.onEvent(requestMethodExceptionEvent);
+        requestListener.onEvent(responseFinishedEvent);
     }
 
     public static class MockResource implements MockResourceInterface {

--- a/dropwizard-hibernate/src/test/resources/hibernate-integration-test.yaml
+++ b/dropwizard-hibernate/src/test/resources/hibernate-integration-test.yaml
@@ -1,0 +1,15 @@
+server:
+  applicationConnectors:
+    - type: http
+      port: 0
+  adminConnectors:
+    - type: http
+      port: 0
+  requestLog:
+    appenders: []
+logging:
+  appenders: []
+dataSource:
+  user: "sa"
+  driverClass: "org.hsqldb.jdbcDriver"
+  validationQuery: "SELECT 1 FROM INFORMATION_SCHEMA.SYSTEM_USERS"


### PR DESCRIPTION
But close the session during the `FINISHED` stage. This allows to the user to catch errors during commiting transactions (constraint violations, e.g) and map them to HTTP error with
an exception mapper.

This approach also is compatible with lazy loading, because the session remain open during serializing Hibernate entities.

Fix #1604