### PR TITLE
Add a jetty-alpn version for the JDK 1.8.0u121

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
-sudo: false
+sudo: true
 language: java
 jdk:
   - oraclejdk8
+before_install:
+  - ulimit -c unlimited -S
 after_success:
   - bash .travis_after_success.sh
 cache:

--- a/dropwizard-http2/pom.xml
+++ b/dropwizard-http2/pom.xml
@@ -375,5 +375,17 @@
                 <alpn-boot.version>8.1.10.v20161026</alpn-boot.version>
             </properties>
         </profile>
+        <profile>
+            <id>jdk-1.8.0_121</id>
+            <activation>
+                <property>
+                    <name>java.version</name>
+                    <value>1.8.0_121</value>
+                </property>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.11.v20170118</alpn-boot.version>
+            </properties>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Should fix the build on the Travis CI machines, which apparently have been already updated to the new JDK.