### PR TITLE
Update DropWizard 1.0.x to Jersey 2.23.2.

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -23,7 +23,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <dropwizard.version>${project.version}</dropwizard.version>
         <guava.version>19.0</guava.version>
-        <jersey.version>2.23.1</jersey.version>
+        <jersey.version>2.23.2</jersey.version>
         <jackson.api.version>2.7.8</jackson.api.version>
         <jackson.version>2.7.8</jackson.version>
         <jetty.version>9.3.9.v20160517</jetty.version>


### PR DESCRIPTION
Update DropWizard 1.0.x to the latest patch release of Jersey 2.23 in
order to pick up HK2 fixes from HK2 2.5.

Fixes #1807.