### PR TITLE
Fix request attribute-related race condition in Logback request logging

### DIFF
--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/async/AsyncLoggingEventAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/async/AsyncLoggingEventAppenderFactory.java
@@ -10,8 +10,8 @@ import ch.qos.logback.core.AsyncAppenderBase;
 public class AsyncLoggingEventAppenderFactory implements AsyncAppenderFactory<ILoggingEvent> {
 
     /**
-     * Creates an {@link AsyncAppenderFactory} of type {@link ILoggingEvent}
-     * @return the {@link AsyncAppenderFactory}
+     * Creates an {@link AsyncAppenderBase} of type {@link ILoggingEvent}
+     * @return the {@link AsyncAppenderBase}
      */
     @Override
     public AsyncAppenderBase<ILoggingEvent> build() {

--- a/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/async/AsyncAccessEventAppenderFactory.java
+++ b/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/async/AsyncAccessEventAppenderFactory.java
@@ -10,17 +10,11 @@ import io.dropwizard.logging.async.AsyncAppenderFactory;
 public class AsyncAccessEventAppenderFactory implements AsyncAppenderFactory<IAccessEvent> {
 
     /**
-     * Creates an {@link AsyncAppenderFactory} of type {@link IAccessEvent} that prepares events
-     * for deferred processing
-     * @return the {@link AsyncAppenderFactory}
+     * Creates an {@link AsyncAppenderBase} of type {@link IAccessEvent}.
+     * @return the {@link AsyncAppenderBase}
      */
     @Override
     public AsyncAppenderBase<IAccessEvent> build() {
-        return new AsyncAppenderBase<IAccessEvent>() {
-            @Override
-            protected void preprocess(IAccessEvent event) {
-                event.prepareForDeferredProcessing();
-            }
-        };
+        return new AsyncAppenderBase<IAccessEvent>();
     }
 }


### PR DESCRIPTION
Addresses #1672 

`i.d.request.logging.async.AsyncAccessEventAppenderFactory` invokes `AccessEvent. prepareForDeferredProcessing`, which triggers a race with an identical invocation [within Logback itself](https://github.com/qos-ch/logback/blob/658963544cc08059fc3cec48f5d35f650de5f6df/logback-core/src/main/java/ch/qos/logback/core/OutputStreamAppender.java#L205). The reported issue indicates that the race manifests in inconsistent logging behavior when request attributes are set within a resource class.

This change removes the `prepareForDeferredProcessing` call from dropwizard-request-logging. As far as I know, all `IAccessEvent`s encountered by this class will be of concrete type `AccessEvent` and all non-async appenders extend `OutputStreamAppender`, so the `prepareForDeferredProcessing` method should always be invoked exactly once.