### PR TITLE
Allow user to override configured JsonProvider

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.jersey.gzip.ConfiguredGZipEncoder;
 import io.dropwizard.jersey.gzip.GZipDecoder;
-import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
+import io.dropwizard.jersey.jackson.JacksonBinder;
 import io.dropwizard.jersey.validation.HibernateValidationFeature;
 import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.lifecycle.Managed;
@@ -403,7 +403,7 @@ public class JerseyClientBuilder {
             config.register(provider);
         }
 
-        config.register(new JacksonMessageBodyProvider(objectMapper));
+        config.register(new JacksonBinder(objectMapper));
         config.register(new HibernateValidationFeature(validator));
 
         for (Map.Entry<String, Object> property : this.properties.entrySet()) {

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
@@ -8,7 +8,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import io.dropwizard.jersey.gzip.ConfiguredGZipEncoder;
 import io.dropwizard.jersey.gzip.GZipDecoder;
-import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
 import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.lifecycle.setup.ExecutorServiceBuilder;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
@@ -154,12 +153,6 @@ public class JerseyClientBuilderTest {
     }
 
     @Test
-    public void usesTheObjectMapperForJson() throws Exception {
-        final Client client = builder.using(executorService, objectMapper).build("test");
-        assertThat(client.getConfiguration().isRegistered(JacksonMessageBodyProvider.class)).isTrue();
-    }
-
-    @Test
     public void createsAnRxEnabledClient() throws Exception {
         final RxClient<RxCompletionStageInvoker> client =
             builder.using(executorService, objectMapper)
@@ -224,13 +217,6 @@ public class JerseyClientBuilderTest {
         assertThat(Iterables.filter(client.getConfiguration().getInstances(), ConfiguredGZipEncoder.class)
                 .iterator().hasNext()).isFalse();
         verify(apacheHttpClientBuilder).disableContentCompression(true);
-    }
-
-    @Test
-    public void usesAnObjectMapperFromTheEnvironment() throws Exception {
-        final Client client = builder.using(environment).build("test");
-
-        assertThat(client.getConfiguration().isRegistered(JacksonMessageBodyProvider.class)).isTrue();
     }
 
     @Test

--- a/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Joiner;
 import com.google.common.io.Resources;
 import io.dropwizard.jersey.filter.AllowedMethodsFilter;
-import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
+import io.dropwizard.jersey.jackson.JacksonBinder;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
 import io.dropwizard.jersey.validation.HibernateValidationFeature;
 import io.dropwizard.jetty.GzipHandlerFactory;
@@ -498,7 +498,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
             if (jerseyRootPath.isPresent()) {
                 jersey.setUrlPattern(jerseyRootPath.get());
             }
-            jersey.register(new JacksonMessageBodyProvider(objectMapper));
+            jersey.register(new JacksonBinder(objectMapper));
             jersey.register(new HibernateValidationFeature(validator));
             if (registerDefaultExceptionMappers == null || registerDefaultExceptionMappers) {
                 jersey.register(new ExceptionMapperBinder(detailedJsonProcessingExceptionMapper));

--- a/dropwizard-e2e/src/main/java/com/example/app1/App1.java
+++ b/dropwizard-e2e/src/main/java/com/example/app1/App1.java
@@ -1,25 +1,25 @@
 package com.example.app1;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-
 import com.github.mustachejava.MustacheNotFoundException;
-
+import com.google.common.base.Throwables;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.jersey.optional.EmptyOptionalException;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
-import io.dropwizard.views.ViewRenderException;
+import org.glassfish.jersey.spi.ExtendedExceptionMapper;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
 
 public class App1 extends Application<Configuration> {
     @Override
     public void initialize(Bootstrap<Configuration> bootstrap) {
-        bootstrap.addBundle(new ViewBundle<Configuration>());
+        bootstrap.addBundle(new ViewBundle<>());
     }
-    
+
     @Override
     public void run(Configuration config, Environment env) throws Exception {
         // Ensure that we can override the default 404 response on an
@@ -30,20 +30,23 @@ public class App1 extends Application<Configuration> {
                 return Response.noContent().build();
             }
         });
-        
+
         // Ensure that we can override the 503 response of a view that refers to
         // a missing Mustache template and return a 404 instead
-        env.jersey().register(new ExceptionMapper<WebApplicationException>() {
+        env.jersey().register(new ExtendedExceptionMapper<WebApplicationException>() {
             @Override
             public Response toResponse(WebApplicationException exception) {
-                if (exception.getCause() instanceof ViewRenderException
-                        && exception.getCause().getCause() instanceof MustacheNotFoundException) {
-                    return Response.status(Response.Status.NOT_FOUND).build();
-                }
-                return exception.getResponse();
+                return Response.status(Response.Status.NOT_FOUND).build();
+            }
+
+            @Override
+            public boolean isMappable(WebApplicationException e) {
+                return Throwables.getRootCause(e).getClass() == MustacheNotFoundException.class;
             }
         });
 
         env.jersey().register(new App1Resource());
+        env.jersey().register(new CustomJsonProvider(env.getObjectMapper()));
+        env.jersey().register(new CustomClassBodyWriter());
     }
 }

--- a/dropwizard-e2e/src/main/java/com/example/app1/App1Resource.java
+++ b/dropwizard-e2e/src/main/java/com/example/app1/App1Resource.java
@@ -2,24 +2,44 @@ package com.example.app1;
 
 import java.util.OptionalInt;
 
+import com.google.common.collect.ImmutableMap;
+
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 
 import io.dropwizard.views.View;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 
 @Path("/")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
 public class App1Resource {
     @GET
     @Path("empty-optional")
     public OptionalInt emptyOptional() {
         return OptionalInt.empty();
     }
-    
+
     @GET
     @Path("view-with-missing-tpl")
+    @Produces(MediaType.TEXT_HTML)
     public View getMissingTemplateView() {
-        return new View("not-found.mustache") {  
+        return new View("not-found.mustache") {
         };
     }
-    
+
+    @POST
+    @Path("mapper")
+    public ImmutableMap<String, String> postMapper(ImmutableMap<String, String> map) {
+        return ImmutableMap.<String, String>builder().putAll(map).put("hello", "world").build();
+    }
+
+    @GET
+    @Path("custom-class")
+    public CustomClass newCustomClass() {
+        return new CustomClass();
+    }
 }

--- a/dropwizard-e2e/src/main/java/com/example/app1/CustomClass.java
+++ b/dropwizard-e2e/src/main/java/com/example/app1/CustomClass.java
@@ -1,0 +1,4 @@
+package com.example.app1;
+
+public class CustomClass {
+}

--- a/dropwizard-e2e/src/main/java/com/example/app1/CustomClassBodyWriter.java
+++ b/dropwizard-e2e/src/main/java/com/example/app1/CustomClassBodyWriter.java
@@ -1,0 +1,47 @@
+package com.example.app1;
+
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+
+/** Demonstration that one can provider their own message body writers (see issue #1005) */
+@Produces(MediaType.APPLICATION_JSON)
+public class CustomClassBodyWriter implements MessageBodyWriter<CustomClass> {
+    private final static byte[] RESPONSE = "I'm a custom class".getBytes(StandardCharsets.UTF_8);
+
+    @Override
+    public boolean isWriteable(Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType) {
+        return true;
+    }
+
+    @Override
+    public long getSize(
+        CustomClass customClass,
+        Class<?> aClass,
+        Type type,
+        Annotation[] annotations,
+        MediaType mediaType
+    ) {
+        return RESPONSE.length;
+    }
+
+    @Override
+    public void writeTo(
+        CustomClass customClass,
+        Class<?> aClass,
+        Type type,
+        Annotation[] annotations,
+        MediaType mediaType,
+        MultivaluedMap<String, Object> multivaluedMap,
+        OutputStream outputStream
+    ) throws IOException, WebApplicationException {
+        outputStream.write(RESPONSE);
+    }
+}

--- a/dropwizard-e2e/src/main/java/com/example/app1/CustomJsonProvider.java
+++ b/dropwizard-e2e/src/main/java/com/example/app1/CustomJsonProvider.java
@@ -1,0 +1,61 @@
+package com.example.app1;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+/** Custom JSON reader and writer that will write a leading HEADER to the JSON output */
+public class CustomJsonProvider extends JacksonJaxbJsonProvider {
+    private static final String HEADER = "/** A Dropwizard specialty */\n";
+    private static final byte[] HEADER_BYTES = HEADER.getBytes(StandardCharsets.UTF_8);
+
+    public CustomJsonProvider(ObjectMapper mapper) {
+        setMapper(mapper);
+    }
+
+    @Override
+    public void writeTo(
+        Object value,
+        Class<?> type,
+        Type genericType,
+        Annotation[] annotations,
+        MediaType mediaType,
+        MultivaluedMap<String, Object> httpHeaders,
+        OutputStream entityStream
+    ) throws IOException {
+        entityStream.write(HEADER_BYTES);
+        super.writeTo(value, type, genericType, annotations, mediaType, httpHeaders, entityStream);
+    }
+
+    @Override
+    public Object readFrom(
+        Class<Object> type,
+        Type genericType,
+        Annotation[] annotations,
+        MediaType mediaType,
+        MultivaluedMap<String, String> httpHeaders,
+        InputStream entityStream
+    ) throws IOException {
+        // Attempt to consume our special header from the input so downstream
+        // deserializer don't have to deal with the header
+        final byte[] ent = new byte[HEADER_BYTES.length];
+        final int read = entityStream.read(ent);
+
+        // If our super awesome header is not encountered, you shall not pass
+        if (read != ent.length || !Objects.deepEquals(ent, HEADER_BYTES)) {
+            throw new WebApplicationException("Super special header not encountered", 400);
+        }
+
+        return super.readFrom(type, genericType, annotations, mediaType, httpHeaders, entityStream);
+    }
+}

--- a/dropwizard-e2e/src/test/java/com/example/app1/App1Test.java
+++ b/dropwizard-e2e/src/test/java/com/example/app1/App1Test.java
@@ -1,39 +1,102 @@
 package com.example.app1;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import javax.ws.rs.client.Client;
-import javax.ws.rs.core.Response;
-
+import com.google.common.collect.ImmutableMap;
+import io.dropwizard.Configuration;
+import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import io.dropwizard.Configuration;
-import io.dropwizard.client.JerseyClientBuilder;
-import io.dropwizard.testing.ResourceHelpers;
-import io.dropwizard.testing.junit.DropwizardAppRule;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Response;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 public class App1Test {
     @ClassRule
     public static final DropwizardAppRule<Configuration> RULE =
         new DropwizardAppRule<>(App1.class, ResourceHelpers.resourceFilePath("app1/config.yml"));
 
+    private static Client client;
+
+    @BeforeClass
+    public static void setup() {
+        client = new JerseyClientBuilder(RULE.getEnvironment())
+            .withProvider(new CustomJsonProvider(Jackson.newObjectMapper()))
+            .build("test client");
+    }
+
     @Test
     public void custom204OnEmptyOptional() {
         final Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("test client 1");
         final String url = String.format("http://localhost:%d/empty-optional", RULE.getLocalPort());
-
         final Response response = client.target(url).request().get();
         assertThat(response.getStatus()).isEqualTo(204);
     }
-    
+
     @Test
     public void custom404OnViewRenderMissingMustacheTemplate() {
         final Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("test client 2");
         final String url = String.format("http://localhost:%d/view-with-missing-tpl", RULE.getLocalPort());
 
         final Response response = client.target(url).request().get();
-        assertThat(response.getStatus()).isEqualTo(404);        
+        assertThat(response.getStatus()).isEqualTo(404);
     }
-    
+
+    @Test
+    public void customJsonProvider() {
+        final String url = String.format("http://localhost:%d/mapper", RULE.getLocalPort());
+        final String response = client.target(url)
+            .request()
+            .post(Entity.json("/** A Dropwizard specialty */\n{\"check\": \"mate\"}"), String.class);
+        assertThat(response).isEqualTo("/** A Dropwizard specialty */\n" +
+            "{\"check\":\"mate\",\"hello\":\"world\"}");
+    }
+
+    @Test
+    public void customJsonProviderMissingHeader() {
+        final String url = String.format("http://localhost:%d/mapper", RULE.getLocalPort());
+        final Response response = client.target(url)
+            .request()
+            .post(Entity.json("{\"check\": \"mate\"}"));
+        assertThat(response.getStatus()).isEqualTo(400);
+    }
+
+    @Test
+    public void customJsonProviderClient() {
+        final String url = String.format("http://localhost:%d/mapper", RULE.getLocalPort());
+        final String response = client.target(url)
+            .request()
+            .post(Entity.json(ImmutableMap.of("check", "mate")), String.class);
+        assertThat(response).isEqualTo("/** A Dropwizard specialty */\n" +
+            "{\"check\":\"mate\",\"hello\":\"world\"}");
+    }
+
+    @Test
+    public void customJsonProviderRoundtrip() {
+        final String url = String.format("http://localhost:%d/mapper", RULE.getLocalPort());
+        final GenericType<Map<String, String>> typ = new GenericType<Map<String, String>>() {
+        };
+
+        final Map<String, String> response = client.target(url)
+            .request()
+            .post(Entity.json(ImmutableMap.of("check", "mate")), typ);
+        assertThat(response).containsExactly(entry("check", "mate"), entry("hello", "world"));
+    }
+
+    @Test
+    public void customBodyWriterTest() {
+        final String url = String.format("http://localhost:%d/custom-class", RULE.getLocalPort());
+        final String response = client.target(url)
+            .request()
+            .get(String.class);
+        assertThat(response).isEqualTo("I'm a custom class");
+    }
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JacksonBinder.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JacksonBinder.java
@@ -1,0 +1,25 @@
+package io.dropwizard.jersey.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+
+/**
+ * An HK2 binder that registers the Jackson JSON provider while allowing users to override.
+ */
+public class JacksonBinder extends AbstractBinder {
+    private final ObjectMapper mapper;
+
+    public JacksonBinder(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    protected void configure() {
+        final JacksonMessageBodyProvider jsonProvider = new JacksonMessageBodyProvider(mapper);
+        bind(jsonProvider).to(MessageBodyWriter.class);
+        bind(jsonProvider).to(MessageBodyReader.class);
+    }
+}

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardTestResourceConfig.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardTestResourceConfig.java
@@ -2,7 +2,7 @@ package io.dropwizard.testing.junit;
 
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.DropwizardResourceConfig;
-import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
+import io.dropwizard.jersey.jackson.JacksonBinder;
 import io.dropwizard.jersey.validation.HibernateValidationFeature;
 import io.dropwizard.setup.ExceptionMapperBinder;
 import org.glassfish.jersey.server.ServerProperties;
@@ -41,7 +41,7 @@ class DropwizardTestResourceConfig extends DropwizardResourceConfig {
         for (Map.Entry<String, Object> property : configuration.properties.entrySet()) {
             property(property.getKey(), property.getValue());
         }
-        register(new JacksonMessageBodyProvider(configuration.mapper));
+        register(new JacksonBinder(configuration.mapper));
         register(new HibernateValidationFeature(configuration.validator));
         for (Object singleton : configuration.singletons) {
             register(singleton);


### PR DESCRIPTION
I wondered if I could create a custom JsonProvider where I could read and write a special payload at the top the body (don't ask why, it's just a thought experiment):

``` json
/* I'm a special header */
{
    "check": "mate"
}
```

This PR allows a user configured `JacksonJaxbJsonProvider` or another appropriate class to take priority over the dropwizard configured class (`JacksonMessageBodyProvider`).

I believe this PR closes #1005

@jplock I used App1 in dropwizard-e2e, not sure if it is too early to call it a theme, but so far it is about overriding defaults 😋 
