### PR TITLE
Register Jackson parameter names module

### DIFF
--- a/dropwizard-jackson/pom.xml
+++ b/dropwizard-jackson/pom.xml
@@ -58,6 +58,10 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-parameter-names</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-afterburner</artifactId>
         </dependency>
         <dependency>
@@ -73,4 +77,25 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <compilerArgument>-parameters</compilerArgument>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 
 /**
  * A utility class for Jackson.
@@ -57,6 +58,7 @@ public class Jackson {
         mapper.registerModule(new JodaModule());
         mapper.registerModule(new AfterburnerModule());
         mapper.registerModule(new FuzzyEnumModule());
+        mapper.registerModule(new ParameterNamesModule());
         mapper.registerModules(new Jdk8Module());
         mapper.registerModules(new JavaTimeModule());
         mapper.setPropertyNamingStrategy(new AnnotationSensitivePropertyNamingStrategy());

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/ParanamerModuleTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/ParanamerModuleTest.java
@@ -1,0 +1,38 @@
+package io.dropwizard.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ParanamerModuleTest {
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Before
+    public void setUp() throws Exception {
+        mapper.registerModule(new ParameterNamesModule());
+    }
+
+    @Test
+    public void deserializePersonWithoutAnnotations() throws IOException {
+        final ObjectReader reader = mapper.readerFor(Person.class);
+        final Person person = reader.readValue("{ \"name\": \"Foo\", \"surname\": \"Bar\" }");
+        assertThat(person.getName()).isEqualTo("Foo");
+        assertThat(person.getSurname()).isEqualTo("Bar");
+    }
+
+    @Test
+    public void serializePersonWithoutAnnotations() throws IOException {
+        final ObjectWriter reader = mapper.writerFor(Person.class);
+        final String person = reader.writeValueAsString(new Person("Foo", "Bar"));
+        assertThat(person)
+            .contains("\"name\":\"Foo\"")
+            .contains("\"surname\":\"Bar\"");
+    }
+}

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/Person.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/Person.java
@@ -1,0 +1,19 @@
+package io.dropwizard.jackson;
+
+public class Person {
+    private final String name;
+    private final String surname;
+
+    public Person(String name, String surname) {
+        this.name = name;
+        this.surname = surname;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+}


### PR DESCRIPTION
Closes #1852

Addresses @arteam's concern about users who don't compile with `-parameters`, as only the `dropwizard-jackson` test module is compiled with `-parameters` and the other modules don't fail.
