### PR TITLE
Fix a test(-only) problem to work with both Jackson 2.7 and 2.8

### DIFF
--- a/dropwizard-core/src/test/java/io/dropwizard/server/SimpleServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/SimpleServerFactoryTest.java
@@ -46,7 +46,7 @@ public class SimpleServerFactoryTest {
     public void setUp() throws Exception {
         objectMapper.getSubtypeResolver().registerSubtypes(ConsoleAppenderFactory.class,
                 FileAppenderFactory.class, SyslogAppenderFactory.class, HttpConnectorFactory.class);
-        http = new YamlConfigurationFactory<>(SimpleServerFactory.class, validator, objectMapper, "dw")
+        http = (SimpleServerFactory) new YamlConfigurationFactory<>(ServerFactory.class, validator, objectMapper, "dw")
                 .build(new File(Resources.getResource("yaml/simple_server.yml").toURI()));
     }
 


### PR DESCRIPTION
(for background, see https://github.com/FasterXML/jackson-databind/issues/1311 on Jackson side)

So: there is a small problem with couple of tests cases, leading to test failures with Jackson 2.8, but not earlier versions, as earlier versions did not check type assignments wrt `defaultImpl` of `@JsonTypeInfo` annotation.

Problem here is that some tests explicitly ask for binding to `SimpleServerFactory` (instead of base type `ServerFactory`); but as per annotations in `ServerFactory`, default implementation is `DefaultServerFactory`. Since `DefaultServerFactory` is NOT a subtype of `SimpleServerFactory` (but only `ServerFactory`), such a request could return an instance of `DefaultServerFactory` and result in a class cast exception. Because of this, Jackson's type handling code throws exception instead.

It is possible that some improvements would make sense on Jackson side (for example, improved error messaging if and as possible); but on short term it would make sense to ensure that test failure is prevented since as far as I can see, this is test-only problem and normal running of a DropWizard service would not hit the same problem. Conversely if there are other problems for actual code, it'd be necessary to get a good reproduction of such usage: I don't think test case as-is reproduces real problem.

So: this patch should remove 5 test failures related to using Jackson 2.8.1 with DW.
(I will try to work on other remaining problems that relate to exception message checking next)


