### PR TITLE
Add support for configuring the blocking timeout for Jetty connectors

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -303,6 +303,9 @@ idleTimeout              30 seconds          The maximum idle time for a connect
                                              or when waiting for a new message to be sent on a connection.
                                              This value is interpreted as the maximum time between some progress being made on the
                                              connection. So if a single byte is read or written, then the timeout is reset.
+blockingTimeout          (none)              The timeout applied to blocking operations. This timeout is in addition to
+                                             the `idleTimeout`, and applies to the total operation (as opposed to the
+                                             idle timeout that applies to the time no data is being sent).
 minBufferPoolSize        64 bytes            The minimum size of the buffer pool.
 bufferPoolIncrement      1KiB                The increment by which the buffer pool should be increased.
 maxBufferPoolSize        64KiB               The maximum size of the buffer pool.

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
@@ -116,6 +116,14 @@ import static com.codahale.metrics.MetricRegistry.name;
  *         </td>
  *     </tr>
  *     <tr>
+ *         <td>{@code blockingTimeout}</td>
+ *         <td>(none)</td>
+ *         <td>The timeout applied to blocking operations. This timeout is in addition to the {@code idleTimeout},
+ *             and applies to the total operation (as opposed to the idle timeout that applies to the time no data
+ *             is being sent).
+ *          </td>
+ *     </tr>
+ *     <tr>
  *         <td>{@code minBufferPoolSize}</td>
  *         <td>64 bytes</td>
  *         <td>The minimum size of the buffer pool.</td>
@@ -219,6 +227,8 @@ public class HttpConnectorFactory implements ConnectorFactory {
     @NotNull
     @MinDuration(value = 1, unit = TimeUnit.MILLISECONDS)
     private Duration idleTimeout = Duration.seconds(30);
+
+    private Duration blockingTimeout = null;
 
     @NotNull
     @MinSize(value = 1, unit = SizeUnit.BYTES)
@@ -335,6 +345,16 @@ public class HttpConnectorFactory implements ConnectorFactory {
     @JsonProperty
     public void setIdleTimeout(Duration idleTimeout) {
         this.idleTimeout = idleTimeout;
+    }
+
+    @JsonProperty
+    public Duration getBlockingTimeout() {
+        return blockingTimeout;
+    }
+
+    @JsonProperty
+    public void setBlockingTimeout(Duration blockingTimeout) {
+        this.blockingTimeout = blockingTimeout;
     }
 
     @JsonProperty
@@ -526,6 +546,9 @@ public class HttpConnectorFactory implements ConnectorFactory {
 
         if (useForwardedHeaders) {
             httpConfig.addCustomizer(new ForwardedRequestCustomizer());
+        }
+        if (blockingTimeout != null) {
+            httpConfig.setBlockingTimeout(blockingTimeout.toMilliseconds());
         }
         return httpConfig;
     }

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
@@ -74,6 +74,7 @@ public class HttpConnectorFactoryTest {
         assertThat(http.isUseServerHeader()).isFalse();
         assertThat(http.isUseDateHeader()).isTrue();
         assertThat(http.isUseForwardedHeaders()).isTrue();
+        assertThat(http.getBlockingTimeout()).isNull();
     }
 
     @Test
@@ -102,6 +103,7 @@ public class HttpConnectorFactoryTest {
         assertThat(http.isUseServerHeader()).isTrue();
         assertThat(http.isUseDateHeader()).isFalse();
         assertThat(http.isUseForwardedHeaders()).isFalse();
+        assertThat(http.getBlockingTimeout()).isEqualTo(Duration.seconds(30));
     }
 
     @Test
@@ -112,6 +114,7 @@ public class HttpConnectorFactoryTest {
         http.setSelectorThreads(2);
         http.setAcceptQueueSize(1024);
         http.setSoLingerTime(Duration.seconds(30));
+        http.setBlockingTimeout(Duration.minutes(1));
 
         Server server = new Server();
         MetricRegistry metrics = new MetricRegistry();
@@ -158,6 +161,7 @@ public class HttpConnectorFactoryTest {
         assertThat(httpConfiguration.getSendDateHeader()).isTrue();
         assertThat(httpConfiguration.getSendServerVersion()).isFalse();
         assertThat(httpConfiguration.getCustomizers()).hasAtLeastOneElementOfType(ForwardedRequestCustomizer.class);
+        assertThat(httpConfiguration.getBlockingTimeout()).isEqualTo(60000L);
 
         connector.stop();
         server.stop();

--- a/dropwizard-jetty/src/test/resources/yaml/http-connector.yml
+++ b/dropwizard-jetty/src/test/resources/yaml/http-connector.yml
@@ -8,6 +8,7 @@ maxRequestHeaderSize: 4KiB
 maxResponseHeaderSize: 4KiB
 inputBufferSize: 4KiB
 idleTimeout: 10 seconds
+blockingTimeout: 30 seconds
 minBufferPoolSize: 128B
 bufferPoolIncrement: 500B
 maxBufferPoolSize: 32KiB


### PR DESCRIPTION
The issue reported in #1794.

Jetty 9.3.2.v20150730 introduced a new option for the configuration of HTTP connection factories. The option is called `blockingTimeout` and allows to configure the timeout which applies to all blocking operations in addition to `idleTimeout`. The rationale behind it is to allow to set a timeout
for blocking operations which perform I/O activity, but with a slow rate (for example serving a big static file). Such tasks won't exhaust the pool of worker threads which should improve the QoS for a Jetty server.

See:
https://dev.eclipse.org/mhonarc/lists/jetty-announce/msg00085.html
https://bugs.eclipse.org/bugs/show_bug.cgi?id=472621