### PR TITLE
Document SSL protocol/cipher suite defaults inherited from the JVM and Jetty

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -401,10 +401,10 @@ Extends the attributes that are available to the :ref:`HTTP connector <man-confi
           jceProvider: (none)
           validateCerts: true
           validatePeers: true
-          supportedProtocols: [SSLv3]
-          excludedProtocols: (none)
-          supportedCipherSuites: [TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256]
-          excludedCipherSuites: (none)
+          supportedProtocols: (JVM default)
+          excludedProtocols: [SSL, SSLv2, SSLv2Hello, SSLv3] # (Jetty's default)
+          supportedCipherSuites: (JVM default)
+          excludedCipherSuites: [.*_(MD5|SHA|SHA1)$] # (Jetty's default)
           allowRenegotiation: true
           endpointIdentificationAlgorithm: (none)
 
@@ -494,6 +494,7 @@ This connector extends the attributes that are available to the :ref:`HTTPS conn
           keyStorePassword: changeit
           trustStorePath: /path/to/file # required
           trustStorePassword: changeit
+          supportedCipherSuites: TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
 
 
 ========================  ========  ===================================================================================

--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -280,9 +280,14 @@ test keystore you can use in the `Dropwizard example project`__.
 
 By default, only secure TLSv1.2 cipher suites are allowed. Older versions of cURL, Java 6 and 7, and
 other clients may be unable to communicate with the allowed cipher suites, but this was a conscious
-decision that sacrifices interoperability for security. Dropwizard allows a workaround by specifying
-a customized list of cipher suites. The following list of excluded cipher suites will allow for
-TLSv1 and TLSv1.1 clients to negotiate a connection similar to pre-Dropwizard 1.0.
+decision that sacrifices interoperability for security.
+
+Dropwizard allows a workaround by specifying a customized list of cipher suites. If no lists of
+supported protocols or cipher suites are specified, then the JVM defaults are used. If no lists of
+excluded protocols or cipher suites are specified, then the defaults are inherited from Jetty.
+
+The following list of excluded cipher suites will allow for TLSv1 and TLSv1.1 clients to negotiate a
+connection similar to pre-Dropwizard 1.0.
 
 .. code-block:: yaml
 

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
@@ -165,7 +165,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *     </tr>
  *     <tr>
  *         <td>{@code supportedProtocols}</td>
- *         <td>(none)</td>
+ *         <td>JVM default</td>
  *         <td>
  *             A list of protocols (e.g., {@code SSLv3}, {@code TLSv1}) which are supported. All
  *             other protocols will be refused.
@@ -173,7 +173,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *     </tr>
  *     <tr>
  *         <td>{@code excludedProtocols}</td>
- *         <td>(none)</td>
+ *         <td>Jetty's default</td>
  *         <td>
  *             A list of protocols (e.g., {@code SSLv3}, {@code TLSv1}) which are excluded. These
  *             protocols will be refused.
@@ -181,15 +181,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *     </tr>
  *     <tr>
  *         <td>{@code supportedCipherSuites}</td>
- *         <td>(none)</td>
+ *         <td>JVM default</td>
  *         <td>
  *             A list of cipher suites (e.g., {@code TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256}) which
  *             are supported. All other cipher suites will be refused
  *         </td>
- *     </tr>
+ *    </tr>
  *    <tr>
  *         <td>{@code excludedCipherSuites}</td>
- *         <td>(none)</td>
+ *         <td>Jetty's default</td>
  *         <td>
  *             A list of cipher suites (e.g., {@code TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256}) which
  *             are excluded. These cipher suites will be refused.


### PR DESCRIPTION
Addresses #1853

This change updates the user manual and the Javadoc of `io.dropwizard.jetty.HttpsConnectorFactory` to call out the fact that the lists of supported and excluded protocols and cipher suites are inherited from the JVM and Jetty. Specifically, the supported lists fall back to JVM defaults and the excluded lists to defaults [hardcoded in Jetty](https://github.com/eclipse/jetty.project/blob/14611d2f76be9ebd955bff6cdd38fde4a008a4c3/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslContextFactory.java#L202-L203).

Note that this change replaces the values of `supportedProtocols` and `supportedCipherSuites` documented in the user manual. Based on my reading of the Jetty code linked above (at the version currently used in Dropwizard, 9.3.14.v20161028), SSLv3 is explicitly excluded, so it doesn't make sense that it would be a supported protocol. Also if the default list of supported cipher suites is [pulled from the JVM](https://github.com/eclipse/jetty.project/blob/14611d2f76be9ebd955bff6cdd38fde4a008a4c3/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslContextFactory.java#L319), then I'm unsure how we arrived at the specified default of TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256. Please advise here.