### PR TITLE
Remove dead code in the jackson provider

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProvider.java
@@ -1,15 +1,10 @@
 package io.dropwizard.jersey.jackson;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreType;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
 
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import java.io.IOException;
-import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
@@ -41,26 +36,6 @@ public class JacksonMessageBodyProvider extends JacksonJaxbJsonProvider {
                                Annotation[] annotations,
                                MediaType mediaType) {
         return isProvidable(type) && super.isWriteable(type, genericType, annotations, mediaType);
-    }
-
-    @Override
-    public Object readFrom(Class<Object> type,
-                           Type genericType,
-                           Annotation[] annotations,
-                           MediaType mediaType,
-                           MultivaluedMap<String, String> httpHeaders,
-                           InputStream entityStream) throws IOException {
-        try {
-            return super.readFrom(type, genericType, annotations, mediaType, httpHeaders, entityStream);
-        } catch (IOException e) {
-            if (e instanceof JsonProcessingException) {
-                throw e;
-            }
-
-            // Deserializing malformatted URLs, for instance, will result in an IOException so
-            // wrap in an exception we can handle
-            throw JsonMappingException.fromUnexpectedIOE(e);
-        }
     }
 
     private boolean isProvidable(Class<?> type) {


### PR DESCRIPTION
The previous workaround rendered useless by the changes in Jackson 2.8.3. 🎉 