### PR TITLE
Add IEEE Minute Abbreviation to Duration

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -27,6 +27,7 @@ v1.1.0: Unreleased
 * Allow to disable caching of Mustache views `#1289 <https://github.com/dropwizard/dropwizard/issues/1289>`_
 * Add the ``httpCompliance`` option to the HTTP configuration `#1825 <https://github.com/dropwizard/dropwizard/pull/1825>`_
 * Add the ``blockingTimeout`` option to the HTTP configuration `#1795 <https://github.com/dropwizard/dropwizard/pull/1795>`_
+* Add ``min`` and ``mins`` as valid ``Duration`` abbreviations `#1833 <https://github.com/dropwizard/dropwizard/pull/1833>`_
 * Upgraded to Jackson 2.8.4 `#1775 <https://github.com/dropwizard/dropwizard/pull/1775>`_
 * Upgraded to Hibernate Validator 5.3.0.Final `#1782 <https://github.com/dropwizard/dropwizard/pull/1782>`_
 * Upgraded to Jetty 9.3.14.v20161028 `#1796 <https://github.com/dropwizard/dropwizard/pull/1796>`_

--- a/dropwizard-util/src/main/java/io/dropwizard/util/Duration.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Duration.java
@@ -30,6 +30,8 @@ public class Duration implements Comparable<Duration> {
             .put("second", TimeUnit.SECONDS)
             .put("seconds", TimeUnit.SECONDS)
             .put("m", TimeUnit.MINUTES)
+            .put("min", TimeUnit.MINUTES)
+            .put("mins", TimeUnit.MINUTES)
             .put("minute", TimeUnit.MINUTES)
             .put("minutes", TimeUnit.MINUTES)
             .put("h", TimeUnit.HOURS)

--- a/dropwizard-util/src/test/java/io/dropwizard/util/DurationTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/DurationTest.java
@@ -82,6 +82,12 @@ public class DurationTest {
         assertThat(Duration.parse("1m"))
                 .isEqualTo(Duration.minutes(1));
 
+        assertThat(Duration.parse("1min"))
+            .isEqualTo(Duration.minutes(1));
+
+        assertThat(Duration.parse("2mins"))
+            .isEqualTo(Duration.minutes(2));
+
         assertThat(Duration.parse("1 minute"))
                 .isEqualTo(Duration.minutes(1));
 


### PR DESCRIPTION
Fancy title for adding `min` and `mins` abbreviations for minute to `Duration`

[The IEEE table of abbreviations](http://www.ewh.ieee.org/soc/ias/pub-dept/abbreviation.pdf) for you viewing pleasure 📚 