### PR TITLE
Include logging options in config

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -591,6 +591,8 @@ Console
       appenders:
         - type: console
           threshold: ALL
+          queueSize: 512
+          discardingThreshold: 0
           timeZone: UTC
           target: stdout
           logFormat: # TODO
@@ -604,10 +606,11 @@ Name                   Default      Description
 type                   REQUIRED     The appender type. Must be ``console``.
 threshold              ALL          The lowest level of events to print to the console.
 queueSize              256          The maximum capacity of the blocking queue.
-discardingThreshold    51           When the blocking queue has only the capacity mentioned in discardingThreshold
-                                    remaining, it will drop events of level TRACE, DEBUG and INFO, keeping only events
-                                    of level WARN and ERROR. If no discarding threshold is specified, then a default
-                                    of queueSize / 5 is used. To keep all events, set discardingThreshold to 0.
+discardingThreshold    51           When the blocking queue has only the capacity mentioned in
+                                    discardingThreshold remaining, it will drop events of level TRACE,
+                                    DEBUG and INFO, keeping only events of level WARN and ERROR.
+                                    If no discarding threshold is specified, then a default of queueSize / 5 is used.
+                                    To keep all events, set discardingThreshold to 0.
 timeZone               UTC          The time zone to which event timestamps will be converted.
 target                 stdout       The name of the standard stream to which events will be written.
                                     Can be ``stdout`` or ``stderr``.
@@ -633,6 +636,8 @@ File
         - type: file
           currentLogFilename: /var/log/myapplication.log
           threshold: ALL
+          queueSize: 512
+          discardingThreshold: 0
           archive: true
           archivedLogFilenamePattern: /var/log/myapplication-%d.log
           archivedFileCount: 5


### PR DESCRIPTION
Adding the queueSize and discardingThreshold logging configuration options to the documentation.  This is related to https://github.com/dropwizard/dropwizard/issues/1856.

A formatting issue in https://github.com/dropwizard/dropwizard/pull/1858 caused the table to disappear and I realized I had forgotten to include the config options in the example. This is fixed with this PR.

