### PR TITLE
Properly integrate dropwizard-e2e into Maven build

### DIFF
--- a/dropwizard-benchmarks/pom.xml
+++ b/dropwizard-benchmarks/pom.xml
@@ -12,8 +12,9 @@
         <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
         <jmh.version>1.15</jmh.version>
         <!-- Skip deployment of this sub-module -->
-        <source.skip>true</source.skip>
+        <maven.source.skip>true</maven.source.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
+        <maven.install.skip>true</maven.install.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.site.skip>true</maven.site.skip>
         <maven.site.deploy.skip>true</maven.site.deploy.skip>

--- a/dropwizard-e2e/pom.xml
+++ b/dropwizard-e2e/pom.xml
@@ -7,18 +7,20 @@
         <maven>3.0.0</maven>
     </prerequisites>
 
+    <parent>
+        <groupId>io.dropwizard</groupId>
+        <artifactId>dropwizard-parent</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
+    </parent>
+
     <artifactId>dropwizard-e2e</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
-    <groupId>io.dropwizard</groupId>
     <name>Dropwizard End-to-end Tests</name>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-
         <!-- No need to deploy dropwizard-e2e -->
+        <maven.source.skip>true</maven.source.skip>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <maven.install.skip>true</maven.install.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.site.skip>true</maven.site.skip>
         <maven.site.deploy.skip>true</maven.site.deploy.skip>
@@ -99,5 +101,4 @@
             </build>
         </profile>
     </profiles>
-
 </project>


### PR DESCRIPTION
This change set properly integrates the `dropwizard-e2e` into the Maven build and gets rid of the Maven warning:

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for io.dropwizard:dropwizard-e2e:jar:1.1.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-enforcer-plugin is missing. @ line 64, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```