### PR TITLE
Allow HttpClientBuilder subclasses to customize the underlying builder

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
@@ -240,6 +240,19 @@ public class HttpClientBuilder {
     }
 
     /**
+     * Configures an Apache {@link org.apache.http.impl.client.HttpClientBuilder HttpClientBuilder}.
+     *
+     * Intended for use by subclasses to inject HttpClientBuilder
+     * configuration. The default implementation is an identity
+     * function.
+     */
+    protected org.apache.http.impl.client.HttpClientBuilder customizeBuilder(
+        org.apache.http.impl.client.HttpClientBuilder builder
+    ) {
+        return builder;
+    }
+
+    /**
      * Map the parameters in {@link HttpClientConfiguration} to configuration on a
      * {@link org.apache.http.impl.client.HttpClientBuilder} instance
      *
@@ -276,7 +289,8 @@ public class HttpClientBuilder {
                 .setSoTimeout(timeout)
                 .build();
 
-        builder.setRequestExecutor(new InstrumentedHttpRequestExecutor(metricRegistry, metricNameStrategy, name))
+        customizeBuilder(builder)
+                .setRequestExecutor(new InstrumentedHttpRequestExecutor(metricRegistry, metricNameStrategy, name))
                 .setConnectionManager(manager)
                 .setDefaultRequestConfig(requestConfig)
                 .setDefaultSocketConfig(socketConfig)


### PR DESCRIPTION
This change adds an overridable method which will allow `io.dropwizard.client.HttpClientBuilder` subclasses to customize the underlying `org.apache.http.impl.client.HttpClientBuilder` that is used. For example, this should allow the injection of [HTTP client caching](https://hc.apache.org/httpcomponents-client-ga/tutorial/html/caching.html), as proposed in #1633.