### PR TITLE
Enhanced the logging mechanism of registered endpoints in DropwizardR…

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -26,7 +26,11 @@ import javax.ws.rs.Path;
 import javax.ws.rs.ext.Provider;
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
-import java.util.*;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeSet;
 
 public class DropwizardResourceConfig extends ResourceConfig {
     private static final Logger LOGGER = LoggerFactory.getLogger(DropwizardResourceConfig.class);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
@@ -144,6 +144,15 @@ public class DropwizardResourceConfigTest {
         
         assertThat(rc.getEndpointsInfo()).isEqualTo(expectedLog);
     }
+    
+    @Test
+    public void testEndpointLoggerPathCleaning() {
+        String dirtyPath = " /this//is///a/dirty//path/     ";
+        String anotherDirtyPath = "a/l//p/h/  /a/b /////  e/t";
+        
+        assertThat(rc.cleanUpPath(dirtyPath)).isEqualTo("/this/is/a/dirty/path/");
+        assertThat(rc.cleanUpPath(anotherDirtyPath)).isEqualTo("a/l/p/h/a/b/e/t");
+    }
 
     @Test
     public void duplicatePathsTest() {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
@@ -3,6 +3,7 @@ package io.dropwizard.jersey;
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.dummy.DummyResource;
 import io.dropwizard.logging.BootstrapLogging;
+import org.glassfish.jersey.server.model.Resource;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -121,6 +122,27 @@ public class DropwizardResourceConfigTest {
                 .contains("    GET     /wrapper/bar (io.dropwizard.jersey.DropwizardResourceConfigTest.ResourcePathOnMethodLevel)")
                 .contains("    GET     /locator/bar (io.dropwizard.jersey.DropwizardResourceConfigTest.ResourcePathOnMethodLevel)")
                 .contains("    UNKNOWN /obj/{it} (java.lang.Object)");
+    }
+    
+    @Test
+    public void logsProgrammaticalEndpoints() {
+        Resource.Builder resourceBuilder = Resource.builder("/prefix");
+        resourceBuilder.addChildResource(Resource.from(DummyResource.class));
+        resourceBuilder.addChildResource(Resource.from(TestResource.class));
+        resourceBuilder.addChildResource(Resource.from(ImplementingResource.class));
+        
+        rc.registerResources(resourceBuilder.build());
+        
+        final String expectedLog = String.format(
+                "The following paths were found for the configured resources:%n"
+                + "%n"
+                + "    GET     /prefix/ (io.dropwizard.jersey.dummy.DummyResource)%n"
+                + "    GET     /prefix/another (io.dropwizard.jersey.DropwizardResourceConfigTest.ImplementingResource)%n"
+                + "    GET     /prefix/async (io.dropwizard.jersey.dummy.DummyResource)%n"
+                + "    GET     /prefix/dummy (io.dropwizard.jersey.DropwizardResourceConfigTest.TestResource)%n"
+        );
+        
+        assertThat(rc.getEndpointsInfo()).isEqualTo(expectedLog);
     }
 
     @Test


### PR DESCRIPTION
…esourceConfig.

With the enclosed changes, the logger also processes programatically added Resources which group other resources together.
This differs from the previous implementation where only the directly added Resource classes were logged.

This pull request accompanies this issue: [#1803](https://github.com/dropwizard/dropwizard/issues/1803)