### PR TITLE
Update Jetty to 9.3.11.v20160721

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -4,6 +4,13 @@
 Release Notes
 #############
 
+.. _rel-1.1.0:
+
+v1.1.0: Unreleased
+==================
+
+* Upgraded to Jetty 9.3.11.v20160721 `#1649 <https://github.com/dropwizard/dropwizard/pull/1649>`_
+
 .. _rel-1.0.0:
 
 v1.0.0: Jul 26 2016

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -26,7 +26,7 @@
         <jersey.version>2.23.1</jersey.version>
         <jackson.api.version>2.7.6</jackson.api.version>
         <jackson.version>2.7.6</jackson.version>
-        <jetty.version>9.3.9.v20160517</jetty.version>
+        <jetty.version>9.3.10.v20160621</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics3.version>3.1.2</metrics3.version>
         <slf4j.version>1.7.21</slf4j.version>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -26,7 +26,7 @@
         <jersey.version>2.23.1</jersey.version>
         <jackson.api.version>2.7.6</jackson.api.version>
         <jackson.version>2.7.6</jackson.version>
-        <jetty.version>9.3.10.v20160621</jetty.version>
+        <jetty.version>9.3.11.v20160721</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics3.version>3.1.2</metrics3.version>
         <slf4j.version>1.7.21</slf4j.version>

--- a/dropwizard-client/src/test/java/io/dropwizard/client/ssl/DropwizardSSLConnectionSocketFactoryTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/ssl/DropwizardSSLConnectionSocketFactoryTest.java
@@ -14,6 +14,7 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.ws.rs.GET;
@@ -169,7 +170,7 @@ public class DropwizardSSLConnectionSocketFactoryTest {
             client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(4))).request().get();
             fail("expected ProcessingException");
         } catch (ProcessingException e) {
-            assertThat(e.getCause()).isInstanceOfAny(SocketException.class, SSLHandshakeException.class);
+            assertThat(e).hasRootCauseInstanceOf(SSLException.class);
         }
     }
 }

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/BiDiGzipHandlerTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/BiDiGzipHandlerTest.java
@@ -38,6 +38,8 @@ public class BiDiGzipHandlerTest {
 
     @Before
     public void setUp() throws Exception {
+        request.setHeader(HttpHeaders.HOST, "localhost");
+
         gzipHandler.setExcludedAgentPatterns();
         gzipHandler.addIncludedMethods("POST");
 

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
@@ -217,7 +217,7 @@ public class HttpsConnectorFactoryTest {
         assertThat(sslContextFactory.getNeedClientAuth()).isTrue();
         assertThat(sslContextFactory.getWantClientAuth()).isTrue();
         assertThat(sslContextFactory.getCertAlias()).isEqualTo("alt_server");
-        assertThat(sslContextFactory.getCrlPath()).isEqualTo("/etc/ctr_list.txt");
+        assertThat(sslContextFactory.getCrlPath()).isEqualTo(new File("/etc/ctr_list.txt").getAbsolutePath());
         assertThat(sslContextFactory.isEnableCRLDP()).isTrue();
         assertThat(sslContextFactory.isEnableOCSP()).isTrue();
         assertThat(sslContextFactory.getMaxCertPathLength()).isEqualTo(4);


### PR DESCRIPTION
This PR supersedes #1608:

- By updating to a newer version of Jetty
- Fixing test case on windows due to window paths
- Fixing test failure found in #1608 with new exception comparison. Admittedly, it seems like a worse exception message to test against (`SSLException` vs `SSLHandshakeException`)