### PR TITLE
Update location of dropwizard-scala repository.

### DIFF
--- a/docs/source/manual/scala.rst
+++ b/docs/source/manual/scala.rst
@@ -6,4 +6,4 @@ Dropwizard & Scala
 
 .. highlight:: text
 
-.. rubric:: The ``dropwizard-scala`` module is now maintained and documented `elsewhere <https://github.com/bretthoerner/dropwizard-scala>`_.
+.. rubric:: The ``dropwizard-scala`` module is now maintained and documented `elsewhere <https://github.com/datasift/dropwizard-scala>`_.


### PR DESCRIPTION
The `dropwizard-scala` docs currently point at my outdated repo, this PR points them to a modern one and I verified this was OK with the owner here: https://github.com/datasift/dropwizard-scala/issues/9

Alternatively this could be dropped from the docs entirely, up to y'all. :)