### PR TITLE
Hibernate validator 5.3.0

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -22,6 +22,7 @@ v1.1.0: Unreleased
 * Use LoadingCache in CachingAuthenticator `#1615 <https://github.com/dropwizard/dropwizard/pull/1615>`_
 * Introduce CachingAuthorizer `#1639 <https://github.com/dropwizard/dropwizard/pull/1639>`_
 * Upgraded to Jackson 2.8.4 `#1775 <https://github.com/dropwizard/dropwizard/pull/1775>`_
+* Upgraded to Hibernate Validator 5.3.0.Final `#1782 <https://github.com/dropwizard/dropwizard/pull/1782>`_
 * Upgraded to Jetty 9.3.12.v20160915
 * Upgraded to tomcat-jdbc 8.5.6
 * Upgraded to Objenesis 2.4 `#1654 <https://github.com/dropwizard/dropwizard/pull/1654>`_

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -68,7 +68,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-validator</artifactId>
-                <version>5.2.4.Final</version>
+                <version>5.3.0.Final</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish</groupId>

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/DurationValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/DurationValidatorTest.java
@@ -69,9 +69,9 @@ public class DurationValidatorTest {
                             "outOfRange must be between 10 MINUTES and 30 MINUTES",
                             "tooBig must be less than or equal to 30 SECONDS",
                             "tooSmall must be greater than or equal to 30 SECONDS",
-                            "maxDurs[0] must be less than or equal to 30 SECONDS",
-                            "minDurs[0] must be greater than or equal to 30 SECONDS",
-                            "rangeDurs[0] must be between 10 MINUTES and 30 MINUTES");
+                            "maxDurs[0].<collection element> must be less than or equal to 30 SECONDS",
+                            "minDurs[0].<collection element> must be greater than or equal to 30 SECONDS",
+                            "rangeDurs[0].<collection element> must be between 10 MINUTES and 30 MINUTES");
         }
     }
 

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/OneOfValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/OneOfValidatorTest.java
@@ -53,7 +53,7 @@ public class OneOfValidatorTest {
         example.basicList = ImmutableList.of("four");
 
         assertThat(format(validator.validate(example)))
-            .containsOnly("basicList[0] must be one of [one, two, three]");
+            .containsOnly("basicList[0].<collection element> must be one of [one, two, three]");
     }
 
     @Test

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/PortRangeValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/PortRangeValidatorTest.java
@@ -79,6 +79,6 @@ public class PortRangeValidatorTest {
     public void rejectsInvalidPortsInList() {
         example.ports = ImmutableList.of(-1);
         assertThat(ConstraintViolations.format(validator.validate(example)))
-            .containsOnly("ports[0] must be between 1 and 65535");
+            .containsOnly("ports[0].<collection element> must be between 1 and 65535");
     }
 }

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/SizeValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/SizeValidatorTest.java
@@ -65,9 +65,9 @@ public class SizeValidatorTest {
                     .containsOnly("outOfRange must be between 10 KILOBYTES and 100 KILOBYTES",
                                   "tooBig must be less than or equal to 30 KILOBYTES",
                                   "tooSmall must be greater than or equal to 30 KILOBYTES",
-                                   "maxSize[0] must be less than or equal to 30 KILOBYTES",
-                                   "minSize[0] must be greater than or equal to 30 KILOBYTES",
-                                   "rangeSize[0] must be between 10 KILOBYTES and 100 KILOBYTES");
+                                   "maxSize[0].<collection element> must be less than or equal to 30 KILOBYTES",
+                                   "minSize[0].<collection element> must be greater than or equal to 30 KILOBYTES",
+                                   "rangeSize[0].<collection element> must be between 10 KILOBYTES and 100 KILOBYTES");
         }
     }
 


### PR DESCRIPTION
Only changes were related to validation annotations on types (#1586). Seems like the validation message was updated. Looks to be a step backwards, but it is as [documented](https://docs.jboss.org/hibernate/stable/validator/reference/en-US/html_single/#type-arguments-constraints) 😋 