### PR TITLE
Jackson 2.8 Redux

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -24,8 +24,8 @@
         <dropwizard.version>${project.version}</dropwizard.version>
         <guava.version>19.0</guava.version>
         <jersey.version>2.23.1</jersey.version>
-        <jackson.api.version>2.7.6</jackson.api.version>
-        <jackson.version>2.7.6</jackson.version>
+        <jackson.api.version>2.8.3</jackson.api.version>
+        <jackson.version>2.8.3</jackson.version>
         <jetty.version>9.3.11.v20160721</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics3.version>3.1.2</metrics3.version>

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryTest.java
@@ -349,7 +349,7 @@ public class ConfigurationFactoryTest {
             failBecauseExceptionWasNotThrown(ConfigurationParsingException.class);
         } catch (ConfigurationParsingException e) {
             assertThat(e.getMessage())
-                    .containsOnlyOnce(" * Failed to parse configuration; Can not instantiate");
+                    .containsOnlyOnce(" * Failed to parse configuration; Can not construct instance of io.dropwizard.configuration.ConfigurationFactoryTest$Example");
         }
     }
 
@@ -453,13 +453,15 @@ public class ConfigurationFactoryTest {
     public void printsDetailedInformationOnMalformedYaml() throws Exception {
         final File resourceFileName = resourceFileName("factory-test-malformed-advanced.yml");
         assertThatThrownBy(() -> factory.build(resourceFileName))
-            .hasMessage("YAML decoding problem: while parsing a flow sequence\n" +
+            .hasMessageContaining(String.format(
+                "factory-test-malformed-advanced.yml has an error:%n" +
+                "  * Malformed YAML at line: 2, column: 21; while parsing a flow sequence\n" +
                 " in 'reader', line 2, column 7:\n" +
                 "    type: [ coder,wizard\n" +
                 "          ^\n" +
                 "expected ',' or ']', but got StreamEnd\n" +
                 " in 'reader', line 2, column 21:\n" +
                 "    wizard\n" +
-                "          ^\n");
+                "          ^"));
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProviderTest.java
@@ -231,7 +231,7 @@ public class JacksonMessageBodyProviderTest {
         } catch (JsonProcessingException e) {
             assertThat(e.getMessage())
                     .startsWith("Unexpected character ('d' (code 100)): " +
-                                        "was expecting comma to separate OBJECT entries\n");
+                                        "was expecting comma to separate Object entries\n");
         }
     }
 


### PR DESCRIPTION
Based on joschi's work in #1647

- Rebased on current master
- Bump to latest 2.8 (2.8.3)
- Maintain compatibility with how we treat errors resulting from JSON input being the wrong type. They should be treated as client errors, not server errors. The current heuristics were not sufficient enough for Jackson 2.8, so another heuristic was added via a straightforward regex.

Can squash/rebase on request.

Can update release notes on merge.