### PR TITLE
Add configuration hooks to UnitOfWorkAwareProxyFactory

### DIFF
--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAspect.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAspect.java
@@ -35,7 +35,7 @@ public class UnitOfWorkAspect {
 
     private final Map<String, SessionFactory> sessionFactories;
 
-    UnitOfWorkAspect(Map<String, SessionFactory> sessionFactories) {
+    public UnitOfWorkAspect(Map<String, SessionFactory> sessionFactories) {
         this.sessionFactories = sessionFactories;
     }
 
@@ -111,7 +111,7 @@ public class UnitOfWorkAspect {
         }
     }
 
-    private void configureSession() {
+    protected void configureSession() {
         session.setDefaultReadOnly(unitOfWork.readOnly());
         session.setCacheMode(unitOfWork.cacheMode());
         session.setFlushMode(unitOfWork.flushMode());
@@ -143,4 +143,13 @@ public class UnitOfWorkAspect {
             txn.commit();
         }
     }
+
+    protected Session getSession() {
+        return session;
+    }
+
+    protected SessionFactory getSessionFactory() {
+        return sessionFactory;
+    }
+
 }

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactory.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactory.java
@@ -75,7 +75,7 @@ public class UnitOfWorkAwareProxyFactory {
                     factory.create(constructorParamTypes, constructorArguments));
             proxy.setHandler((self, overridden, proceed, args) -> {
                 final UnitOfWork unitOfWork = overridden.getAnnotation(UnitOfWork.class);
-                final UnitOfWorkAspect unitOfWorkAspect = newAspect();
+                final UnitOfWorkAspect unitOfWorkAspect = newAspect(sessionFactories);
                 try {
                     unitOfWorkAspect.beforeStart(unitOfWork);
                     Object result = proceed.invoke(self, args);
@@ -99,9 +99,17 @@ public class UnitOfWorkAwareProxyFactory {
     }
 
     /**
-     * @return a new
+     * @return a new aspect
      */
     public UnitOfWorkAspect newAspect() {
+        return new UnitOfWorkAspect(sessionFactories);
+    }
+
+    /**
+     * @return a new aspect
+     * @param sessionFactories
+     */
+    public UnitOfWorkAspect newAspect(ImmutableMap<String, SessionFactory> sessionFactories) {
         return new UnitOfWorkAspect(sessionFactories);
     }
 }


### PR DESCRIPTION
Ran into a situation where I want to be able to do some configuration sessions that are set up by the `UnitOfWorkAwareProxyFactory`. Specifically, in our app I wanted to set up a bunch of default hibernate filters that should be turned on for every session. 

In our resource methods that use `UnitOfWork`, we do that by implementing Jersey event listeners with lower priority than the UnitOfWork listener. I wanted to do something similar and poke some configuration in between the session being set up, and my code actually running.

With the current state of things (using 1.0.5) that required us to rewrite our own version of `UnitOfWorkAwareProxyFactory`. Additionally, because `UnitOfWorkAspect` is still package private in the latest release, we also had to copy and create our own version of that.

I spiked out what this change might look like in this PR, it simply takes in two lambdas for a before and after configuration and provides the session factory to both. I'm open to feedback on other approaches to solve this, but I figured the discussion is easier if there is some code.

Let me know any feed back on if this change in general seems reasonable, and on the specific implementation I added.