### PR TITLE
Fix guava deprecations with 20.0 update

### DIFF
--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.lifecycle.setup;
 
-import com.google.common.base.Throwables;
 import io.dropwizard.util.Duration;
 import org.junit.Before;
 import org.junit.Test;
@@ -126,7 +125,7 @@ public class ExecutorServiceBuilderTest {
             try {
                 latch.await();
             } catch (InterruptedException ex) {
-                Throwables.propagate(ex);
+                throw new RuntimeException(ex);
             }
         };
 
@@ -139,7 +138,7 @@ public class ExecutorServiceBuilderTest {
                 .as("2 tasks executed concurrently on " + exe)
                 .isTrue();
         } catch (InterruptedException ex) {
-            Throwables.propagate(ex);
+            throw new RuntimeException(ex);
         }
     }
 }

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
@@ -2,6 +2,7 @@ package io.dropwizard.testing;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.dropwizard.Application;
@@ -18,6 +19,7 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 
 import javax.annotation.Nullable;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -25,7 +27,6 @@ import java.util.Set;
 import java.util.function.Function;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.common.base.Throwables.propagate;
 
 /**
  * A test support class for starting and stopping your application at the start and end of a test class.
@@ -159,7 +160,8 @@ public class DropwizardTestSupport<C extends Configuration> {
             try {
                 jettyServer.stop();
             } catch (Exception e) {
-                throw propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             } finally {
                 jettyServer = null;
             }
@@ -221,7 +223,8 @@ public class DropwizardTestSupport<C extends Configuration> {
 
             command.run(bootstrap, namespace);
         } catch (Exception e) {
-            throw propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -245,8 +248,8 @@ public class DropwizardTestSupport<C extends Configuration> {
     public Application<C> newApplication() {
         try {
             return applicationClass.getConstructor().newInstance();
-        } catch (Exception e) {
-            throw propagate(e);
+        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DAOTestRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DAOTestRule.java
@@ -197,7 +197,8 @@ public class DAOTestRule extends ExternalResource {
             return result;
         } catch (final Exception e) {
             transaction.rollback();
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/dropwizard-util/src/main/java/io/dropwizard/util/Enums.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Enums.java
@@ -21,7 +21,7 @@ public class Enums {
      * @return The enum or null, if no enum constant matched the input value.
      */
     public static Enum<?> fromStringFuzzy(String value, Enum<?>[] constants) {
-        final String text = CharMatcher.WHITESPACE
+        final String text = CharMatcher.whitespace()
             .removeFrom(value)
             .replace('-', '_')
             .replace('.', '_');


### PR DESCRIPTION
Fixes the deprecations introduced in the Guava 20.0 update.

Most of the `propagate` can be converted to a `throw new RuntimeException`. The one instance where `throwIfUnchecked` functionality is kept is in `DAOTestRule` due mainly to a test that is written an older junit style that only looks at the shallowest exception and not the root cause. 