### PR TITLE
Allow use of custom HostnameVerifier on clients.

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactory.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactory.java
@@ -19,9 +19,15 @@ import java.util.List;
 public class DropwizardSSLConnectionSocketFactory {
 
     private final TlsConfiguration configuration;
+    private final HostnameVerifier verifier;
 
     public DropwizardSSLConnectionSocketFactory(TlsConfiguration configuration) {
+        this(configuration, null);
+    }
+
+    public DropwizardSSLConnectionSocketFactory(TlsConfiguration configuration, HostnameVerifier verifier) {
         this.configuration = configuration;
+        this.verifier = verifier;
     }
 
     public SSLConnectionSocketFactory getSocketFactory() throws SSLInitializationException {
@@ -46,13 +52,11 @@ public class DropwizardSSLConnectionSocketFactory {
     }
 
     private HostnameVerifier chooseHostnameVerifier() {
-        HostnameVerifier hostnameVerifier;
         if (configuration.isVerifyHostname()) {
-            hostnameVerifier = SSLConnectionSocketFactory.getDefaultHostnameVerifier();
+            return verifier != null ? verifier : SSLConnectionSocketFactory.getDefaultHostnameVerifier();
         } else {
-            hostnameVerifier = new NoopHostnameVerifier();
+            return new NoopHostnameVerifier();
         }
-        return hostnameVerifier;
     }
 
     private SSLContext buildSslContext() throws SSLInitializationException {

--- a/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
@@ -11,6 +11,7 @@ import io.dropwizard.jersey.validation.HibernateValidationFeature;
 import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.setup.Environment;
+import javax.net.ssl.HostnameVerifier;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.HttpRequestRetryHandler;
 import org.apache.http.config.Registry;
@@ -221,6 +222,22 @@ public class JerseyClientBuilder {
      */
     public JerseyClientBuilder using(DnsResolver resolver) {
         apacheHttpClientBuilder.using(resolver);
+        return this;
+    }
+
+    /**
+     * Use the given {@link HostnameVerifier} instance.
+     *
+     * Note that if {@link io.dropwizard.client.ssl.TlsConfiguration#isVerifyHostname()}
+     * returns false, all host name verification is bypassed, including
+     * host name verification performed by a verifier specified
+     * through this interface.
+     *
+     * @param verifier a {@link HostnameVerifier} instance
+     * @return {@code this}
+     */
+    public JerseyClientBuilder using(HostnameVerifier verifier) {
+        apacheHttpClientBuilder.using(verifier);
         return this;
     }
 

--- a/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
@@ -1,16 +1,25 @@
 package io.dropwizard.client;
 
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.httpclient.HttpClientMetricNameStrategies;
-import com.codahale.metrics.httpclient.InstrumentedHttpClientConnectionManager;
-import com.codahale.metrics.httpclient.InstrumentedHttpRequestExecutor;
-import com.google.common.collect.ImmutableList;
-import io.dropwizard.client.proxy.AuthConfiguration;
-import io.dropwizard.client.proxy.ProxyConfiguration;
-import io.dropwizard.lifecycle.Managed;
-import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
-import io.dropwizard.setup.Environment;
-import io.dropwizard.util.Duration;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.validateMockitoUsage;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
+import javax.net.ssl.HostnameVerifier;
+
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.http.Header;
 import org.apache.http.HeaderIterator;
@@ -51,26 +60,24 @@ import org.apache.http.message.BasicListHeaderIterator;
 import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.protocol.HTTP;
 import org.apache.http.protocol.HttpContext;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.net.InetSocketAddress;
-import java.net.Proxy;
-import java.net.ProxySelector;
-import java.net.SocketAddress;
-import java.net.URI;
-import java.util.List;
-import java.util.Optional;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.httpclient.HttpClientMetricNameStrategies;
+import com.codahale.metrics.httpclient.InstrumentedHttpClientConnectionManager;
+import com.codahale.metrics.httpclient.InstrumentedHttpRequestExecutor;
+import com.google.common.collect.ImmutableList;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import io.dropwizard.client.proxy.AuthConfiguration;
+import io.dropwizard.client.proxy.ProxyConfiguration;
+import io.dropwizard.client.ssl.TlsConfiguration;
+import io.dropwizard.lifecycle.Managed;
+import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.util.Duration;
 
 public class HttpClientBuilderTest {
     private final Class<?> httpClientBuilderClass;
@@ -83,7 +90,7 @@ public class HttpClientBuilderTest {
     private HttpClientBuilder builder;
     private InstrumentedHttpClientConnectionManager connectionManager;
     private org.apache.http.impl.client.HttpClientBuilder apacheBuilder;
-
+    
     public HttpClientBuilderTest() throws ClassNotFoundException {
         this.httpClientBuilderClass = Class.forName("org.apache.http.impl.client.HttpClientBuilder");
         this.httpClientClass = Class.forName("org.apache.http.impl.client.InternalHttpClient");
@@ -96,10 +103,14 @@ public class HttpClientBuilderTest {
         builder = new HttpClientBuilder(metricRegistry);
         connectionManager = spy(new InstrumentedHttpClientConnectionManager(metricRegistry, registry));
         apacheBuilder = org.apache.http.impl.client.HttpClientBuilder.create();
-
         initMocks(this);
     }
 
+    @After
+    public void validate() {
+        validateMockitoUsage();
+    }
+    
     @Test
     public void setsTheMaximumConnectionPoolSize() throws Exception {
         configuration.setMaxConnections(412);
@@ -158,6 +169,88 @@ public class HttpClientBuilderTest {
         assertThat(dnsResolverField.get(connectOperator)).isInstanceOf(SystemDefaultDnsResolver.class);
     }
 
+    @Test
+    public void canUseACustomHostnameVerifierWhenTlsConfigurationNotSpecified() throws Exception {
+        final HostnameVerifier customVerifier = (s, sslSession) -> false;
+
+        final Registry<ConnectionSocketFactory> configuredRegistry;
+        configuredRegistry = builder.using(customVerifier).createConfiguredRegistry();
+        assertThat(configuredRegistry).isNotNull();
+
+        final SSLConnectionSocketFactory socketFactory = 
+                (SSLConnectionSocketFactory) configuredRegistry.lookup("https");
+        assertThat(socketFactory).isNotNull();
+
+        final Field hostnameVerifierField =
+                FieldUtils.getField(SSLConnectionSocketFactory.class, "hostnameVerifier", true);
+        assertThat(hostnameVerifierField.get(socketFactory)).isSameAs(customVerifier);
+    }
+
+    @Test
+    public void canUseACustomHostnameVerifierWhenTlsConfigurationSpecified() throws Exception {
+        final TlsConfiguration tlsConfiguration = new TlsConfiguration();
+        tlsConfiguration.setVerifyHostname(true);
+        configuration.setTlsConfiguration(tlsConfiguration);
+
+        final HostnameVerifier customVerifier = (s, sslSession) -> false;
+
+        final Registry<ConnectionSocketFactory> configuredRegistry;
+        configuredRegistry = builder.using(configuration).using(customVerifier).createConfiguredRegistry();
+        assertThat(configuredRegistry).isNotNull();
+
+        final SSLConnectionSocketFactory socketFactory = 
+                (SSLConnectionSocketFactory) configuredRegistry.lookup("https");
+        assertThat(socketFactory).isNotNull();
+
+        final Field hostnameVerifierField =
+                FieldUtils.getField(SSLConnectionSocketFactory.class, "hostnameVerifier", true);
+        assertThat(hostnameVerifierField.get(socketFactory)).isSameAs(customVerifier);
+    }
+
+    @Test
+    public void canUseASystemHostnameVerifierByDefaultWhenTlsConfigurationNotSpecified() throws Exception {
+        final Registry<ConnectionSocketFactory> configuredRegistry;
+        configuredRegistry = builder.createConfiguredRegistry();
+        assertThat(configuredRegistry).isNotNull();
+
+        final SSLConnectionSocketFactory socketFactory = 
+                (SSLConnectionSocketFactory) configuredRegistry.lookup("https");
+        assertThat(socketFactory).isNotNull();
+
+        final Field hostnameVerifierField =
+                FieldUtils.getField(SSLConnectionSocketFactory.class, "hostnameVerifier", true);
+        assertThat(hostnameVerifierField.get(socketFactory)).isInstanceOf(HostnameVerifier.class);
+    }
+   
+    @Test
+    public void canUseASystemHostnameVerifierByDefaultWhenTlsConfigurationSpecified() throws Exception {
+        final TlsConfiguration tlsConfiguration = new TlsConfiguration();
+        tlsConfiguration.setVerifyHostname(true);
+        configuration.setTlsConfiguration(tlsConfiguration);
+
+        final Registry<ConnectionSocketFactory> configuredRegistry;
+        configuredRegistry = builder.using(configuration).createConfiguredRegistry();
+        assertThat(configuredRegistry).isNotNull();
+
+        final SSLConnectionSocketFactory socketFactory = 
+                (SSLConnectionSocketFactory) configuredRegistry.lookup("https");
+        assertThat(socketFactory).isNotNull();
+
+        final Field hostnameVerifierField =
+                FieldUtils.getField(SSLConnectionSocketFactory.class, "hostnameVerifier", true);
+        assertThat(hostnameVerifierField.get(socketFactory)).isInstanceOf(HostnameVerifier.class);
+    }
+
+    @Test
+    public void createClientCanPassCustomVerifierToApacheBuilder() throws Exception {
+        final HostnameVerifier customVerifier = (s, sslSession) -> false;
+
+        assertThat(builder.using(customVerifier).createClient(apacheBuilder, connectionManager, "test")).isNotNull();
+        
+        final Field hostnameVerifierField =
+                FieldUtils.getField(org.apache.http.impl.client.HttpClientBuilder.class, "hostnameVerifier", true);
+        assertThat(hostnameVerifierField.get(apacheBuilder)).isSameAs(customVerifier);
+    }
 
     @Test
     public void doesNotReuseConnectionsIfKeepAliveIsZero() throws Exception {

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
@@ -31,6 +31,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
@@ -260,6 +261,13 @@ public class JerseyClientBuilderTest {
         final DnsResolver customDnsResolver = new SystemDefaultDnsResolver();
         builder.using(customDnsResolver);
         verify(apacheHttpClientBuilder).using(customDnsResolver);
+    }
+
+    @Test
+    public void usesACustomHostnameVerifier() {
+        final HostnameVerifier customHostnameVerifier = new NoopHostnameVerifier();
+        builder.using(customHostnameVerifier);
+        verify(apacheHttpClientBuilder).using(customHostnameVerifier);
     }
 
     @Test

--- a/dropwizard-client/src/test/java/io/dropwizard/client/ssl/DropwizardSSLConnectionSocketFactoryTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/ssl/DropwizardSSLConnectionSocketFactoryTest.java
@@ -1,7 +1,34 @@
 package io.dropwizard.client.ssl;
 
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.net.SocketException;
+import java.util.Optional;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.glassfish.jersey.client.ClientResponse;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
+import io.dropwizard.client.DropwizardSSLConnectionSocketFactory;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.setup.Environment;
@@ -9,25 +36,6 @@ import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import io.dropwizard.util.Duration;
-import org.glassfish.jersey.client.ClientResponse;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-
-import javax.net.ssl.SSLHandshakeException;
-import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.core.Response;
-import java.io.File;
-import java.net.SocketException;
-import java.util.Optional;
-
-import static java.util.Arrays.asList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 public class DropwizardSSLConnectionSocketFactoryTest {
     private TlsConfiguration tlsConfiguration;
@@ -77,6 +85,16 @@ public class DropwizardSSLConnectionSocketFactoryTest {
         jerseyClientConfiguration.setTlsConfiguration(tlsConfiguration);
         jerseyClientConfiguration.setConnectionTimeout(Duration.milliseconds(2000));
         jerseyClientConfiguration.setTimeout(Duration.milliseconds(5000));
+    }
+
+    @Test
+    public void configOnlyConstructorShouldSetNullCustomVerifier() throws Exception {
+        final DropwizardSSLConnectionSocketFactory socketFactory;
+        socketFactory = new DropwizardSSLConnectionSocketFactory(tlsConfiguration);
+
+        final Field verifierField =
+                FieldUtils.getField(DropwizardSSLConnectionSocketFactory.class, "verifier", true);
+        assertThat(verifierField.get(socketFactory)).isNull();
     }
 
     @Test
@@ -154,10 +172,37 @@ public class DropwizardSSLConnectionSocketFactoryTest {
     }
 
     @Test
+    public void shouldErrorIfHostnameVerificationOnAndServerHostnameMatchesAndFailVerifierSpecified() throws Exception {
+        final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).using(new FailVerifier()).build("bad_host_broken_fail_verifier");
+        try {
+            client.target(String.format("https://localhost:%d", TLS_APP_RULE.getLocalPort())).request().get();
+            fail("Expected ProcessingException");
+        } catch (ProcessingException e) {
+            assertThat(e.getCause()).isExactlyInstanceOf(SSLPeerUnverifiedException.class);
+            assertThat(e.getCause().getMessage()).isEqualTo("Host name 'localhost' does not match the certificate subject provided by the peer (O=server, CN=localhost)");
+        }
+    }
+
+    @Test
+    public void shouldBeOkIfHostnameVerificationOnAndServerHostnameDoesntMatchAndNoopVerifierSpecified() throws Exception {
+        final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).using(new NoopHostnameVerifier()).build("bad_host_noop_verifier_working");
+        final Response response = client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(3))).request().get();
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
     public void shouldBeOkIfHostnameVerificationOffAndServerHostnameDoesntMatch() throws Exception {
         tlsConfiguration.setVerifyHostname(false);
         final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).build("bad_host_working");
         final Response response = client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(3))).request().get();
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    public void shouldBeOkIfHostnameVerificationOffAndServerHostnameMatchesAndFailVerfierSpecified() throws Exception {
+        tlsConfiguration.setVerifyHostname(false);
+        final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).using(new FailVerifier()).build("bad_host_fail_verifier_working");
+        final Response response = client.target(String.format("https://localhost:%d", TLS_APP_RULE.getLocalPort())).request().get();
         assertThat(response.getStatus()).isEqualTo(200);
     }
 
@@ -170,6 +215,13 @@ public class DropwizardSSLConnectionSocketFactoryTest {
             fail("expected ProcessingException");
         } catch (ProcessingException e) {
             assertThat(e.getCause()).isInstanceOfAny(SocketException.class, SSLHandshakeException.class);
+        }
+    }
+    
+    private static class FailVerifier implements HostnameVerifier {
+        @Override
+        public boolean verify(String arg0, SSLSession arg1) {
+            return false;
         }
     }
 }


### PR DESCRIPTION
While the improvements to TLS configuration of HTTP clients in 1.0.0
(maybe prior) are awesome, as part of that process the ability to set a
custom HostnameVerifier easily on the HTTP client has been lost.

You used to be able to do e.g. as:

JerseyClientConfiguration myJerseyClientConfiguration = <some
configuration>;
HostnameVerifier verifier = new MyCustomHostnameVerifier();
JerseyClientBuilder clientBuilder = new JerseyClientBuilder(env);
clientBuilder.using(myJerseyClientConfiguration).using(verifier);
Client httpClient = clientBuilder.build();
Same is true for HttpClientBuilder too.

You can still do it by creating a custom Apache
Registry<ConnectionSocketFactory> but you need to set up socket
factories for every scheme.

This change restores the ability to set a custom HostnameVerifier
for clients.

[Fixes #1663]