### PR TITLE
Dependency updates

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -39,7 +39,7 @@ v1.1.0: Unreleased
 * Upgraded to AssertJ 3.6.1
 * Upgraded to classmate 1.3.3
 * Upgraded to Mustache 0.9.4 `#1766 <https://github.com/dropwizard/dropwizard/pull/1766>`_
-* Upgraded to Mockito 2.4.1
+* Upgraded to Mockito 2.6.1
 * Upgraded to Liquibase 3.5.3
 * Upgraded to Logback 1.1.8
 * Upgraded to JDBI 2.77

--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -45,7 +45,7 @@ v1.1.0: Unreleased
 * Upgraded to JDBI 2.77
 * Upgraded to Jersey 2.25
 * Upgraded to javassist 3.21.0-GA
-* Upgraded to Guava 20.0
+* Upgraded to Guava 21.0
 * Upgraded to SLF4J 1.7.22
 * Upgraded to H2 1.4.193
 * Upgraded to Joda-Time 2.9.7

--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -31,7 +31,7 @@ v1.1.0: Unreleased
 * Add the ``httpCompliance`` option to the HTTP configuration `#1825 <https://github.com/dropwizard/dropwizard/pull/1825>`_
 * Add the ``blockingTimeout`` option to the HTTP configuration `#1795 <https://github.com/dropwizard/dropwizard/pull/1795>`_
 * Add ``min`` and ``mins`` as valid ``Duration`` abbreviations `#1833 <https://github.com/dropwizard/dropwizard/pull/1833>`_
-* Upgraded to Jackson 2.8.5 `#1838 <https://github.com/dropwizard/dropwizard/pull/1838>`_
+* Upgraded to Jackson 2.8.6
 * Upgraded to Hibernate Validator 5.3.4.Final
 * Upgraded to Jetty 9.3.14.v20161028 `#1796 <https://github.com/dropwizard/dropwizard/pull/1796>`_
 * Upgraded to tomcat-jdbc 8.5.9

--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -33,7 +33,7 @@ v1.1.0: Unreleased
 * Add ``min`` and ``mins`` as valid ``Duration`` abbreviations `#1833 <https://github.com/dropwizard/dropwizard/pull/1833>`_
 * Upgraded to Jackson 2.8.6
 * Upgraded to Hibernate Validator 5.3.4.Final
-* Upgraded to Jetty 9.3.14.v20161028 `#1796 <https://github.com/dropwizard/dropwizard/pull/1796>`_
+* Upgraded to Jetty 9.3.15.v20161220
 * Upgraded to tomcat-jdbc 8.5.9
 * Upgraded to Objenesis 2.4 `#1654 <https://github.com/dropwizard/dropwizard/pull/1654>`_
 * Upgraded to AssertJ 3.6.1

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -24,7 +24,7 @@
         <dropwizard.version>${project.version}</dropwizard.version>
         <guava.version>20.0</guava.version>
         <jersey.version>2.25</jersey.version>
-        <jackson.version>2.8.5.1</jackson.version>
+        <jackson.version>2.8.6</jackson.version>
         <jetty.version>9.3.14.v20161028</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics3.version>3.1.2</metrics3.version>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -22,7 +22,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <dropwizard.version>${project.version}</dropwizard.version>
-        <guava.version>20.0</guava.version>
+        <guava.version>21.0</guava.version>
         <jersey.version>2.25</jersey.version>
         <jackson.version>2.8.6</jackson.version>
         <jetty.version>9.3.14.v20161028</jetty.version>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -25,7 +25,7 @@
         <guava.version>21.0</guava.version>
         <jersey.version>2.25</jersey.version>
         <jackson.version>2.8.6</jackson.version>
-        <jetty.version>9.3.14.v20161028</jetty.version>
+        <jetty.version>9.3.15.v20161220</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics3.version>3.1.2</metrics3.version>
         <slf4j.version>1.7.22</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <maven.site.deploy.skip>true</maven.site.deploy.skip>
         <junit.version>4.12</junit.version>
         <assertj.version>3.6.1</assertj.version>
-        <mockito.version>2.4.1</mockito.version>
+        <mockito.version>2.6.1</mockito.version>
     </properties>
 
     <developers>


### PR DESCRIPTION
* Jackson 2.8.6
* Guava 21.0
* Mockito 2.6.1
* Jetty 9.3.15.v20161220 (although this one might make problems, as usual)