### PR TITLE
Update to mustache.java 0.9.4

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -181,7 +181,7 @@
             <dependency>
                 <groupId>com.github.spullara.mustache.java</groupId>
                 <artifactId>compiler</artifactId>
-                <version>0.9.3</version>
+                <version>0.9.4</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.google.guava</groupId>


### PR DESCRIPTION
[Based on the forums](https://groups.google.com/forum/#!msg/mustachejava/84_oxOao8hM/0d4PW1L7AgAJ) closes #1696

I think this PR should be considered for 1.0.3 (0.9.2 -> 0.9.4), if that's available.