### PR TITLE
Gracefully shut down default ExecutorService used by JerseyClientBuilder

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardExecutorProvider.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardExecutorProvider.java
@@ -1,10 +1,38 @@
 package io.dropwizard.client;
 
+import com.google.common.util.concurrent.ForwardingExecutorService;
 import org.glassfish.jersey.spi.ExecutorServiceProvider;
 
 import java.util.concurrent.ExecutorService;
 
+/**
+ * An {@link ExecutorServiceProvider} implementation for use within
+ * Dropwizard.
+ *
+ * With {DropwizardExecutorProvider.DisposableExecutorService}, one
+ * can signal that an {ExecutorService} is to be gracefully shut down
+ * upon its disposal by the Jersey runtime. It is used as a means of
+ * signaling to {@link DropwizardExecutorProvider} that the executor
+ * is not shared.
+ */
 class DropwizardExecutorProvider implements ExecutorServiceProvider {
+    /**
+     * An {@link ExecutorService} decorator used as a marker by
+     * {@link DropwizardExecutorProvider#dispose} to induce service
+     * shutdown.
+     */
+    static class DisposableExecutorService extends ForwardingExecutorService {
+        private final ExecutorService delegate;
+
+        public DisposableExecutorService(ExecutorService delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        protected ExecutorService delegate() {
+            return delegate;
+        }
+    }
 
     private final ExecutorService threadPool;
 
@@ -19,5 +47,8 @@ class DropwizardExecutorProvider implements ExecutorServiceProvider {
 
     @Override
     public void dispose(ExecutorService executorService) {
+        if (executorService instanceof DisposableExecutorService) {
+            executorService.shutdown();
+        }
     }
 }

--- a/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
@@ -308,12 +308,18 @@ public class JerseyClientBuilder {
         }
 
         if (executorService == null) {
-            executorService = environment.lifecycle()
+            // Create an ExecutorService based on the provided
+            // configuration. The DisposableExecutorService decorator
+            // is used to ensure that the service is shut down if the
+            // Jersey client disposes of it.
+            executorService = new DropwizardExecutorProvider.DisposableExecutorService(
+                environment.lifecycle()
                     .executorService("jersey-client-" + name + "-%d")
                     .minThreads(configuration.getMinThreads())
                     .maxThreads(configuration.getMaxThreads())
                     .workQueue(new ArrayBlockingQueue<>(configuration.getWorkQueueSize()))
-                    .build();
+                    .build()
+            );
         }
 
         if (objectMapper == null) {

--- a/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardExecutorProviderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardExecutorProviderTest.java
@@ -1,0 +1,39 @@
+package io.dropwizard.client;
+
+import org.glassfish.jersey.spi.ExecutorServiceProvider;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DropwizardExecutorProviderTest {
+    @Test
+    public void doesntShutDownNonDisposableExecutorService() {
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        final ExecutorServiceProvider provider = new DropwizardExecutorProvider(executor);
+
+        assertThat(executor.isShutdown()).isFalse();
+        provider.dispose(executor);
+        assertThat(executor.isShutdown()).isFalse();
+        executor.shutdown();
+    }
+
+    @Test
+    public void shutsDownDisposableExecutorService() {
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        final ExecutorService disposableExecutor =
+            new DropwizardExecutorProvider.DisposableExecutorService(executor);
+
+        final ExecutorServiceProvider provider =
+            new DropwizardExecutorProvider(disposableExecutor);
+
+        assertThat(executor.isShutdown()).isFalse();
+        provider.dispose(disposableExecutor);
+        assertThat(executor.isShutdown()).isTrue();
+    }
+}

--- a/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardExecutorProviderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardExecutorProviderTest.java
@@ -1,5 +1,6 @@
 package io.dropwizard.client;
 
+import io.dropwizard.util.Duration;
 import org.glassfish.jersey.spi.ExecutorServiceProvider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -12,10 +13,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DropwizardExecutorProviderTest {
+    private static final Duration SHUTDOWN_TIME = Duration.seconds(5);
+
     @Test
     public void doesntShutDownNonDisposableExecutorService() {
         final ExecutorService executor = Executors.newSingleThreadExecutor();
-        final ExecutorServiceProvider provider = new DropwizardExecutorProvider(executor);
+        final ExecutorServiceProvider provider =
+            new DropwizardExecutorProvider(executor, SHUTDOWN_TIME);
 
         assertThat(executor.isShutdown()).isFalse();
         provider.dispose(executor);
@@ -30,7 +34,7 @@ public class DropwizardExecutorProviderTest {
             new DropwizardExecutorProvider.DisposableExecutorService(executor);
 
         final ExecutorServiceProvider provider =
-            new DropwizardExecutorProvider(disposableExecutor);
+            new DropwizardExecutorProvider(disposableExecutor, SHUTDOWN_TIME);
 
         assertThat(executor.isShutdown()).isFalse();
         provider.dispose(disposableExecutor);

--- a/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
@@ -80,7 +80,7 @@ import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Duration;
 
 public class HttpClientBuilderTest {
-    class CustomBuilder extends HttpClientBuilder {
+    static class CustomBuilder extends HttpClientBuilder {
         public boolean customized;
 
         public CustomBuilder(MetricRegistry metricRegistry) {
@@ -107,7 +107,7 @@ public class HttpClientBuilderTest {
     private HttpClientBuilder builder;
     private InstrumentedHttpClientConnectionManager connectionManager;
     private org.apache.http.impl.client.HttpClientBuilder apacheBuilder;
-    
+
     public HttpClientBuilderTest() throws ClassNotFoundException {
         this.httpClientBuilderClass = Class.forName("org.apache.http.impl.client.HttpClientBuilder");
         this.httpClientClass = Class.forName("org.apache.http.impl.client.InternalHttpClient");
@@ -127,7 +127,7 @@ public class HttpClientBuilderTest {
     public void validate() {
         validateMockitoUsage();
     }
-    
+
     @Test
     public void setsTheMaximumConnectionPoolSize() throws Exception {
         configuration.setMaxConnections(412);
@@ -194,7 +194,7 @@ public class HttpClientBuilderTest {
         configuredRegistry = builder.using(customVerifier).createConfiguredRegistry();
         assertThat(configuredRegistry).isNotNull();
 
-        final SSLConnectionSocketFactory socketFactory = 
+        final SSLConnectionSocketFactory socketFactory =
                 (SSLConnectionSocketFactory) configuredRegistry.lookup("https");
         assertThat(socketFactory).isNotNull();
 
@@ -215,7 +215,7 @@ public class HttpClientBuilderTest {
         configuredRegistry = builder.using(configuration).using(customVerifier).createConfiguredRegistry();
         assertThat(configuredRegistry).isNotNull();
 
-        final SSLConnectionSocketFactory socketFactory = 
+        final SSLConnectionSocketFactory socketFactory =
                 (SSLConnectionSocketFactory) configuredRegistry.lookup("https");
         assertThat(socketFactory).isNotNull();
 
@@ -230,7 +230,7 @@ public class HttpClientBuilderTest {
         configuredRegistry = builder.createConfiguredRegistry();
         assertThat(configuredRegistry).isNotNull();
 
-        final SSLConnectionSocketFactory socketFactory = 
+        final SSLConnectionSocketFactory socketFactory =
                 (SSLConnectionSocketFactory) configuredRegistry.lookup("https");
         assertThat(socketFactory).isNotNull();
 
@@ -238,7 +238,7 @@ public class HttpClientBuilderTest {
                 FieldUtils.getField(SSLConnectionSocketFactory.class, "hostnameVerifier", true);
         assertThat(hostnameVerifierField.get(socketFactory)).isInstanceOf(HostnameVerifier.class);
     }
-   
+
     @Test
     public void canUseASystemHostnameVerifierByDefaultWhenTlsConfigurationSpecified() throws Exception {
         final TlsConfiguration tlsConfiguration = new TlsConfiguration();
@@ -249,7 +249,7 @@ public class HttpClientBuilderTest {
         configuredRegistry = builder.using(configuration).createConfiguredRegistry();
         assertThat(configuredRegistry).isNotNull();
 
-        final SSLConnectionSocketFactory socketFactory = 
+        final SSLConnectionSocketFactory socketFactory =
                 (SSLConnectionSocketFactory) configuredRegistry.lookup("https");
         assertThat(socketFactory).isNotNull();
 
@@ -263,7 +263,7 @@ public class HttpClientBuilderTest {
         final HostnameVerifier customVerifier = (s, sslSession) -> false;
 
         assertThat(builder.using(customVerifier).createClient(apacheBuilder, connectionManager, "test")).isNotNull();
-        
+
         final Field hostnameVerifierField =
                 FieldUtils.getField(org.apache.http.impl.client.HttpClientBuilder.class, "hostnameVerifier", true);
         assertThat(hostnameVerifierField.get(apacheBuilder)).isSameAs(customVerifier);


### PR DESCRIPTION
Addresses #1671 & #1679

This change introduces a package-private `ExecutorService` decorator which is used to signal to `DropwizardExecutorProvider` that the executor should be shut down upon its disposal by the Jersey runtime. This enables graceful shutdown of the default `ExecutorService`s created within `JerseyClientBuilder` if the builder isn't configured with one.

Included tests for this graceful shutdown behavior, as well as its absence in the case where a "non-disposable" `ExecutorService` is used.