### PR TITLE
Speed up servlet tester tests by closing connection

### DIFF
--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/BiDiGzipHandlerTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/BiDiGzipHandlerTest.java
@@ -39,6 +39,7 @@ public class BiDiGzipHandlerTest {
     @Before
     public void setUp() throws Exception {
         request.setHeader(HttpHeaders.HOST, "localhost");
+        request.setHeader("Connection", "close");
 
         gzipHandler.setExcludedAgentPatterns();
         gzipHandler.addIncludedMethods("POST");


### PR DESCRIPTION
The four tests in `BiDiGzipHandlerTest` took at least 10 seconds each. By closing the connection after use, the tests are much much faster. Each test is about ~50ms now.

See related [stackoverflow](http://stackoverflow.com/questions/20428371/why-is-servlettester-in-jetty-9-x-so-slow)