### PR TITLE
Upgrade to Jackson 2.8.4

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -20,7 +20,7 @@ v1.1.0: Unreleased
 * Allow constraints to be applied to type `#1586 <https://github.com/dropwizard/dropwizard/pull/1586>`_
 * Use LoadingCache in CachingAuthenticator `#1615 <https://github.com/dropwizard/dropwizard/pull/1615>`_
 * Introduce CachingAuthorizer `#1639 <https://github.com/dropwizard/dropwizard/pull/1639>`_
-* Upgraded to Jackson 2.8.3 `#1749 <https://github.com/dropwizard/dropwizard/pull/1749>`_
+* Upgraded to Jackson 2.8.4 `#1775 <https://github.com/dropwizard/dropwizard/pull/1775>`_
 * Upgraded to Jetty 9.3.12.v20160915
 * Upgraded to tomcat-jdbc 8.5.6
 * Upgraded to Objenesis 2.4 `#1654 <https://github.com/dropwizard/dropwizard/pull/1654>`_

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -24,8 +24,7 @@
         <dropwizard.version>${project.version}</dropwizard.version>
         <guava.version>19.0</guava.version>
         <jersey.version>2.23.2</jersey.version>
-        <jackson.api.version>2.8.3</jackson.api.version>
-        <jackson.version>2.8.3</jackson.version>
+        <jackson.version>2.8.4</jackson.version>
         <jetty.version>9.3.12.v20160915</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics3.version>3.1.2</metrics3.version>
@@ -291,9 +290,16 @@
 
             <!-- Jackson -->
             <dependency>
+                <groupId>com.github.joschi.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.api.version}</version>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
This PR also includes the (unofficial) Jackson BOM so that users can include Jackson dependencies in the correct version into their projects.