### PR TITLE
Allow overriding of configuration class

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/Application.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/Application.java
@@ -40,7 +40,7 @@ public abstract class Application<T extends Configuration> {
      * @return the configuration class
      * @see Generics#getTypeParameter(Class, Class)
      */
-    public final Class<T> getConfigurationClass() {
+    public Class<T> getConfigurationClass() {
         return Generics.getTypeParameter(getClass(), Configuration.class);
     }
 


### PR DESCRIPTION
I'm opening this PR to get your thoughts on removing the final modifier from `Application#getConfigurationClass`. My use-case is creating a reusable subclass of `Application` so that we have less boilerplate and duplication in each of our REST APIs (of which we have ~400). I put our subclass in a gist [here](https://gist.github.com/jhaber/136d46c6c795117d5a5c56d035cac434#file-restapplication-java), a usage would look like:
```java
public class Main {
  
  public static void main(String... args) throws Exception {
    RestApplication.newBuilder().modules(new MyGuiceModule()).build().run(args);
  }
}
```
This works, but only as long as everyone is using the same configuration class. We would like to allow users to subclass our default configuration, which we could do by modifying our subclass to look like [this](https://gist.github.com/jhaber/136d46c6c795117d5a5c56d035cac434#file-restapplication2-java) (note the [override](https://gist.github.com/jhaber/136d46c6c795117d5a5c56d035cac434#file-restapplication2-java-L32-L35)). The only issue we're running into is that this method is final.
 