### PR TITLE
Catch Throwable and return false if any command errors out

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/cli/Cli.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/Cli.java
@@ -1,6 +1,5 @@
 package io.dropwizard.cli;
 
-import io.dropwizard.configuration.ConfigurationException;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.util.JarLocation;
 import net.sourceforge.argparse4j.ArgumentParsers;
@@ -83,8 +82,9 @@ public class Cli {
             stdErr.println(e.getMessage());
             e.getParser().printHelp(stdErr);
             return false;
-        } catch (ConfigurationException e) {
-            stdErr.println(e.getMessage());
+        } catch (Throwable t) {
+            // Unexpected exceptions should result in non-zero exit status of the process
+            stdErr.println(t.getMessage());
             return false;
         }
     }


### PR DESCRIPTION
Dropwizard should exit gracefully with a non-zero (`1`) status code in the event that a command throws an `Exception` instead of just exiting the `Application`/JVM. This PR is the result of https://github.com/dropwizard/dropwizard/issues/1680#issuecomment-240132023