### PR TITLE
Set FAIL_ON_UNKNOWN_PROPERTIES in DefaultConfigurationFactoryFactory

### DIFF
--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/DefaultConfigurationFactoryFactory.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/DefaultConfigurationFactoryFactory.java
@@ -1,5 +1,6 @@
 package io.dropwizard.configuration;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import javax.validation.Validator;
@@ -11,6 +12,11 @@ public class DefaultConfigurationFactoryFactory<T> implements ConfigurationFacto
             Validator    validator,
             ObjectMapper objectMapper,
             String       propertyPrefix) {
-        return new YamlConfigurationFactory<>(klass, validator, objectMapper, propertyPrefix);
+        return new YamlConfigurationFactory<>(
+            klass,
+            validator,
+            objectMapper.copy()
+                .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES),
+            propertyPrefix);
     }
 }

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/DefaultConfigurationFactoryFactory.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/DefaultConfigurationFactoryFactory.java
@@ -15,8 +15,20 @@ public class DefaultConfigurationFactoryFactory<T> implements ConfigurationFacto
         return new YamlConfigurationFactory<>(
             klass,
             validator,
-            objectMapper.copy()
-                .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES),
+            configureObjectMapper(objectMapper.copy()),
             propertyPrefix);
     }
+
+    /**
+     * Provides additional configuration for the {@link ObjectMapper} used to read
+     * the configuration. By default {@link DeserializationFeature#FAIL_ON_UNKNOWN_PROPERTIES}
+     * is enabled to protect against misconfiguration.
+     *
+     * @param objectMapper template to be configured
+     * @return configured object mapper
+     */
+    protected ObjectMapper configureObjectMapper(ObjectMapper objectMapper) {
+        return objectMapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    }
+
 }

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/YamlConfigurationFactory.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/YamlConfigurationFactory.java
@@ -1,6 +1,5 @@
 package io.dropwizard.configuration;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -21,7 +20,6 @@ import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -69,8 +67,7 @@ public class YamlConfigurationFactory<T> implements ConfigurationFactory<T> {
             mapper = null;
             yamlFactory = null;
         } else {
-            mapper = objectMapper.copy()
-                    .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+            mapper = objectMapper;
             yamlFactory = new YAMLFactory();
         }
         this.validator = validator;

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryFactoryTest.java
@@ -1,11 +1,15 @@
 package io.dropwizard.configuration;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;
 import io.dropwizard.configuration.ConfigurationFactoryTest.Example;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.validation.BaseValidator;
-import org.junit.Before;
+
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import javax.validation.Validator;
 import java.io.File;
@@ -15,21 +19,54 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConfigurationFactoryFactoryTest {
 
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
     private final ConfigurationFactoryFactory<Example> factoryFactory = new DefaultConfigurationFactoryFactory<>();
     private final Validator validator = BaseValidator.newValidator();
-    private File validFile;
-
-    @Before
-    public void setUp() throws Exception {
-        this.validFile = new File(Resources.getResource("factory-test-valid.yml").toURI());
-    }
 
     @Test
     public void createDefaultFactory() throws Exception {
+        File validFile = new File(Resources.getResource("factory-test-valid.yml").toURI());
         ConfigurationFactory<Example> factory =
             factoryFactory.create(Example.class, validator, Jackson.newObjectMapper(), "dw");
         final Example example = factory.build(validFile);
         assertThat(example.getName())
             .isEqualTo("Coda Hale");
+    }
+
+    @Test
+    public void createDefaultFactoryFailsUnknownProperty() throws Exception {
+        File validFileWithUnknownProp = new File(
+            Resources.getResource("factory-test-unknown-property.yml").toURI());
+        ConfigurationFactory<Example> factory =
+            factoryFactory.create(Example.class, validator, Jackson.newObjectMapper(), "dw");
+        expectedException.expect(ConfigurationException.class);
+        expectedException.expectMessage("Unrecognized field at: trait");
+        factory.build(validFileWithUnknownProp);
+    }
+
+    @Test
+    public void createFactoryAllowingUnknownProperties() throws Exception {
+        ConfigurationFactoryFactory<Example> customFactory = new PassThroughConfigurationFactoryFactory();
+        File validFileWithUnknownProp = new File(
+            Resources.getResource("factory-test-unknown-property.yml").toURI());
+        ConfigurationFactory<Example> factory =
+            customFactory.create(
+                Example.class,
+                validator,
+                Jackson.newObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES),
+                "dw");
+        Example example = factory.build(validFileWithUnknownProp);
+        assertThat(example.getName())
+            .isEqualTo("Mighty Wizard");
+    }
+
+    private static final class PassThroughConfigurationFactoryFactory
+            extends DefaultConfigurationFactoryFactory<Example> {
+        @Override
+        protected ObjectMapper configureObjectMapper(ObjectMapper objectMapper) {
+            return objectMapper;
+        }
     }
 }

--- a/dropwizard-configuration/src/test/resources/factory-test-unknown-property.yml
+++ b/dropwizard-configuration/src/test/resources/factory-test-unknown-property.yml
@@ -1,0 +1,12 @@
+name: Mighty Wizard
+type:
+    - coder
+    - wizard
+trait: Nearly Bald
+properties:
+  debug: true
+  settings.enabled: false
+servers:
+  - port: 8080
+  - port: 8081
+  - port: 8082


### PR DESCRIPTION
The logic is moved to DefaultConfigurationFactoryFactory from
YamlConfigurationFactory, making it easier to modify with a
custom ConfigurationFactoryFactory implementation.

There are some (uncommon) use cases where it's benefitial to
update an application without modifying the configuration, which
may fail if the application configuration has removed a configuration
property.