### PR TITLE
Have the abstract command pass in the Database rather than Connection…

### DIFF
--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/AbstractLiquibaseCommand.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/AbstractLiquibaseCommand.java
@@ -86,9 +86,9 @@ public abstract class AbstractLiquibaseCommand<T extends Configuration> extends 
         return liquibase;
     }
 
-    private Database createDatabase(final ManagedDataSource dataSource, Namespace namespace) throws SQLException, LiquibaseException {
-        DatabaseConnection conn = new JdbcConnection(dataSource.getConnection());
-        Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(conn);
+    private Database createDatabase(ManagedDataSource dataSource, Namespace namespace) throws SQLException, LiquibaseException {
+        final DatabaseConnection conn = new JdbcConnection(dataSource.getConnection());
+        final Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(conn);
 
         final String catalogName = namespace.getString("catalog");
         final String schemaName = namespace.getString("schema");

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/AbstractLiquibaseCommand.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/AbstractLiquibaseCommand.java
@@ -86,7 +86,10 @@ public abstract class AbstractLiquibaseCommand<T extends Configuration> extends 
         return liquibase;
     }
 
-    private Database createDatabase(ManagedDataSource dataSource, Namespace namespace) throws SQLException, LiquibaseException {
+    private Database createDatabase(
+        ManagedDataSource dataSource,
+        Namespace namespace
+    ) throws SQLException, LiquibaseException {
         final DatabaseConnection conn = new JdbcConnection(dataSource.getConnection());
         final Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(conn);
 

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibase.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibase.java
@@ -2,7 +2,7 @@ package io.dropwizard.migrations;
 
 import io.dropwizard.db.ManagedDataSource;
 import liquibase.Liquibase;
-import liquibase.database.DatabaseConnection;
+import liquibase.database.Database;
 import liquibase.exception.LiquibaseException;
 import liquibase.resource.ResourceAccessor;
 
@@ -11,8 +11,8 @@ import java.sql.SQLException;
 public abstract class CloseableLiquibase extends Liquibase implements AutoCloseable {
     private final ManagedDataSource dataSource;
 
-    public CloseableLiquibase(String changeLogFile, ResourceAccessor resourceAccessor, DatabaseConnection conn, ManagedDataSource dataSource) throws LiquibaseException, SQLException {
-        super(changeLogFile, resourceAccessor, conn);
+    public CloseableLiquibase(String changeLogFile, ResourceAccessor resourceAccessor, Database database, ManagedDataSource dataSource) throws LiquibaseException, SQLException {
+        super(changeLogFile, resourceAccessor, database);
         this.dataSource = dataSource;
     }
 

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibase.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibase.java
@@ -12,7 +12,12 @@ import java.sql.SQLException;
 public abstract class CloseableLiquibase extends Liquibase implements AutoCloseable {
     private final ManagedDataSource dataSource;
 
-    CloseableLiquibase(String changeLogFile, ResourceAccessor resourceAccessor, Database database, ManagedDataSource dataSource) throws LiquibaseException, SQLException {
+    CloseableLiquibase(
+        String changeLogFile,
+        ResourceAccessor resourceAccessor,
+        Database database,
+        ManagedDataSource dataSource
+    ) throws LiquibaseException, SQLException {
         super(changeLogFile, resourceAccessor, database);
         this.dataSource = dataSource;
     }

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibase.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibase.java
@@ -3,6 +3,7 @@ package io.dropwizard.migrations;
 import io.dropwizard.db.ManagedDataSource;
 import liquibase.Liquibase;
 import liquibase.database.Database;
+import liquibase.database.DatabaseConnection;
 import liquibase.exception.LiquibaseException;
 import liquibase.resource.ResourceAccessor;
 
@@ -11,8 +12,13 @@ import java.sql.SQLException;
 public abstract class CloseableLiquibase extends Liquibase implements AutoCloseable {
     private final ManagedDataSource dataSource;
 
-    public CloseableLiquibase(String changeLogFile, ResourceAccessor resourceAccessor, Database database, ManagedDataSource dataSource) throws LiquibaseException, SQLException {
+    CloseableLiquibase(String changeLogFile, ResourceAccessor resourceAccessor, Database database, ManagedDataSource dataSource) throws LiquibaseException, SQLException {
         super(changeLogFile, resourceAccessor, database);
+        this.dataSource = dataSource;
+    }
+
+    public CloseableLiquibase(String changeLogFile, ResourceAccessor resourceAccessor, DatabaseConnection conn, ManagedDataSource dataSource) throws LiquibaseException, SQLException {
+        super(changeLogFile, resourceAccessor, conn);
         this.dataSource = dataSource;
     }
 

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibaseWithClassPathMigrationsFile.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibaseWithClassPathMigrationsFile.java
@@ -11,16 +11,24 @@ import java.sql.SQLException;
 
 public class CloseableLiquibaseWithClassPathMigrationsFile extends CloseableLiquibase implements AutoCloseable {
 
-    CloseableLiquibaseWithClassPathMigrationsFile(ManagedDataSource dataSource, Database database, String file) throws LiquibaseException, SQLException {
+    CloseableLiquibaseWithClassPathMigrationsFile(
+        ManagedDataSource dataSource,
+        Database database,
+        String file
+    ) throws LiquibaseException, SQLException {
         super(file,
               new ClassLoaderResourceAccessor(),
               database,
               dataSource);
     }
 
-    public CloseableLiquibaseWithClassPathMigrationsFile(ManagedDataSource dataSource, String file) throws LiquibaseException, SQLException {
+    public CloseableLiquibaseWithClassPathMigrationsFile(
+        ManagedDataSource dataSource,
+        String file
+    ) throws LiquibaseException, SQLException {
         this(dataSource,
-            DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(dataSource.getConnection())),
+            DatabaseFactory.getInstance()
+                .findCorrectDatabaseImplementation(new JdbcConnection(dataSource.getConnection())),
             file);
     }
 }

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibaseWithClassPathMigrationsFile.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibaseWithClassPathMigrationsFile.java
@@ -2,6 +2,8 @@ package io.dropwizard.migrations;
 
 import io.dropwizard.db.ManagedDataSource;
 import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.LiquibaseException;
 import liquibase.resource.ClassLoaderResourceAccessor;
 
@@ -9,11 +11,16 @@ import java.sql.SQLException;
 
 public class CloseableLiquibaseWithClassPathMigrationsFile extends CloseableLiquibase implements AutoCloseable {
 
-    public CloseableLiquibaseWithClassPathMigrationsFile(ManagedDataSource dataSource, Database database, String file) throws LiquibaseException, SQLException {
+    CloseableLiquibaseWithClassPathMigrationsFile(ManagedDataSource dataSource, Database database, String file) throws LiquibaseException, SQLException {
         super(file,
               new ClassLoaderResourceAccessor(),
               database,
               dataSource);
     }
 
+    public CloseableLiquibaseWithClassPathMigrationsFile(ManagedDataSource dataSource, String file) throws LiquibaseException, SQLException {
+        this(dataSource,
+            DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(dataSource.getConnection())),
+            file);
+    }
 }

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibaseWithClassPathMigrationsFile.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibaseWithClassPathMigrationsFile.java
@@ -1,7 +1,7 @@
 package io.dropwizard.migrations;
 
 import io.dropwizard.db.ManagedDataSource;
-import liquibase.database.jvm.JdbcConnection;
+import liquibase.database.Database;
 import liquibase.exception.LiquibaseException;
 import liquibase.resource.ClassLoaderResourceAccessor;
 
@@ -9,10 +9,10 @@ import java.sql.SQLException;
 
 public class CloseableLiquibaseWithClassPathMigrationsFile extends CloseableLiquibase implements AutoCloseable {
 
-    public CloseableLiquibaseWithClassPathMigrationsFile(ManagedDataSource dataSource, String file) throws LiquibaseException, SQLException {
+    public CloseableLiquibaseWithClassPathMigrationsFile(ManagedDataSource dataSource, Database database, String file) throws LiquibaseException, SQLException {
         super(file,
               new ClassLoaderResourceAccessor(),
-              new JdbcConnection(dataSource.getConnection()),
+              database,
               dataSource);
     }
 

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibaseWithFileSystemMigrationsFile.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibaseWithFileSystemMigrationsFile.java
@@ -2,6 +2,8 @@ package io.dropwizard.migrations;
 
 import io.dropwizard.db.ManagedDataSource;
 import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.LiquibaseException;
 import liquibase.resource.FileSystemResourceAccessor;
 
@@ -9,11 +11,16 @@ import java.sql.SQLException;
 
 public class CloseableLiquibaseWithFileSystemMigrationsFile extends CloseableLiquibase implements AutoCloseable {
 
-    public CloseableLiquibaseWithFileSystemMigrationsFile(ManagedDataSource dataSource, Database database, String file) throws LiquibaseException, SQLException {
+    CloseableLiquibaseWithFileSystemMigrationsFile(ManagedDataSource dataSource, Database database, String file) throws LiquibaseException, SQLException {
         super(file,
               new FileSystemResourceAccessor(),
               database,
               dataSource);
     }
 
+    public CloseableLiquibaseWithFileSystemMigrationsFile(ManagedDataSource dataSource, String file) throws LiquibaseException, SQLException {
+        this(dataSource,
+            DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(dataSource.getConnection())),
+            file);
+    }
 }

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibaseWithFileSystemMigrationsFile.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibaseWithFileSystemMigrationsFile.java
@@ -11,16 +11,24 @@ import java.sql.SQLException;
 
 public class CloseableLiquibaseWithFileSystemMigrationsFile extends CloseableLiquibase implements AutoCloseable {
 
-    CloseableLiquibaseWithFileSystemMigrationsFile(ManagedDataSource dataSource, Database database, String file) throws LiquibaseException, SQLException {
+    CloseableLiquibaseWithFileSystemMigrationsFile(
+        ManagedDataSource dataSource,
+        Database database,
+        String file
+    ) throws LiquibaseException, SQLException {
         super(file,
               new FileSystemResourceAccessor(),
               database,
               dataSource);
     }
 
-    public CloseableLiquibaseWithFileSystemMigrationsFile(ManagedDataSource dataSource, String file) throws LiquibaseException, SQLException {
+    public CloseableLiquibaseWithFileSystemMigrationsFile(
+        ManagedDataSource dataSource,
+        String file
+    ) throws LiquibaseException, SQLException {
         this(dataSource,
-            DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(dataSource.getConnection())),
+            DatabaseFactory.getInstance()
+                .findCorrectDatabaseImplementation(new JdbcConnection(dataSource.getConnection())),
             file);
     }
 }

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibaseWithFileSystemMigrationsFile.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibaseWithFileSystemMigrationsFile.java
@@ -1,7 +1,7 @@
 package io.dropwizard.migrations;
 
 import io.dropwizard.db.ManagedDataSource;
-import liquibase.database.jvm.JdbcConnection;
+import liquibase.database.Database;
 import liquibase.exception.LiquibaseException;
 import liquibase.resource.FileSystemResourceAccessor;
 
@@ -9,10 +9,10 @@ import java.sql.SQLException;
 
 public class CloseableLiquibaseWithFileSystemMigrationsFile extends CloseableLiquibase implements AutoCloseable {
 
-    public CloseableLiquibaseWithFileSystemMigrationsFile(ManagedDataSource dataSource, String file) throws LiquibaseException, SQLException {
+    public CloseableLiquibaseWithFileSystemMigrationsFile(ManagedDataSource dataSource, Database database, String file) throws LiquibaseException, SQLException {
         super(file,
               new FileSystemResourceAccessor(),
-              new JdbcConnection(dataSource.getConnection()),
+              database,
               dataSource);
     }
 

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/CloseableLiquibaseTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/CloseableLiquibaseTest.java
@@ -3,6 +3,10 @@ package io.dropwizard.migrations;
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.db.ManagedPooledDataSource;
+import liquibase.database.Database;
+import liquibase.database.DatabaseConnection;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
 import net.jcip.annotations.NotThreadSafe;
 import org.apache.tomcat.jdbc.pool.ConnectionPool;
 import org.junit.Before;
@@ -25,7 +29,9 @@ public class CloseableLiquibaseTest {
         factory.setUser("DbTest");
 
         dataSource = (ManagedPooledDataSource) factory.build(new MetricRegistry(), "DbTest");
-        liquibase = new CloseableLiquibaseWithClassPathMigrationsFile(dataSource, "migrations.xml");
+        DatabaseConnection conn = new JdbcConnection(dataSource.getConnection());
+        Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(conn);
+        liquibase = new CloseableLiquibaseWithClassPathMigrationsFile(dataSource, database, "migrations.xml");
     }
 
     @Test

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/CloseableLiquibaseTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/CloseableLiquibaseTest.java
@@ -3,10 +3,6 @@ package io.dropwizard.migrations;
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.db.ManagedPooledDataSource;
-import liquibase.database.Database;
-import liquibase.database.DatabaseConnection;
-import liquibase.database.core.H2Database;
-import liquibase.database.jvm.JdbcConnection;
 import net.jcip.annotations.NotThreadSafe;
 import org.apache.tomcat.jdbc.pool.ConnectionPool;
 import org.junit.Before;
@@ -29,10 +25,7 @@ public class CloseableLiquibaseTest {
         factory.setUser("DbTest");
 
         dataSource = (ManagedPooledDataSource) factory.build(new MetricRegistry(), "DbTest");
-        DatabaseConnection conn = new JdbcConnection(dataSource.getConnection());
-        Database database = new H2Database();
-        database.setConnection(conn);
-        liquibase = new CloseableLiquibaseWithClassPathMigrationsFile(dataSource, database, "migrations.xml");
+        liquibase = new CloseableLiquibaseWithClassPathMigrationsFile(dataSource, "migrations.xml");
     }
 
     @Test

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCustomSchemaTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCustomSchemaTest.java
@@ -1,0 +1,46 @@
+package io.dropwizard.migrations;
+
+import com.google.common.collect.ImmutableMap;
+import net.jcip.annotations.NotThreadSafe;
+import net.sourceforge.argparse4j.inf.Namespace;
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@NotThreadSafe
+public class DbMigrateCustomSchemaTest extends AbstractMigrationTest {
+
+    private DbMigrateCommand<TestMigrationConfiguration> migrateCommand = new DbMigrateCommand<>(
+        TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations-custom-schema.xml");
+    private TestMigrationConfiguration conf;
+    private String databaseUrl;
+
+    @Before
+    public void setUp() throws Exception {
+        databaseUrl = "jdbc:h2:" + createTempFile();
+        conf = createConfiguration(databaseUrl);
+    }
+
+    @Test
+    public void testRunMigrationWithCustomSchema() throws Exception {
+        String schemaName = "customschema";
+        try (Handle handle = new DBI(databaseUrl, "sa", "").open()) {
+            handle.execute("create schema " + schemaName);
+        }
+        Namespace namespace = new Namespace(ImmutableMap.of("schema", schemaName));
+        migrateCommand.run(null, namespace, conf);
+        try (Handle handle = new DBI(databaseUrl, "sa", "").open()) {
+            final List<Map<String, Object>> rows = handle.select("select * from " + schemaName + ".persons");
+            assertThat(rows).hasSize(1);
+            assertThat(rows.get(0)).isEqualTo(
+                ImmutableMap.of("id", 1, "name", "Bill Smith", "email", "bill@smith.me"));
+        }
+    }
+
+}

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCustomSchemaTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCustomSchemaTest.java
@@ -29,7 +29,7 @@ public class DbMigrateCustomSchemaTest extends AbstractMigrationTest {
         String schemaName = "customschema";
         DBI dbi = new DBI(databaseUrl, "sa", "");
         dbi.useHandle(h -> h.execute("create schema " + schemaName));
-        Namespace namespace = new Namespace(ImmutableMap.of("schema", schemaName));
+        Namespace namespace = new Namespace(ImmutableMap.of("schema", schemaName, "catalog", "public"));
         migrateCommand.run(null, namespace, conf);
         dbi.useHandle(handle -> {
             assertThat(handle

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCustomSchemaTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCustomSchemaTest.java
@@ -3,13 +3,10 @@ package io.dropwizard.migrations;
 import com.google.common.collect.ImmutableMap;
 import net.jcip.annotations.NotThreadSafe;
 import net.sourceforge.argparse4j.inf.Namespace;
+import org.assertj.core.data.Index;
 import org.junit.Before;
 import org.junit.Test;
 import org.skife.jdbi.v2.DBI;
-import org.skife.jdbi.v2.Handle;
-
-import java.util.List;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,17 +27,16 @@ public class DbMigrateCustomSchemaTest extends AbstractMigrationTest {
     @Test
     public void testRunMigrationWithCustomSchema() throws Exception {
         String schemaName = "customschema";
-        try (Handle handle = new DBI(databaseUrl, "sa", "").open()) {
-            handle.execute("create schema " + schemaName);
-        }
+        DBI dbi = new DBI(databaseUrl, "sa", "");
+        dbi.useHandle(h -> h.execute("create schema " + schemaName));
         Namespace namespace = new Namespace(ImmutableMap.of("schema", schemaName));
         migrateCommand.run(null, namespace, conf);
-        try (Handle handle = new DBI(databaseUrl, "sa", "").open()) {
-            final List<Map<String, Object>> rows = handle.select("select * from " + schemaName + ".persons");
-            assertThat(rows).hasSize(1);
-            assertThat(rows.get(0)).isEqualTo(
-                ImmutableMap.of("id", 1, "name", "Bill Smith", "email", "bill@smith.me"));
-        }
+        dbi.useHandle(handle -> {
+            assertThat(handle
+                .select("select * from " + schemaName + ".persons"))
+                .hasSize(1)
+                .contains(ImmutableMap.of("id", 1, "name", "Bill Smith", "email", "bill@smith.me"), Index.atIndex(0));
+        });
     }
 
 }

--- a/dropwizard-migrations/src/test/resources/migrations-custom-schema.xml
+++ b/dropwizard-migrations/src/test/resources/migrations-custom-schema.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="1" author="db_dev">
+        <createTable tableName="persons">
+            <column name="id" type="int" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="name" type="varchar(256)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2" author="db_dev">
+        <addColumn schemaName="${database.defaultSchemaName}" tableName="persons">
+            <column name="email" type="varchar(128)"/>
+        </addColumn>
+        <sql>insert into ${database.defaultSchemaName}.persons (name, email) values ('Bill Smith', 'bill@smith.me')</sql>
+    </changeSet>
+    <changeSet id="3" author="db_dev">
+        <sql>create index email_idx on ${database.defaultSchemaName}.persons(email)</sql>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
…, so that default schema / catalog can be provided before constructing Liquibase.

This is to address #1857