### PR TITLE
Enable deeper jackson deserialization of enums

### DIFF
--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/FuzzyEnumModule.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/FuzzyEnumModule.java
@@ -11,12 +11,13 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.deser.Deserializers;
-import com.fasterxml.jackson.databind.deser.std.EnumDeserializer;
 import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
 import io.dropwizard.util.Enums;
 
 import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -74,9 +75,19 @@ public class FuzzyEnumModule extends Module {
             final Collection<AnnotatedMethod> factoryMethods = desc.getFactoryMethods();
             if (factoryMethods != null) {
                 for (AnnotatedMethod am : factoryMethods) {
-                    final JsonCreator creator = am.getAnnotation(JsonCreator.class);
-                    if (creator != null) {
-                        return EnumDeserializer.deserializerForCreator(config, type, am, null, null);
+                    if (am.hasAnnotation(JsonCreator.class)) {
+                        return null;
+                    }
+                }
+            }
+
+            // If any enum choice is annotated with an annotation from jackson, defer to
+            // Jackson to do the deserialization
+            for (Field field : type.getFields()) {
+                for (Annotation annotation : field.getAnnotations()) {
+                    final String packageName = annotation.annotationType().getPackage().getName();
+                    if (packageName.equals("com.fasterxml.jackson.annotation")) {
+                        return null;
                     }
                 }
             }


### PR DESCRIPTION
Closes #1888

Returning a `null` JsonDeserializer will make Jackson look elsewhere, which is preferable in all cases when we shouldn't or can't handle the deserialization.