### PR TITLE
Protect against NPE from rogue deserializers

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapper.java
@@ -65,10 +65,11 @@ public class JsonProcessingExceptionMapper extends LoggingExceptionMapper<JsonPr
             // Until completely foolproof mechanism can be worked out in coordination
             // with Jackson on how to communicate client vs server fault, compare
             // start of message with known server faults.
-            final boolean beanError = cause.getMessage().startsWith("No suitable constructor found") ||
+            final boolean beanError = cause.getMessage() == null ||
+                (cause.getMessage().startsWith("No suitable constructor found") ||
                 cause.getMessage().startsWith("No serializer found for class") ||
                 (cause.getMessage().startsWith("Can not construct instance") &&
-                    !WRONG_TYPE_REGEX.matcher(cause.getMessage()).find());
+                    !WRONG_TYPE_REGEX.matcher(cause.getMessage()).find()));
 
             if (beanError && !clientCause) {
                 return super.toResponse(exception); // LoggingExceptionMapper will log exception

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/CustomDeserialization.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/CustomDeserialization.java
@@ -1,0 +1,43 @@
+package io.dropwizard.jersey.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+
+/**
+ * A custom deserializer of your nightmares. It tries to get {@link JsonProcessingExceptionMapper}
+ * to fail due to a null message. Jackson does a great job of preventing accidental null
+ * propagation, but it won't stop someone who'll do anything to get an unexpected null pointer
+ * exception somewhere.
+ */
+public class CustomDeserialization extends StdDeserializer<CustomRepresentation> {
+    public CustomDeserialization() {
+        super((Class) null);
+    }
+
+    @Override
+    public CustomRepresentation deserialize(
+        JsonParser jsonParser,
+        DeserializationContext deserializationContext
+    ) throws IOException {
+        throw new MyNastyException(jsonParser);
+    }
+
+    /**
+     * We can't get a regular {@link JsonMappingException} to report a null message, so we'll derive
+     * our own for our devious plan.
+     */
+    public static class MyNastyException extends JsonMappingException {
+        public MyNastyException(JsonParser jp) {
+            super(jp::close, null);
+        }
+
+        @Override
+        public String getMessage() {
+            return null;
+        }
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/CustomRepresentation.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/CustomRepresentation.java
@@ -1,0 +1,8 @@
+package io.dropwizard.jersey.jackson;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+@JsonDeserialize(using = CustomDeserialization.class)
+public class CustomRepresentation {
+    public int id;
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapperTest.java
@@ -81,6 +81,14 @@ public class JsonProcessingExceptionMapperTest extends JerseyTest {
     }
 
     @Test
+    public void returnsA500ForBadDeserializers() throws Exception {
+        Response response = target("/json/custom").request(MediaType.APPLICATION_JSON)
+            .post(Entity.entity("{}", MediaType.APPLICATION_JSON));
+        assertThat(response.getStatus()).isEqualTo(500);
+        assertThat(response.getMediaType()).isEqualTo(MediaType.APPLICATION_JSON_TYPE);
+    }
+
+    @Test
     public void returnsA400ForMalformedInputCausingIoException() throws Exception {
         assertEndpointReturns400("url", "\"no-scheme.com\"");
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonResource.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonResource.java
@@ -40,6 +40,11 @@ public class JsonResource {
     }
 
     @POST
+    @Path("/custom")
+    public void custom(CustomRepresentation rep) {
+    }
+
+    @POST
     @Path("/url")
     public void url(URL url) {
     }


### PR DESCRIPTION
If someone defines a custom jackson deserializer, throws a custom `JacksonMappingException`, and overrides `getMessage()` to return `null`, `JsonProcessingExceptionMapper` will have a NPE as reported in #1869. If someone creates such a devious deserializer, it should be treated as a server error, hence a 500 status code is returned.

Closes #1869

thanks @kjetilv
cc @cowtowncoder so that he is aware of this edge case. Not 100% what the behavior of 2.9 will/should be in this situation, but I figured I'd give you a heads up in case this changes anything.