### PR TITLE
Add support for HTTP client managed by DropwizardAppRule

### DIFF
--- a/docs/source/manual/testing.rst
+++ b/docs/source/manual/testing.rst
@@ -338,6 +338,10 @@ running and stop it again when they've completed (roughly equivalent to having u
 ``DropwizardAppRule`` also exposes the app's ``Configuration``,
 ``Environment`` and the app object itself so that these can be queried by the tests.
 
+If you don't want to use the ``dropwizard-client`` module or find it excessive for testing, you can get access to
+a Jersey HTTP client by calling the `client` method on the rule. The returned client is managed by the rule
+and can be reused across tests.
+
 .. code-block:: java
 
     public class LoginAcceptanceTest {

--- a/dropwizard-example/src/test/java/com/example/helloworld/IntegrationTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/IntegrationTest.java
@@ -5,14 +5,10 @@ import com.example.helloworld.core.Person;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import java.io.File;
@@ -31,21 +27,9 @@ public class IntegrationTest {
             HelloWorldApplication.class, CONFIG_PATH,
             ConfigOverride.config("database.url", "jdbc:h2:" + TMP_FILE));
 
-    private Client client;
-
     @BeforeClass
     public static void migrateDb() throws Exception {
         RULE.getApplication().run("db", "migrate", CONFIG_PATH);
-    }
-
-    @Before
-    public void setUp() throws Exception {
-        client = ClientBuilder.newClient();
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        client.close();
     }
 
     private static String createTempFile() {
@@ -59,7 +43,7 @@ public class IntegrationTest {
     @Test
     public void testHelloWorld() throws Exception {
         final Optional<String> name = Optional.of("Dr. IntegrationTest");
-        final Saying saying = client.target("http://localhost:" + RULE.getLocalPort() + "/hello-world")
+        final Saying saying = RULE.client().target("http://localhost:" + RULE.getLocalPort() + "/hello-world")
                 .queryParam("name", name.get())
                 .request()
                 .get(Saying.class);
@@ -69,7 +53,7 @@ public class IntegrationTest {
     @Test
     public void testPostPerson() throws Exception {
         final Person person = new Person("Dr. IntegrationTest", "Chief Wizard");
-        final Person newPerson = client.target("http://localhost:" + RULE.getLocalPort() + "/people")
+        final Person newPerson = RULE.client().target("http://localhost:" + RULE.getLocalPort() + "/people")
                 .request()
                 .post(Entity.entity(person, MediaType.APPLICATION_JSON_TYPE))
                 .readEntity(Person.class);

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
@@ -9,9 +9,12 @@ import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.DropwizardTestSupport;
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.JerseyClientBuilder;
 import org.junit.rules.ExternalResource;
 
 import javax.annotation.Nullable;
+import javax.ws.rs.client.Client;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -66,9 +69,13 @@ import java.util.function.Function;
  */
 public class DropwizardAppRule<C extends Configuration> extends ExternalResource {
 
+    private static final int DEFAULT_CONNECT_TIMEOUT_MS = 1000;
+    private static final int DEFAULT_READ_TIMEOUT_MS = 5000;
+
     private final DropwizardTestSupport<C> testSupport;
 
     private final AtomicInteger recursiveCallCount = new AtomicInteger(0);
+    private Client client;
 
     public DropwizardAppRule(Class<? extends Application<C>> applicationClass) {
         this(applicationClass, (String) null);
@@ -152,6 +159,11 @@ public class DropwizardAppRule<C extends Configuration> extends ExternalResource
     protected void after() {
         if (recursiveCallCount.decrementAndGet() == 0) {
             testSupport.after();
+            synchronized (this) {
+                if (client != null) {
+                    client.close();
+                }
+            }
         }
     }
 
@@ -200,5 +212,28 @@ public class DropwizardAppRule<C extends Configuration> extends ExternalResource
 
     public DropwizardTestSupport<C> getTestSupport() {
         return testSupport;
+    }
+
+    /**
+     * Returns a new HTTP Jersey {@link Client} for performing HTTP requests against the tested
+     * Dropwizard server. The client can be reused across different tests and automatically
+     * closed along with the server. The client can be augmented by overriding the
+     * {@link #clientBuilder()} method.
+     *
+     * @return a new {@link Client} managed by the rule.
+     */
+    public Client client() {
+        synchronized (this) {
+            if (client == null) {
+                client = clientBuilder().build();
+            }
+            return client;
+        }
+    }
+
+    protected JerseyClientBuilder clientBuilder() {
+        return new JerseyClientBuilder()
+            .property(ClientProperties.CONNECT_TIMEOUT, DEFAULT_CONNECT_TIMEOUT_MS)
+            .property(ClientProperties.READ_TIMEOUT, DEFAULT_READ_TIMEOUT_MS);
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/GzipDefaultVaryBehaviourTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/GzipDefaultVaryBehaviourTest.java
@@ -6,7 +6,6 @@ import io.dropwizard.testing.junit.TestConfiguration;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Response;
 
 import java.util.Collections;
@@ -25,7 +24,7 @@ public class GzipDefaultVaryBehaviourTest {
 
     @Test
     public void testDefaultVaryHeader() {
-        final Response clientResponse = ClientBuilder.newClient().target(
+        final Response clientResponse = RULE.client().target(
             "http://localhost:" + RULE.getLocalPort() + "/test").request().header(ACCEPT_ENCODING, "gzip").get();
 
         assertThat(clientResponse.getHeaders().get(VARY)).isEqualTo(Collections.singletonList((Object) ACCEPT_ENCODING));

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleConfigOverrideTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleConfigOverrideTest.java
@@ -3,7 +3,6 @@ package io.dropwizard.testing.junit;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import javax.ws.rs.client.ClientBuilder;
 import java.util.Optional;
 
 import static io.dropwizard.testing.ConfigOverride.config;
@@ -23,7 +22,7 @@ public class DropwizardAppRuleConfigOverrideTest {
 
     @Test
     public void supportsConfigAttributeOverrides() {
-        final String content = ClientBuilder.newClient().target("http://localhost:" + RULE.getLocalPort() + "/test")
+        final String content = RULE.client().target("http://localhost:" + RULE.getLocalPort() + "/test")
                 .request().get(String.class);
 
         assertThat(content, is("A new way to say Hooray!"));

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleTest.java
@@ -56,7 +56,7 @@ public class DropwizardAppRuleTest {
     @Test
     public void canPerformAdminTask() {
         final String response
-                = ClientBuilder.newClient().target("http://localhost:"
+                = RULE.client().target("http://localhost:"
                         + RULE.getAdminPort() + "/tasks/hello?name=test_user")
                 .request()
                 .post(Entity.entity("", MediaType.TEXT_PLAIN), String.class);
@@ -67,7 +67,7 @@ public class DropwizardAppRuleTest {
     @Test
     public void canPerformAdminTaskWithPostBody() {
         final String response
-            = ClientBuilder.newClient().target("http://localhost:"
+            = RULE.client().target("http://localhost:"
             + RULE.getAdminPort() + "/tasks/echo")
             .request()
             .post(Entity.entity("Custom message", MediaType.TEXT_PLAIN), String.class);

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleWithExplicitTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleWithExplicitTest.java
@@ -12,8 +12,6 @@ import org.junit.Test;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Map;
@@ -36,11 +34,10 @@ public class DropwizardAppRuleWithExplicitTest {
         RULE = new DropwizardAppRule<>(TestApplication.class, config);
     }
 
-    Client client = ClientBuilder.newClient();
 
     @Test
     public void runWithExplicitConfig() {
-        Map<?, ?> response = client.target("http://localhost:" + RULE.getLocalPort() + "/test")
+        Map<?, ?> response = RULE.client().target("http://localhost:" + RULE.getLocalPort() + "/test")
                 .request()
                 .get(Map.class);
         Assert.assertEquals(ImmutableMap.of("message", "stuff!"), response);

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleWithoutConfigTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleWithoutConfigTest.java
@@ -12,8 +12,6 @@ import org.junit.Test;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Map;
@@ -25,11 +23,9 @@ public class DropwizardAppRuleWithoutConfigTest {
         ConfigOverride.config("server.applicationConnectors[0].port", "0"),
         ConfigOverride.config("server.adminConnectors[0].port", "0"));
 
-    Client client = ClientBuilder.newClient();
-
     @Test
     public void runWithoutConfigFile() {
-        Map<?, ?> response = client.target("http://localhost:" + RULE.getLocalPort() + "/test")
+        Map<?, ?> response = RULE.client().target("http://localhost:" + RULE.getLocalPort() + "/test")
                 .request()
                 .get(Map.class);
         Assert.assertEquals(ImmutableMap.of("color", "orange"), response);


### PR DESCRIPTION
A common use case for the users of `DropwizardAppRule` is creating an HTTP client which performs requests against the tested server. I think we could make it little bit easier by providing a method for `DropwizardAppRule`which creates a new Jersey HTTP client client managed by the rule. The user
doesn't need to care about creating own client and shutting it down. The created is also have default sane timeouts in contrary to the default Jersey client. In the end, this allows to write tests like that:

```java
RULE.client().target("http://localhost:" + RULE.getLocalPort() + "/hello-world")
    .queryParam("name", name.get())
    .request()
    .get(Saying.class);
```

It makes testing easy for users who don't use the `dropwizard-client` module or find it excessive for testing.