### PR TITLE
Bring back request logging with logback-classic

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -10,6 +10,7 @@ v1.0.4
 ==================
 
 * Upgraded to Jersey 2.23.2 `#1808 <https://github.com/dropwizard/dropwizard/pull/1808>`_
+* Bring back support for request logging with ``logback-classic`` `#1813 <https://github.com/dropwizard/dropwizard/pull/1813>`_
 
 .. _rel-1.0.3:
 

--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -102,12 +102,44 @@ GZip
 Request Log
 ...........
 
+The new request log uses the `logback-access`_ library for processing request logs, which allow to use an extended set
+of logging patterns. See the `logback-access-pattern`_ docs for the reference.
+
 .. code-block:: yaml
 
     server:
       requestLog:
-        timeZone: UTC
+        appenders:
+          - type: console
 
+.. _logback-access: http://logback.qos.ch/access.html
+.. _logback-access-pattern: http://logback.qos.ch/manual/layouts.html#AccessPatternLayout
+
+====================== ================ ===========
+Name                   Default          Description
+====================== ================ ===========
+appenders              console appender The set of AppenderFactory appenders to which requests will be logged.
+                                        *TODO* See logging/appender refs for more info
+====================== ================ ===========
+
+
+Classic Request Log
+...........
+
+The classic request log uses the `logback-classic`_ library for processing request logs. It produces logs only in the
+standard `NCSA common log format`_, but allows to use an extended set of appenders.
+
+.. code-block:: yaml
+
+    server:
+      requestLog:
+        type: classic
+        timeZone: UTC
+        appenders:
+          - type: console
+
+.. _logback-classic: http://logback.qos.ch/
+.. _NCSA common log format: https://en.wikipedia.org/wiki/Common_Log_Format
 
 ====================== ================ ===========
 Name                   Default          Description
@@ -116,6 +148,7 @@ timeZone               UTC              The time zone to which request timestamp
 appenders              console appender The set of AppenderFactory appenders to which requests will be logged.
                                         *TODO* See logging/appender refs for more info
 ====================== ================ ===========
+
 
 .. _man-configuration-server-push:
 

--- a/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/old/DropwizardSlf4jRequestLog.java
+++ b/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/old/DropwizardSlf4jRequestLog.java
@@ -1,0 +1,66 @@
+package io.dropwizard.request.logging.old;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.spi.AppenderAttachableImpl;
+import org.eclipse.jetty.server.AbstractNCSARequestLog;
+import org.eclipse.jetty.server.RequestLog;
+
+import java.io.IOException;
+import java.util.TimeZone;
+
+/**
+ * A SLF4J-backed {@link RequestLog} implementation of {@link AbstractNCSARequestLog}.
+ */
+class DropwizardSlf4jRequestLog extends AbstractNCSARequestLog {
+    private final AppenderAttachableImpl<ILoggingEvent> appenders;
+
+    /**
+     * Creates a new request log.
+     *
+     * @param appenders the appenders to which requests will be logged
+     * @param timeZone  the timezone to which timestamps will be converted
+     */
+    DropwizardSlf4jRequestLog(AppenderAttachableImpl<ILoggingEvent> appenders, TimeZone timeZone) {
+        this.appenders = appenders;
+
+        setLogLatency(true);
+        setLogTimeZone(timeZone);
+        setExtended(true);
+        setPreferProxiedForAddress(true);
+
+        // the appenders already started
+        try {
+            start();
+        } catch (Exception e) {
+            throw new IllegalStateException("Should have succeeded doing a noop start", e);
+        }
+    }
+
+    @Override
+    protected boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public void write(String entry) throws IOException {
+        final LoggingEvent event = new LoggingEvent();
+        event.setLevel(Level.INFO);
+        event.setLoggerName("http.request");
+        event.setMessage(entry);
+        event.setTimeStamp(System.currentTimeMillis());
+
+        appenders.appendLoopOnAppenders(event);
+    }
+
+    void setLogTimeZone(TimeZone tz) {
+        setLogTimeZone(tz.getID());
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        appenders.detachAndStopAllAppenders();
+        super.doStop();
+    }
+}

--- a/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/old/LogbackClassicRequestLogFactory.java
+++ b/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/old/LogbackClassicRequestLogFactory.java
@@ -1,0 +1,117 @@
+package io.dropwizard.request.logging.old;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.CoreConstants;
+import ch.qos.logback.core.pattern.PatternLayoutBase;
+import ch.qos.logback.core.spi.AppenderAttachableImpl;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.dropwizard.logging.AppenderFactory;
+import io.dropwizard.logging.ConsoleAppenderFactory;
+import io.dropwizard.logging.async.AsyncAppenderFactory;
+import io.dropwizard.logging.async.AsyncLoggingEventAppenderFactory;
+import io.dropwizard.logging.filter.LevelFilterFactory;
+import io.dropwizard.logging.filter.NullLevelFilterFactory;
+import io.dropwizard.logging.layout.LayoutFactory;
+import io.dropwizard.request.logging.RequestLogFactory;
+import org.eclipse.jetty.server.RequestLog;
+import org.slf4j.LoggerFactory;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.Map;
+import java.util.TimeZone;
+
+/**
+ * A factory for creating {@link RequestLog} instances using logback-classic.
+ * <p/>
+ * <b>Configuration Parameters:</b>
+ * <table>
+ *     <tr>
+ *         <td>Name</td>
+ *         <td>Default</td>
+ *         <td>Description</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code timeZone}</td>
+ *         <td>UTC</td>
+ *         <td>The time zone to which request timestamps will be converted.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code appenders}</td>
+ *         <td>a default {@link ConsoleAppenderFactory console} appender</td>
+ *         <td>
+ *             The set of {@link AppenderFactory appenders} to which requests will be logged.
+ *         </td>
+ *     </tr>
+ * </table>
+ */
+@JsonTypeName("classic")
+public class LogbackClassicRequestLogFactory implements RequestLogFactory {
+    private static class RequestLogLayout extends PatternLayoutBase<ILoggingEvent> {
+        @Override
+        public String doLayout(ILoggingEvent event) {
+            return event.getFormattedMessage() + CoreConstants.LINE_SEPARATOR;
+        }
+
+        @Override
+        public Map<String, String> getDefaultConverterMap() {
+            return ImmutableMap.of();
+        }
+    }
+
+    @NotNull
+    private TimeZone timeZone = TimeZone.getTimeZone("UTC");
+
+    @Valid
+    @NotNull
+    private ImmutableList<AppenderFactory<ILoggingEvent>> appenders = ImmutableList.of(
+        new ConsoleAppenderFactory<ILoggingEvent>()
+    );
+
+    @JsonProperty
+    public ImmutableList<AppenderFactory<ILoggingEvent>> getAppenders() {
+        return appenders;
+    }
+
+    @JsonProperty
+    public void setAppenders(ImmutableList<AppenderFactory<ILoggingEvent>> appenders) {
+        this.appenders = appenders;
+    }
+
+    @JsonProperty
+    public TimeZone getTimeZone() {
+        return timeZone;
+    }
+
+    @JsonProperty
+    public void setTimeZone(TimeZone timeZone) {
+        this.timeZone = timeZone;
+    }
+
+    @JsonIgnore
+    public boolean isEnabled() {
+        return !appenders.isEmpty();
+    }
+
+    public RequestLog build(String name) {
+        final Logger logger = (Logger) LoggerFactory.getLogger("http.request");
+        logger.setAdditive(false);
+
+        final LoggerContext context = logger.getLoggerContext();
+        final LevelFilterFactory<ILoggingEvent> levelFilterFactory = new NullLevelFilterFactory<>();
+        final AsyncAppenderFactory<ILoggingEvent> asyncAppenderFactory = new AsyncLoggingEventAppenderFactory();
+        final LayoutFactory<ILoggingEvent> layoutFactory = (c, tz) -> new RequestLogLayout();
+        final AppenderAttachableImpl<ILoggingEvent> attachable = new AppenderAttachableImpl<>();
+        for (AppenderFactory<ILoggingEvent> appender : appenders) {
+            attachable.addAppender(appender.build(context, name, layoutFactory, levelFilterFactory, asyncAppenderFactory));
+        }
+
+        return new DropwizardSlf4jRequestLog(attachable, timeZone);
+    }
+}

--- a/dropwizard-request-logging/src/main/resources/META-INF.services/io.dropwizard.request.logging.RequestLogFactory
+++ b/dropwizard-request-logging/src/main/resources/META-INF.services/io.dropwizard.request.logging.RequestLogFactory
@@ -1,1 +1,2 @@
 io.dropwizard.request.logging.LogbackAccessRequestLogFactory
+io.dropwizard.request.logging.old.LogbackClassicRequestLogFactory

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/old/DropwizardSlf4jRequestLogTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/old/DropwizardSlf4jRequestLogTest.java
@@ -1,0 +1,81 @@
+package io.dropwizard.request.logging.old;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.spi.AppenderAttachableImpl;
+import io.dropwizard.logging.BootstrapLogging;
+import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.server.HttpChannelState;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class DropwizardSlf4jRequestLogTest {
+
+    static {
+        BootstrapLogging.bootstrap();
+    }
+
+    @SuppressWarnings("unchecked")
+    private final Appender<ILoggingEvent> appender = mock(Appender.class);
+    private final AppenderAttachableImpl<ILoggingEvent> appenders = new AppenderAttachableImpl<>();
+    private final DropwizardSlf4jRequestLog slf4jRequestLog = new DropwizardSlf4jRequestLog(appenders, TimeZone.getTimeZone("UTC"));
+
+    private final Request request = mock(Request.class);
+    private final Response response = mock(Response.class, RETURNS_DEEP_STUBS);
+    private final HttpChannelState channelState = mock(HttpChannelState.class);
+
+    @Before
+    public void setUp() throws Exception {
+        when(channelState.isInitial()).thenReturn(true);
+
+        when(request.getRemoteAddr()).thenReturn("10.0.0.1");
+        when(request.getTimeStamp()).thenReturn(TimeUnit.SECONDS.toMillis(1353042047));
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getHttpURI()).thenReturn(new HttpURI("/test/things?yay"));
+        when(request.getProtocol()).thenReturn("HTTP/1.1");
+        when(request.getHttpChannelState()).thenReturn(channelState);
+        when(request.getTimeStamp()).thenReturn(TimeUnit.SECONDS.toMillis(1353042048));
+
+        when(response.getCommittedMetaData().getStatus()).thenReturn(200);
+        when(response.getHttpChannel().getBytesWritten()).thenReturn(8290L);
+
+        appenders.addAppender(appender);
+
+        slf4jRequestLog.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        slf4jRequestLog.stop();
+    }
+
+    @Test
+    public void logsRequestsToTheAppenders() throws Exception {
+        final ILoggingEvent event = logAndCapture();
+
+        // It would be lovely if the clock could be injected so we could test this reliably, but
+        // I suppose we should just trust the Jetty folks.
+        assertThat(event.getFormattedMessage()).startsWith("10.0.0.1");
+        assertThat(event.getLevel()).isEqualTo(Level.INFO);
+    }
+
+    private ILoggingEvent logAndCapture() {
+        slf4jRequestLog.log(request, response);
+
+        final ArgumentCaptor<ILoggingEvent> captor = ArgumentCaptor.forClass(ILoggingEvent.class);
+        verify(appender, timeout(1000)).doAppend(captor.capture());
+
+        return captor.getValue();
+    }
+}

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/old/LogbackClassicRequestLogFactoryTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/old/LogbackClassicRequestLogFactoryTest.java
@@ -1,0 +1,45 @@
+package io.dropwizard.request.logging.old;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.Resources;
+import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.logging.BootstrapLogging;
+import io.dropwizard.logging.ConsoleAppenderFactory;
+import io.dropwizard.logging.FileAppenderFactory;
+import io.dropwizard.logging.SyslogAppenderFactory;
+import io.dropwizard.validation.BaseValidator;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.TimeZone;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LogbackClassicRequestLogFactoryTest {
+
+    static {
+        BootstrapLogging.bootstrap();
+    }
+
+    private LogbackClassicRequestLogFactory requestLog;
+
+    @Before
+    public void setUp() throws Exception {
+        final ObjectMapper objectMapper = Jackson.newObjectMapper();
+        objectMapper.getSubtypeResolver().registerSubtypes(ConsoleAppenderFactory.class, FileAppenderFactory.class,
+            SyslogAppenderFactory.class);
+        this.requestLog = new YamlConfigurationFactory<>(LogbackClassicRequestLogFactory.class,
+            BaseValidator.newValidator(), objectMapper, "dw")
+            .build(new File(Resources.getResource("yaml/logbackClassicRequestLog.yml").toURI()));
+    }
+
+    @Test
+    public void testDeserialized() {
+        assertThat(requestLog.getTimeZone()).isEqualTo(TimeZone.getTimeZone("Europe/Amsterdam"));
+        assertThat(requestLog.getAppenders()).hasSize(3).extractingResultOf("getClass").contains(
+            ConsoleAppenderFactory.class, FileAppenderFactory.class, SyslogAppenderFactory.class
+        );
+    }
+}

--- a/dropwizard-request-logging/src/test/resources/yaml/logbackClassicRequestLog.yml
+++ b/dropwizard-request-logging/src/test/resources/yaml/logbackClassicRequestLog.yml
@@ -1,0 +1,10 @@
+type: classic
+timeZone: Europe/Amsterdam
+appenders:
+  - type: console
+  - type: file
+    currentLogFilename: "/var/log/dingo/dingo.log"
+    archivedLogFilenamePattern: "/var/log/dingo/dingo-%d.log.zip"
+    archivedFileCount: 5
+  - type: syslog
+    facility: LOCAL5


### PR DESCRIPTION
Several users reported that they have issues with the logback-access implementation.
See #1801, #1812, #1737. It would be great to allow these users to continue to use `logback-classic`,
while they can't move their appenders to `logback-access`.