### PR TITLE
Enable option to load Mustache templates from file system

### DIFF
--- a/dropwizard-views-mustache/src/main/java/io/dropwizard/views/mustache/MustacheViewRenderer.java
+++ b/dropwizard-views-mustache/src/main/java/io/dropwizard/views/mustache/MustacheViewRenderer.java
@@ -28,16 +28,15 @@ import java.util.Optional;
 public class MustacheViewRenderer implements ViewRenderer {
     private final LoadingCache<Class<? extends View>, MustacheFactory> factories;
     private boolean useCache = true;
-    private File fileRoot;
+    private Optional<File> fileRoot = Optional.empty();
 
     public MustacheViewRenderer() {
-        this.factories = CacheBuilder.newBuilder()
-                                     .build(new CacheLoader<Class<? extends View>, MustacheFactory>() {
-                                         @Override
-                                         public MustacheFactory load(Class<? extends View> key) throws Exception {
-                                             return createNewMustacheFactory(key);
-                                         }
-                                     });
+        this.factories = CacheBuilder.newBuilder().build(new CacheLoader<Class<? extends View>, MustacheFactory>() {
+            @Override
+            public MustacheFactory load(Class<? extends View> key) throws Exception {
+                return createNewMustacheFactory(key);
+            }
+        });
     }
 
     @Override
@@ -48,8 +47,8 @@ public class MustacheViewRenderer implements ViewRenderer {
     @Override
     public void render(View view, Locale locale, OutputStream output) throws IOException {
         try {
-            final MustacheFactory mustacheFactory = useCache ? factories.get(view.getClass()) :
-                createNewMustacheFactory(view.getClass());
+            final MustacheFactory mustacheFactory = useCache ? factories.get(view.getClass())
+                    : createNewMustacheFactory(view.getClass());
             final Mustache template = mustacheFactory.compile(view.getTemplateName());
             final Charset charset = view.getCharset().orElse(StandardCharsets.UTF_8);
             try (OutputStreamWriter writer = new OutputStreamWriter(output, charset)) {
@@ -62,12 +61,8 @@ public class MustacheViewRenderer implements ViewRenderer {
 
     @Override
     public void configure(Map<String, String> options) {
-        useCache = Optional.ofNullable(options.get("cache"))
-            .map(Boolean::parseBoolean)
-            .orElse(true);
-        if (options.containsKey("fileRoot")) {
-            fileRoot = new File(options.get("fileRoot"));
-        }
+        useCache = Optional.ofNullable(options.get("cache")).map(Boolean::parseBoolean).orElse(true);
+        fileRoot = Optional.ofNullable(options.get("fileRoot")).map(File::new);
     }
 
     @VisibleForTesting
@@ -81,8 +76,8 @@ public class MustacheViewRenderer implements ViewRenderer {
     }
 
     private MustacheFactory createNewMustacheFactory(Class<? extends View> key) {
-        return (fileRoot != null) ? new DefaultMustacheFactory(new FileSystemResolver(fileRoot))
-                : new DefaultMustacheFactory(new PerClassMustacheResolver(key));
+        return new DefaultMustacheFactory(
+                fileRoot.isPresent() ? new FileSystemResolver(fileRoot.get()) : new PerClassMustacheResolver(key));
     }
 
 }

--- a/dropwizard-views-mustache/src/main/java/io/dropwizard/views/mustache/MustacheViewRenderer.java
+++ b/dropwizard-views-mustache/src/main/java/io/dropwizard/views/mustache/MustacheViewRenderer.java
@@ -3,6 +3,7 @@ package io.dropwizard.views.mustache;
 import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheFactory;
+import com.github.mustachejava.resolver.FileSystemResolver;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -11,6 +12,7 @@ import io.dropwizard.views.View;
 import io.dropwizard.views.ViewRenderException;
 import io.dropwizard.views.ViewRenderer;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -26,6 +28,7 @@ import java.util.Optional;
 public class MustacheViewRenderer implements ViewRenderer {
     private final LoadingCache<Class<? extends View>, MustacheFactory> factories;
     private boolean useCache = true;
+    private File fileRoot;
 
     public MustacheViewRenderer() {
         this.factories = CacheBuilder.newBuilder()
@@ -62,6 +65,9 @@ public class MustacheViewRenderer implements ViewRenderer {
         useCache = Optional.ofNullable(options.get("cache"))
             .map(Boolean::parseBoolean)
             .orElse(true);
+        if (options.containsKey("fileRoot")) {
+            fileRoot = new File(options.get("fileRoot"));
+        }
     }
 
     @VisibleForTesting
@@ -75,7 +81,8 @@ public class MustacheViewRenderer implements ViewRenderer {
     }
 
     private MustacheFactory createNewMustacheFactory(Class<? extends View> key) {
-        return new DefaultMustacheFactory(new PerClassMustacheResolver(key));
+        return (fileRoot != null) ? new DefaultMustacheFactory(new FileSystemResolver(fileRoot))
+                : new DefaultMustacheFactory(new PerClassMustacheResolver(key));
     }
 
 }

--- a/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererFileSystemTest.java
+++ b/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererFileSystemTest.java
@@ -22,7 +22,13 @@ import javax.ws.rs.core.MediaType;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
-public class MustacheViewRendererTest extends JerseyTest {
+/**
+ * Test class for {@link MustacheViewRenderer} configured to load Mustache
+ * templates from the file system.
+ * 
+ * @since 1.1.0
+ */
+public class MustacheViewRendererFileSystemTest extends JerseyTest {
     static {
         BootstrapLogging.bootstrap();
     }
@@ -60,6 +66,7 @@ public class MustacheViewRendererTest extends JerseyTest {
         forceSet(TestProperties.CONTAINER_PORT, "0");
         ResourceConfig config = new ResourceConfig();
         final ViewRenderer renderer = new MustacheViewRenderer();
+        renderer.configure(ImmutableMap.of("fileRoot", "src/test/resources"));
         config.register(new ViewMessageBodyWriter(new MetricRegistry(), ImmutableList.of(renderer)));
         config.register(new ViewRenderExceptionMapper());
         config.register(new ExampleResource());
@@ -106,17 +113,4 @@ public class MustacheViewRendererTest extends JerseyTest {
         }
     }
 
-    @Test
-    public void cacheByDefault() {
-        MustacheViewRenderer mustacheViewRenderer = new MustacheViewRenderer();
-        mustacheViewRenderer.configure(ImmutableMap.of());
-        assertThat(mustacheViewRenderer.isUseCache()).isTrue();
-    }
-
-    @Test
-    public void canDisableCache() {
-        MustacheViewRenderer mustacheViewRenderer = new MustacheViewRenderer();
-        mustacheViewRenderer.configure(ImmutableMap.of("cache", "false"));
-        assertThat(mustacheViewRenderer.isUseCache()).isFalse();
-    }
 }

--- a/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererTest.java
+++ b/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererTest.java
@@ -31,7 +31,7 @@ public class MustacheViewRendererTest extends JerseyTest {
 
     private ViewRenderer renderer;
 
-    protected static final Map<String,String> DEFAULT_RENDERER_CFG = ImmutableMap.of();
+    protected static final Map<String, String> DEFAULT_RENDERER_CFG = ImmutableMap.of();
 
     @Path("/test/")
     @Produces(MediaType.TEXT_HTML)

--- a/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererTest.java
+++ b/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererTest.java
@@ -22,10 +22,16 @@ import javax.ws.rs.core.MediaType;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
+import java.util.Map;
+
 public class MustacheViewRendererTest extends JerseyTest {
     static {
         BootstrapLogging.bootstrap();
     }
+
+    private ViewRenderer renderer;
+
+    protected static final Map<String,String> DEFAULT_RENDERER_CFG = ImmutableMap.of();
 
     @Path("/test/")
     @Produces(MediaType.TEXT_HTML)
@@ -59,7 +65,8 @@ public class MustacheViewRendererTest extends JerseyTest {
     protected Application configure() {
         forceSet(TestProperties.CONTAINER_PORT, "0");
         ResourceConfig config = new ResourceConfig();
-        final ViewRenderer renderer = new MustacheViewRenderer();
+        renderer = new MustacheViewRenderer();
+        renderer.configure(DEFAULT_RENDERER_CFG);
         config.register(new ViewMessageBodyWriter(new MetricRegistry(), ImmutableList.of(renderer)));
         config.register(new ViewRenderExceptionMapper());
         config.register(new ExampleResource());
@@ -73,9 +80,29 @@ public class MustacheViewRendererTest extends JerseyTest {
     }
 
     @Test
+    public void rendersViewsWithAbsoluteTemplatePathsFromFileSystem() throws Exception {
+        try {
+            renderer.configure(ImmutableMap.of("fileRoot", "src/test/resources", "cache", "false"));
+            rendersViewsWithAbsoluteTemplatePaths();
+        } finally {
+            renderer.configure(DEFAULT_RENDERER_CFG);
+        }
+    }
+
+    @Test
     public void rendersViewsWithRelativeTemplatePaths() throws Exception {
         final String response = target("/test/relative").request().get(String.class);
         assertThat(response).isEqualTo("Ok.\n");
+    }
+
+    @Test
+    public void rendersViewsWithRelativeTemplatePathsFromFileSystem() throws Exception {
+        try {
+            renderer.configure(ImmutableMap.of("fileRoot", "src/test/resources", "cache", "false"));
+            rendersViewsWithRelativeTemplatePaths();
+        } finally {
+            renderer.configure(DEFAULT_RENDERER_CFG);
+        }
     }
 
     @Test


### PR DESCRIPTION
This PR is for adding the ability to load Mustache templates from the file system instead of from the classpath.

To use this feature, add the new, Mustache-specific config option called `fileRoot` pointing to the directory in the file system where Mustache templates should be loaded. When specified, a `FileSystemResolver` will be used instead of `PerClassSystemResolver`. When combined with the new cache options from #1289 , you can update Mustache templates in the file system and Dropwizard will pick up the changes w/o restarting the application.

From implementation point of view, please see whether there is a better way to handle the tests. AFAIK each `JerseyTest` class can only configure the server once normally, so I cheated and added an instance variable to store the `MustacheViewRenderer` object, such that I can configure it. For each relevant test, I then added a "load from file system" version of the test by configuring the renderer with the `fileRoot` and `cache` option.

Thanks.