### PR TITLE
Add example of multipart forms test

### DIFF
--- a/docs/source/manual/forms.rst
+++ b/docs/source/manual/forms.rst
@@ -23,6 +23,44 @@ Then, in your application's ``initialize`` method, add a new ``MultiPartBundle``
         bootstrap.addBundle(new MultiPartBundle());
     }
 
+.. _man-forms-testing:
+
+Testing
+=======
+
+To test resources that utilize multi-part form features, one must add ``MultiPartFeature.class`` to
+the ``ResourceTestRule`` as a provider, and register it on the client like the following:
+
+.. code-block:: java
+
+    public class MultiPartTest {
+        @ClassRule
+        public static final ResourceTestRule resource = ResourceTestRule.builder()
+                .addProvider(MultiPartFeature.class)
+                .addResource(new TestResource())
+                .build();
+
+        @Test
+        public void testClientMultipart() {
+            final FormDataMultiPart multiPart = new FormDataMultiPart()
+                    .field("test-data", "Hello Multipart");
+            final String response = resource.target("/test")
+                    .register(MultiPartFeature.class)
+                    .request()
+                    .post(Entity.entity(multiPart, multiPart.getMediaType()), String.class);
+            assertThat(response).isEqualTo("Hello Multipart");
+        }
+
+        @Path("test")
+        public static class TestResource {
+            @POST
+            @Consumes(MediaType.MULTIPART_FORM_DATA)
+            public String post(@FormDataParam("test-data") String testData) {
+                return testData;
+            }
+        }
+    }
+
 More Information
 ================
 


### PR DESCRIPTION
Takes @psamsotha [comment](https://github.com/dropwizard/dropwizard/issues/1496#issuecomment-202352516) and adds it to the documentation as it failed my litmus test of a dropwizard feature that has testing documented 😋 

Docs will slightly change once #1778 is merged (use `target` instead of `client`), so feel free to merge in any order and I can make the appropriate change.