### PR TITLE
Add Windows CI via AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,3 @@
+test_script:
+  - mvn package
+build: off

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalDateTimeTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalDateTimeTest.java
@@ -36,7 +36,7 @@ public class GuavaOptionalDateTimeTest {
         dataSourceFactory.setInitialSize(1);
         final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
         try (Handle h = dbi.open()) {
-            h.execute("CREATE TABLE tasks (" +
+            h.execute("CREATE TABLE IF NOT EXISTS tasks (" +
                     "id INT PRIMARY KEY, " +
                     "assignee VARCHAR(255) NOT NULL, " +
                     "start_date TIMESTAMP, " +

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalInstantTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalInstantTest.java
@@ -36,7 +36,7 @@ public class GuavaOptionalInstantTest {
         dataSourceFactory.setInitialSize(1);
         final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
         try (Handle h = dbi.open()) {
-            h.execute("CREATE TABLE tasks (" +
+            h.execute("CREATE TABLE IF NOT EXISTS tasks (" +
                     "id INT PRIMARY KEY, " +
                     "assignee VARCHAR(255) NOT NULL, " +
                     "start_date TIMESTAMP, " +

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalLocalDateTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalLocalDateTest.java
@@ -35,7 +35,7 @@ public class GuavaOptionalLocalDateTest {
         dataSourceFactory.setInitialSize(1);
         final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
         try (Handle h = dbi.open()) {
-            h.execute("CREATE TABLE tasks (" +
+            h.execute("CREATE TABLE IF NOT EXISTS tasks (" +
                     "id INT PRIMARY KEY, " +
                     "assignee VARCHAR(255) NOT NULL, " +
                     "start_date TIMESTAMP, " +

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalLocalDateTimeTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalLocalDateTimeTest.java
@@ -35,7 +35,7 @@ public class GuavaOptionalLocalDateTimeTest {
         dataSourceFactory.setInitialSize(1);
         final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
         try (Handle h = dbi.open()) {
-            h.execute("CREATE TABLE tasks (" +
+            h.execute("CREATE TABLE IF NOT EXISTS tasks (" +
                     "id INT PRIMARY KEY, " +
                     "assignee VARCHAR(255) NOT NULL, " +
                     "start_date TIMESTAMP, " +

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalOffsetDateTimeTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalOffsetDateTimeTest.java
@@ -36,7 +36,7 @@ public class GuavaOptionalOffsetDateTimeTest {
         dataSourceFactory.setInitialSize(1);
         final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
         try (Handle h = dbi.open()) {
-            h.execute("CREATE TABLE tasks (" +
+            h.execute("CREATE TABLE IF NOT EXISTS tasks (" +
                     "id INT PRIMARY KEY, " +
                     "assignee VARCHAR(255) NOT NULL, " +
                     "start_date TIMESTAMP, " +

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalZonedDateTimeTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalZonedDateTimeTest.java
@@ -36,7 +36,7 @@ public class GuavaOptionalZonedDateTimeTest {
         dataSourceFactory.setInitialSize(1);
         final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
         try (Handle h = dbi.open()) {
-            h.execute("CREATE TABLE tasks (" +
+            h.execute("CREATE TABLE IF NOT EXISTS tasks (" +
                     "id INT PRIMARY KEY, " +
                     "assignee VARCHAR(255) NOT NULL, " +
                     "start_date TIMESTAMP, " +

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalDateTimeTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalDateTimeTest.java
@@ -37,7 +37,7 @@ public class OptionalDateTimeTest {
         dataSourceFactory.setInitialSize(1);
         final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
         try (Handle h = dbi.open()) {
-            h.execute("CREATE TABLE tasks (" +
+            h.execute("CREATE TABLE IF NOT EXISTS tasks (" +
                     "id INT PRIMARY KEY, " +
                     "assignee VARCHAR(255) NOT NULL, " +
                     "start_date TIMESTAMP, " +

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalInstantTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalInstantTest.java
@@ -36,7 +36,7 @@ public class OptionalInstantTest {
         dataSourceFactory.setInitialSize(1);
         final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
         try (Handle h = dbi.open()) {
-            h.execute("CREATE TABLE tasks (" +
+            h.execute("CREATE TABLE IF NOT EXISTS tasks (" +
                     "id INT PRIMARY KEY, " +
                     "assignee VARCHAR(255) NOT NULL, " +
                     "start_date TIMESTAMP, " +

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalLocalDateTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalLocalDateTest.java
@@ -35,7 +35,7 @@ public class OptionalLocalDateTest {
         dataSourceFactory.setInitialSize(1);
         final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
         try (Handle h = dbi.open()) {
-            h.execute("CREATE TABLE tasks (" +
+            h.execute("CREATE TABLE IF NOT EXISTS tasks (" +
                     "id INT PRIMARY KEY, " +
                     "assignee VARCHAR(255) NOT NULL, " +
                     "start_date TIMESTAMP, " +

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalLocalDateTimeTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalLocalDateTimeTest.java
@@ -35,7 +35,7 @@ public class OptionalLocalDateTimeTest {
         dataSourceFactory.setInitialSize(1);
         final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
         try (Handle h = dbi.open()) {
-            h.execute("CREATE TABLE tasks (" +
+            h.execute("CREATE TABLE IF NOT EXISTS tasks (" +
                     "id INT PRIMARY KEY, " +
                     "assignee VARCHAR(255) NOT NULL, " +
                     "start_date TIMESTAMP, " +

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalOffsetDateTimeTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalOffsetDateTimeTest.java
@@ -36,7 +36,7 @@ public class OptionalOffsetDateTimeTest {
         dataSourceFactory.setInitialSize(1);
         final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
         try (Handle h = dbi.open()) {
-            h.execute("CREATE TABLE tasks (" +
+            h.execute("CREATE TABLE IF NOT EXISTS tasks (" +
                     "id INT PRIMARY KEY, " +
                     "assignee VARCHAR(255) NOT NULL, " +
                     "start_date TIMESTAMP, " +

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalZonedDateTimeTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalZonedDateTimeTest.java
@@ -36,7 +36,7 @@ public class OptionalZonedDateTimeTest {
         dataSourceFactory.setInitialSize(1);
         final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
         try (Handle h = dbi.open()) {
-            h.execute("CREATE TABLE tasks (" +
+            h.execute("CREATE TABLE IF NOT EXISTS tasks (" +
                     "id INT PRIMARY KEY, " +
                     "assignee VARCHAR(255) NOT NULL, " +
                     "start_date TIMESTAMP, " +


### PR DESCRIPTION
We need a windows ci runner, as many of my commits deal with fixing broken windows builds. These, ideally, should be fixed before a PR is merged. Since I'm most familiar with AppVeyor, I decided to go with them -- it was pretty simple, add `appveyor.yml` file to invoke maven.

Some notes:

- Something was going on with H2 where the same table existed when on setup, so I modified the tests to create the table if not already existing.
- I enabled the CI on my fork, and [this CI run](https://ci.appveyor.com/project/nickbabcock/dropwizard/build/1.0.5) would have caught the #1699 issue before #1678 was merged.
- To test, I reverted mentioned pull request and the [CI does pass](https://ci.appveyor.com/project/nickbabcock/dropwizard/build/1.0.4)

We'll have to add AppVeyor as a trusted integration, like we do with Travis. I haven't checked if I have permission to do so.