### PR TITLE
Log WebApplicationException redirects

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/LoggingExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/LoggingExceptionMapper.java
@@ -23,6 +23,7 @@ public abstract class LoggingExceptionMapper<E extends Throwable> implements Exc
             final Response response = ((WebApplicationException) exception).getResponse();
             Response.Status.Family family = response.getStatusInfo().getFamily();
             if (family.equals(Response.Status.Family.REDIRECTION)) {
+                logException(exception);
                 return response;
             }
             if (family.equals(Response.Status.Family.SERVER_ERROR)) {


### PR DESCRIPTION
Example use case: log OAuth2 errors. 