### PR TITLE
Make the aspect easily available to other DI frameworks

### DIFF
--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAspect.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAspect.java
@@ -11,12 +11,31 @@ import java.util.Map;
  * An aspect providing operations around a method with the {@link UnitOfWork} annotation.
  * It opens a Hibernate session and optionally a transaction.
  * <p>It should be created for every invocation of the method.</p>
+ * <p>Usage :</p>
+ * <pre>
+ * {@code
+ *   UnitOfWorkProxyFactory unitOfWorkProxyFactory = ...
+ *   UnitOfWork unitOfWork = ...         // get annotation from method.
+ *
+ *   UnitOfWorkAspect aspect = unitOfWorkProxyFactory.newAspect();
+ *   try {
+ *     aspect.beforeStart(unitOfWork);
+ *     ...                               // perform business logic.
+ *     aspect.afterEnd();
+ *   } catch (Exception e) {
+ *     aspect.onError();
+ *     throw e;
+ *   } finally {
+ *     aspect.onFinish();
+ *   }
+ * }
+ * </pre>
  */
-class UnitOfWorkAspect {
+public class UnitOfWorkAspect {
 
     private final Map<String, SessionFactory> sessionFactories;
 
-    public UnitOfWorkAspect(Map<String, SessionFactory> sessionFactories) {
+    UnitOfWorkAspect(Map<String, SessionFactory> sessionFactories) {
         this.sessionFactories = sessionFactories;
     }
 

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactory.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactory.java
@@ -75,7 +75,7 @@ public class UnitOfWorkAwareProxyFactory {
                     factory.create(constructorParamTypes, constructorArguments));
             proxy.setHandler((self, overridden, proceed, args) -> {
                 final UnitOfWork unitOfWork = overridden.getAnnotation(UnitOfWork.class);
-                final UnitOfWorkAspect unitOfWorkAspect = new UnitOfWorkAspect(sessionFactories);
+                final UnitOfWorkAspect unitOfWorkAspect = newAspect();
                 try {
                     unitOfWorkAspect.beforeStart(unitOfWork);
                     Object result = proceed.invoke(self, args);
@@ -96,5 +96,12 @@ public class UnitOfWorkAwareProxyFactory {
                 InvocationTargetException e) {
             throw new IllegalStateException("Unable to create a proxy for the class '" + clazz + "'", e);
         }
+    }
+
+    /**
+     * @return a new
+     */
+    public UnitOfWorkAspect newAspect() {
+        return new UnitOfWorkAspect(sessionFactories);
     }
 }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
@@ -87,6 +87,16 @@ public class UnitOfWorkAwareProxyFactoryTest {
                 .authenticate("b812ae4");
     }
 
+    @Test
+    public void testNewAspect() {
+        final UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory =
+                new UnitOfWorkAwareProxyFactory("default", sessionFactory);
+
+        UnitOfWorkAspect aspect1 = unitOfWorkAwareProxyFactory.newAspect();
+        UnitOfWorkAspect aspect2 = unitOfWorkAwareProxyFactory.newAspect();
+        assertThat(aspect1).isNotSameAs(aspect2);
+    }
+
     static class SessionDao {
 
         private SessionFactory sessionFactory;


### PR DESCRIPTION
The current proxy implementation makes it hard for DI frameworks to play nice with the `@UnitOfWork` annotation. It is required to have an object, its proxy and wire the two in difficult way. For instance, using Guice, there are several solutions, but none are natural.

This simple change makes `UnitOfWorkAspect` public, but only accessible from a `UnitOfWorkAwareProxyFactory` instance.

This way, DI framework users can implement their own `@UnitOfWork` behavior. This moves the responsibility to the user. Therefore a guide has been written under the form of Javadoc for the `UnitOfWorkAspect` class. It basically says how to properly use the aspect, as intended by the original developer of `UnitOfWorkAwareProxyFactory`.

For instance, my original Guice solution took 300 lines of code, made heavy use the included proxy mechanism as well as an extra one and Objenesis, and was prone to memory leaks for some of the slightest changes. This change reduce it to ~20 lines, using the standard Guice way of things.