### PR TITLE
Upgrade Jetty to 9.4.1.v20170120

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -33,7 +33,7 @@ v1.1.0: Unreleased
 * Add ``min`` and ``mins`` as valid ``Duration`` abbreviations `#1833 <https://github.com/dropwizard/dropwizard/pull/1833>`_
 * Upgraded to Jackson 2.8.6
 * Upgraded to Hibernate Validator 5.3.4.Final
-* Upgraded to Jetty 9.4.0.v20161208 `#1875 <https://github.com/dropwizard/dropwizard/pull/1875>`
+* Upgraded to Jetty 9.4.1.v20170120 `#1901 <https://github.com/dropwizard/dropwizard/pull/1901>`
 * Upgraded to tomcat-jdbc 8.5.9
 * Upgraded to Objenesis 2.4 `#1654 <https://github.com/dropwizard/dropwizard/pull/1654>`_
 * Upgraded to AssertJ 3.6.1

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -25,7 +25,7 @@
         <guava.version>21.0</guava.version>
         <jersey.version>2.25</jersey.version>
         <jackson.version>2.8.6</jackson.version>
-        <jetty.version>9.4.0.v20161208</jetty.version>
+        <jetty.version>9.4.1.v20170120</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics3.version>3.1.2</metrics3.version>
         <slf4j.version>1.7.22</slf4j.version>


### PR DESCRIPTION
See changelog here: https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.1.v20170120