### PR TITLE
Use correct alpn-boot for jdk8_u112

### DIFF
--- a/dropwizard-http2/pom.xml
+++ b/dropwizard-http2/pom.xml
@@ -303,7 +303,7 @@
                 <jdk>1.8.0_112</jdk>
             </activation>
             <properties>
-                <alpn-boot.version>8.1.9.v20160720</alpn-boot.version>
+                <alpn-boot.version>8.1.10.v20161026</alpn-boot.version>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
Taken from [jetty's pom](https://github.com/eclipse/jetty.project/blob/338e924a5d8f0ce8589a788a85cdc53b20f92030/pom.xml#L1185)