### PR TITLE
Upgrade tomcat-jdbc to 8.5.9

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -33,7 +33,7 @@ v1.1.0: Unreleased
 * Upgraded to Jackson 2.8.5 `#1838 <https://github.com/dropwizard/dropwizard/pull/1838>`_
 * Upgraded to Hibernate Validator 5.3.0.Final `#1782 <https://github.com/dropwizard/dropwizard/pull/1782>`_
 * Upgraded to Jetty 9.3.14.v20161028 `#1796 <https://github.com/dropwizard/dropwizard/pull/1796>`_
-* Upgraded to tomcat-jdbc 8.5.6
+* Upgraded to tomcat-jdbc 8.5.9
 * Upgraded to Objenesis 2.4 `#1654 <https://github.com/dropwizard/dropwizard/pull/1654>`_
 * Upgraded to AssertJ 3.5.2 `#1654 <https://github.com/dropwizard/dropwizard/pull/1654>`_
 * Upgraded to classmate 1.3.3

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -94,7 +94,7 @@
             <dependency>
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-jdbc</artifactId>
-                <version>8.5.6</version>
+                <version>8.5.9</version>
             </dependency>
             <dependency>
                 <groupId>com.h2database</groupId>


### PR DESCRIPTION
Unfortunately, the tomcat-jdbc project doesn't provide own release notes, but
you can find the changelog for the Tomcat project here: (you can see the `tomcat-jdbc` section):
https://tomcat.apache.org/tomcat-8.0-doc/changelog.html. The list of commits here:
https://github.com/apache/tomcat/commits/trunk/modules/jdbc-pool

The biggest feature which  is an additional statistic for the connection pool plus
some bugfixes for handling various timeouts.