### PR TITLE
Add Dropwizard forms e2e

### DIFF
--- a/dropwizard-e2e/pom.xml
+++ b/dropwizard-e2e/pom.xml
@@ -51,6 +51,10 @@
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-forms</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-views-mustache</artifactId>
         </dependency>
     </dependencies>

--- a/dropwizard-e2e/src/main/java/com/example/forms/FormsApp.java
+++ b/dropwizard-e2e/src/main/java/com/example/forms/FormsApp.java
@@ -1,0 +1,19 @@
+package com.example.forms;
+
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.forms.MultiPartBundle;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+
+public class FormsApp extends Application<Configuration> {
+    @Override
+    public void initialize(Bootstrap<Configuration> bootstrap) {
+        bootstrap.addBundle(new MultiPartBundle());
+    }
+
+    @Override
+    public void run(Configuration configuration, Environment environment) throws Exception {
+        environment.jersey().register(new FormsResource());
+    }
+}

--- a/dropwizard-e2e/src/main/java/com/example/forms/FormsResource.java
+++ b/dropwizard-e2e/src/main/java/com/example/forms/FormsResource.java
@@ -1,0 +1,32 @@
+package com.example.forms;
+
+import com.google.common.io.ByteStreams;
+import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
+import org.glassfish.jersey.media.multipart.FormDataParam;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.StreamingOutput;
+import java.io.InputStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+@Path("/")
+public class FormsResource {
+    @POST
+    @Path("uploadFile")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.TEXT_PLAIN)
+    public StreamingOutput uploadFile(@FormDataParam("file") InputStream file,
+                                      @FormDataParam("file") FormDataContentDisposition fileDisposition) {
+
+        // Silly example that echoes back the file name and the contents
+        return output -> {
+            output.write(String.format("%s:\n", fileDisposition.getFileName()).getBytes(UTF_8));
+            ByteStreams.copy(file, output);
+        };
+    }
+}

--- a/dropwizard-e2e/src/test/java/com/example/forms/FormsAppTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/forms/FormsAppTest.java
@@ -1,0 +1,63 @@
+package com.example.forms;
+
+import io.dropwizard.Configuration;
+import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.client.JerseyClientConfiguration;
+import io.dropwizard.jersey.errors.ErrorMessage;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
+import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.glassfish.jersey.media.multipart.MultiPart;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FormsAppTest {
+    @ClassRule
+    public static final DropwizardAppRule<Configuration> RULE = new DropwizardAppRule<>(FormsApp.class);
+
+    @Test
+    public void canSubmitFormAndReceiveResponse() {
+        final JerseyClientConfiguration config = new JerseyClientConfiguration();
+        config.setChunkedEncodingEnabled(false);
+
+        final Client client = new JerseyClientBuilder(RULE.getEnvironment())
+            .using(config)
+            .build("test client 1");
+
+        final MultiPart mp = new FormDataMultiPart()
+            .bodyPart(new FormDataBodyPart(
+                FormDataContentDisposition.name("file").fileName("fileName").build(), "CONTENT"));
+
+        final String url = String.format("http://localhost:%d/uploadFile", RULE.getLocalPort());
+        final String response = client.target(url).register(MultiPartFeature.class).request()
+            .post(Entity.entity(mp, mp.getMediaType()), String.class);
+        assertThat(response).isEqualTo("fileName:\nCONTENT");
+    }
+
+    /** Test confirms that chunked encoding has to be disabled in order for sending forms to work.
+     *  Maybe someday this requirement will be relaxed and this test can be updated for the new
+     *  behavior. For more info, see issues #1013 and #1094 */
+    @Test
+    public void failOnNoChunkedEncoding() {
+        final Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("test client 2");
+
+        final MultiPart mp = new FormDataMultiPart()
+            .bodyPart(new FormDataBodyPart(
+                FormDataContentDisposition.name("file").fileName("fileName").build(), "CONTENT"));
+
+        final String url = String.format("http://localhost:%d/uploadFile", RULE.getLocalPort());
+        final Response response = client.target(url).register(MultiPartFeature.class).request()
+            .post(Entity.entity(mp, mp.getMediaType()));
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.readEntity(ErrorMessage.class))
+            .isEqualTo(new ErrorMessage(400, "HTTP 400 Bad Request"));
+    }
+}


### PR DESCRIPTION
There were no examples of using dropwizard-forms, so I decided to add it as a module to `e2e` as an example so that it is easier to point people to (maybe even a link from the documentation !?)