### PR TITLE
correct sample code on building apache http client

### DIFF
--- a/docs/source/manual/client.rst
+++ b/docs/source/manual/client.rst
@@ -49,7 +49,7 @@ Then, in your application's ``run`` method, create a new ``HttpClientBuilder``:
     public void run(ExampleConfiguration config,
                     Environment environment) {
         final HttpClient httpClient = new HttpClientBuilder(environment).using(config.getHttpClientConfiguration())
-                                                                        .build();
+                                                                        .build(getName());
         environment.jersey().register(new ExternalServiceResource(httpClient));
     }
 


### PR DESCRIPTION
This contract with [HttpClientBuilder$build](https://github.com/dropwizard/dropwizard/blob/master/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java#L220-L226) is the following:

```
public CloseableHttpClient build(String name);
```