### PR TITLE
Add `characterEncoding` and `useUnicode` to JDBC properties.

### DIFF
--- a/docs/source/manual/hibernate.rst
+++ b/docs/source/manual/hibernate.rst
@@ -77,6 +77,8 @@ Your application's configuration file will then look like this:
       # any properties specific to your JDBC driver:
       properties:
         charSet: UTF-8
+        characterEncoding: UTF-8
+        useUnicode: true
         hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
 
       # the maximum amount of time to wait on an empty pool before throwing an exception


### PR DESCRIPTION
I am proposing the addition of these two properties as part of the example because they required in the DW 1.0 app I am currently working on. It is worth noting that the DB is MySQL, so this is potentially only an issue with MySQL implementations. Omitting `characterEncoding` and `useUnicode` does not cause anything to fail but it prevents the app from properly enforcing UTF-8. A simple example includes persisting and retrieving the ™ symbol.