### PR TITLE
Illustrate subresource method usage in DropwizardResourceConfigTest

### DIFF
--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
@@ -132,6 +132,17 @@ public class DropwizardResourceConfigTest {
         assertThat(rc.getEndpointsInfo()).containsOnlyOnce("    GET     /callme (io.dropwizard.jersey.DropwizardResourceConfigTest.TestDuplicateResource)");
     }
 
+    @Test
+    public void logsSubResourceEndpoints() {
+        rc.register(ResourceReturningResource.class);
+
+        final String expectedLog = String.format("The following paths were found for the configured resources:%n" + "%n"
+            + "    GET     /dummy/ (io.dropwizard.jersey.DropwizardResourceConfigTest.ResourceReturningResource)%n"
+            + "    GET     /dummy/iface (io.dropwizard.jersey.DropwizardResourceConfigTest.ResourceReturningResource)%n");
+
+        assertThat(rc.getEndpointsInfo()).contains(expectedLog);
+    }
+
     @Path("/dummy")
     public static class TestResource {
         @GET
@@ -215,6 +226,21 @@ public class DropwizardResourceConfigTest {
         @Override
         public String bar() {
             return "";
+        }
+    }
+
+    @Path("/dummy")
+    public static class ResourceReturningResource {
+        @GET
+        @Path("/")
+        public TestResource foo() {
+            return new TestResource();
+        }
+
+        @GET
+        @Path("/iface")
+        public ResourceInterface any() {
+            return new ImplementingResource();
         }
     }
 }


### PR DESCRIPTION
This adds a test case to `DropwizardResourceConfigTest` that ensure that subresource methods are supported. This functionality was called into question in #1716.