### PR TITLE
Fixup Jackson 2.8 deprecations

### DIFF
--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/YamlConfigurationFactory.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/YamlConfigurationFactory.java
@@ -9,9 +9,9 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.databind.node.TreeTraversingParser;
+import com.fasterxml.jackson.dataformat.yaml.JacksonYAMLParseException;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.snakeyaml.error.MarkedYAMLException;
-import com.fasterxml.jackson.dataformat.yaml.snakeyaml.error.YAMLException;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 
@@ -84,7 +84,7 @@ public class YamlConfigurationFactory<T> implements ConfigurationFactory<T> {
             }
 
             return build(node, path);
-        } catch (YAMLException e) {
+        } catch (JacksonYAMLParseException e) {
             final ConfigurationParsingException.Builder builder = ConfigurationParsingException
                     .builder("Malformed YAML")
                     .setCause(e)

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/FuzzyEnumModule.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/FuzzyEnumModule.java
@@ -76,7 +76,7 @@ public class FuzzyEnumModule extends Module {
                 for (AnnotatedMethod am : factoryMethods) {
                     final JsonCreator creator = am.getAnnotation(JsonCreator.class);
                     if (creator != null) {
-                        return EnumDeserializer.deserializerForCreator(config, type, am);
+                        return EnumDeserializer.deserializerForCreator(config, type, am, null, null);
                     }
                 }
             }


### PR DESCRIPTION
There remains a couple more deprecations in the yaml package where Jackson's `MarkedYAMLException` and `Mark` have been deprecated in favor of the underlying snakeyaml implementation (see https://github.com/FasterXML/jackson-dataformat-yaml/issues/63), but Jackson still throws the deprecated exceptions. Hence not all deprecations have been removed as they are still needed.

cc @cowtowncoder 