### PR TITLE
Bind default exception mappers

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -1219,14 +1219,23 @@ and then registering the exception mapper:
 Overriding Default Exception Mappers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you want more control, you can disable the exception mappers Dropwizard provides by default. This is done
-by setting ``server.registerDefaultExceptionMappers`` to ``false``. Since this disables all default exception
-mappers make sure to re-enable exception mappers that are wanted. The default exception mappers are:
+To override a specific exception mapper, register your own class that implements the same
+``ExceptionMapper<T>`` as one of the default. For instance, we can customize responses caused by
+Jackson exceptions:
 
-- ``LoggingExceptionMapper<Throwable>``
-- ``JerseyViolationExceptionMapper``
-- ``JsonProcessingExceptionMapper``
-- ``EarlyEofExceptionMapper``
+.. code-block:: java
+
+    public class JsonProcessingExceptionMapper implements ExceptionMapper<JsonProcessingException> {
+        @Override
+        public Response toResponse(JsonProcessingException exception) {
+            // create the response
+        }
+    }
+
+With this method, one doesn't need to know what the default exception mappers are, as they are
+overridden if the user supplies a conflicting mapper. While not preferential, one can also disable
+all default exception mappers, by setting ``server.registerDefaultExceptionMappers`` to ``false``.
+See the class ``ExceptionMapperBinder`` for a list of the default exception mappers.
 
 .. _man-core-resources-uris:
 

--- a/docs/source/manual/validation.rst
+++ b/docs/source/manual/validation.rst
@@ -441,14 +441,15 @@ response through an ``ExceptionMapper<JerseyViolationException>``:
         }
     }
 
+To register ``MyJerseyViolationExceptionMapper`` and have it override the default:
 
-To register ``MyJerseyViolationExceptionMapper``, you'll need to first set
-``registerDefaultExceptionMappers`` to false in the configuration file or in code before registering
-your exception mapper with jersey. Then, optionally, register other default exception mappers:
+.. code-block:: java
 
-* ``LoggingExceptionMapper<Throwable>``
-* ``JsonProcessingExceptionMapper``
-* ``EarlyEofExceptionMapper``
+    @Override
+    public void run(final MyConfiguration conf, final Environment env) {
+        env.jersey().register(new MyJerseyViolationExceptionMapper());
+        env.jersey().register(new Resource());
+    }
 
 Dropwizard calculates the validation error message through ``ConstraintMessage.getMessage``.
 

--- a/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
@@ -12,14 +12,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Joiner;
 import com.google.common.io.Resources;
-import io.dropwizard.jersey.errors.EarlyEofExceptionMapper;
-import io.dropwizard.jersey.errors.LoggingExceptionMapper;
 import io.dropwizard.jersey.filter.AllowedMethodsFilter;
 import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
-import io.dropwizard.jersey.jackson.JsonProcessingExceptionMapper;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
 import io.dropwizard.jersey.validation.HibernateValidationFeature;
-import io.dropwizard.jersey.validation.JerseyViolationExceptionMapper;
 import io.dropwizard.jetty.GzipHandlerFactory;
 import io.dropwizard.jetty.MutableServletContextHandler;
 import io.dropwizard.jetty.NonblockingServletHolder;
@@ -28,6 +24,7 @@ import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import io.dropwizard.request.logging.LogbackAccessRequestLogFactory;
 import io.dropwizard.request.logging.RequestLogFactory;
 import io.dropwizard.servlets.ThreadNameFilter;
+import io.dropwizard.setup.ExceptionMapperBinder;
 import io.dropwizard.util.Duration;
 import io.dropwizard.validation.MinDuration;
 import io.dropwizard.validation.ValidationMethod;
@@ -504,11 +501,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
             jersey.register(new JacksonMessageBodyProvider(objectMapper));
             jersey.register(new HibernateValidationFeature(validator));
             if (registerDefaultExceptionMappers == null || registerDefaultExceptionMappers) {
-                jersey.register(new LoggingExceptionMapper<Throwable>() {
-                });
-                jersey.register(new JerseyViolationExceptionMapper());
-                jersey.register(new JsonProcessingExceptionMapper(detailedJsonProcessingExceptionMapper));
-                jersey.register(new EarlyEofExceptionMapper());
+                jersey.register(new ExceptionMapperBinder(detailedJsonProcessingExceptionMapper));
             }
             handler.addServlet(new NonblockingServletHolder(jerseyContainer), jersey.getUrlPattern());
         }

--- a/dropwizard-core/src/main/java/io/dropwizard/setup/ExceptionMapperBinder.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/ExceptionMapperBinder.java
@@ -1,0 +1,30 @@
+package io.dropwizard.setup;
+
+import io.dropwizard.jersey.errors.EarlyEofExceptionMapper;
+import io.dropwizard.jersey.errors.LoggingExceptionMapper;
+import io.dropwizard.jersey.jackson.JsonProcessingExceptionMapper;
+import io.dropwizard.jersey.validation.JerseyViolationExceptionMapper;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+
+import javax.ws.rs.ext.ExceptionMapper;
+
+public class ExceptionMapperBinder extends AbstractBinder {
+    private final boolean showDetails;
+
+    public ExceptionMapperBinder(boolean showDetails) {
+        this.showDetails = showDetails;
+    }
+
+    @Override
+    protected void configure() {
+        bind(new LoggingExceptionMapper<Throwable>() {
+        }).to(ExceptionMapper.class);
+        bind(new JerseyViolationExceptionMapper()).to(ExceptionMapper.class);
+        bind(new JsonProcessingExceptionMapper(isShowDetails())).to(ExceptionMapper.class);
+        bind(new EarlyEofExceptionMapper()).to(ExceptionMapper.class);
+    }
+
+    public boolean isShowDetails() {
+        return showDetails;
+    }
+}

--- a/dropwizard-core/src/main/java/io/dropwizard/setup/ExceptionMapperBinder.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/ExceptionMapperBinder.java
@@ -8,6 +8,10 @@ import org.glassfish.hk2.utilities.binding.AbstractBinder;
 
 import javax.ws.rs.ext.ExceptionMapper;
 
+/**
+ * An HK2 binder that registers all the default exception mappers while allowing users to override
+ * individual exception mappers without disabling all others.
+ */
 public class ExceptionMapperBinder extends AbstractBinder {
     private final boolean showDetails;
 

--- a/dropwizard-core/src/test/java/io/dropwizard/server/SimpleServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/SimpleServerFactoryTest.java
@@ -97,7 +97,7 @@ public class SimpleServerFactoryTest {
         assertEquals(http.getApplicationContextPath(), environment.getApplicationContext().getContextPath());
     }
 
-    private static String httpRequest(String requestMethod, String url) throws Exception {
+    public static String httpRequest(String requestMethod, String url) throws Exception {
         final HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
         connection.setRequestMethod(requestMethod);
         connection.connect();

--- a/dropwizard-core/src/test/java/io/dropwizard/setup/ExceptionMapperBinderTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/setup/ExceptionMapperBinderTest.java
@@ -1,0 +1,76 @@
+package io.dropwizard.setup;
+
+import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.Resources;
+import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jersey.validation.JerseyViolationException;
+import io.dropwizard.jetty.HttpConnectorFactory;
+import io.dropwizard.logging.ConsoleAppenderFactory;
+import io.dropwizard.logging.FileAppenderFactory;
+import io.dropwizard.logging.SyslogAppenderFactory;
+import io.dropwizard.server.ServerFactory;
+import io.dropwizard.server.SimpleServerFactory;
+import io.dropwizard.validation.BaseValidator;
+import org.eclipse.jetty.server.AbstractNetworkConnector;
+import org.eclipse.jetty.server.Server;
+import org.hibernate.validator.constraints.NotEmpty;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.validation.Validator;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import java.io.File;
+
+import static io.dropwizard.server.SimpleServerFactoryTest.httpRequest;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExceptionMapperBinderTest {
+    private SimpleServerFactory http;
+    private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+    private Validator validator = BaseValidator.newValidator();
+    private Environment environment = new Environment("testEnvironment", objectMapper, validator, new MetricRegistry(),
+        ClassLoader.getSystemClassLoader());
+
+    @Before
+    public void setUp() throws Exception {
+        objectMapper.getSubtypeResolver().registerSubtypes(ConsoleAppenderFactory.class,
+            FileAppenderFactory.class, SyslogAppenderFactory.class, HttpConnectorFactory.class);
+        http = (SimpleServerFactory) new YamlConfigurationFactory<>(ServerFactory.class, validator, objectMapper, "dw")
+            .build(new File(Resources.getResource("yaml/simple_server.yml").toURI()));
+    }
+
+    @Test
+    public void testOverrideDefaultExceptionMapper() throws Exception {
+        environment.jersey().register(new TestValidationResource());
+        environment.jersey().register(new MyJerseyExceptionMapper());
+        final Server server = http.build(environment);
+        server.start();
+
+        final int port = ((AbstractNetworkConnector) server.getConnectors()[0]).getLocalPort();
+        assertThat(httpRequest("GET", "http://localhost:" + port + "/service/test")).isEqualTo("alright!");
+        server.stop();
+    }
+
+    private static class MyJerseyExceptionMapper implements ExceptionMapper<JerseyViolationException> {
+        @Override
+        public Response toResponse(JerseyViolationException e) {
+            return Response.ok("alright!").build();
+        }
+    }
+
+    @Path("/test")
+    @Produces("application/json")
+    private static class TestValidationResource {
+        @GET
+        public String get(@NotEmpty @QueryParam("foo") String foo) {
+            return foo;
+        }
+    }
+}

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardTestResourceConfig.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardTestResourceConfig.java
@@ -2,12 +2,9 @@ package io.dropwizard.testing.junit;
 
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.DropwizardResourceConfig;
-import io.dropwizard.jersey.errors.EarlyEofExceptionMapper;
-import io.dropwizard.jersey.errors.LoggingExceptionMapper;
 import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
-import io.dropwizard.jersey.jackson.JsonProcessingExceptionMapper;
 import io.dropwizard.jersey.validation.HibernateValidationFeature;
-import io.dropwizard.jersey.validation.JerseyViolationExceptionMapper;
+import io.dropwizard.setup.ExceptionMapperBinder;
 import org.glassfish.jersey.server.ServerProperties;
 
 import javax.servlet.ServletConfig;
@@ -35,11 +32,7 @@ class DropwizardTestResourceConfig extends DropwizardResourceConfig {
         super(true, new MetricRegistry());
 
         if (configuration.registerDefaultExceptionMappers) {
-            register(new LoggingExceptionMapper<Throwable>() {
-            });
-            register(new JerseyViolationExceptionMapper());
-            register(new JsonProcessingExceptionMapper());
-            register(new EarlyEofExceptionMapper());
+            register(new ExceptionMapperBinder(false));
         }
         for (Class<?> provider : configuration.providers) {
             register(provider);


### PR DESCRIPTION
Currently when a user wants to override one of the default exception mappers they must specify `registerDefaultExceptionMappers: false` in their configuration, register their exception mapper, and then re-register all the other default exception mappers they want. This is not user friendly. A user should be able to register their own exception mapper, override the default exception mapper while preserving other default exception mappers.

It should be possible to achieve this behavior as alluded to in [JERSEY-2722](https://java.net/jira/browse/JERSEY-2722)

> your own ExceptionMapper<ValidationException> should always have a higher priority than anything provided by Jersey

and alluded in [Jersey's Bean Validation code](https://github.com/jersey/jersey/blob/1a7919181d8a1f550c7fc20898db67fe9da5d596/ext/bean-validation/src/main/java/org/glassfish/jersey/server/validation/internal/ValidationBinder.java#L102)

```java
// Custom Exception Mapper and Writer - registering in binder to make possible for users register their own providers.
bind(ValidationExceptionMapper.class).to(ExceptionMapper.class).in(Singleton.class);
bind(ValidationErrorMessageBodyWriter.class).to(MessageBodyWriter.class).in(Singleton.class);
```

This pull request takes a crack at introducing this to Dropwizard, while remaining 100% backwards compatible. I've tried creating this behavior before in #1144, but it didn't work out, so I'd appreciate some help testing this :smile:. I believe it is working as I have an app that has:


```java
@Override
public void run(final DropwizardSampleConfiguration configuration,
                final Environment environment) {
    environment.jersey().register(new Resource());
    environment.jersey().register(new MyJerseyException());
}


public class MyJerseyException implements ExceptionMapper<JerseyViolationException> {
    @Override
    public Response toResponse(JerseyViolationException e) {
        return Response.ok("Oh yeah").build();
    }
}
```

and I receive the "Oh yeah" response with every restart and request (100 requests across 10 restarts).

We can even keep around the `registerDefaultExceptionMappers` for users who want no default exception mappers registered, but I'm assuming most users will not use this option and opt for overriding specific exception mappers.

The major benefit to this approach is the ability to add new exception mappers without having the relatively large cost of forcing the user to know them all 😋 

TODO:
- [x] Add tests
- [x] Update docs
- [x] To use the provider annotation or not?