### PR TITLE
Avoid NPE while processing NPE

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapper.java
@@ -65,10 +65,11 @@ public class JsonProcessingExceptionMapper extends LoggingExceptionMapper<JsonPr
             // Until completely foolproof mechanism can be worked out in coordination
             // with Jackson on how to communicate client vs server fault, compare
             // start of message with known server faults.
-            final boolean beanError = cause.getMessage().startsWith("No suitable constructor found") ||
-                cause.getMessage().startsWith("No serializer found for class") ||
-                (cause.getMessage().startsWith("Can not construct instance") &&
-                    !WRONG_TYPE_REGEX.matcher(cause.getMessage()).find());
+            final boolean beanError = cause.getMessage() != null &&
+                (cause.getMessage().startsWith("No suitable constructor found") ||
+                    cause.getMessage().startsWith("No serializer found for class") ||
+                    (cause.getMessage().startsWith("Can not construct instance") &&
+                        !WRONG_TYPE_REGEX.matcher(cause.getMessage()).find()));
 
             if (beanError && !clientCause) {
                 return super.toResponse(exception); // LoggingExceptionMapper will log exception


### PR DESCRIPTION
Some exceptions, most notably NullPointerException, have null messages.
Masking them with a new NullPointerException is unhelpful.