### PR TITLE
Add web test container agnostic client target

### DIFF
--- a/docs/source/manual/auth.rst
+++ b/docs/source/manual/auth.rst
@@ -270,13 +270,13 @@ When you build your ``ResourceTestRule``, add the ``GrizzlyWebTestContainerFacto
             .build();
 
 
-In this example, we are testing the oauth authentication, so we need to set the header manually. Note the use of ``resources.getJerseyTest()`` to make the test work
+In this example, we are testing the oauth authentication, so we need to set the header manually.
 
 .. code-block:: java
 
     @Test
     public void testProtected() throws Exception {
-        final Response response = rule.getJerseyTest().target("/protected")
+        final Response response = rule.target("/protected")
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .header("Authorization", "Bearer TOKEN")
                 .get();
@@ -292,7 +292,7 @@ resources. For example you may want Basic authentication for one resource and OA
 for another resource, at the same time using a different `Principal` for each
 authentication scheme.
 
-For this use case, there is the ``PolymorphicAuthDynamicFeature`` and the 
+For this use case, there is the ``PolymorphicAuthDynamicFeature`` and the
 ``PolymorphicAuthValueFactoryProvider``. With these two components, we can use different
 combinations of authentication schemes/authenticators/authorizers/principals. To use this
 feature, we need to do a few things:
@@ -310,7 +310,7 @@ a different principal for each.
 
 .. code-block:: java
 
-    final AuthFilter<BasicCredentials, BasicPrincipal> basicFilter 
+    final AuthFilter<BasicCredentials, BasicPrincipal> basicFilter
             = new BasicCredentialAuthFilter.Builder<BasicPrincipal>()
                     .setAuthenticator(new ExampleAuthenticator())
                     .setRealm("SUPER SECRET STUFF")
@@ -323,7 +323,7 @@ a different principal for each.
 
     final PolymorphicAuthDynamicFeature feature = new PolymorphicAuthDynamicFeature<>(
         ImmutableMap.of(
-            BasicPrincipal.class, basicFilter, 
+            BasicPrincipal.class, basicFilter,
             OAuthPrincipal.class, oauthFilter));
     final AbstractBinder binder = new PolymorphicAuthValueFactoryProvider.Binder<>(
         ImmutableSet.of(BasicPrincipal.class, OAuthPrincipal.class));
@@ -363,7 +363,7 @@ So continuing with the previous example you should add the following configurati
 
     ... = new OAuthCredentialAuthFilter.Builder<OAuthPrincipal>()
             .setAuthorizer(new ExampleAuthorizer())..  // set authorizer
-    
+
     environment.jersey().register(RolesAllowedDynamicFeature.class);
 
 Now we can do

--- a/docs/source/manual/testing.rst
+++ b/docs/source/manual/testing.rst
@@ -188,7 +188,7 @@ loads a given resource instance in an in-memory Jersey server:
 
         @Test
         public void testGetPerson() {
-            assertThat(resources.client().target("/person/blah").request().get(Person.class))
+            assertThat(resources.target("/person/blah").request().get(Person.class))
                     .isEqualTo(person);
             verify(dao).fetchPerson("blah");
         }
@@ -199,7 +199,7 @@ want to test via ``ResourceTestRule.Builder#addResource(Object)``. Use a ``@Clas
 to have the rule wrap the entire test class or the ``@Rule`` annotation to have the rule wrap
 each test individually (make sure to remove static final modifier from ``resources``).
 
-In your tests, use ``#client()``, which returns a Jersey ``Client`` instance to talk to and test
+In your tests, use ``#target(String path)``, which initializes a request to talk to and test
 your instances.
 
 This doesn't require opening a port, but ``ResourceTestRule`` tests will perform all the serialization,
@@ -266,7 +266,7 @@ dependency for the Jersey Test Framework providers to your Maven POM and set ``G
 
         @Test
         public void testResource() {
-            assertThat(RULE.getJerseyTest().target("/example").request()
+            assertThat(RULE.target("/example").request()
                 .get(String.class))
                 .isEqualTo("example");
         }

--- a/docs/source/manual/validation.rst
+++ b/docs/source/manual/validation.rst
@@ -401,8 +401,7 @@ code and ensure that the error messages are user friendly.
     public void personNeedsAName() {
         // Tests what happens when a person with a null name is sent to
         // the endpoint.
-        final Response post = resources.client()
-                .target("/person/v1").request()
+        final Response post = resources.target("/person/v1").request()
                 .post(Entity.json(new Person(null)));
 
         // Clients will receive a 422 on bad request entity

--- a/dropwizard-example/src/test/java/com/example/helloworld/resources/PeopleResourceTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/resources/PeopleResourceTest.java
@@ -56,7 +56,7 @@ public class PeopleResourceTest {
     @Test
     public void createPerson() throws JsonProcessingException {
         when(PERSON_DAO.create(any(Person.class))).thenReturn(person);
-        final Response response = RESOURCES.client().target("/people")
+        final Response response = RESOURCES.target("/people")
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .post(Entity.entity(person, MediaType.APPLICATION_JSON_TYPE));
 
@@ -70,7 +70,7 @@ public class PeopleResourceTest {
         final ImmutableList<Person> people = ImmutableList.of(person);
         when(PERSON_DAO.findAll()).thenReturn(people);
 
-        final List<Person> response = RESOURCES.client().target("/people")
+        final List<Person> response = RESOURCES.target("/people")
             .request().get(new GenericType<List<Person>>() {
             });
 

--- a/dropwizard-example/src/test/java/com/example/helloworld/resources/PersonResourceTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/resources/PersonResourceTest.java
@@ -45,7 +45,7 @@ public class PersonResourceTest {
     public void getPersonSuccess() {
         when(DAO.findById(1L)).thenReturn(Optional.of(person));
 
-        Person found = RULE.getJerseyTest().target("/people/1").request().get(Person.class);
+        Person found = RULE.target("/people/1").request().get(Person.class);
 
         assertThat(found.getId()).isEqualTo(person.getId());
         verify(DAO).findById(1L);
@@ -54,7 +54,7 @@ public class PersonResourceTest {
     @Test
     public void getPersonNotFound() {
         when(DAO.findById(2L)).thenReturn(Optional.empty());
-        final Response response = RULE.getJerseyTest().target("/people/2").request().get();
+        final Response response = RULE.target("/people/2").request().get();
 
         assertThat(response.getStatusInfo().getStatusCode()).isEqualTo(Response.Status.NOT_FOUND.getStatusCode());
         verify(DAO).findById(2L);

--- a/dropwizard-example/src/test/java/com/example/helloworld/resources/ProtectedClassResourceTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/resources/ProtectedClassResourceTest.java
@@ -39,7 +39,7 @@ public final class ProtectedClassResourceTest {
 
     @Test
     public void testProtectedAdminEndpoint() {
-        String secret = RULE.getJerseyTest().target("/protected/admin").request()
+        String secret = RULE.target("/protected/admin").request()
             .header(HttpHeaders.AUTHORIZATION, "Basic Y2hpZWYtd2l6YXJkOnNlY3JldA==")
             .get(String.class);
         assertThat(secret).startsWith("Hey there, chief-wizard. It looks like you are an admin.");
@@ -47,7 +47,7 @@ public final class ProtectedClassResourceTest {
 
     @Test
     public void testProtectedBasicUserEndpoint() {
-        String secret = RULE.getJerseyTest().target("/protected").request()
+        String secret = RULE.target("/protected").request()
             .header(HttpHeaders.AUTHORIZATION, "Basic Z29vZC1ndXk6c2VjcmV0")
             .get(String.class);
         assertThat(secret).startsWith("Hey there, good-guy. You seem to be a basic user.");
@@ -55,7 +55,7 @@ public final class ProtectedClassResourceTest {
 
     @Test
     public void testProtectedBasicUserEndpointAsAdmin() {
-        String secret = RULE.getJerseyTest().target("/protected").request()
+        String secret = RULE.target("/protected").request()
             .header(HttpHeaders.AUTHORIZATION, "Basic Y2hpZWYtd2l6YXJkOnNlY3JldA==")
             .get(String.class);
         assertThat(secret).startsWith("Hey there, chief-wizard. You seem to be a basic user.");
@@ -63,7 +63,7 @@ public final class ProtectedClassResourceTest {
 
     @Test
     public void testProtectedGuestEndpoint() {
-        String secret = RULE.getJerseyTest().target("/protected/guest").request()
+        String secret = RULE.target("/protected/guest").request()
             .header(HttpHeaders.AUTHORIZATION, "Basic Z3Vlc3Q6c2VjcmV0")
             .get(String.class);
         assertThat(secret).startsWith("Hey there, guest. You know the secret!");
@@ -72,7 +72,7 @@ public final class ProtectedClassResourceTest {
     @Test
     public void testProtectedBasicUserEndpointPrincipalIsNotAuthorized403() {
         try {
-            RULE.getJerseyTest().target("/protected").request()
+            RULE.target("/protected").request()
             .header(HttpHeaders.AUTHORIZATION, "Basic Z3Vlc3Q6c2VjcmV0")
             .get(String.class);
             failBecauseExceptionWasNotThrown(ForbiddenException.class);

--- a/dropwizard-example/src/test/java/com/example/helloworld/resources/ProtectedResourceTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/resources/ProtectedResourceTest.java
@@ -39,7 +39,7 @@ public class ProtectedResourceTest {
 
     @Test
     public void testProtectedEndpoint() {
-        String secret = RULE.getJerseyTest().target("/protected").request()
+        String secret = RULE.target("/protected").request()
                 .header(HttpHeaders.AUTHORIZATION, "Basic Z29vZC1ndXk6c2VjcmV0")
                 .get(String.class);
         assertThat(secret).startsWith("Hey there, good-guy. You know the secret!");
@@ -48,7 +48,7 @@ public class ProtectedResourceTest {
     @Test
     public void testProtectedEndpointNoCredentials401() {
         try {
-            RULE.getJerseyTest().target("/protected").request()
+            RULE.target("/protected").request()
                 .get(String.class);
             failBecauseExceptionWasNotThrown(NotAuthorizedException.class);
         } catch (NotAuthorizedException e) {
@@ -62,7 +62,7 @@ public class ProtectedResourceTest {
     @Test
     public void testProtectedEndpointBadCredentials401() {
         try {
-            RULE.getJerseyTest().target("/protected").request()
+            RULE.target("/protected").request()
                 .header(HttpHeaders.AUTHORIZATION, "Basic c25lYWt5LWJhc3RhcmQ6YXNkZg==")
                 .get(String.class);
             failBecauseExceptionWasNotThrown(NotAuthorizedException.class);
@@ -76,7 +76,7 @@ public class ProtectedResourceTest {
 
     @Test
     public void testProtectedAdminEndpoint() {
-        String secret = RULE.getJerseyTest().target("/protected/admin").request()
+        String secret = RULE.target("/protected/admin").request()
                 .header(HttpHeaders.AUTHORIZATION, "Basic Y2hpZWYtd2l6YXJkOnNlY3JldA==")
                 .get(String.class);
         assertThat(secret).startsWith("Hey there, chief-wizard. It looks like you are an admin.");
@@ -85,7 +85,7 @@ public class ProtectedResourceTest {
     @Test
     public void testProtectedAdminEndpointPrincipalIsNotAuthorized403() {
         try {
-            RULE.getJerseyTest().target("/protected/admin").request()
+            RULE.target("/protected/admin").request()
                     .header(HttpHeaders.AUTHORIZATION, "Basic Z29vZC1ndXk6c2VjcmV0")
                     .get(String.class);
             failBecauseExceptionWasNotThrown(ForbiddenException.class);

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ResourceTestRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ResourceTestRule.java
@@ -18,6 +18,7 @@ import org.junit.runners.model.Statement;
 
 import javax.validation.Validator;
 import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -133,10 +134,32 @@ public class ResourceTestRule implements TestRule {
         return configuration.clientConfigurator;
     }
 
+    /**
+     * Creates a web target to be sent to the resource under testing.
+     *
+     * @param path relative path (from tested application base URI) this web target should point to.
+     * @return the created JAX-RS web target.
+     */
+    public WebTarget target(String path) {
+        return getJerseyTest().target(path);
+    }
+
+    /**
+     * Returns the pre-configured {@link Client} for this test. For sending
+     * requests prefer {@link #target(String)}
+     *
+     * @return the {@link JerseyTest} configured {@link Client}
+     */
     public Client client() {
         return test.client();
     }
 
+    /**
+     * Returns the underlying {@link JerseyTest}. For sending requests prefer
+     * {@link #target(String)}.
+     *
+     * @return the underlying {@link JerseyTest}
+     */
     public JerseyTest getJerseyTest() {
         return test;
     }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResourceExceptionMapperTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResourceExceptionMapperTest.java
@@ -35,7 +35,7 @@ public class PersonResourceExceptionMapperTest {
 
     @Test
     public void testDefaultConstraintViolation() {
-        assertThat(RESOURCES.client().target("/person/blah/index")
+        assertThat(RESOURCES.target("/person/blah/index")
             .queryParam("ind", -1).request()
             .get().readEntity(String.class))
             .isEqualTo("Invalid data");
@@ -43,7 +43,7 @@ public class PersonResourceExceptionMapperTest {
 
     @Test
     public void testDefaultJsonProcessingMapper() {
-        assertThat(RESOURCES.client().target("/person/blah/runtime-exception")
+        assertThat(RESOURCES.target("/person/blah/runtime-exception")
             .request()
             .post(Entity.json("{ \"he: \"ho\"}"))
             .readEntity(String.class))
@@ -52,7 +52,7 @@ public class PersonResourceExceptionMapperTest {
 
     @Test
     public void testDefaultExceptionMapper() {
-        assertThat(RESOURCES.client().target("/person/blah/runtime-exception")
+        assertThat(RESOURCES.target("/person/blah/runtime-exception")
             .request()
             .post(Entity.json("{}"))
             .readEntity(String.class))
@@ -61,7 +61,7 @@ public class PersonResourceExceptionMapperTest {
 
     @Test
     public void testDefaultEofExceptionMapper() {
-        assertThat(RESOURCES.client().target("/person/blah/eof-exception")
+        assertThat(RESOURCES.target("/person/blah/eof-exception")
             .request()
             .get().readEntity(String.class))
             .isEqualTo("Something went wrong: I'm an eof exception!");

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResourceTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResourceTest.java
@@ -56,7 +56,7 @@ public class PersonResourceTest {
 
     @Test
     public void testGetPerson() {
-        assertThat(RESOURCES.client().target("/person/blah").request()
+        assertThat(RESOURCES.target("/person/blah").request()
                 .get(Person.class))
                 .isEqualTo(person);
         verify(PEOPLE_STORE).fetchPerson("blah");
@@ -64,7 +64,7 @@ public class PersonResourceTest {
 
     @Test
     public void testGetImmutableListOfPersons() {
-        assertThat(RESOURCES.client().target("/person/blah/list").request()
+        assertThat(RESOURCES.target("/person/blah/list").request()
             .get(new GenericType<ImmutableList<Person>>() {
             })).isEqualTo(ImmutableList.of(person));
     }
@@ -73,7 +73,7 @@ public class PersonResourceTest {
     public void testGetPersonWithQueryParam() {
         // Test to ensure that the dropwizard validator is registered so that
         // it can validate the "ind" IntParam.
-        assertThat(RESOURCES.client().target("/person/blah/index")
+        assertThat(RESOURCES.target("/person/blah/index")
             .queryParam("ind", 0).request()
             .get(Person.class))
             .isEqualTo(person);
@@ -82,7 +82,7 @@ public class PersonResourceTest {
 
     @Test
     public void testDefaultConstraintViolation() {
-        assertThat(RESOURCES.client().target("/person/blah/index")
+        assertThat(RESOURCES.target("/person/blah/index")
             .queryParam("ind", -1).request()
             .get().readEntity(String.class))
             .isEqualTo("{\"errors\":[\"query param ind must be greater than or equal to 0\"]}");
@@ -90,7 +90,7 @@ public class PersonResourceTest {
 
     @Test
     public void testDefaultJsonProcessingMapper() {
-        assertThat(RESOURCES.client().target("/person/blah/runtime-exception")
+        assertThat(RESOURCES.target("/person/blah/runtime-exception")
             .request()
             .post(Entity.json("{ \"he: \"ho\"}"))
             .readEntity(String.class))
@@ -99,7 +99,7 @@ public class PersonResourceTest {
 
     @Test
     public void testDefaultExceptionMapper() {
-        assertThat(RESOURCES.client().target("/person/blah/runtime-exception")
+        assertThat(RESOURCES.target("/person/blah/runtime-exception")
             .request()
             .post(Entity.json("{}"))
             .readEntity(String.class))
@@ -108,7 +108,7 @@ public class PersonResourceTest {
 
     @Test
     public void testDefaultEofExceptionMapper() {
-        assertThat(RESOURCES.client().target("/person/blah/eof-exception")
+        assertThat(RESOURCES.target("/person/blah/eof-exception")
             .request()
             .get().getStatus())
             .isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
@@ -116,7 +116,7 @@ public class PersonResourceTest {
 
     @Test
     public void testValidationGroupsException() {
-        final Response resp = RESOURCES.client().target("/person/blah/validation-groups-exception")
+        final Response resp = RESOURCES.target("/person/blah/validation-groups-exception")
             .request()
             .post(Entity.json("{}"));
         assertThat(resp.getStatus()).isEqualTo(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestWithGrizzly.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestWithGrizzly.java
@@ -26,14 +26,14 @@ public class ResourceTestWithGrizzly {
 
     @Test
     public void testResource() {
-        assertThat(RESOURCES.getJerseyTest().target("test").request()
+        assertThat(RESOURCES.target("test").request()
                 .get(String.class))
                 .isEqualTo("test");
     }
 
     @Test
     public void testExceptionMapper() {
-        final Response resp = RESOURCES.getJerseyTest().target("test").request()
+        final Response resp = RESOURCES.target("test").request()
                 .post(Entity.json(""));
         assertThat(resp.getStatus()).isEqualTo(500);
         assertThat(resp.readEntity(String.class)).isEqualTo("Can't touch this");


### PR DESCRIPTION
Depending on the web test container passed to
`ResourceTestRule#setTestContainerFactory`, one would either invoke
`client()` or `getJerseyTest()`, which is inconvenient. The fix is to
standardize on a new method that can be used regardless of web test
container that also doesn't infringe on the law of Demeter (as the other
solution would be to rewrite all usage as using `getJerseyTest()`)