### PR TITLE
Evaluate CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,18 @@
+machine:
+  timezone: UTC
+  java:
+    version: oraclejdk8
+  environment:
+    _JAVA_OPTIONS: '-Xms512m -Xmx2g'
+dependencies:
+  override:
+    - mvn dependency:go-offline --fail-never
+compile:
+  override:
+    - mvn compile
+test:
+  override:
+    - mvn test
+  post:
+    - mkdir -p $CIRCLE_TEST_REPORTS/junit/
+    - find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;

--- a/dropwizard-e2e/src/test/java/com/example/forms/FormsAppTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/forms/FormsAppTest.java
@@ -5,11 +5,13 @@ import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.jersey.errors.ErrorMessage;
 import io.dropwizard.testing.junit.DropwizardAppRule;
+import io.dropwizard.util.Duration;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.glassfish.jersey.media.multipart.MultiPart;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -23,9 +25,15 @@ public class FormsAppTest {
     @ClassRule
     public static final DropwizardAppRule<Configuration> RULE = new DropwizardAppRule<>(FormsApp.class);
 
+    private final JerseyClientConfiguration config = new JerseyClientConfiguration();
+
+    @Before
+    public void setUp() throws Exception {
+        config.setTimeout(Duration.seconds(2));
+    }
+
     @Test
     public void canSubmitFormAndReceiveResponse() {
-        final JerseyClientConfiguration config = new JerseyClientConfiguration();
         config.setChunkedEncodingEnabled(false);
 
         final Client client = new JerseyClientBuilder(RULE.getEnvironment())
@@ -47,7 +55,9 @@ public class FormsAppTest {
      *  behavior. For more info, see issues #1013 and #1094 */
     @Test
     public void failOnNoChunkedEncoding() {
-        final Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("test client 2");
+        final Client client = new JerseyClientBuilder(RULE.getEnvironment())
+            .using(config)
+            .build("test client 2");
 
         final MultiPart mp = new FormDataMultiPart()
             .bodyPart(new FormDataBodyPart(

--- a/dropwizard-e2e/src/test/java/com/example/request_log/AbstractRequestLogPatternIntegrationTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/request_log/AbstractRequestLogPatternIntegrationTest.java
@@ -6,10 +6,12 @@ import com.google.common.collect.Iterables;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
+import io.dropwizard.util.Duration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -74,7 +76,11 @@ public abstract class AbstractRequestLogPatternIntegrationTest {
 
     @Before
     public void setUp() throws Exception {
-        client = new JerseyClientBuilder(dropwizardAppRule.getEnvironment()).build("test-request-logs");
+        final JerseyClientConfiguration configuration = new JerseyClientConfiguration();
+        configuration.setTimeout(Duration.seconds(2));
+        client = new JerseyClientBuilder(dropwizardAppRule.getEnvironment())
+            .using(configuration)
+            .build("test-request-logs");
     }
 
     @After


### PR DESCRIPTION
Add support for running tests on CircleCI. The idea is too have an additional CI sever for running tests on the Linux environment, because in recent times we have had some issues with Travis CI.

The reason for that is PR #1875. Currently we have a CircleCI integration set up for the Dropwizard repository, but without a `circle.yml` config file all other pull requests fail. So I would like to merge it to master, so #1875 doesn't block other pull requests, but still allows to run tests in TravisCI and CircleCI.