### PR TITLE
added run from root directory for maven command in example readme

### DIFF
--- a/dropwizard-example/README.md
+++ b/dropwizard-example/README.md
@@ -29,7 +29,7 @@ As with all the modules the db example is wired up in the `initialize` function 
 
 To test the example application run the following commands.
 
-* To package the example run.
+* To package the example run the following from the root dropwizard directory.
 
         mvn package
 


### PR DESCRIPTION
This small addition should reduce the confusion that caused the following issues: https://github.com/dropwizard/dropwizard/issues/1760, https://github.com/dropwizard/dropwizard/issues/1510