### PR TITLE
Refactored DropwizardAppRule support running different EnvironmentCommands

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
@@ -3,6 +3,8 @@ package io.dropwizard.testing.junit;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
+import io.dropwizard.cli.Command;
+import io.dropwizard.cli.ServerCommand;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.ConfigOverride;
@@ -12,6 +14,7 @@ import org.junit.rules.ExternalResource;
 import javax.annotation.Nullable;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 
 /**
@@ -78,8 +81,14 @@ public class DropwizardAppRule<C extends Configuration> extends ExternalResource
     }
 
     public DropwizardAppRule(Class<? extends Application<C>> applicationClass, String configPath,
-                                 Optional<String> customPropertyPrefix, ConfigOverride... configOverrides) {
-        this(new DropwizardTestSupport<>(applicationClass, configPath, customPropertyPrefix,
+                             Optional<String> customPropertyPrefix, ConfigOverride... configOverrides) {
+        this(applicationClass, configPath, customPropertyPrefix, ServerCommand::new, configOverrides);
+    }
+
+    public DropwizardAppRule(Class<? extends Application<C>> applicationClass, String configPath,
+                             Optional<String> customPropertyPrefix, Function<Application<C>,
+                             Command> commandInstantiator, ConfigOverride... configOverrides) {
+        this(new DropwizardTestSupport<>(applicationClass, configPath, customPropertyPrefix, commandInstantiator,
                 configOverrides));
     }
 
@@ -90,8 +99,18 @@ public class DropwizardAppRule<C extends Configuration> extends ExternalResource
      * @since 0.9
      */
     public DropwizardAppRule(Class<? extends Application<C>> applicationClass,
-            C configuration) {
+                             C configuration) {
         this(new DropwizardTestSupport<>(applicationClass, configuration));
+    }
+
+    /**
+     * Alternate constructor that allows specifying the command the Dropwizard application is started with.
+     *
+     * @since 1.1.0
+     */
+    public DropwizardAppRule(Class<? extends Application<C>> applicationClass,
+                             C configuration, Function<Application<C>, Command> commandInstantiator) {
+        this(new DropwizardTestSupport<>(applicationClass, configuration, commandInstantiator));
     }
 
     public DropwizardAppRule(DropwizardTestSupport<C> testSupport) {


### PR DESCRIPTION
I'm working on writing a [gRPC](http://www.grpc.io/) `EnvironmentCommand` for running gRPC in Dropwizard and needed the ability to be able to use a `DropwizardAppRule` for testing. 

This pull request adds constructor parameters to `DropwizardAppRule` and `DropwizardTestSupport` so you can specify a `Function` that will instantiate the `EnvironmentCommand` that's run from `DropwizardTestSupport`. `ServerCommand` was used everywhere as a default to maintain backwards compatibility.