### PR TITLE
Prefer use of assertj's java8 exception assertions

### DIFF
--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkApplicationListenerTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkApplicationListenerTest.java
@@ -13,7 +13,6 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.hibernate.context.internal.ManagedSessionContext;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -21,6 +20,7 @@ import org.mockito.InOrder;
 import java.lang.reflect.Method;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hibernate.resource.transaction.spi.TransactionStatus.ACTIVE;
 import static org.hibernate.resource.transaction.spi.TransactionStatus.NOT_ACTIVE;
 import static org.mockito.Mockito.doAnswer;
@@ -240,13 +240,10 @@ public class UnitOfWorkApplicationListenerTest {
 
     @Test
     public void throwsExceptionOnNotRegisteredDatabase() throws Exception {
-        try {
-            prepareAppEvent("methodWithUnitOfWorkOnNotRegisteredDatabase");
-            execute();
-            Assert.fail();
-        } catch (IllegalArgumentException e) {
-            Assert.assertEquals(e.getMessage(), "Unregistered Hibernate bundle: 'warehouse'");
-        }
+        prepareAppEvent("methodWithUnitOfWorkOnNotRegisteredDatabase");
+        assertThatThrownBy(this::execute)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Unregistered Hibernate bundle: 'warehouse'");
     }
 
     private void prepareAppEvent(String resourceMethodName) throws NoSuchMethodException {

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/assets/ResourceURLTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/assets/ResourceURLTest.java
@@ -11,7 +11,7 @@ import java.net.URL;
 import java.util.jar.JarEntry;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class ResourceURLTest {
     private File directory;
@@ -78,14 +78,10 @@ public class ResourceURLTest {
 
     @Test
     public void isDirectoryThrowsResourceNotFoundExceptionForMissingDirectories() throws Exception {
-        URL url = Resources.getResource("META-INF/");
-        url = new URL(url.toExternalForm() + "missing");
-        try {
-            ResourceURL.isDirectory(url);
-            fail("should have thrown an exception");
-        } catch (ResourceNotFoundException ignored) {
-            // expected
-        }
+        final URL url = Resources.getResource("META-INF/");
+        final URL nurl = new URL(url.toExternalForm() + "missing");
+        assertThatThrownBy(() -> ResourceURL.isDirectory(nurl))
+            .isInstanceOf(ResourceNotFoundException.class);
     }
 
     @Test


### PR DESCRIPTION
The current usage of `fail()` in tests can't beat the messages produced by assertj's built in exception assertions. It also can't beat the conciseness 😄 

The next step may be to examine if we want to replace `failBecauseExceptionWasNotThrown` with exception assertions