### PR TITLE
Config override for showDetails in JsonProcessingExceptionMapper

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
@@ -250,6 +250,8 @@ public abstract class AbstractServerFactory implements ServerFactory {
 
     private Boolean registerDefaultExceptionMappers = Boolean.TRUE;
 
+    private Boolean detailedJsonProcessingExceptionMapper = Boolean.FALSE;
+
     private Duration shutdownGracePeriod = Duration.seconds(30);
 
     @NotNull
@@ -421,6 +423,14 @@ public abstract class AbstractServerFactory implements ServerFactory {
         this.registerDefaultExceptionMappers = registerDefaultExceptionMappers;
     }
 
+    public Boolean getDetailedJsonProcessingExceptionMapper() {
+        return detailedJsonProcessingExceptionMapper;
+    }
+
+    public void setDetailedJsonProcessingExceptionMapper(Boolean detailedJsonProcessingExceptionMapper) {
+        this.detailedJsonProcessingExceptionMapper = detailedJsonProcessingExceptionMapper;
+    }
+
     @JsonProperty
     public Duration getShutdownGracePeriod() {
         return shutdownGracePeriod;
@@ -497,7 +507,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
                 jersey.register(new LoggingExceptionMapper<Throwable>() {
                 });
                 jersey.register(new JerseyViolationExceptionMapper());
-                jersey.register(new JsonProcessingExceptionMapper());
+                jersey.register(new JsonProcessingExceptionMapper(detailedJsonProcessingExceptionMapper));
                 jersey.register(new EarlyEofExceptionMapper());
             }
             handler.addServlet(new NonblockingServletHolder(jerseyContainer), jersey.getUrlPattern());

--- a/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
@@ -136,6 +136,34 @@ public class DefaultServerFactoryTest {
     }
 
     @Test
+    public void defaultsDetailedJsonProcessingExceptionToFalse() throws Exception {
+        http.build(environment);
+        JsonProcessingExceptionMapper exceptionMapper = null;
+        for (Object singleton : environment.jersey().getResourceConfig().getSingletons()) {
+            if (singleton instanceof JsonProcessingExceptionMapper) {
+                exceptionMapper = (JsonProcessingExceptionMapper) singleton;
+            }
+        }
+        assertThat(exceptionMapper).isNotNull();
+        assertThat(exceptionMapper.isShowDetails()).isFalse();
+    }
+
+    @Test
+    public void doesNotDefaultDetailedJsonProcessingExceptionToFalse() throws Exception {
+        http.setDetailedJsonProcessingExceptionMapper(true);
+
+        http.build(environment);
+        JsonProcessingExceptionMapper exceptionMapper = null;
+        for (Object singleton : environment.jersey().getResourceConfig().getSingletons()) {
+            if (singleton instanceof JsonProcessingExceptionMapper) {
+                exceptionMapper = (JsonProcessingExceptionMapper) singleton;
+            }
+        }
+        assertThat(exceptionMapper).isNotNull();
+        assertThat(exceptionMapper.isShowDetails()).isTrue();
+    }
+
+    @Test
     public void testGracefulShutdown() throws Exception {
         CountDownLatch requestReceived = new CountDownLatch(1);
         CountDownLatch shutdownInvoked = new CountDownLatch(1);

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapper.java
@@ -28,6 +28,10 @@ public class JsonProcessingExceptionMapper implements ExceptionMapper<JsonProces
         this.showDetails = showDetails;
     }
 
+    public boolean isShowDetails() {
+        return showDetails;
+    }
+
     @Override
     public Response toResponse(JsonProcessingException exception) {
         /*


### PR DESCRIPTION
From a discussion in https://github.com/dropwizard/dropwizard/issues/1597 there is some want to have the ability to override the showDetails flag when registering the `JsonProcessingExceptionMapper` with jersey. If I just override the existing registered component in my application I receive the following warning log event at application startup which is less than ideal, though also not anything to be concerned about as I am intentionally re-registering this component.

```
{
  "@timestamp":"2016-08-23T03:07:17.054+00:00",
  "@version": 1,
  "message":"The following warnings have been detected: WARNING: Cannot create new registration for component type class io.dropwizard.jersey.jackson.JsonProcessingExceptionMapper: Existing previous registration found for the type.\n",
  "logger_name":"org.glassfish.jersey.internal.Errors",
  "thread_name":"main",
  "level":"WARN",
  "level_value":30000
}
```

The approach I took was to:

1. Add config property to AbstractServerFactory to expose setting of this boolean property
2. Default to existing behavior `showDetails=false` (the default constructor in `JsonProcessingExceptionMapper`).
3. Added tests for both default and override cases (which required me to expose the value of `showDetails` within the `JsonProcessingExceptionMapper` via a getter).