### PR TITLE
Avoid needlessly binding 8080 and 8081 in tests

### DIFF
--- a/dropwizard-client/src/test/resources/yaml/jerseyIgnoreRequestUserAgentHeaderFilterTest.yml
+++ b/dropwizard-client/src/test/resources/yaml/jerseyIgnoreRequestUserAgentHeaderFilterTest.yml
@@ -3,3 +3,6 @@ server:
   applicationConnectors:
     - type: http
       port: 0
+  adminConnectors:
+    - type: http
+      port: 0

--- a/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
@@ -174,6 +174,7 @@ public class DefaultServerFactoryTest {
         final Server server = http.build(environment);
 
         ((AbstractNetworkConnector) server.getConnectors()[0]).setPort(0);
+        ((AbstractNetworkConnector) server.getConnectors()[1]).setPort(0);
 
         ScheduledFuture<Void> cleanup = executor.schedule(() -> {
             if (!server.isStopped()) {

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleWithoutConfigTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleWithoutConfigTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.ConfigOverride;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -20,7 +21,9 @@ import java.util.Map;
 public class DropwizardAppRuleWithoutConfigTest {
 
     @ClassRule
-    public static final DropwizardAppRule<Configuration> RULE = new DropwizardAppRule<>(TestApplication.class);
+    public static final DropwizardAppRule<Configuration> RULE = new DropwizardAppRule<>(TestApplication.class, null,
+        ConfigOverride.config("server.applicationConnectors[0].port", "0"),
+        ConfigOverride.config("server.adminConnectors[0].port", "0"));
 
     Client client = ClientBuilder.newClient();
 


### PR DESCRIPTION
This way I can have a default dropwizard app I'm testing and still run all of dropwizard's tests.