### PR TITLE
Empty optional exception mapper

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/setup/ExceptionMapperBinder.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/ExceptionMapperBinder.java
@@ -3,6 +3,7 @@ package io.dropwizard.setup;
 import io.dropwizard.jersey.errors.EarlyEofExceptionMapper;
 import io.dropwizard.jersey.errors.LoggingExceptionMapper;
 import io.dropwizard.jersey.jackson.JsonProcessingExceptionMapper;
+import io.dropwizard.jersey.optional.EmptyOptionalExceptionMapper;
 import io.dropwizard.jersey.validation.JerseyViolationExceptionMapper;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 
@@ -26,6 +27,7 @@ public class ExceptionMapperBinder extends AbstractBinder {
         bind(new JerseyViolationExceptionMapper()).to(ExceptionMapper.class);
         bind(new JsonProcessingExceptionMapper(isShowDetails())).to(ExceptionMapper.class);
         bind(new EarlyEofExceptionMapper()).to(ExceptionMapper.class);
+        bind(new EmptyOptionalExceptionMapper()).to(ExceptionMapper.class);
     }
 
     public boolean isShowDetails() {

--- a/dropwizard-e2e/pom.xml
+++ b/dropwizard-e2e/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <prerequisites>
+        <maven>3.0.0</maven>
+    </prerequisites>
+
+    <artifactId>dropwizard-e2e</artifactId>
+    <version>1.1.0-SNAPSHOT</version>
+    <groupId>io.dropwizard</groupId>
+    <name>Dropwizard End-to-end Tests</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+
+        <!-- No need to deploy dropwizard-e2e -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.site.skip>true</maven.site.skip>
+        <maven.site.deploy.skip>true</maven.site.deploy.skip>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.dropwizard</groupId>
+                <artifactId>dropwizard-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-testing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-client</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <configuration>
+                            <rules>
+                                <DependencyConvergence />
+                            </rules>
+                        </configuration>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/dropwizard-e2e/src/main/java/com/example/app1/App1.java
+++ b/dropwizard-e2e/src/main/java/com/example/app1/App1.java
@@ -1,0 +1,25 @@
+package com.example.app1;
+
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.jersey.optional.EmptyOptionalException;
+import io.dropwizard.setup.Environment;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+public class App1 extends Application<Configuration> {
+    @Override
+    public void run(Configuration config, Environment env) throws Exception {
+        // Ensure that we can override the default 404 response on an
+        // empty optional and return a 204 instead
+        env.jersey().register(new ExceptionMapper<EmptyOptionalException>() {
+            @Override
+            public Response toResponse(EmptyOptionalException exception) {
+                return Response.noContent().build();
+            }
+        });
+
+        env.jersey().register(new App1Resource());
+    }
+}

--- a/dropwizard-e2e/src/main/java/com/example/app1/App1Resource.java
+++ b/dropwizard-e2e/src/main/java/com/example/app1/App1Resource.java
@@ -1,0 +1,14 @@
+package com.example.app1;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import java.util.OptionalInt;
+
+@Path("/")
+public class App1Resource {
+    @GET
+    @Path("empty-optional")
+    public OptionalInt emptyOptional() {
+        return OptionalInt.empty();
+    }
+}

--- a/dropwizard-e2e/src/test/java/com/example/app1/App1Test.java
+++ b/dropwizard-e2e/src/test/java/com/example/app1/App1Test.java
@@ -1,0 +1,28 @@
+package com.example.app1;
+
+import io.dropwizard.Configuration;
+import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class App1Test {
+    @ClassRule
+    public static final DropwizardAppRule<Configuration> RULE =
+        new DropwizardAppRule<>(App1.class, ResourceHelpers.resourceFilePath("app1/config.yml"));
+
+    @Test
+    public void custom204OnEmptyOptional() {
+        final Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("test client");
+        final String url = String.format("http://localhost:%d/empty-optional", RULE.getLocalPort());
+
+        final Response response = client.target(url).request().get();
+        assertThat(response.getStatus()).isEqualTo(204);
+    }
+}

--- a/dropwizard-e2e/src/test/resources/app1/config.yml
+++ b/dropwizard-e2e/src/test/resources/app1/config.yml
@@ -1,0 +1,7 @@
+server:
+  applicationConnectors:
+    - type: http
+      port: 0
+  adminConnectors:
+    - type: http
+      port: 0

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
@@ -7,6 +7,7 @@ import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.errors.ErrorMessage;
 import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
+import io.dropwizard.jersey.optional.EmptyOptionalExceptionMapper;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import io.dropwizard.logging.BootstrapLogging;
 import io.dropwizard.setup.Environment;
@@ -130,6 +131,7 @@ public class JerseyIntegrationTest extends JerseyTest {
         config.register(new PersonResource(new PersonDAO(sessionFactory)));
         config.register(new JacksonMessageBodyProvider(Jackson.newObjectMapper()));
         config.register(new DataExceptionMapper());
+        config.register(new EmptyOptionalExceptionMapper());
 
         return config;
     }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/guava/OptionalMessageBodyWriter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/guava/OptionalMessageBodyWriter.java
@@ -1,10 +1,10 @@
 package io.dropwizard.jersey.guava;
 
 import com.google.common.base.Optional;
+import io.dropwizard.jersey.optional.EmptyOptionalException;
 import org.glassfish.jersey.message.MessageBodyWorkers;
 
 import javax.inject.Inject;
-import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
@@ -47,7 +47,7 @@ public class OptionalMessageBodyWriter implements MessageBodyWriter<Optional<?>>
                         OutputStream entityStream)
             throws IOException {
         if (!entity.isPresent()) {
-            throw new NotFoundException();
+            throw EmptyOptionalException.INSTANCE;
         }
 
         final ParameterizedType actualGenericType = (ParameterizedType) genericType;

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/EmptyOptionalException.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/EmptyOptionalException.java
@@ -1,0 +1,11 @@
+package io.dropwizard.jersey.optional;
+
+/**
+ * An exception thrown when a resource endpoint attempts to write out an
+ * optional that is empty.
+ */
+public class EmptyOptionalException extends RuntimeException {
+    public static final EmptyOptionalException INSTANCE = new EmptyOptionalException();
+
+    private EmptyOptionalException() { }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/EmptyOptionalExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/EmptyOptionalExceptionMapper.java
@@ -1,0 +1,15 @@
+package io.dropwizard.jersey.optional;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+/**
+ * The default response when an empty optional is returned, is to respond with
+ * a 404 NOT FOUND response.
+ */
+public class EmptyOptionalExceptionMapper implements ExceptionMapper<EmptyOptionalException> {
+    @Override
+    public Response toResponse(EmptyOptionalException exception) {
+        return Response.status(Response.Status.NOT_FOUND).build();
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalDoubleMessageBodyWriter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalDoubleMessageBodyWriter.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey.optional;
 
-import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
@@ -37,7 +36,7 @@ public class OptionalDoubleMessageBodyWriter implements MessageBodyWriter<Option
                         MultivaluedMap<String, Object> httpHeaders,
                         OutputStream entityStream) throws IOException {
         if (!entity.isPresent()) {
-            throw new NotFoundException();
+            throw EmptyOptionalException.INSTANCE;
         }
 
         entityStream.write(Double.toString(entity.getAsDouble()).getBytes(StandardCharsets.US_ASCII));

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalIntMessageBodyWriter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalIntMessageBodyWriter.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey.optional;
 
-import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
@@ -37,7 +36,7 @@ public class OptionalIntMessageBodyWriter implements MessageBodyWriter<OptionalI
                         MultivaluedMap<String, Object> httpHeaders,
                         OutputStream entityStream) throws IOException {
         if (!entity.isPresent()) {
-            throw new NotFoundException();
+            throw EmptyOptionalException.INSTANCE;
         }
 
         entityStream.write(Integer.toString(entity.getAsInt()).getBytes(StandardCharsets.US_ASCII));

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalLongMessageBodyWriter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalLongMessageBodyWriter.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey.optional;
 
-import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
@@ -36,7 +35,7 @@ public class OptionalLongMessageBodyWriter implements MessageBodyWriter<Optional
                         MultivaluedMap<String, Object> httpHeaders,
                         OutputStream entityStream) throws IOException {
         if (!entity.isPresent()) {
-            throw new NotFoundException();
+            throw EmptyOptionalException.INSTANCE;
         }
 
         entityStream.write(Long.toString(entity.getAsLong()).getBytes(StandardCharsets.US_ASCII));

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalMessageBodyWriter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalMessageBodyWriter.java
@@ -3,7 +3,6 @@ package io.dropwizard.jersey.optional;
 import org.glassfish.jersey.message.MessageBodyWorkers;
 
 import javax.inject.Inject;
-import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
@@ -47,7 +46,7 @@ public class OptionalMessageBodyWriter implements MessageBodyWriter<Optional<?>>
                         OutputStream entityStream)
             throws IOException {
         if (!entity.isPresent()) {
-            throw new NotFoundException();
+            throw EmptyOptionalException.INSTANCE;
         }
 
         final Type innerGenericType = (genericType instanceof ParameterizedType) ?

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalMessageBodyWriterTest.java
@@ -3,6 +3,7 @@ package io.dropwizard.jersey.guava;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Optional;
 import io.dropwizard.jersey.DropwizardResourceConfig;
+import io.dropwizard.jersey.optional.EmptyOptionalExceptionMapper;
 import io.dropwizard.logging.BootstrapLogging;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.TestProperties;
@@ -30,6 +31,7 @@ public class OptionalMessageBodyWriterTest extends JerseyTest {
     protected Application configure() {
         forceSet(TestProperties.CONTAINER_PORT, "0");
         return DropwizardResourceConfig.forTesting(new MetricRegistry())
+                .register(new EmptyOptionalExceptionMapper())
                 .register(OptionalReturnResource.class);
     }
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalDoubleMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalDoubleMessageBodyWriterTest.java
@@ -31,7 +31,8 @@ public class OptionalDoubleMessageBodyWriterTest extends JerseyTest {
     protected Application configure() {
         forceSet(TestProperties.CONTAINER_PORT, "0");
         return DropwizardResourceConfig.forTesting(new MetricRegistry())
-                .register(OptionalDoubleReturnResource.class);
+                    .register(new EmptyOptionalExceptionMapper())
+                    .register(OptionalDoubleReturnResource.class);
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalIntMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalIntMessageBodyWriterTest.java
@@ -31,6 +31,7 @@ public class OptionalIntMessageBodyWriterTest extends JerseyTest {
     protected Application configure() {
         forceSet(TestProperties.CONTAINER_PORT, "0");
         return DropwizardResourceConfig.forTesting(new MetricRegistry())
+                .register(new EmptyOptionalExceptionMapper())
                 .register(OptionalIntReturnResource.class);
     }
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalLongMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalLongMessageBodyWriterTest.java
@@ -31,6 +31,7 @@ public class OptionalLongMessageBodyWriterTest extends JerseyTest {
     protected Application configure() {
         forceSet(TestProperties.CONTAINER_PORT, "0");
         return DropwizardResourceConfig.forTesting(new MetricRegistry())
+                .register(new EmptyOptionalExceptionMapper())
                 .register(OptionalLongReturnResource.class);
     }
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalMessageBodyWriterTest.java
@@ -31,6 +31,7 @@ public class OptionalMessageBodyWriterTest extends JerseyTest {
     protected Application configure() {
         forceSet(TestProperties.CONTAINER_PORT, "0");
         return DropwizardResourceConfig.forTesting(new MetricRegistry())
+                .register(new EmptyOptionalExceptionMapper())
                 .register(OptionalReturnResource.class);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <module>dropwizard-benchmarks</module>
         <module>dropwizard-http2</module>
         <module>dropwizard-request-logging</module>
+        <module>dropwizard-e2e</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
Another implementation of #1732, but using exceptionmappers, which now have a lower code tax due to #1768. By default, backwards compatibility is preserved with the ability to easily remap it to a 204.

The shape of the custom exception (`EmptyOptionalException`) inspired by netty's [ReadTimeoutException](https://github.com/netty/netty/blob/cfa5b85075f9f3a74e7eb46e344f44775dbcea57/handler/src/main/java/io/netty/handler/timeout/ReadTimeoutException.java) to be a lightweight exception, as 204's may be a normal state and shouldn't be treated exceptionally.

Maybe controversial, but I've decided to add another submodule, dropwizard-e2e (end-to-end). It's like dropwizard-example except that it is meant to hold multiple `Applications`, as it's possible that a single example application can't represent all options especially if some are conflicting. It also presents another avenue for tests that ensure unit + integration tests work. If others want to verify it looks correct, it'd be much appreciated.

Closes #1727

cc original author: @qinfchen 

I can update the release notes once this is merged.