### PR TITLE
Support Dropwizard applications without logback

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -11,6 +11,7 @@ v1.2.0: Unreleased
 
 * Support configuring FileAppender#bufferSize `#1951 <https://github.com/dropwizard/dropwizard/pull/1951>`_
 * Improve error handling of `@FormParam` resources `#1982 <https://github.com/dropwizard/dropwizard/pull/1982>`_
+* Support Dropwizard applications without logback `#1900 <https://github.com/dropwizard/dropwizard/pull/1900>`_
 
 .. _rel-1.1.0:
 

--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -732,6 +732,59 @@ slf4j provides the following logging levels:
 ``TRACE``
   Finer-grained informational events than the ``DEBUG`` level.
 
+.. note::
+
+    If you don't want to use Logback, you can exclude it from Dropwizard and use an alternative logging configuration:
+
+    * Exclude Logback from the `dropwizard-core` artifact
+
+        .. code-block:: xml
+
+            <dependency>
+                <groupId>io.dropwizard</groupId>
+                <artifactId>dropwizard-core</artifactId>
+                <version>{$dropwizard.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-classic</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-access</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>log4j-over-slf4j</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+    * Mark the logging configuration as external in your Dropwizard config
+
+        .. code-block:: yaml
+
+            server:
+              type: simple
+              applicationContextPath: /application
+              adminContextPath: /admin
+              requestLog:
+                type: external
+            logging:
+              type: external
+
+    * Disable bootstrapping Logback in your application
+
+        .. code-block:: java
+
+            public class ExampleApplication extends Application<ExampleConfiguration> {
+
+                @Override
+                protected void bootstrapLogging() {
+                }
+            }
+
+
 .. _man-core-logging-format:
 
 Log Format
@@ -812,6 +865,8 @@ Console Logging
 
 By default, Dropwizard applications log ``INFO`` and higher to ``STDOUT``. You can configure this by
 editing the ``logging`` section of your YAML configuration file:
+
+
 
 .. code-block:: yaml
 

--- a/dropwizard-core/src/main/java/io/dropwizard/Application.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/Application.java
@@ -23,8 +23,7 @@ import io.dropwizard.util.JarLocation;
  */
 public abstract class Application<T extends Configuration> {
     protected Application() {
-        // make sure spinning up Hibernate Validator doesn't yell at us
-        BootstrapLogging.bootstrap(bootstrapLogLevel());
+        bootstrapLogging();
     }
 
     /**
@@ -32,6 +31,11 @@ public abstract class Application<T extends Configuration> {
      */
     protected Level bootstrapLogLevel() {
         return Level.WARN;
+    }
+
+    protected void bootstrapLogging() {
+        // make sure spinning up Hibernate Validator doesn't yell at us
+        BootstrapLogging.bootstrap(bootstrapLogLevel());
     }
 
     /**

--- a/dropwizard-core/src/main/java/io/dropwizard/Configuration.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/Configuration.java
@@ -65,8 +65,7 @@ public class Configuration {
     private ServerFactory server = new DefaultServerFactory();
 
     @Valid
-    @NotNull
-    private LoggingFactory logging = new DefaultLoggingFactory();
+    private LoggingFactory logging;
 
     @Valid
     @NotNull
@@ -96,7 +95,11 @@ public class Configuration {
      * @return logging-specific configuration parameters
      */
     @JsonProperty("logging")
-    public LoggingFactory getLoggingFactory() {
+    public synchronized LoggingFactory getLoggingFactory() {
+        if (logging == null) {
+            // Lazy init to avoid a hard dependency to logback
+            logging = new DefaultLoggingFactory();
+        }
         return logging;
     }
 
@@ -104,7 +107,7 @@ public class Configuration {
      * Sets the logging-specific section of the configuration file.
      */
     @JsonProperty("logging")
-    public void setLoggingFactory(LoggingFactory factory) {
+    public synchronized void setLoggingFactory(LoggingFactory factory) {
         this.logging = factory;
     }
 
@@ -121,9 +124,9 @@ public class Configuration {
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                .add("server", server)
-                .add("logging", logging)
-                .add("metrics", metrics)
-                .toString();
+            .add("server", server)
+            .add("logging", logging)
+            .add("metrics", metrics)
+            .toString();
     }
 }

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/ExternalLoggingFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/ExternalLoggingFactory.java
@@ -1,0 +1,24 @@
+package io.dropwizard.logging;
+
+import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * A logging factory which does configure a logging infrastructure.
+ * Useful when the users doesn't want to use the Dropwizard logging configuration abilities.
+ */
+@JsonTypeName("external")
+public class ExternalLoggingFactory implements LoggingFactory {
+
+    @Override
+    public void configure(MetricRegistry metricRegistry, String name) {
+    }
+
+    @Override
+    public void stop() {
+    }
+
+    @Override
+    public void reset() {
+    }
+}

--- a/dropwizard-logging/src/main/resources/META-INF/services/io.dropwizard.logging.LoggingFactory
+++ b/dropwizard-logging/src/main/resources/META-INF/services/io.dropwizard.logging.LoggingFactory
@@ -1,1 +1,2 @@
 io.dropwizard.logging.DefaultLoggingFactory
+io.dropwizard.logging.ExternalLoggingFactory

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/ExternalLoggingFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/ExternalLoggingFactoryTest.java
@@ -1,0 +1,30 @@
+package io.dropwizard.logging;
+
+import com.google.common.io.Resources;
+import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.DiscoverableSubtypeResolver;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.validation.BaseValidator;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExternalLoggingFactoryTest {
+
+    @Test
+    public void canBeDeserialized() throws Exception {
+        LoggingFactory externalRequestLogFactory = new YamlConfigurationFactory<>(LoggingFactory.class,
+            BaseValidator.newValidator(), Jackson.newObjectMapper(), "dw")
+            .build(new File(Resources.getResource("yaml/logging_external.yml").toURI()));
+        assertThat(externalRequestLogFactory).isNotNull();
+        assertThat(externalRequestLogFactory).isInstanceOf(ExternalLoggingFactory.class);
+    }
+
+    @Test
+    public void isDiscoverable() throws Exception {
+        assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
+            .contains(ExternalLoggingFactory.class);
+    }
+}

--- a/dropwizard-logging/src/test/resources/yaml/logging_external.yml
+++ b/dropwizard-logging/src/test/resources/yaml/logging_external.yml
@@ -1,0 +1,1 @@
+type: external

--- a/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/ExternalRequestLogFactory.java
+++ b/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/ExternalRequestLogFactory.java
@@ -1,0 +1,32 @@
+package io.dropwizard.request.logging;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.eclipse.jetty.server.RequestLog;
+import org.eclipse.jetty.server.Slf4jRequestLog;
+
+/**
+ * A request log factory which writes request logs via Slf4j and doesn't configure any logging infrastructure.
+ * Useful when the user doesn't want to configure request logging via the Dropwizard configuration.
+ */
+@JsonTypeName("external")
+public class ExternalRequestLogFactory implements RequestLogFactory {
+
+    private boolean enabled = true;
+
+    @JsonProperty
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    @Override
+    @JsonProperty
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public RequestLog build(String name) {
+        return new Slf4jRequestLog();
+    }
+}

--- a/dropwizard-request-logging/src/main/resources/META-INF/services/io.dropwizard.request.logging.RequestLogFactory
+++ b/dropwizard-request-logging/src/main/resources/META-INF/services/io.dropwizard.request.logging.RequestLogFactory
@@ -1,2 +1,3 @@
 io.dropwizard.request.logging.LogbackAccessRequestLogFactory
 io.dropwizard.request.logging.old.LogbackClassicRequestLogFactory
+io.dropwizard.request.logging.ExternalRequestLogFactory

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/ExternalRequestLogFactoryTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/ExternalRequestLogFactoryTest.java
@@ -1,0 +1,36 @@
+package io.dropwizard.request.logging;
+
+import com.google.common.io.Resources;
+import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.DiscoverableSubtypeResolver;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.logging.BootstrapLogging;
+import io.dropwizard.validation.BaseValidator;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExternalRequestLogFactoryTest {
+
+    static {
+        BootstrapLogging.bootstrap();
+    }
+
+    @Test
+    public void canBeDeserialized() throws Exception {
+        RequestLogFactory externalRequestLogFactory = new YamlConfigurationFactory<>(RequestLogFactory.class,
+            BaseValidator.newValidator(), Jackson.newObjectMapper(), "dw")
+            .build(new File(Resources.getResource("yaml/externalRequestLog.yml").toURI()));
+        assertThat(externalRequestLogFactory).isNotNull();
+        assertThat(externalRequestLogFactory).isInstanceOf(ExternalRequestLogFactory.class);
+        assertThat(externalRequestLogFactory.isEnabled()).isTrue();
+    }
+
+    @Test
+    public void isDiscoverable() throws Exception {
+        assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
+            .contains(ExternalRequestLogFactory.class);
+    }
+}

--- a/dropwizard-request-logging/src/test/resources/yaml/externalRequestLog.yml
+++ b/dropwizard-request-logging/src/test/resources/yaml/externalRequestLog.yml
@@ -1,0 +1,1 @@
+type: external

--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/LogConfigurationTask.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/LogConfigurationTask.java
@@ -3,6 +3,7 @@ package io.dropwizard.servlets.tasks;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
 import com.google.common.collect.ImmutableMultimap;
+import org.slf4j.ILoggerFactory;
 import org.slf4j.LoggerFactory;
 
 import java.io.PrintWriter;
@@ -30,34 +31,33 @@ import java.util.List;
  */
 public class LogConfigurationTask extends Task {
 
-    private final LoggerContext loggerContext;
+    private final ILoggerFactory loggerContext;
 
     /**
      * Creates a new LogConfigurationTask.
      */
     public LogConfigurationTask() {
-        this((LoggerContext) LoggerFactory.getILoggerFactory());
+        this(LoggerFactory.getILoggerFactory());
     }
 
     /**
-     * Creates a new LogConfigurationTask with the given {@link ch.qos.logback.classic.LoggerContext} instance.
+     * Creates a new LogConfigurationTask with the given {@link ILoggerFactory} instance.
      * <p/>
      * <b>Use {@link LogConfigurationTask#LogConfigurationTask()} instead.</b>
      *
-     * @param loggerContext a {@link ch.qos.logback.classic.LoggerContext} instance
+     * @param loggerContext a {@link ILoggerFactory} instance
      */
-    public LogConfigurationTask(LoggerContext loggerContext) {
+    public LogConfigurationTask(ILoggerFactory loggerContext) {
         super("log-level");
         this.loggerContext = loggerContext;
     }
 
-    @Override
     public void execute(ImmutableMultimap<String, String> parameters, PrintWriter output) throws Exception {
         final List<String> loggerNames = getLoggerNames(parameters);
         final Level loggerLevel = getLoggerLevel(parameters);
 
         for (String loggerName : loggerNames) {
-            loggerContext.getLogger(loggerName).setLevel(loggerLevel);
+            ((LoggerContext) loggerContext).getLogger(loggerName).setLevel(loggerLevel);
             output.println(String.format("Configured logging level for %s to %s", loggerName, loggerLevel));
             output.flush();
         }


### PR DESCRIPTION
This is a prototype for splitting the tight integration between Dropwizard and Logback. This feature was requested several times (See #1367). The idea is too provide users the ability to exclude Logback from Dropwizard and replace it with an external logging solution, if they really want to. The main work of this PR is too initialize the Logback infrastructure lazily, so the user can swap it to an external logging mechanism in the config file.

With this change users can swap logback to other logging implementation like that:
```xml
 <dependencies>

        <dependency>
            <groupId>io.dropwizard</groupId>
            <artifactId>dropwizard-core</artifactId>
            <version>1.1.0-SNAPSHOT</version>
            <exclusions>
                <exclusion>
                    <groupId>ch.qos.logback</groupId>
                    <artifactId>logback-classic</artifactId>
                </exclusion>
                <exclusion>
                    <groupId>ch.qos.logback</groupId>
                    <artifactId>logback-access</artifactId>
                </exclusion>
                <exclusion>
                    <groupId>org.slf4j</groupId>
                    <artifactId>log4j-over-slf4j</artifactId>
                </exclusion>
            </exclusions>
        </dependency>

        <dependency>
            <groupId>log4j</groupId>
            <artifactId>log4j</artifactId>
            <version>1.2.17</version>
        </dependency>

        <dependency>
            <groupId>org.slf4j</groupId>
            <artifactId>slf4j-log4j12</artifactId>
            <version>1.7.21</version>
        </dependency>

    </dependencies>
``` 

```yml
server:
  type: simple
  applicationContextPath: /application
  adminContextPath: /admin
  connector:
    type: http
    port: 8080
  requestLog:
    type: external
logging:
  type: external
```

```java
public class ExampleApplication extends Application<ExampleConfiguration> {

    @Override
    protected void bootstrapLogging() {
    }
}
```