### PR TITLE
Support maxFileSize and archivedFileCount

### DIFF
--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
@@ -220,16 +220,19 @@ public class FileAppenderFactory<E extends DeferredProcessingAware> extends Abst
 
             if (maxFileSize != null && !archivedLogFilenamePattern.contains("%d")) {
                 final FixedWindowRollingPolicy rollingPolicy = new FixedWindowRollingPolicy();
-                final SizeBasedTriggeringPolicy<E> triggeringPolicy = new SizeBasedTriggeringPolicy<>();
-                triggeringPolicy.setMaxFileSize(String.valueOf(maxFileSize.toBytes()));
-                triggeringPolicy.setContext(context);
                 rollingPolicy.setContext(context);
                 rollingPolicy.setMaxIndex(getArchivedFileCount());
                 rollingPolicy.setFileNamePattern(getArchivedLogFilenamePattern());
-                appender.setRollingPolicy(rollingPolicy);
-                appender.setTriggeringPolicy(triggeringPolicy);
                 rollingPolicy.setParent(appender);
                 rollingPolicy.start();
+                appender.setRollingPolicy(rollingPolicy);
+                
+                final SizeBasedTriggeringPolicy<E> triggeringPolicy = new SizeBasedTriggeringPolicy<>();
+                triggeringPolicy.setMaxFileSize(String.valueOf(maxFileSize.toBytes()));
+                triggeringPolicy.setContext(context);
+                triggeringPolicy.start();
+                appender.setTriggeringPolicy(triggeringPolicy);
+                
                 return appender;
             } else {
                 final TimeBasedFileNamingAndTriggeringPolicy<E> triggeringPolicy;

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
@@ -190,7 +190,10 @@ public class FileAppenderFactoryTest {
         RollingFileAppender<ILoggingEvent> appender = (RollingFileAppender<ILoggingEvent>) fileAppenderFactory.buildAppender(new LoggerContext());
 
         assertThat(appender.getRollingPolicy()).isInstanceOf(FixedWindowRollingPolicy.class);
+        assertThat(appender.getRollingPolicy().isStarted());
+        
         assertThat(appender.getTriggeringPolicy()).isInstanceOf(SizeBasedTriggeringPolicy.class);
+        assertThat(appender.getTriggeringPolicy().isStarted());
         assertThat(((SizeBasedTriggeringPolicy) appender.getTriggeringPolicy()).getMaxFileSize()).isEqualTo("1024");
     }
 

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
@@ -190,10 +190,10 @@ public class FileAppenderFactoryTest {
         RollingFileAppender<ILoggingEvent> appender = (RollingFileAppender<ILoggingEvent>) fileAppenderFactory.buildAppender(new LoggerContext());
 
         assertThat(appender.getRollingPolicy()).isInstanceOf(FixedWindowRollingPolicy.class);
-        assertThat(appender.getRollingPolicy().isStarted());
+        assertThat(appender.getRollingPolicy().isStarted()).isTrue();
         
         assertThat(appender.getTriggeringPolicy()).isInstanceOf(SizeBasedTriggeringPolicy.class);
-        assertThat(appender.getTriggeringPolicy().isStarted());
+        assertThat(appender.getTriggeringPolicy().isStarted()).isTrue();
         assertThat(((SizeBasedTriggeringPolicy) appender.getTriggeringPolicy()).getMaxFileSize()).isEqualTo("1024");
     }
 


### PR DESCRIPTION
When the `%i` log format pattern is used with the `maxFileSize` and `archivedFileCount ` properties, the logs are not rotated properly. It appear that the issue was that the triggering policy was not started.

```
-rw-r--r-- 1 dw dw  1368 Aug  1 18:02 dw_server-1.log.gz
-rw-r--r-- 1 dw dw  1807 Aug  1 18:01 dw_server-2.log.gz
-rw-r--r-- 1 dw dw  2151 Aug  1 18:00 dw_server-3.log.gz
-rw-r--r-- 1 dw dw  2170 Aug  1 18:00 dw_server-4.log.gz
-rw-r--r-- 1 dw dw  2149 Aug  1 18:00 dw_server-5.log.gz
-rw-r--r-- 1 dw dw  1384 Aug  1 18:00 dw_server_access-1.log.gz
-rw-r--r-- 1 dw dw  1378 Aug  1 18:00 dw_server_access-2.log.gz
-rw-r--r-- 1 dw dw  1419 Aug  1 18:00 dw_server_access-3.log.gz
-rw-r--r-- 1 dw dw  1403 Aug  1 18:00 dw_server_access-4.log.gz
-rw-r--r-- 1 dw dw  1410 Aug  1 18:00 dw_server_access-5.log.gz
-rw-r--r-- 1 dw dw 10101 Aug  1 18:00 dw_server_access.log
-rw-r--r-- 1 dw dw  3564 Aug  1 18:02 dw_server.log
[vagrant@server ~]$ for i in {1..100}; do curl -s http://localhost:8080/stuff > /dev/null; done
[vagrant@server ~]$ ll /opt/dw/server/logs/
total 76
-rw-r--r-- 1 dw dw  2950 Aug  1 18:03 dw_server-1.log.gz
-rw-r--r-- 1 dw dw  2934 Aug  1 18:03 dw_server-2.log.gz
-rw-r--r-- 1 dw dw  2963 Aug  1 18:03 dw_server-3.log.gz
-rw-r--r-- 1 dw dw  2967 Aug  1 18:03 dw_server-4.log.gz
-rw-r--r-- 1 dw dw  2940 Aug  1 18:03 dw_server-5.log.gz
-rw-r--r-- 1 dw dw  1582 Aug  1 18:03 dw_server_access-1.log.gz
-rw-r--r-- 1 dw dw  1589 Aug  1 18:03 dw_server_access-2.log.gz
-rw-r--r-- 1 dw dw  1387 Aug  1 18:03 dw_server_access-3.log.gz
-rw-r--r-- 1 dw dw  1384 Aug  1 18:00 dw_server_access-4.log.gz
-rw-r--r-- 1 dw dw  1378 Aug  1 18:00 dw_server_access-5.log.gz
-rw-r--r-- 1 dw dw   777 Aug  1 18:03 dw_server_access.log
-rw-r--r-- 1 dw dw 30130 Aug  1 18:03 dw_server.log
```
