### PR TITLE
Add  integration tests for request logs

### DIFF
--- a/dropwizard-e2e/src/test/java/com/example/request_log/AbstractRequestLogPatternIntegrationTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/request_log/AbstractRequestLogPatternIntegrationTest.java
@@ -1,0 +1,84 @@
+package com.example.request_log;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Context;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+public abstract class AbstractRequestLogPatternIntegrationTest {
+
+    public static class TestApplication extends Application<Configuration> {
+        public static void main(String[] args) throws Exception {
+            new TestApplication().run(args);
+        }
+
+        @Override
+        public void run(Configuration configuration, Environment environment) throws Exception {
+            environment.jersey().register(TestResource.class);
+            environment.healthChecks().register("dummy", new HealthCheck() {
+                @Override
+                protected Result check() throws Exception {
+                    return Result.healthy();
+                }
+            });
+        }
+    }
+
+    @Path("/greet")
+    public static class TestResource {
+
+        @GET
+        public String get(@QueryParam("name") String name, @Context HttpServletRequest httpRequest) {
+            return String.format("Hello, %s!", name);
+        }
+    }
+
+    protected final String tempFile = createTempFile();
+    protected Client client;
+
+    @Rule
+    public DropwizardAppRule<Configuration> dropwizardAppRule = new DropwizardAppRule<>(TestApplication.class,
+        ResourceHelpers.resourceFilePath("request_log/test-custom-request-log.yml"),
+        Iterables.toArray(configOverrides(), ConfigOverride.class));
+
+    private static String createTempFile() {
+        try {
+            return File.createTempFile("request-logs", null).getAbsolutePath();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    protected List<ConfigOverride> configOverrides() {
+        return ImmutableList.of(ConfigOverride.config("server.requestLog.appenders[0].currentLogFilename", tempFile));
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        client = new JerseyClientBuilder(dropwizardAppRule.getEnvironment()).build("test-request-logs");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        client.close();
+    }
+}

--- a/dropwizard-e2e/src/test/java/com/example/request_log/CustomRequestLogPatternIntegrationTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/request_log/CustomRequestLogPatternIntegrationTest.java
@@ -1,0 +1,45 @@
+package com.example.request_log;
+
+import com.google.common.collect.ImmutableList;
+import io.dropwizard.testing.ConfigOverride;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CustomRequestLogPatternIntegrationTest extends AbstractRequestLogPatternIntegrationTest {
+
+    private static final String LOG_FORMAT = "%h|%reqParameter{name}|%m|%U|%s|%b|%i{User-Agent}|%responseHeader{Content-Type}";
+
+    @Override
+    protected List<ConfigOverride> configOverrides() {
+        return ImmutableList.<ConfigOverride>builder()
+            .addAll(super.configOverrides())
+            .add(ConfigOverride.config("server.requestLog.appenders[0].logFormat", LOG_FORMAT))
+            .build();
+    }
+
+    @Test
+    public void testCustomPattern() throws Exception {
+        String url = String.format("http://localhost:%d/greet?name=Charley", dropwizardAppRule.getLocalPort());
+        for (int i = 0; i < 100; i++) {
+            client.target(url).request().get();
+        }
+
+        Thread.sleep(100); // To let async logs to finish
+
+        List<String> logs;
+        try (BufferedReader reader = new BufferedReader(new FileReader(new File(tempFile)))) {
+            logs = reader.lines().collect(Collectors.toList());
+        }
+
+        // We should have exactly 100 log entries with correct data
+        assertThat(logs).hasSize(100).containsOnly(
+            "127.0.0.1|Charley|GET|/greet|200|15|TestApplication (test-request-logs)|text/plain");
+    }
+}

--- a/dropwizard-e2e/src/test/java/com/example/request_log/RequestLogPatternIntegrationTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/request_log/RequestLogPatternIntegrationTest.java
@@ -1,0 +1,35 @@
+package com.example.request_log;
+
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RequestLogPatternIntegrationTest extends AbstractRequestLogPatternIntegrationTest {
+
+    private static final Pattern REQUEST_LOG_PATTERN = Pattern.compile(
+        "127\\.0\\.0\\.1 - - \\[.+\\] \"GET /greet\\?name=Charley HTTP/1\\.1\" 200 15 \"-\" \"TestApplication \\(test-request-logs\\)\" \\d+"
+    );
+
+    @Test
+    public void testDefaultPattern() throws Exception {
+        String url = String.format("http://localhost:%d/greet?name=Charley", dropwizardAppRule.getLocalPort());
+        for (int i = 0; i < 100; i++) {
+            client.target(url).request().get();
+        }
+
+        Thread.sleep(100); // To let async logs to finish
+
+        List<String> logs;
+        try (BufferedReader reader = new BufferedReader(new FileReader(new File(tempFile)))) {
+            logs = reader.lines().collect(Collectors.toList());
+        }
+        assertThat(logs).hasSize(100).allMatch(s -> REQUEST_LOG_PATTERN.matcher(s).matches());
+    }
+}

--- a/dropwizard-e2e/src/test/resources/request_log/test-custom-request-log.yml
+++ b/dropwizard-e2e/src/test/resources/request_log/test-custom-request-log.yml
@@ -1,0 +1,11 @@
+server:
+  requestLog:
+    appenders:
+      - type: file
+        archive: false
+  applicationConnectors:
+    - type: http
+      port: 0
+  adminConnectors:
+    - type: http
+      port: 0


### PR DESCRIPTION
We recently had several reports about issues with request logging. It would be great to have some integration tests which verify that Dropwizard produces correct request logs. This should allow to us
to catch errors with it more early and not let our users down.