### PR TITLE
ensuring that server-side JsonProcessingExceptions return JSON, consistent with other 500 errors

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapper.java
@@ -45,8 +45,7 @@ public class JsonProcessingExceptionMapper extends LoggingExceptionMapper<JsonPr
          * If the error is in the JSON generation, it's a server error.
          */
         if (exception instanceof JsonGenerationException) {
-            LOGGER.warn("Error generating JSON", exception);
-            return Response.serverError().build();
+            return super.toResponse(exception); // LoggingExceptionMapper will log exception
         }
 
         final String message = exception.getOriginalMessage();

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapper.java
@@ -13,12 +13,11 @@ import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 import java.util.regex.Pattern;
 
 @Provider
-public class JsonProcessingExceptionMapper extends LoggingExceptionMapper<JsonProcessingException> implements ExceptionMapper<JsonProcessingException> {
+public class JsonProcessingExceptionMapper extends LoggingExceptionMapper<JsonProcessingException> {
     // Pattern to match jackson error messages where a class lacks a single argument constructor
     // or factory to handle a given type. For example:
     // "no boolean/Boolean-argument constructor/factory method to deserialize from boolean value"

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapper.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.exc.PropertyBindingException;
 import com.google.common.base.Throwables;
 import io.dropwizard.jersey.errors.ErrorMessage;
+import io.dropwizard.jersey.errors.LoggingExceptionMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,7 +18,7 @@ import javax.ws.rs.ext.Provider;
 import java.util.regex.Pattern;
 
 @Provider
-public class JsonProcessingExceptionMapper implements ExceptionMapper<JsonProcessingException> {
+public class JsonProcessingExceptionMapper extends LoggingExceptionMapper<JsonProcessingException> implements ExceptionMapper<JsonProcessingException> {
     // Pattern to match jackson error messages where a class lacks a single argument constructor
     // or factory to handle a given type. For example:
     // "no boolean/Boolean-argument constructor/factory method to deserialize from boolean value"
@@ -72,8 +73,7 @@ public class JsonProcessingExceptionMapper implements ExceptionMapper<JsonProces
                     !WRONG_TYPE_REGEX.matcher(cause.getMessage()).find());
 
             if (beanError && !clientCause) {
-                LOGGER.error("Unable to serialize or deserialize the specific type", exception);
-                return Response.serverError().build();
+                return super.toResponse(exception); // LoggingExceptionMapper will log exception
             }
         }
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapperTest.java
@@ -42,6 +42,7 @@ public class JsonProcessingExceptionMapperTest extends JerseyTest {
         Response response = target("/json/broken").request(MediaType.APPLICATION_JSON)
                 .post(Entity.entity(new BrokenRepresentation(ImmutableList.of("whee")), MediaType.APPLICATION_JSON));
         assertThat(response.getStatus()).isEqualTo(500);
+        assertThat(response.getMediaType()).isEqualTo(MediaType.APPLICATION_JSON_TYPE);
     }
 
     @Test
@@ -53,12 +54,14 @@ public class JsonProcessingExceptionMapperTest extends JerseyTest {
         Response response = target("/json/brokenList").request(MediaType.APPLICATION_JSON)
             .post(Entity.entity(ent, MediaType.APPLICATION_JSON));
         assertThat(response.getStatus()).isEqualTo(500);
+        assertThat(response.getMediaType()).isEqualTo(MediaType.APPLICATION_JSON_TYPE);
     }
 
     @Test
     public void returnsA500ForNonSerializableRepresentationClassesOutbound() throws Exception {
         Response response = target("/json/brokenOutbound").request(MediaType.APPLICATION_JSON).get();
         assertThat(response.getStatus()).isEqualTo(500);
+        assertThat(response.getMediaType()).isEqualTo(MediaType.APPLICATION_JSON_TYPE);
     }
 
     @Test
@@ -66,6 +69,7 @@ public class JsonProcessingExceptionMapperTest extends JerseyTest {
         Response response = target("/json/interface").request(MediaType.APPLICATION_JSON)
             .post(Entity.entity("\"hello\"", MediaType.APPLICATION_JSON));
         assertThat(response.getStatus()).isEqualTo(500);
+        assertThat(response.getMediaType()).isEqualTo(MediaType.APPLICATION_JSON_TYPE);
     }
 
     @Test
@@ -73,6 +77,7 @@ public class JsonProcessingExceptionMapperTest extends JerseyTest {
         Response response = target("/json/interfaceList").request(MediaType.APPLICATION_JSON)
             .post(Entity.entity("[\"hello\"]", MediaType.APPLICATION_JSON));
         assertThat(response.getStatus()).isEqualTo(500);
+        assertThat(response.getMediaType()).isEqualTo(MediaType.APPLICATION_JSON_TYPE);
     }
 
     @Test


### PR DESCRIPTION
Currently, most 500s from Dropwizard internal exceptions return as application/json, with a nice logging ID, courtesy of `LoggingExceptionMapper`. This is a pleasant default.

However, `JsonProcessingException`s that have been determined to be server-side issues are still returning as the default Jersey HTML format, which is less pleasant.

This PR causes server-side JsonProcessingException 500s to return as application/json. It re-uses the `LoggingExceptionMapper` code and returns in the exact same format as other internal exceptions.

Feedback welcomed.