### PR TITLE
Remove the test scope from `jetty-client` in the BOM

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -267,13 +267,11 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-client</artifactId>
                 <version>${jetty.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty.http2</groupId>
                 <artifactId>http2-http-client-transport</artifactId>
                 <version>${jetty.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty.toolchain.setuid</groupId>


### PR DESCRIPTION
Some Dropwizard users may want to use this library with the compile scope as an HTTP/2 client. But currently the BOM forces the test scope, so users are forced to declare the dependency with the compile scope in their projects. This especially not very convenient when the library is pulled as a transitive dependency. An example is https://github.com/arteam/dropwizard-http2-client. See this [discussion](https://github.com/arteam/dropwizard-http2-client/issues/1).