### PR TITLE
Upgrade to Hibernate 5.2

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -54,6 +54,7 @@ v1.1.0: Unreleased
 * Upgraded to H2 1.4.193
 * Upgraded to Joda-Time 2.9.7
 * Upgraded to commons-lang3 3.5
+* Upgraded to Hibernate ORM 5.2.5 `#1871 <https://github.com/dropwizard/dropwizard/pull/1871>`
 
 .. _rel-1.0.6:
 

--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -9,6 +9,7 @@ Release Notes
 v1.1.0: Unreleased
 ==================
 
+* Upgraded to Hibernate ORM 5.2.7, introducing a series of deprecations and API changes in preparation for Hibernate ORM 6 `#1871 <https://github.com/dropwizard/dropwizard/pull/1871>`
 * Add runtime certificate reload via admin task `#1799 <https://github.com/dropwizard/dropwizard/pull/1799>`_
 * Invalid enum request parameters result in 400 response with possible choices `#1734 <https://github.com/dropwizard/dropwizard/pull/1734>`_
 * Enum request parameters are deserialized in the same fuzzy manner, as the request body `#1734 <https://github.com/dropwizard/dropwizard/pull/1734>`_
@@ -54,7 +55,6 @@ v1.1.0: Unreleased
 * Upgraded to H2 1.4.193
 * Upgraded to Joda-Time 2.9.7
 * Upgraded to commons-lang3 3.5
-* Upgraded to Hibernate ORM 5.2.5 `#1871 <https://github.com/dropwizard/dropwizard/pull/1871>`
 
 .. _rel-1.0.6:
 

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -119,7 +119,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-core</artifactId>
-                <version>5.2.5.Final</version>
+                <version>5.2.7.Final</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jboss.logging</groupId>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -104,12 +104,8 @@
             <dependency>
                 <groupId>org.jadira.usertype</groupId>
                 <artifactId>usertype.core</artifactId>
-                <version>5.0.0.GA</version>
+                <version>6.0.1.GA</version>
                 <exclusions>
-                    <exclusion>
-                        <groupId>org.hibernate</groupId>
-                        <artifactId>hibernate-entitymanager</artifactId>
-                    </exclusion>
                     <exclusion>
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-api</artifactId>
@@ -123,7 +119,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-core</artifactId>
-                <version>5.1.0.Final</version>
+                <version>5.2.5.Final</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jboss.logging</groupId>

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/AbstractDAO.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/AbstractDAO.java
@@ -4,9 +4,9 @@ import io.dropwizard.util.Generics;
 import org.hibernate.Criteria;
 import org.hibernate.Hibernate;
 import org.hibernate.HibernateException;
-import org.hibernate.Query;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.query.Query;
 
 import java.io.Serializable;
 import java.util.List;

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/AbstractDAO.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/AbstractDAO.java
@@ -7,9 +7,12 @@ import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
+import org.hibernate.query.internal.AbstractProducedQuery;
 
 import java.io.Serializable;
 import java.util.List;
+
+import javax.persistence.criteria.CriteriaQuery;
 
 import static java.util.Objects.requireNonNull;
 
@@ -73,6 +76,22 @@ public class AbstractDAO<E> {
     }
 
     /**
+     * Convenience method to return a single instance that matches the criteria query,
+     * or null if the criteria returns no results.
+     *
+     * @param criteriaQuery the {@link CriteriaQuery} query to run
+     * @return the single result or {@code null}
+     * @throws HibernateException if there is more than one matching result
+     */
+    protected E uniqueResult(CriteriaQuery<E> criteriaQuery) throws HibernateException {
+        return AbstractProducedQuery.uniqueElement(
+            currentSession()
+                .createQuery(requireNonNull(criteriaQuery))
+                .getResultList()
+        );
+    }
+
+    /**
      * Convenience method to return a single instance that matches the criteria, or null if the
      * criteria returns no results.
      *
@@ -95,9 +114,8 @@ public class AbstractDAO<E> {
      * @throws HibernateException if there is more than one matching result
      * @see Query#uniqueResult()
      */
-    @SuppressWarnings("unchecked")
-    protected E uniqueResult(Query query) throws HibernateException {
-        return (E) requireNonNull(query).uniqueResult();
+    protected E uniqueResult(Query<E> query) throws HibernateException {
+        return requireNonNull(query).uniqueResult();
     }
 
     /**
@@ -113,14 +131,23 @@ public class AbstractDAO<E> {
     }
 
     /**
+     * Get the results of a {@link CriteriaQuery} query.
+     *
+     * @param criteria the {@link CriteriaQuery} query to run
+     * @return the list of matched query results
+     */
+    protected List<E> list(CriteriaQuery<E> criteria) throws HibernateException {
+        return currentSession().createQuery(requireNonNull(criteria)).getResultList();
+    }
+
+    /**
      * Get the results of a query.
      *
      * @param query the query to run
      * @return the list of matched query results
      * @see Query#list()
      */
-    @SuppressWarnings("unchecked")
-    protected List<E> list(Query query) throws HibernateException {
+    protected List<E> list(Query<E> query) throws HibernateException {
         return requireNonNull(query).list();
     }
 

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryHealthCheck.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryHealthCheck.java
@@ -44,7 +44,7 @@ public class SessionFactoryHealthCheck extends HealthCheck {
             try (Session session = sessionFactory.openSession()) {
                 final Transaction txn = session.beginTransaction();
                 try {
-                    session.createSQLQuery(validationQuery).list();
+                    session.createNativeQuery(validationQuery).list();
                     txn.commit();
                 } catch (Exception e) {
                     if (txn.getStatus().canRollback()) {

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAspect.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAspect.java
@@ -114,7 +114,7 @@ public class UnitOfWorkAspect {
     protected void configureSession() {
         session.setDefaultReadOnly(unitOfWork.readOnly());
         session.setCacheMode(unitOfWork.cacheMode());
-        session.setFlushMode(unitOfWork.flushMode());
+        session.setHibernateFlushMode(unitOfWork.flushMode());
     }
 
     private void beginTransaction() {

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/AbstractDAOTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/AbstractDAOTest.java
@@ -3,9 +3,9 @@ package io.dropwizard.hibernate;
 import com.google.common.collect.ImmutableList;
 import org.hibernate.Criteria;
 import org.hibernate.HibernateException;
-import org.hibernate.Query;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.query.Query;
 import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.proxy.LazyInitializer;
 import org.junit.Before;
@@ -84,7 +84,7 @@ public class AbstractDAOTest {
 
     private final SessionFactory factory = mock(SessionFactory.class);
     private final Criteria criteria = mock(Criteria.class);
-    private final org.hibernate.query.Query query = mock(org.hibernate.query.Query.class);
+    private final Query query = mock(Query.class);
     private final Session session = mock(Session.class);
     private final MockDAO dao = new MockDAO(factory);
 

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/AbstractDAOTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/AbstractDAOTest.java
@@ -1,8 +1,10 @@
 package io.dropwizard.hibernate;
 
 import com.google.common.collect.ImmutableList;
+
 import org.hibernate.Criteria;
 import org.hibernate.HibernateException;
+import org.hibernate.NonUniqueResultException;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
@@ -13,6 +15,8 @@ import org.junit.Test;
 
 import java.io.Serializable;
 import java.util.List;
+
+import javax.persistence.criteria.CriteriaQuery;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -52,7 +56,7 @@ public class AbstractDAOTest {
         }
 
         @Override
-        public String uniqueResult(Query query) throws HibernateException {
+        public String uniqueResult(Query<String> query) throws HibernateException {
             return super.uniqueResult(query);
         }
 
@@ -62,7 +66,7 @@ public class AbstractDAOTest {
         }
 
         @Override
-        public List<String> list(Query query) throws HibernateException {
+        public List<String> list(Query<String> query) throws HibernateException {
             return super.list(query);
         }
 
@@ -84,7 +88,10 @@ public class AbstractDAOTest {
 
     private final SessionFactory factory = mock(SessionFactory.class);
     private final Criteria criteria = mock(Criteria.class);
-    private final Query query = mock(Query.class);
+    @SuppressWarnings("unchecked")
+    private final CriteriaQuery<String> criteriaQuery = mock(CriteriaQuery.class);
+    @SuppressWarnings("unchecked")
+    private final Query<String> query = mock(Query.class);
     private final Session session = mock(Session.class);
     private final MockDAO dao = new MockDAO(factory);
 
@@ -132,6 +139,23 @@ public class AbstractDAOTest {
     }
 
     @Test
+    public void returnsUniqueResultsFromJpaCriteriaQueries() throws Exception {
+        when(session.createQuery(criteriaQuery)).thenReturn(query);
+        when(query.getResultList()).thenReturn(ImmutableList.of("woo"));
+
+        assertThat(dao.uniqueResult(criteriaQuery))
+            .isEqualTo("woo");
+    }
+
+    @Test(expected = NonUniqueResultException.class)
+    public void throwsOnNonUniqueResultsFromJpaCriteriaQueries() throws Exception {
+        when(session.createQuery(criteriaQuery)).thenReturn(query);
+        when(query.getResultList()).thenReturn(ImmutableList.of("woo", "boo"));
+
+        dao.uniqueResult(criteriaQuery);
+    }
+
+    @Test
     public void returnsUniqueResultsFromQueries() throws Exception {
         when(query.uniqueResult()).thenReturn("woo");
 
@@ -147,6 +171,14 @@ public class AbstractDAOTest {
                 .containsOnly("woo");
     }
 
+    @Test
+    public void returnsUniqueListsFromJpaCriteriaQueries() throws Exception {
+        when(session.createQuery(criteriaQuery)).thenReturn(query);
+        when(query.getResultList()).thenReturn(ImmutableList.of("woo"));
+
+        assertThat(dao.list(criteriaQuery))
+            .containsOnly("woo");
+    }
 
     @Test
     public void returnsUniqueListsFromQueries() throws Exception {

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/AbstractDAOTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/AbstractDAOTest.java
@@ -84,7 +84,7 @@ public class AbstractDAOTest {
 
     private final SessionFactory factory = mock(SessionFactory.class);
     private final Criteria criteria = mock(Criteria.class);
-    private final Query query = mock(Query.class);
+    private final org.hibernate.query.Query query = mock(org.hibernate.query.Query.class);
     private final Session session = mock(Session.class);
     private final MockDAO dao = new MockDAO(factory);
 

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/DataExceptionMapper.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/DataExceptionMapper.java
@@ -1,22 +1,18 @@
 package io.dropwizard.hibernate;
 
-import io.dropwizard.jersey.errors.ErrorMessage;
 import org.hibernate.exception.DataException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
+import io.dropwizard.jersey.errors.ErrorMessage;
+
 @Provider
 public class DataExceptionMapper implements ExceptionMapper<DataException> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(DataException.class);
-
     @Override
     public Response toResponse(DataException e) {
-        LOGGER.error("Hibernate error", e);
         String message = e.getCause().getMessage().contains("EMAIL") ? "Wrong email" : "Wrong input";
 
         return Response.status(Response.Status.BAD_REQUEST)

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
@@ -16,6 +16,7 @@ import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.TestProperties;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.After;
@@ -117,7 +118,7 @@ public class JerseyIntegrationTest extends JerseyTest {
                                             ImmutableList.of(Person.class));
 
         try (Session session = sessionFactory.openSession()) {
-            session.beginTransaction();
+            Transaction transaction = session.beginTransaction();
             session.createNativeQuery("DROP TABLE people IF EXISTS").executeUpdate();
             session.createNativeQuery(
                 "CREATE TABLE people (name varchar(100) primary key, email varchar(16), birthday timestamp with time zone)")
@@ -125,6 +126,7 @@ public class JerseyIntegrationTest extends JerseyTest {
             session.createNativeQuery(
                 "INSERT INTO people VALUES ('Coda', 'coda@example.com', '1979-01-02 00:22:00+0:00')")
                 .executeUpdate();
+            transaction.commit();
         }
 
         final DropwizardResourceConfig config = DropwizardResourceConfig.forTesting(new MetricRegistry());

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
@@ -131,6 +131,7 @@ public class JerseyIntegrationTest extends JerseyTest {
         config.register(new UnitOfWorkApplicationListener("hr-db", sessionFactory));
         config.register(new PersonResource(new PersonDAO(sessionFactory)));
         config.register(new JacksonMessageBodyProvider(Jackson.newObjectMapper()));
+        config.register(new PersistenceExceptionMapper());
         config.register(new DataExceptionMapper());
         config.register(new EmptyOptionalExceptionMapper());
 

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
@@ -117,11 +117,12 @@ public class JerseyIntegrationTest extends JerseyTest {
                                             ImmutableList.of(Person.class));
 
         try (Session session = sessionFactory.openSession()) {
-            session.createSQLQuery("DROP TABLE people IF EXISTS").executeUpdate();
-            session.createSQLQuery(
+            session.beginTransaction();
+            session.createNativeQuery("DROP TABLE people IF EXISTS").executeUpdate();
+            session.createNativeQuery(
                 "CREATE TABLE people (name varchar(100) primary key, email varchar(16), birthday timestamp with time zone)")
                 .executeUpdate();
-            session.createSQLQuery(
+            session.createNativeQuery(
                 "INSERT INTO people VALUES ('Coda', 'coda@example.com', '1979-01-02 00:22:00+0:00')")
                 .executeUpdate();
         }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/LazyLoadingTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/LazyLoadingTest.java
@@ -70,6 +70,7 @@ public class LazyLoadingTest {
 
             environment.jersey().register(new UnitOfWorkApplicationListener("hr-db", sessionFactory));
             environment.jersey().register(new DogResource(new DogDAO(sessionFactory)));
+            environment.jersey().register(new PersistenceExceptionMapper());
             environment.jersey().register(new ConstraintViolationExceptionMapper());
         }
 

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/LazyLoadingTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/LazyLoadingTest.java
@@ -75,16 +75,17 @@ public class LazyLoadingTest {
 
         private void initDatabase(SessionFactory sessionFactory) {
             try (Session session = sessionFactory.openSession()) {
-                session.createSQLQuery(
+                session.beginTransaction();
+                session.createNativeQuery(
                     "CREATE TABLE people (name varchar(100) primary key, email varchar(16), birthday timestamp with time zone)")
                     .executeUpdate();
-                session.createSQLQuery(
+                session.createNativeQuery(
                     "INSERT INTO people VALUES ('Coda', 'coda@example.com', '1979-01-02 00:22:00+0:00')")
                     .executeUpdate();
-                session.createSQLQuery(
+                session.createNativeQuery(
                     "CREATE TABLE dogs (name varchar(100) primary key, owner varchar(100), CONSTRAINT fk_owner FOREIGN KEY (owner) REFERENCES people(name))")
                     .executeUpdate();
-                session.createSQLQuery(
+                session.createNativeQuery(
                     "INSERT INTO dogs VALUES ('Raf', 'Coda')")
                     .executeUpdate();
             }
@@ -109,7 +110,7 @@ public class LazyLoadingTest {
         }
 
         Dog create(Dog dog) throws HibernateException {
-            currentSession().setFlushMode(FlushMode.COMMIT);
+            currentSession().setHibernateFlushMode(FlushMode.COMMIT);
             currentSession().save(requireNonNull(dog));
             return dog;
         }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/LazyLoadingTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/LazyLoadingTest.java
@@ -17,6 +17,7 @@ import org.hibernate.FlushMode;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
 import org.hibernate.exception.ConstraintViolationException;
 import org.junit.After;
 import org.junit.Test;
@@ -76,7 +77,7 @@ public class LazyLoadingTest {
 
         private void initDatabase(SessionFactory sessionFactory) {
             try (Session session = sessionFactory.openSession()) {
-                session.beginTransaction();
+                Transaction transaction = session.beginTransaction();
                 session.createNativeQuery(
                     "CREATE TABLE people (name varchar(100) primary key, email varchar(16), birthday timestamp with time zone)")
                     .executeUpdate();
@@ -89,6 +90,7 @@ public class LazyLoadingTest {
                 session.createNativeQuery(
                     "INSERT INTO dogs VALUES ('Raf', 'Coda')")
                     .executeUpdate();
+                transaction.commit();
             }
         }
     }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/PersistenceExceptionMapper.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/PersistenceExceptionMapper.java
@@ -17,7 +17,7 @@ public class PersistenceExceptionMapper implements ExceptionMapper<PersistenceEx
     private static final Logger LOGGER = LoggerFactory.getLogger(DataException.class);
 
     @Context
-    Providers providers;
+    private Providers providers;
 
     @Override
     public Response toResponse(PersistenceException e) {

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/PersistenceExceptionMapper.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/PersistenceExceptionMapper.java
@@ -1,0 +1,37 @@
+package io.dropwizard.hibernate;
+
+import org.hibernate.exception.DataException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.persistence.PersistenceException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import javax.ws.rs.ext.Providers;
+
+@Provider
+public class PersistenceExceptionMapper implements ExceptionMapper<PersistenceException> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DataException.class);
+
+    @Context
+    Providers providers;
+
+    @Override
+    public Response toResponse(PersistenceException e) {
+        LOGGER.error("Hibernate error", e);
+
+        Throwable t = e.getCause();
+
+        // PersistenceException wraps the real exception, so we look for the real exception mapper for it
+        // Cast is necessary since the return type is ExceptionMapper<? extends Throwable> and Java
+        // does not allow calling toResponse on the method with a Throwable
+        @SuppressWarnings("unchecked")
+        final ExceptionMapper<Throwable> exceptionMapper = (ExceptionMapper<Throwable>) providers.getExceptionMapper(t.getClass());
+
+        return exceptionMapper.toResponse(t);
+
+    }
+}

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/PersistenceExceptionMapper.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/PersistenceExceptionMapper.java
@@ -1,5 +1,6 @@
 package io.dropwizard.hibernate;
 
+import org.glassfish.jersey.spi.ExtendedExceptionMapper;
 import org.hibernate.exception.DataException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,7 +13,7 @@ import javax.ws.rs.ext.Provider;
 import javax.ws.rs.ext.Providers;
 
 @Provider
-public class PersistenceExceptionMapper implements ExceptionMapper<PersistenceException> {
+public class PersistenceExceptionMapper implements ExtendedExceptionMapper<PersistenceException> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DataException.class);
 
@@ -32,6 +33,10 @@ public class PersistenceExceptionMapper implements ExceptionMapper<PersistenceEx
         final ExceptionMapper<Throwable> exceptionMapper = (ExceptionMapper<Throwable>) providers.getExceptionMapper(t.getClass());
 
         return exceptionMapper.toResponse(t);
+    }
 
+    @Override
+    public boolean isMappable(PersistenceException e) {
+        return providers.getExceptionMapper(e.getCause().getClass()) != null;
     }
 }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryFactoryTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryFactoryTest.java
@@ -105,9 +105,10 @@ public class SessionFactoryFactoryTest {
         build();
 
         try (Session session = sessionFactory.openSession()) {
-            session.createSQLQuery("DROP TABLE people IF EXISTS").executeUpdate();
-            session.createSQLQuery("CREATE TABLE people (name varchar(100) primary key, email varchar(100), birthday timestamp(0))").executeUpdate();
-            session.createSQLQuery("INSERT INTO people VALUES ('Coda', 'coda@example.com', '1979-01-02 00:22:00')").executeUpdate();
+            session.beginTransaction();
+            session.createNativeQuery("DROP TABLE people IF EXISTS").executeUpdate();
+            session.createNativeQuery("CREATE TABLE people (name varchar(100) primary key, email varchar(100), birthday timestamp(0))").executeUpdate();
+            session.createNativeQuery("INSERT INTO people VALUES ('Coda', 'coda@example.com', '1979-01-02 00:22:00')").executeUpdate();
 
             final Person entity = session.get(Person.class, "Coda");
 

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryFactoryTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryFactoryTest.java
@@ -11,6 +11,7 @@ import io.dropwizard.setup.Environment;
 import org.hibernate.EmptyInterceptor;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.service.ServiceRegistry;
 import org.joda.time.DateTime;
@@ -105,10 +106,11 @@ public class SessionFactoryFactoryTest {
         build();
 
         try (Session session = sessionFactory.openSession()) {
-            session.beginTransaction();
+            Transaction transaction = session.beginTransaction();
             session.createNativeQuery("DROP TABLE people IF EXISTS").executeUpdate();
             session.createNativeQuery("CREATE TABLE people (name varchar(100) primary key, email varchar(100), birthday timestamp(0))").executeUpdate();
             session.createNativeQuery("INSERT INTO people VALUES ('Coda', 'coda@example.com', '1979-01-02 00:22:00')").executeUpdate();
+            transaction.commit();
 
             final Person entity = session.get(Person.class, "Coda");
 

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryHealthCheckTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryHealthCheckTest.java
@@ -2,10 +2,10 @@ package io.dropwizard.hibernate;
 
 import com.codahale.metrics.health.HealthCheck;
 import org.hibernate.HibernateException;
-import org.hibernate.SQLQuery;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
+import org.hibernate.query.NativeQuery;
 import org.junit.Test;
 import org.mockito.InOrder;
 
@@ -44,8 +44,8 @@ public class SessionFactoryHealthCheckTest {
         final Transaction transaction = mock(Transaction.class);
         when(session.beginTransaction()).thenReturn(transaction);
 
-        final SQLQuery query = mock(SQLQuery.class);
-        when(session.createSQLQuery(anyString())).thenReturn(query);
+        final NativeQuery query = mock(NativeQuery.class);
+        when(session.createNativeQuery(anyString())).thenReturn(query);
 
         assertThat(healthCheck.execute())
                 .isEqualTo(HealthCheck.Result.healthy());
@@ -53,7 +53,7 @@ public class SessionFactoryHealthCheckTest {
         final InOrder inOrder = inOrder(factory, session, transaction, query);
         inOrder.verify(factory).openSession();
         inOrder.verify(session).beginTransaction();
-        inOrder.verify(session).createSQLQuery("SELECT 1");
+        inOrder.verify(session).createNativeQuery("SELECT 1");
         inOrder.verify(query).list();
         inOrder.verify(transaction).commit();
         inOrder.verify(session).close();
@@ -68,8 +68,8 @@ public class SessionFactoryHealthCheckTest {
         when(session.beginTransaction()).thenReturn(transaction);
         when(transaction.getStatus()).thenReturn(ACTIVE);
 
-        final SQLQuery query = mock(SQLQuery.class);
-        when(session.createSQLQuery(anyString())).thenReturn(query);
+        final NativeQuery query = mock(NativeQuery.class);
+        when(session.createNativeQuery(anyString())).thenReturn(query);
         when(query.list()).thenThrow(new HibernateException("OH NOE"));
 
         assertThat(healthCheck.execute().isHealthy())
@@ -78,7 +78,7 @@ public class SessionFactoryHealthCheckTest {
         final InOrder inOrder = inOrder(factory, session, transaction, query);
         inOrder.verify(factory).openSession();
         inOrder.verify(session).beginTransaction();
-        inOrder.verify(session).createSQLQuery("SELECT 1");
+        inOrder.verify(session).createNativeQuery("SELECT 1");
         inOrder.verify(query).list();
         inOrder.verify(transaction).rollback();
         inOrder.verify(session).close();

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkApplicationListenerTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkApplicationListenerTest.java
@@ -125,7 +125,7 @@ public class UnitOfWorkApplicationListenerTest {
 
         execute();
 
-        verify(session).setFlushMode(FlushMode.ALWAYS);
+        verify(session).setHibernateFlushMode(FlushMode.ALWAYS);
     }
 
     @Test

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
@@ -52,11 +52,12 @@ public class UnitOfWorkAwareProxyFactoryTest {
         sessionFactory = new SessionFactoryFactory()
                 .build(bundle, environment, dataSourceFactory, ImmutableList.of());
         try (Session session = sessionFactory.openSession()) {
-            session.beginTransaction();
+            Transaction transaction = session.beginTransaction();
             session.createNativeQuery("create table user_sessions (token varchar(64) primary key, username varchar(16))")
                 .executeUpdate();
             session.createNativeQuery("insert into user_sessions values ('67ab89d', 'jeff_28')")
                 .executeUpdate();
+            transaction.commit();
         }
     }
 

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
@@ -9,6 +9,7 @@ import io.dropwizard.logging.BootstrapLogging;
 import io.dropwizard.setup.Environment;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -51,9 +52,10 @@ public class UnitOfWorkAwareProxyFactoryTest {
         sessionFactory = new SessionFactoryFactory()
                 .build(bundle, environment, dataSourceFactory, ImmutableList.of());
         try (Session session = sessionFactory.openSession()) {
-            session.createSQLQuery("create table user_sessions (token varchar(64) primary key, username varchar(16))")
+            session.beginTransaction();
+            session.createNativeQuery("create table user_sessions (token varchar(64) primary key, username varchar(16))")
                 .executeUpdate();
-            session.createSQLQuery("insert into user_sessions values ('67ab89d', 'jeff_28')")
+            session.createNativeQuery("insert into user_sessions values ('67ab89d', 'jeff_28')")
                 .executeUpdate();
         }
     }
@@ -125,7 +127,7 @@ public class UnitOfWorkAwareProxyFactoryTest {
 
         public boolean isExist(String token) {
             return sessionFactory.getCurrentSession()
-                    .createSQLQuery("select username from user_sessions where token=:token")
+                    .createNativeQuery("select username from user_sessions where token=:token")
                     .setParameter("token", token)
                     .list()
                     .size() > 0;
@@ -170,8 +172,10 @@ public class UnitOfWorkAwareProxyFactoryTest {
         @Override
         protected void configureSession() {
             super.configureSession();
-            getSession().createSQLQuery("insert into user_sessions values ('gr6f9y0', 'jeff_29')")
+            Transaction transaction = getSession().beginTransaction();
+            getSession().createNativeQuery("insert into user_sessions values ('gr6f9y0', 'jeff_29')")
                 .executeUpdate();
+            transaction.commit();
         }
     }
 }


### PR DESCRIPTION
 - fix deprecation notices where type isn't exposed on DW public API (AbstractDAO API doesn't change)
 - upgrade Jadira usertypes to compatible version
 - Hibernate removes hibernate-entitymanager with 5.2 and merges JPA support into core
 - one side effect of this is wrapping previous SQL exceptions in a PersistenceException, tests needed an additional ExceptionMapper to pass