### PR TITLE
Fix NPE of non-resource sub-resource methods

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -186,7 +186,11 @@ public class DropwizardResourceConfig extends ResourceConfig {
                         final Class<?> erasedType = !responseType.getTypeBindings().isEmpty() ?
                                 responseType.getTypeBindings().getBoundType(0).getErasedType() :
                                 responseType.getErasedType();
-                        populate(path, erasedType, true, endpointLogLines);
+                        if (Resource.from(erasedType) == null) {
+                            endpointLogLines.add(new EndpointLogLine(method.getHttpMethod(), path, erasedType));
+                        } else {
+                            populate(path, erasedType, true, endpointLogLines);
+                        }
                     }
                 }
             }
@@ -216,7 +220,8 @@ public class DropwizardResourceConfig extends ResourceConfig {
 
         @Override
         public String toString() {
-            return String.format("    %-7s %s (%s)", httpMethod, basePath, klass.getCanonicalName());
+            final String method = httpMethod == null ? "UNKNOWN" : httpMethod;
+            return String.format("    %-7s %s (%s)", method, basePath, klass.getCanonicalName());
         }
     }
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
@@ -10,6 +10,7 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
@@ -118,7 +119,8 @@ public class DropwizardResourceConfigTest {
 
         assertThat(rc.getEndpointsInfo())
                 .contains("    GET     /wrapper/bar (io.dropwizard.jersey.DropwizardResourceConfigTest.ResourcePathOnMethodLevel)")
-                .contains("    GET     /locator/bar (io.dropwizard.jersey.DropwizardResourceConfigTest.ResourcePathOnMethodLevel)");
+                .contains("    GET     /locator/bar (io.dropwizard.jersey.DropwizardResourceConfigTest.ResourcePathOnMethodLevel)")
+                .contains("    UNKNOWN /obj/{it} (java.lang.Object)");
     }
 
     @Test
@@ -201,6 +203,14 @@ public class DropwizardResourceConfigTest {
         @Path("locator")
         public Class<ResourcePathOnMethodLevel> getNested2() {
             return ResourcePathOnMethodLevel.class;
+        }
+
+        @Path("obj/{it}")
+        public Object getNested3(@PathParam("it") String path) {
+            if (path.equals("implement")) {
+                return new ImplementingResource();
+            }
+            return new ResourcePathOnMethodLevel();
         }
     }
 


### PR DESCRIPTION
Closes #1716
Supersedes #1717

Whether it is a good idea to have a method return `Object` can be left up to discussion, but the code should not throw a NPE.