### PR TITLE
Bump jetty

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -24,7 +24,7 @@ v1.1.0: Unreleased
 * Introduce CachingAuthorizer `#1639 <https://github.com/dropwizard/dropwizard/pull/1639>`_
 * Upgraded to Jackson 2.8.4 `#1775 <https://github.com/dropwizard/dropwizard/pull/1775>`_
 * Upgraded to Hibernate Validator 5.3.0.Final `#1782 <https://github.com/dropwizard/dropwizard/pull/1782>`_
-* Upgraded to Jetty 9.3.12.v20160915
+* Upgraded to Jetty 9.3.13.v20161014 `#1790 <https://github.com/dropwizard/dropwizard/pull/1790>`_
 * Upgraded to tomcat-jdbc 8.5.6
 * Upgraded to Objenesis 2.4 `#1654 <https://github.com/dropwizard/dropwizard/pull/1654>`_
 * Upgraded to AssertJ 3.5.2 `#1654 <https://github.com/dropwizard/dropwizard/pull/1654>`_

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -25,7 +25,7 @@
         <guava.version>19.0</guava.version>
         <jersey.version>2.23.2</jersey.version>
         <jackson.version>2.8.4</jackson.version>
-        <jetty.version>9.3.12.v20160915</jetty.version>
+        <jetty.version>9.3.13.v20161014</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics3.version>3.1.2</metrics3.version>
         <slf4j.version>1.7.21</slf4j.version>


### PR DESCRIPTION
The [release notes are pretty small](https://github.com/eclipse/jetty.project/blob/206122756f8988cf9e5abf4a4b4da83a3a562e07/VERSION.txt#L3-L22), but contain an important snippet:

> Support certificates hot reload

Which'll set the ground for better integration with Let's Encrypt (for instance), for those eschewing tls termination proxies.

Just wanted to point it out, as, in the future, I may be tinkering with it a bit 😄 