### PR TITLE
Bump archetype maven compiler plugin

### DIFF
--- a/dropwizard-archetypes/java-simple/src/main/resources/archetype-resources/pom.xml
+++ b/dropwizard-archetypes/java-simple/src/main/resources/archetype-resources/pom.xml
@@ -95,7 +95,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.6.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>


### PR DESCRIPTION
I keep running into compiler bugs using the given archetype compiler version, and
I have to keep remembering to update to a new version.