### PR TITLE
Add ResourceCollection support ServletEnvironment

### DIFF
--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/setup/ServletEnvironment.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/setup/ServletEnvironment.java
@@ -148,6 +148,17 @@ public class ServletEnvironment {
     }
 
     /**
+     * Sets the base resources for this context.
+     *
+     * @param resources A list of strings representing the base resources to serve static
+     *                  content for the context. Any string accepted by Resource.newResource(String)
+     *                  may be passed and the call is equivalent to {@link #setBaseResource(Resource...)}}
+     */
+    public void setBaseResource(String... resources) {
+        handler.setBaseResource(new ResourceCollection(resources));
+    }
+
+    /**
      * Sets the base resource for this context.
      * @param resourceBase A string representing the base resource for the context. Any
      *                     string accepted by Resource.newResource(String) may be passed
@@ -156,18 +167,6 @@ public class ServletEnvironment {
     public void setResourceBase(String resourceBase) {
         handler.setResourceBase(resourceBase);
     }
-
-    /**
-     * Sets the base resources for this context.
-     *
-     * @param resources A list of strings representing the base resources to serve static
-     *                  content for the context. Any string accepted by Resource.newResource(String)
-     *                  may be passed and the call is equivalent to {@link #setBaseResource(Resource...)}}
-     */
-    public void setResourceBase(String... resources) {
-        handler.setBaseResource(new ResourceCollection(resources));
-    }
-
 
     /**
      * Set an initialization parameter.

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/setup/ServletEnvironment.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/setup/ServletEnvironment.java
@@ -7,6 +7,7 @@ import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.resource.ResourceCollection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -130,24 +131,43 @@ public class ServletEnvironment {
     /**
      * Sets the base resource for this context.
      *
-     * @param baseResource The resource used as the base for all static content
-     *                     of this context.
+     * @param baseResource The resource to be used as the base for all static content of this context.
      */
     public void setBaseResource(Resource baseResource) {
         handler.setBaseResource(baseResource);
     }
 
     /**
-     * Sets the base resource for this context.
+     * Sets the base resources for this context.
      *
-     * @param resourceBase A string representing the base resource for the
-     *                     context. Any string accepted by Resource.newResource(String)
-     *                     may be passed and the call is equivalent to
-     *                     {@link #setBaseResource(Resource)}}
+     * @param baseResources The list of resources to be used as the base for all static
+     *                      content of this context.
+     */
+    public void setBaseResource(Resource... baseResources) {
+        handler.setBaseResource(new ResourceCollection(baseResources));
+    }
+
+    /**
+     * Sets the base resource for this context.
+     * @param resourceBase A string representing the base resource for the context. Any
+     *                     string accepted by Resource.newResource(String) may be passed
+     *                     and the call is equivalent to {@link #setBaseResource(Resource)}}
      */
     public void setResourceBase(String resourceBase) {
         handler.setResourceBase(resourceBase);
     }
+
+    /**
+     * Sets the base resources for this context.
+     *
+     * @param resources A list of strings representing the base resources to serve static
+     *                  content for the context. Any string accepted by Resource.newResource(String)
+     *                  may be passed and the call is equivalent to {@link #setBaseResource(Resource...)}}
+     */
+    public void setResourceBase(String... resources) {
+        handler.setBaseResource(new ResourceCollection(resources));
+    }
+
 
     /**
      * Set an initialization parameter.

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/setup/ServletEnvironmentTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/setup/ServletEnvironmentTest.java
@@ -161,12 +161,12 @@ public class ServletEnvironmentTest {
     }
 
     @Test
-    public void setsResourceBaseList() throws Exception {
+    public void setsBaseResourceStringList() throws Exception {
         String wooResource = tempDir.newFolder().getAbsolutePath();
         String fooResource = tempDir.newFolder().getAbsolutePath();
 
         final String[] testResources = new String[]{wooResource, fooResource};
-        environment.setResourceBase(testResources);
+        environment.setBaseResource(testResources);
 
         ArgumentCaptor<Resource> captor = ArgumentCaptor.forClass(Resource.class);
         verify(handler).setBaseResource(captor.capture());

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/setup/ServletEnvironmentTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/setup/ServletEnvironmentTest.java
@@ -8,8 +8,12 @@ import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.resource.ResourceCollection;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 
 import javax.servlet.Filter;
@@ -28,6 +32,9 @@ public class ServletEnvironmentTest {
     private final ServletHandler servletHandler = mock(ServletHandler.class);
     private final MutableServletContextHandler handler = mock(MutableServletContextHandler.class);
     private final ServletEnvironment environment = new ServletEnvironment(handler);
+
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
 
     @Before
     public void setUp() throws Exception {
@@ -120,10 +127,57 @@ public class ServletEnvironmentTest {
     }
 
     @Test
+    public void setsBaseResource() throws Exception {
+        final Resource testResource = Resource.newResource(tempDir.newFolder());
+        environment.setBaseResource(testResource);
+
+        verify(handler).setBaseResource(testResource);
+    }
+
+    @Test
+    public void setsBaseResourceList() throws Exception {
+        Resource wooResource = Resource.newResource(tempDir.newFolder());
+        Resource fooResource = Resource.newResource(tempDir.newFolder());
+
+        final Resource[] testResources = new Resource[]{wooResource, fooResource};
+        environment.setBaseResource(testResources);
+
+        ArgumentCaptor<Resource> captor = ArgumentCaptor.forClass(Resource.class);
+        verify(handler).setBaseResource(captor.capture());
+
+        Resource actualResource = captor.getValue();
+        assertThat(actualResource).isInstanceOf(ResourceCollection.class);
+
+        ResourceCollection actualResourceCollection = (ResourceCollection) actualResource;
+        assertThat(actualResourceCollection.getResources()).contains(wooResource, fooResource);
+
+    }
+
+    @Test
     public void setsResourceBase() throws Exception {
         environment.setResourceBase("/woo");
 
         verify(handler).setResourceBase("/woo");
+    }
+
+    @Test
+    public void setsResourceBaseList() throws Exception {
+        String wooResource = tempDir.newFolder().getAbsolutePath();
+        String fooResource = tempDir.newFolder().getAbsolutePath();
+
+        final String[] testResources = new String[]{wooResource, fooResource};
+        environment.setResourceBase(testResources);
+
+        ArgumentCaptor<Resource> captor = ArgumentCaptor.forClass(Resource.class);
+        verify(handler).setBaseResource(captor.capture());
+
+        Resource actualResource = captor.getValue();
+        assertThat(actualResource).isInstanceOf(ResourceCollection.class);
+
+        ResourceCollection actualResourceCollection = (ResourceCollection) actualResource;
+        assertThat(actualResourceCollection.getResources()).contains(Resource.newResource(wooResource),
+            Resource.newResource(fooResource));
+
     }
 
     @Test


### PR DESCRIPTION
PR to support adding a collection of static resource folders in `ServletEnvironment`. 

Basically this was done to negate the need for consumers to have a dependency on `jetty-util` library, as they would need to create a `ResourceCollection` if they have multiple resources for serving static content.