### PR TITLE
Log Jetty initialized SSLContext not the Default

### DIFF
--- a/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2ConnectorFactory.java
+++ b/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2ConnectorFactory.java
@@ -98,8 +98,6 @@ public class Http2ConnectorFactory extends HttpsConnectorFactory {
         setSupportedProtocols(ImmutableList.of("TLSv1.2"));
         setSupportedCipherSuites(ImmutableList.of("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"));
 
-        logSupportedParameters();
-
         // Setup connection factories
         final HttpConfiguration httpConfig = buildHttpConfiguration();
         final HttpConnectionFactory http1 = buildHttpConnectionFactory(httpConfig);
@@ -111,6 +109,7 @@ public class Http2ConnectorFactory extends HttpsConnectorFactory {
         alpn.setDefaultProtocol(HTTP_1_1); // Speak HTTP 1.1 over TLS if negotiation fails
 
         final SslContextFactory sslContextFactory = buildSslContextFactory();
+        sslContextFactory.addLifeCycleListener(logSslInfoOnStart(sslContextFactory));
         server.addBean(sslContextFactory);
 
         // We should use ALPN as a negotiation protocol. Old clients that don't support it will be served


### PR DESCRIPTION
Instead of listing supported cipher suites, protocols, etc of the default
SSLContext algorithm, log what Jetty's will actually use, which as of this
commit is a "TLS" SSLContext. This will also future proof the logging if
this property ever becomes configurable in Dropwizard.