### PR TITLE
Remove references to old auth code in docs

### DIFF
--- a/docs/source/manual/testing.rst
+++ b/docs/source/manual/testing.rst
@@ -227,8 +227,8 @@ all custom exception mappers will need to be registered on the builder, similarl
 Test Containers
 ---------------
 
-Note that the in-memory Jersey test container does not support all features, such as the ``@Context`` injection used by
-``BasicAuthFactory`` and ``OAuthFactory``. A different `test container`__ can be used via
+Note that the in-memory Jersey test container does not support all features, such as the ``@Context`` injection.
+A different `test container`__ can be used via
 ``ResourceTestRule.Builder#setTestContainerFactory(TestContainerFactory)``.
 
 For example, if you want to use the `Grizzly`_ HTTP server (which supports ``@Context`` injections) you need to add the


### PR DESCRIPTION
The factories were removed when we moved to filter based auth.