### PR TITLE
Add a way to delegate the proxy creation to the user

### DIFF
--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
@@ -70,6 +70,21 @@ public class UnitOfWorkAwareProxyFactoryTest {
     }
 
     @Test
+    public void testManualProxyWorks() throws Exception {
+        final SessionDao sessionDao = new SessionDao(sessionFactory);
+        final UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory =
+                new UnitOfWorkAwareProxyFactory("default", sessionFactory);
+        final ProxyFactory proxyFactory = new ProxyFactory();
+        proxyFactory.setSuperclass(OAuthAuthenticator.class);
+        final OAuthAuthenticator oAuthAuthenticator = (OAuthAuthenticator)proxyFactory.createClass()
+                .getConstructor(SessionDao.class)
+                .newInstance(sessionDao);
+        unitOfWorkAwareProxyFactory.injectMethodHandler(oAuthAuthenticator);
+        assertThat(oAuthAuthenticator.authenticate("67ab89d")).isTrue();
+        assertThat(oAuthAuthenticator.authenticate("bd1e23a")).isFalse();
+    }
+    
+    @Test
     public void testProxyWorksWithoutUnitOfWork() {
         assertThat(new UnitOfWorkAwareProxyFactory("default", sessionFactory)
                 .create(PlainAuthenticator.class)

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
@@ -7,6 +7,7 @@ import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import io.dropwizard.logging.BootstrapLogging;
 import io.dropwizard.setup.Environment;
+import javassist.util.proxy.ProxyFactory;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.junit.Before;


### PR DESCRIPTION
Because of dependency injection frameworks, I need to create the proxy by myself. Using Objenesis is the way to go. This pull request lets `UnitOfWorkAwareProxyFactory` inject my javassist-created proxy with the factory's custom `MethodHandler` really easily.

Design choices:

1. It is preferrable that `UnitOfWorkAwareProxyFactory` performs the injection rather than exposing its `MethodHandler`. This way, the interface doesn't depend on javassist.
2. I think it's preferable to accept a `java.lang.Object` rather than a `javassist.util.proxy.Proxy` as the user code will be more readable.
3. If a non-proxy object is provided, an `IllegalArgumentException` is thrown rather than a `ClassCastException` to insist on the fact that the argument is incorrect and hide the implementation details.