### PR TITLE
JerseyClientBuilder can create rx-capable client

### DIFF
--- a/docs/source/manual/client.rst
+++ b/docs/source/manual/client.rst
@@ -34,7 +34,7 @@ To create a :ref:`managed <man-core-managed>`, instrumented ``HttpClient`` insta
         public HttpClientConfiguration getHttpClientConfiguration() {
             return httpClient;
         }
-        
+
         @JsonProperty("httpClient")
         public void setHttpClientConfiguration(HttpClientConfiguration httpClient) {
             this.httpClient = httpClient;
@@ -179,3 +179,40 @@ the `Jersey Client Properties`_ can be used.
 
 .. _Jersey Client Configuration: https://jersey.java.net/documentation/latest/appendix-properties.html#appendix-properties-client
 .. _Jersey Client Properties: https://jersey.java.net/apidocs/2.22/jersey/org/glassfish/jersey/client/ClientProperties.html
+
+.. _man-client-jersey-rx-usage:
+
+Rx Usage
+-------
+
+To increase the ergonomics of asynchronous client requests, Jersey allows creation of `rx-clients`_.
+You can instruct Dropwizard to create such a client:
+
+.. code-block:: java
+
+    @Override
+    public void run(ExampleConfiguration config,
+                    Environment environment) {
+
+        final RxClient<RxCompletionStageInvoker> client =
+            new JerseyClientBuilder(environment)
+                .using(config.getJerseyClientConfiguration())
+                .buildRx(getName(), RxCompletionStageInvoker.class);
+        environment.jersey().register(new ExternalServiceResource(client));
+    }
+
+``RxCompletionStageInvoker.class`` is the Java 8 implementation and can be added to the pom:
+
+.. code-block:: xml
+
+    <dependency>
+        <groupId>org.glassfish.jersey.ext.rx</groupId>
+        <artifactId>jersey-rx-client-java8</artifactId>
+    </dependency>
+
+Alternatively, there are RxJava, Guava, and JSR-166e implementations.
+
+By allowing Dropwizard to create the rx-client, the same thread pool that is utilized by traditional
+synchronous and asynchronous requests, is used for rx requests.
+
+.. _rx-clients: https://jersey.java.net/documentation/2.23.1/rx-client.html

--- a/dropwizard-client/pom.xml
+++ b/dropwizard-client/pom.xml
@@ -33,6 +33,10 @@
             <artifactId>jersey-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.jersey.ext.rx</groupId>
+            <artifactId>jersey-rx-client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>
@@ -47,6 +51,11 @@
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.ext.rx</groupId>
+            <artifactId>jersey-rx-client-java8</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
@@ -19,6 +19,9 @@ import org.apache.http.conn.DnsResolver;
 import org.apache.http.conn.routing.HttpRoutePlanner;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.rx.Rx;
+import org.glassfish.jersey.client.rx.RxClient;
+import org.glassfish.jersey.client.rx.RxInvoker;
 import org.glassfish.jersey.client.spi.ConnectorProvider;
 
 import javax.net.ssl.HostnameVerifier;
@@ -308,6 +311,15 @@ public class JerseyClientBuilder {
     public JerseyClientBuilder using(CredentialsProvider credentialsProvider) {
         apacheHttpClientBuilder.using(credentialsProvider);
         return this;
+    }
+
+    /**
+     * Builds the {@link RxClient} instance.
+     *
+     * @return a fully-configured {@link RxClient}
+     */
+    public <RX extends RxInvoker> RxClient<RX> buildRx(String name, Class<RX> invokerType) {
+        return Rx.from(build(name), invokerType, executorService);
     }
 
     /**

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
@@ -26,6 +26,8 @@ import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 import org.apache.http.impl.client.SystemDefaultCredentialsProvider;
 import org.apache.http.impl.conn.SystemDefaultDnsResolver;
 import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
+import org.glassfish.jersey.client.rx.RxClient;
+import org.glassfish.jersey.client.rx.java8.RxCompletionStageInvoker;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -155,6 +157,20 @@ public class JerseyClientBuilderTest {
     public void usesTheObjectMapperForJson() throws Exception {
         final Client client = builder.using(executorService, objectMapper).build("test");
         assertThat(client.getConfiguration().isRegistered(JacksonMessageBodyProvider.class)).isTrue();
+    }
+
+    @Test
+    public void createsAnRxEnabledClient() throws Exception {
+        final RxClient<RxCompletionStageInvoker> client =
+            builder.using(executorService, objectMapper)
+                .buildRx("test", RxCompletionStageInvoker.class);
+
+        for (Object o : client.getConfiguration().getInstances()) {
+            if (o instanceof DropwizardExecutorProvider) {
+                final DropwizardExecutorProvider provider = (DropwizardExecutorProvider) o;
+                assertThat(provider.getExecutorService()).isSameAs(executorService);
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
Jersey allows for clients to have a reactive api if created appropriately:
https://jersey.java.net/documentation/latest/rx-client.html

This functionality for creating an rx-capable client is not currently in
dropwizard, which may lead users down the wrong path. They'll try wrapping
the dropwizard configured client like so (Java8 example):

```java
RxCompletionStage.from(client);
```

This is very bad because this will not use the executor carefully crafted
by dropwizard, but instead use `ForkJoinPool#commonPool`, which is, by
default, created to only have as many threads as there are numbers of CPUs - 1.
The end result is that many requests will end up blocking, the exact
opposite of what a user may think by using this API.

This commit introduces an rx-capable client that wraps the dropwizard
client with the dropwizard created executor so that both `async` and `rx`
methods can take advantage of the same thread pool, something that is more
intuitive than the current behavior.

Jersey supports four different reactive libraries and this commit works
with any of them and all future versions.

An alternative implementation would be to expose the executor that
dropwizard cofigures, but I find the approach taken in this commit better.