### PR TITLE
Backport of httpCompliance to Release/1.0.x

### DIFF
--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
@@ -174,6 +174,21 @@ import static com.codahale.metrics.MetricRegistry.name;
  *             {@link ForwardedRequestCustomizer} for details.
  *         </td>
  *     </tr>
+ *     <tr>
+ *         <td>{@code httpCompliance}</td>
+ *         <td>RFC7230</td>
+ *         <td>
+ *             This sets the http compliance level used by Jetty when parsing http, this can be useful when using a
+ *             non-RFC7230 compliant front end, such as nginx, which can produce multi-line headers when forwarding
+ *             client certificates using proxy_set_header X-SSL-CERT $ssl_client_cert;
+ *
+ *             Possible values are set forth in the org.eclipse.jetty.http.HttpCompliance enum:
+ *             <ul>
+ *                 <li>RFC7230: Disallow header folding.</li>
+ *                 <li>RFC2616: Allow header folding.</li>
+ *             </ul>
+ *         </td>
+ *     </tr>
  * </table>
  */
 @JsonTypeName("http")

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
@@ -9,6 +9,7 @@ import io.dropwizard.util.SizeUnit;
 import io.dropwizard.validation.MinDuration;
 import io.dropwizard.validation.MinSize;
 import io.dropwizard.validation.PortRange;
+import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.io.ArrayByteBufferPool;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.server.ConnectionFactory;
@@ -246,6 +247,7 @@ public class HttpConnectorFactory implements ConnectorFactory {
     private boolean useServerHeader = false;
     private boolean useDateHeader = true;
     private boolean useForwardedHeaders = true;
+    private HttpCompliance httpCompliance = HttpCompliance.RFC7230;
 
     @JsonProperty
     public int getPort() {
@@ -447,6 +449,17 @@ public class HttpConnectorFactory implements ConnectorFactory {
         this.useForwardedHeaders = useForwardedHeaders;
     }
 
+    @JsonProperty
+    public HttpCompliance getHttpCompliance() {
+        return httpCompliance;
+    }
+
+    @JsonProperty
+    public void setHttpCompliance(HttpCompliance httpCompliance) {
+        this.httpCompliance = httpCompliance;
+    }
+
+
     @Override
     public Connector build(Server server,
                            MetricRegistry metrics,
@@ -510,7 +523,7 @@ public class HttpConnectorFactory implements ConnectorFactory {
     }
 
     protected HttpConnectionFactory buildHttpConnectionFactory(HttpConfiguration httpConfig) {
-        final HttpConnectionFactory httpConnectionFactory = new HttpConnectionFactory(httpConfig);
+        final HttpConnectionFactory httpConnectionFactory = new HttpConnectionFactory(httpConfig, httpCompliance);
         httpConnectionFactory.setInputBufferSize((int) inputBufferSize.toBytes());
         return httpConnectionFactory;
     }

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
@@ -12,6 +12,7 @@ import io.dropwizard.logging.SyslogAppenderFactory;
 import io.dropwizard.util.Duration;
 import io.dropwizard.util.Size;
 import io.dropwizard.validation.BaseValidator;
+import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.io.ArrayByteBufferPool;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.server.ForwardedRequestCustomizer;
@@ -74,6 +75,7 @@ public class HttpConnectorFactoryTest {
         assertThat(http.isUseServerHeader()).isFalse();
         assertThat(http.isUseDateHeader()).isTrue();
         assertThat(http.isUseForwardedHeaders()).isTrue();
+        assertThat(http.getHttpCompliance()).isEqualTo(HttpCompliance.RFC7230);
     }
 
     @Test
@@ -102,6 +104,7 @@ public class HttpConnectorFactoryTest {
         assertThat(http.isUseServerHeader()).isTrue();
         assertThat(http.isUseDateHeader()).isFalse();
         assertThat(http.isUseForwardedHeaders()).isFalse();
+        assertThat(http.getHttpCompliance()).isEqualTo(HttpCompliance.RFC2616);
     }
 
     @Test
@@ -149,6 +152,7 @@ public class HttpConnectorFactoryTest {
                 .isSameAs(metrics.timer("org.eclipse.jetty.server.HttpConnectionFactory.127.0.0.1.8080.connections"));
         HttpConnectionFactory httpConnectionFactory = (HttpConnectionFactory)  connectionFactory.getConnectionFactory();
         assertThat(httpConnectionFactory.getInputBufferSize()).isEqualTo(8192);
+        assertThat(httpConnectionFactory.getHttpCompliance()).isEqualByComparingTo(HttpCompliance.RFC7230);
 
         HttpConfiguration httpConfiguration = httpConnectionFactory.getHttpConfiguration();
         assertThat(httpConfiguration.getHeaderCacheSize()).isEqualTo(512);

--- a/dropwizard-jetty/src/test/resources/yaml/http-connector.yml
+++ b/dropwizard-jetty/src/test/resources/yaml/http-connector.yml
@@ -19,3 +19,4 @@ soLingerTime: 30s
 useServerHeader: true
 useDateHeader: false
 useForwardedHeaders: false
+httpCompliance: RFC2616


### PR DESCRIPTION
Hi, what is the ETA for 1.1.0?

I'd very much like to avoid having to drag around a local fork, so how do you guys feel about having the httpCompliance setting backported to 1.0.x?

