### PR TITLE
dropwizard-servlets: Combine unnecessarily nested if blocks in TaskServlet

### DIFF
--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/TaskServlet.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/TaskServlet.java
@@ -200,19 +200,21 @@ public class TaskServlet extends HttpServlet {
             this.exceptionClass = exceptionClass;
         }
 
+        private boolean isReallyAssignableFrom(Exception e) {
+            return exceptionClass.isAssignableFrom(e.getClass()) ||
+                (e.getCause() != null && exceptionClass.isAssignableFrom(e.getCause().getClass()));
+        }
+
         @Override
         public void executeTask(ImmutableMultimap<String, String> params, PrintWriter output) throws Exception {
             try {
                 underlying.executeTask(params, output);
             } catch (Exception e) {
-                if (exceptionMeter != null) {
-                    if (exceptionClass.isAssignableFrom(e.getClass()) ||
-                            (e.getCause() != null && exceptionClass.isAssignableFrom(e.getCause().getClass()))) {
-                        exceptionMeter.mark();
-                    }
+                if (exceptionMeter != null && isReallyAssignableFrom(e)) {
+                    exceptionMeter.mark();
+                } else {
+                    throw e;
                 }
-
-                throw e;
             }
         }
     }


### PR DESCRIPTION
These two nested if statements within `io.dropwizard.servlets.tasks.TaskServlet` were [flagged by Code Climate](https://codeclimate.com/github/dropwizard/dropwizard/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/TaskServlet.java) and can be flattened.