### PR TITLE
Finer-grain control of exception behaviour in view renderers

### DIFF
--- a/dropwizard-e2e/pom.xml
+++ b/dropwizard-e2e/pom.xml
@@ -49,6 +49,10 @@
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-views-mustache</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/dropwizard-e2e/src/main/java/com/example/app1/App1.java
+++ b/dropwizard-e2e/src/main/java/com/example/app1/App1.java
@@ -1,14 +1,25 @@
 package com.example.app1;
 
-import io.dropwizard.Application;
-import io.dropwizard.Configuration;
-import io.dropwizard.jersey.optional.EmptyOptionalException;
-import io.dropwizard.setup.Environment;
-
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 
+import com.github.mustachejava.MustacheNotFoundException;
+
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.jersey.optional.EmptyOptionalException;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.views.ViewBundle;
+import io.dropwizard.views.ViewRenderException;
+
 public class App1 extends Application<Configuration> {
+    @Override
+    public void initialize(Bootstrap<Configuration> bootstrap) {
+        bootstrap.addBundle(new ViewBundle<Configuration>());
+    }
+    
     @Override
     public void run(Configuration config, Environment env) throws Exception {
         // Ensure that we can override the default 404 response on an
@@ -17,6 +28,19 @@ public class App1 extends Application<Configuration> {
             @Override
             public Response toResponse(EmptyOptionalException exception) {
                 return Response.noContent().build();
+            }
+        });
+        
+        // Ensure that we can override the 503 response of a view that refers to
+        // a missing Mustache template and return a 404 instead
+        env.jersey().register(new ExceptionMapper<WebApplicationException>() {
+            @Override
+            public Response toResponse(WebApplicationException exception) {
+                if (exception.getCause() instanceof ViewRenderException
+                        && exception.getCause().getCause() instanceof MustacheNotFoundException) {
+                    return Response.status(Response.Status.NOT_FOUND).build();
+                }
+                return exception.getResponse();
             }
         });
 

--- a/dropwizard-e2e/src/main/java/com/example/app1/App1Resource.java
+++ b/dropwizard-e2e/src/main/java/com/example/app1/App1Resource.java
@@ -1,8 +1,11 @@
 package com.example.app1;
 
+import java.util.OptionalInt;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import java.util.OptionalInt;
+
+import io.dropwizard.views.View;
 
 @Path("/")
 public class App1Resource {
@@ -11,4 +14,12 @@ public class App1Resource {
     public OptionalInt emptyOptional() {
         return OptionalInt.empty();
     }
+    
+    @GET
+    @Path("view-with-missing-tpl")
+    public View getMissingTemplateView() {
+        return new View("not-found.mustache") {  
+        };
+    }
+    
 }

--- a/dropwizard-e2e/src/test/java/com/example/app1/App1Test.java
+++ b/dropwizard-e2e/src/test/java/com/example/app1/App1Test.java
@@ -1,16 +1,17 @@
 package com.example.app1;
 
-import io.dropwizard.Configuration;
-import io.dropwizard.client.JerseyClientBuilder;
-import io.dropwizard.testing.ResourceHelpers;
-import io.dropwizard.testing.junit.DropwizardAppRule;
-import org.junit.ClassRule;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import io.dropwizard.Configuration;
+import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit.DropwizardAppRule;
 
 public class App1Test {
     @ClassRule
@@ -19,10 +20,20 @@ public class App1Test {
 
     @Test
     public void custom204OnEmptyOptional() {
-        final Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("test client");
+        final Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("test client 1");
         final String url = String.format("http://localhost:%d/empty-optional", RULE.getLocalPort());
 
         final Response response = client.target(url).request().get();
         assertThat(response.getStatus()).isEqualTo(204);
     }
+    
+    @Test
+    public void custom404OnViewRenderMissingMustacheTemplate() {
+        final Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("test client 2");
+        final String url = String.format("http://localhost:%d/view-with-missing-tpl", RULE.getLocalPort());
+
+        final Response response = client.target(url).request().get();
+        assertThat(response.getStatus()).isEqualTo(404);        
+    }
+    
 }

--- a/dropwizard-views-freemarker/src/main/java/io/dropwizard/views/freemarker/FreemarkerViewRenderer.java
+++ b/dropwizard-views-freemarker/src/main/java/io/dropwizard/views/freemarker/FreemarkerViewRenderer.java
@@ -10,6 +10,7 @@ import freemarker.template.Template;
 import freemarker.template.TemplateException;
 import freemarker.template.Version;
 import io.dropwizard.views.View;
+import io.dropwizard.views.ViewRenderException;
 import io.dropwizard.views.ViewRenderer;
 
 import java.io.IOException;
@@ -71,8 +72,8 @@ public class FreemarkerViewRenderer implements ViewRenderer {
             final Charset charset = view.getCharset().orElseGet(() -> Charset.forName(configuration.getEncoding(locale)));
             final Template template = configuration.getTemplate(view.getTemplateName(), locale, charset.name());
             template.process(view, new OutputStreamWriter(output, template.getEncoding()));
-        } catch (TemplateException e) {
-            throw new RuntimeException(e);
+        } catch (Exception e) {
+            throw new ViewRenderException(e);
         }
     }
 

--- a/dropwizard-views-freemarker/src/main/java/io/dropwizard/views/freemarker/FreemarkerViewRenderer.java
+++ b/dropwizard-views-freemarker/src/main/java/io/dropwizard/views/freemarker/FreemarkerViewRenderer.java
@@ -7,7 +7,6 @@ import com.google.common.collect.ImmutableMap;
 import freemarker.template.Configuration;
 import freemarker.template.DefaultObjectWrapperBuilder;
 import freemarker.template.Template;
-import freemarker.template.TemplateException;
 import freemarker.template.Version;
 import io.dropwizard.views.View;
 import io.dropwizard.views.ViewRenderException;

--- a/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/FreemarkerViewRendererTest.java
+++ b/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/FreemarkerViewRendererTest.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.logging.BootstrapLogging;
 import io.dropwizard.views.ViewMessageBodyWriter;
+import io.dropwizard.views.ViewRenderExceptionMapper;
 import io.dropwizard.views.ViewRenderer;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
@@ -58,6 +59,7 @@ public class FreemarkerViewRendererTest extends JerseyTest {
         final ViewRenderer renderer = new FreemarkerViewRenderer();
         config.register(new ViewMessageBodyWriter(new MetricRegistry(), ImmutableList.of(renderer)));
         config.register(new ExampleResource());
+        config.register(new ViewRenderExceptionMapper());
         return config;
     }
 
@@ -87,7 +89,7 @@ public class FreemarkerViewRendererTest extends JerseyTest {
                     .isEqualTo(500);
 
             assertThat(e.getResponse().readEntity(String.class))
-                .isEqualTo(ViewMessageBodyWriter.TEMPLATE_ERROR_MSG);
+                .isEqualTo(ViewRenderExceptionMapper.TEMPLATE_ERROR_MSG);
         }
     }
 
@@ -101,7 +103,7 @@ public class FreemarkerViewRendererTest extends JerseyTest {
                     .isEqualTo(500);
 
             assertThat(e.getResponse().readEntity(String.class))
-                    .isEqualTo(ViewMessageBodyWriter.TEMPLATE_ERROR_MSG);
+                    .isEqualTo(ViewRenderExceptionMapper.TEMPLATE_ERROR_MSG);
         }
     }
 }

--- a/dropwizard-views-mustache/src/main/java/io/dropwizard/views/mustache/MustacheViewRenderer.java
+++ b/dropwizard-views-mustache/src/main/java/io/dropwizard/views/mustache/MustacheViewRenderer.java
@@ -8,6 +8,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import io.dropwizard.views.View;
+import io.dropwizard.views.ViewRenderException;
 import io.dropwizard.views.ViewRenderer;
 
 import java.io.IOException;
@@ -52,7 +53,7 @@ public class MustacheViewRenderer implements ViewRenderer {
                 template.execute(writer, view);
             }
         } catch (Throwable e) {
-            throw new RuntimeException("Mustache template error: " + view.getTemplateName(), e);
+            throw new ViewRenderException("Mustache template error: " + view.getTemplateName(), e);
         }
     }
 

--- a/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererTest.java
+++ b/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererTest.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.dropwizard.logging.BootstrapLogging;
 import io.dropwizard.views.ViewMessageBodyWriter;
+import io.dropwizard.views.ViewRenderExceptionMapper;
 import io.dropwizard.views.ViewRenderer;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
@@ -60,6 +61,7 @@ public class MustacheViewRendererTest extends JerseyTest {
         ResourceConfig config = new ResourceConfig();
         final ViewRenderer renderer = new MustacheViewRenderer();
         config.register(new ViewMessageBodyWriter(new MetricRegistry(), ImmutableList.of(renderer)));
+        config.register(new ViewRenderExceptionMapper());
         config.register(new ExampleResource());
         return config;
     }
@@ -86,7 +88,7 @@ public class MustacheViewRendererTest extends JerseyTest {
                     .isEqualTo(500);
 
             assertThat(e.getResponse().readEntity(String.class))
-                    .isEqualTo(ViewMessageBodyWriter.TEMPLATE_ERROR_MSG);
+                    .isEqualTo(ViewRenderExceptionMapper.TEMPLATE_ERROR_MSG);
         }
     }
 
@@ -100,7 +102,7 @@ public class MustacheViewRendererTest extends JerseyTest {
                     .isEqualTo(500);
 
             assertThat(e.getResponse().readEntity(String.class))
-                .isEqualTo(ViewMessageBodyWriter.TEMPLATE_ERROR_MSG);
+                .isEqualTo(ViewRenderExceptionMapper.TEMPLATE_ERROR_MSG);
         }
     }
 

--- a/dropwizard-views/src/main/java/io/dropwizard/views/ViewMessageBodyWriter.java
+++ b/dropwizard-views/src/main/java/io/dropwizard/views/ViewMessageBodyWriter.java
@@ -3,8 +3,6 @@ package io.dropwizard.views;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.google.common.annotations.VisibleForTesting;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
@@ -27,7 +25,6 @@ import static com.codahale.metrics.MetricRegistry.name;
 @Provider
 @Produces({ MediaType.TEXT_HTML, MediaType.APPLICATION_XHTML_XML })
 public class ViewMessageBodyWriter implements MessageBodyWriter<View> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(MessageBodyWriter.class);
 
     @Context
     private HttpHeaders headers;
@@ -77,7 +74,6 @@ public class ViewMessageBodyWriter implements MessageBodyWriter<View> {
             }
             throw new ViewRenderException("Unable to find a renderer for " + t.getTemplateName());
         } catch (ViewRenderException e) {
-            LOGGER.error("Template Error", e);
             throw new WebApplicationException(e);
         } finally {
             context.stop();

--- a/dropwizard-views/src/main/java/io/dropwizard/views/ViewMessageBodyWriter.java
+++ b/dropwizard-views/src/main/java/io/dropwizard/views/ViewMessageBodyWriter.java
@@ -12,7 +12,6 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.Provider;
 import java.io.IOException;
@@ -29,11 +28,6 @@ import static com.codahale.metrics.MetricRegistry.name;
 @Produces({ MediaType.TEXT_HTML, MediaType.APPLICATION_XHTML_XML })
 public class ViewMessageBodyWriter implements MessageBodyWriter<View> {
     private static final Logger LOGGER = LoggerFactory.getLogger(MessageBodyWriter.class);
-    public static final String TEMPLATE_ERROR_MSG =
-            "<html>" +
-                "<head><title>Template Error</title></head>" +
-                "<body><h1>Template Error</h1><p>Something went wrong rendering the page</p></body>" +
-            "</html>";
 
     @Context
     private HttpHeaders headers;
@@ -82,12 +76,9 @@ public class ViewMessageBodyWriter implements MessageBodyWriter<View> {
                 }
             }
             throw new ViewRenderException("Unable to find a renderer for " + t.getTemplateName());
-        } catch (Exception e) {
+        } catch (ViewRenderException e) {
             LOGGER.error("Template Error", e);
-            throw new WebApplicationException(Response.serverError()
-                                                      .type(MediaType.TEXT_HTML_TYPE)
-                                                      .entity(TEMPLATE_ERROR_MSG)
-                                                      .build());
+            throw new WebApplicationException(e);
         } finally {
             context.stop();
         }

--- a/dropwizard-views/src/main/java/io/dropwizard/views/ViewRenderException.java
+++ b/dropwizard-views/src/main/java/io/dropwizard/views/ViewRenderException.java
@@ -17,4 +17,46 @@ public class ViewRenderException extends IOException {
     public ViewRenderException(String message) {
         super(message);
     }
+
+    /**
+     * Constructs an {@code ViewRenderException} with the specified detail
+     * message and cause.
+     *
+     * <p>
+     * Note that the detail message associated with {@code cause} is <i>not</i>
+     * automatically incorporated into this exception's detail message.
+     *
+     * @param message
+     *            The detail message (which is saved for later retrieval by the
+     *            {@link #getMessage()} method)
+     *
+     * @param cause
+     *            The cause (which is saved for later retrieval by the
+     *            {@link #getCause()} method). (A null value is permitted, and
+     *            indicates that the cause is nonexistent or unknown.)
+     *
+     * @since 1.1.0
+     */
+    public ViewRenderException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs an {@code ViewRenderException} with the specified cause and a
+     * detail message of {@code (cause==null ? null : cause.toString())} (which
+     * typically contains the class and detail message of {@code cause}). This
+     * constructor is useful for IO exceptions that are little more than
+     * wrappers for other throwables.
+     *
+     * @param cause
+     *            The cause (which is saved for later retrieval by the
+     *            {@link #getCause()} method). (A null value is permitted, and
+     *            indicates that the cause is nonexistent or unknown.)
+     *
+     * @since 1.1.0
+     */
+    public ViewRenderException(Throwable cause) {
+        super(cause);
+    }
+
 }

--- a/dropwizard-views/src/main/java/io/dropwizard/views/ViewRenderExceptionMapper.java
+++ b/dropwizard-views/src/main/java/io/dropwizard/views/ViewRenderExceptionMapper.java
@@ -1,0 +1,38 @@
+package io.dropwizard.views;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * An {@link ExceptionMapper} that returns a 500 error response with a generic
+ * HTML error page when a {@link ViewRenderException} is thrown.
+ * 
+ * @since 1.1.0
+ */
+@Provider
+public class ViewRenderExceptionMapper implements ExceptionMapper<WebApplicationException> {
+
+    /**
+     * The generic HTML error page template.
+     */
+    public static final String TEMPLATE_ERROR_MSG =
+            "<html>" +
+                "<head><title>Template Error</title></head>" +
+                "<body><h1>Template Error</h1><p>Something went wrong rendering the page</p></body>" +
+            "</html>";
+
+    @Override
+    public Response toResponse(WebApplicationException exception) {
+        if (exception.getCause() instanceof ViewRenderException) {
+            return Response.serverError()
+                    .type(MediaType.TEXT_HTML_TYPE)
+                    .entity(TEMPLATE_ERROR_MSG)
+                    .build();
+        }
+        return exception.getResponse();
+    }
+
+}

--- a/dropwizard-views/src/main/java/io/dropwizard/views/ViewRenderExceptionMapper.java
+++ b/dropwizard-views/src/main/java/io/dropwizard/views/ViewRenderExceptionMapper.java
@@ -6,6 +6,9 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * An {@link ExceptionMapper} that returns a 500 error response with a generic
  * HTML error page when a {@link ViewRenderException} is thrown.
@@ -14,6 +17,8 @@ import javax.ws.rs.ext.Provider;
  */
 @Provider
 public class ViewRenderExceptionMapper implements ExceptionMapper<WebApplicationException> {
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(ViewRenderExceptionMapper.class);
 
     /**
      * The generic HTML error page template.
@@ -26,7 +31,9 @@ public class ViewRenderExceptionMapper implements ExceptionMapper<WebApplication
 
     @Override
     public Response toResponse(WebApplicationException exception) {
-        if (exception.getCause() instanceof ViewRenderException) {
+        Throwable cause = exception.getCause();
+        if (cause instanceof ViewRenderException) {
+            LOGGER.error("Template Error", cause);
             return Response.serverError()
                     .type(MediaType.TEXT_HTML_TYPE)
                     .entity(TEMPLATE_ERROR_MSG)


### PR DESCRIPTION
This PR is one possible implementation of issue #1811. In short, I am standardizing the exception thrown by each `ViewRenderer` implementation as `ViewRenderException`, which is then caught and rethrown as `WebApplicationException` by `ViewMessageBodyWriter`.

To preserve previous behavior of returning an HTML error response on render exceptions, I have added a new `ViewRenderExceptionMapper` class which should be registered. Consequently I am still changing the original behavior by adding this registration requirement. Let me know if this is OK from backward-compatibility standpoint - if needed we can register the mapper in `ViewBundle`, although I don't know how I can register another exception mapper afterwards if I want custom behaviour. This also requires change to the documentation.

Otherwise, one can choose to provide their own `ExceptionMapper` to catch `WebApplicationException` and check that the cause is `ViewRenderException`, then do whatever is needed with its cause in the form of an exception thrown by the rendering code (Viewmarker, Mustache, etc.)

I tried updating the tests to verify both cases of with and without `ViewRenderExceptionMapper`, but I can't seem to get registration in each test case working like this:

` target("/test/bad").regsiter(new ViewRenderExceptionMapper()).request().get(String.class);`

I had to register the mapper in `configure()`. Please let me know if you have any solution to this so I can increase the test coverage.

Thanks.