### PR TITLE
Switch cert and peer validation to false by default

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -399,8 +399,8 @@ Extends the attributes that are available to the :ref:`HTTP connector <man-confi
           maxCertPathLength: (unlimited)
           ocspResponderUrl: (none)
           jceProvider: (none)
-          validateCerts: true
-          validatePeers: true
+          validateCerts: false
+          validatePeers: false
           supportedProtocols: [SSLv3]
           excludedProtocols: (none)
           supportedCipherSuites: [TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256]
@@ -432,9 +432,13 @@ enableOCSP                       false               Whether or not On-Line Cert
 maxCertPathLength                (unlimited)         The maximum certification path length.
 ocspResponderUrl                 (none)              The location of the OCSP responder.
 jceProvider                      (none)              The name of the JCE provider to use for cryptographic support.
-validateCerts                    true                Whether or not to validate TLS certificates before starting. If enabled, Dropwizard
-                                                     will refuse to start with expired or otherwise invalid certificates.
-validatePeers                    true                Whether or not to validate TLS peer certificates.
+validateCerts                    false               Whether or not to validate TLS certificates before starting. If enabled, Dropwizard
+                                                     will refuse to start with expired or otherwise invalid certificates. This option will
+                                                     cause unconditional failure in Dropwizard 1.x until a new validation mechanism can be
+                                                     implemented.
+validatePeers                    false               Whether or not to validate TLS peer certificates. This option will
+                                                     cause unconditional failure in Dropwizard 1.x until a new validation mechanism can be
+                                                     implemented.
 supportedProtocols               (none)              A list of protocols (e.g., ``SSLv3``, ``TLSv1``) which are supported. All
                                                      other protocols will be refused.
 excludedProtocols                (none)              A list of protocols (e.g., ``SSLv3``, ``TLSv1``) which are excluded. These

--- a/dropwizard-client/src/test/resources/yaml/ssl_connection_socket_factory_test.yml
+++ b/dropwizard-client/src/test/resources/yaml/ssl_connection_socket_factory_test.yml
@@ -4,38 +4,28 @@ server:
         port: 0
         keyStoreType: PKCS12
         keyStorePassword: password
-        validateCerts: false
-        validatePeers: false
         trustStoreType: PKCS12
         supportedProtocols: ["TLSv1.2"]
       - type: https
         port: 0
         keyStoreType: PKCS12
         keyStorePassword: password
-        validateCerts: false
-        validatePeers: false
         trustStoreType: PKCS12
       - type: https
         port: 0
         keyStoreType: PKCS12
         keyStorePassword: password
-        validateCerts: false
-        validatePeers: false
         supportedProtocols: ["TLSv1.2"]
       - type: https
         port: 0
         keyStoreType: PKCS12
         keyStorePassword: password
-        validateCerts: false
-        validatePeers: false
         trustStoreType: PKCS12
         supportedProtocols: ["TLSv1.2"]
       - type: https
         port: 0
         keyStoreType: PKCS12
         keyStorePassword: password
-        validateCerts: false
-        validatePeers: false
         trustStoreType: PKCS12
         supportedProtocols: ["TLSv1.2"]
   adminConnectors:

--- a/dropwizard-e2e/src/test/resources/sslreload/config.yml
+++ b/dropwizard-e2e/src/test/resources/sslreload/config.yml
@@ -4,12 +4,8 @@ server:
           port: 0
           keyStorePath: keystore.jks
           keyStorePassword: password
-          validateCerts: false
-          validatePeers: false
     adminConnectors:
         - type: https
           port: 0
           keyStorePath: keystore.jks
           keyStorePassword: password
-          validateCerts: false
-          validatePeers: false

--- a/dropwizard-example/example.yml
+++ b/dropwizard-example/example.yml
@@ -34,15 +34,11 @@ server:
       port: 8443
       keyStorePath: example.keystore
       keyStorePassword: example
-      validateCerts: false
-      validatePeers: false
     #this requires the alpn-boot library on the JVM's boot classpath
     #- type: h2
     #  port: 8445
     #  keyStorePath: example.keystore
     #  keyStorePassword: example
-    #  validateCerts: false
-    #  validatePeers: false
   adminConnectors:
     - type: http
       port: 8081
@@ -50,8 +46,6 @@ server:
       port: 8444
       keyStorePath: example.keystore
       keyStorePassword: example
-      validateCerts: false
-      validatePeers: false
 
 # Logging settings.
 logging:

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
@@ -152,16 +152,22 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *     </tr>
  *     <tr>
  *         <td>{@code validateCerts}</td>
- *         <td>true</td>
+ *         <td>false</td>
  *         <td>
  *             Whether or not to validate TLS certificates before starting. If enabled, Dropwizard
- *             will refuse to start with expired or otherwise invalid certificates.
+ *             will refuse to start with expired or otherwise invalid certificates. This option will
+ *             cause unconditional failure in Dropwizard 1.x until a new validation mechanism can be
+ *             implemented.
  *         </td>
  *     </tr>
  *     <tr>
  *         <td>{@code validatePeers}</td>
- *         <td>true</td>
- *         <td>Whether or not to validate TLS peer certificates.</td>
+ *         <td>false</td>
+ *         <td>
+ *             Whether or not to validate TLS peer certificates. This option will
+ *             cause unconditional failure in Dropwizard 1.x until a new validation mechanism can be
+ *             implemented.
+ *         </td>
  *     </tr>
  *     <tr>
  *         <td>{@code supportedProtocols}</td>
@@ -247,8 +253,8 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
     private Integer maxCertPathLength;
     private URI ocspResponderUrl;
     private String jceProvider;
-    private boolean validateCerts = true;
-    private boolean validatePeers = true;
+    private boolean validateCerts = false;
+    private boolean validatePeers = false;
     private List<String> supportedProtocols;
     private List<String> excludedProtocols;
     private List<String> supportedCipherSuites;


### PR DESCRIPTION
If any either of these two options are enabled, a HTTPs enabled Dropwizard
app will most likely fail to start with cryptic error messages. Since
Jetty has these options disabled by default, we should follow their lead
and disable these options as well.

Future work includes adding in additional certificate features as
Certificate Revocation List (CRL),  CRL Distribution Points Protocol
(CRLDP), On-Line Certificate Status Protocol (OCSP)

This may be considered a bugfix and is a candidate for either 1.0.x or 1.1