### PR TITLE
Upgrade Guava to 20.0

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -38,6 +38,7 @@ v1.1.0: Unreleased
 * Upgraded to JDBI 2.77
 * Upgraded to Jersey 2.24
 * Upgraded to javassist 3.21.0-GA
+* Upgraded to Guava 20.0
 
 .. _rel-1.0.3:
 

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -22,7 +22,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <dropwizard.version>${project.version}</dropwizard.version>
-        <guava.version>19.0</guava.version>
+        <guava.version>20.0</guava.version>
         <jersey.version>2.24</jersey.version>
         <jackson.version>2.8.4</jackson.version>
         <jetty.version>9.3.14.v20161028</jetty.version>


### PR DESCRIPTION
Release notes: https://github.com/google/guava/wiki/Release20