### PR TITLE
Convencience AbstractDAO method for Query<T>

### DIFF
--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/AbstractDAO.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/AbstractDAO.java
@@ -66,6 +66,16 @@ public class AbstractDAO<E> {
     }
 
     /**
+     * Returns a typed {@link Query<E>}
+     *
+     * @param queryString HQL query
+     * @return typed query
+     */
+    protected Query<E> query(String queryString) {
+        return currentSession().createQuery(requireNonNull(queryString), getEntityClass());
+    }
+
+    /**
      * Returns the entity class managed by this DAO.
      *
      * @return the entity class managed by this DAO

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/AbstractDAOTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/AbstractDAOTest.java
@@ -20,6 +20,7 @@ import javax.persistence.criteria.CriteriaQuery;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -100,6 +101,7 @@ public class AbstractDAOTest {
         when(factory.getCurrentSession()).thenReturn(session);
         when(session.createCriteria(String.class)).thenReturn(criteria);
         when(session.getNamedQuery(anyString())).thenReturn(query);
+        when(session.createQuery(anyString(), same(String.class))).thenReturn(query);
     }
 
     @Test
@@ -120,6 +122,14 @@ public class AbstractDAOTest {
                 .isEqualTo(query);
 
         verify(session).getNamedQuery("query-name");
+    }
+
+    @Test
+    public void getsTypedQueries() throws Exception {
+        assertThat(dao.query("HQL"))
+            .isEqualTo(query);
+
+        verify(session).createQuery("HQL", String.class);
     }
 
     @Test


### PR DESCRIPTION
I've been migrating our codebase to 1.1 and this popped up to be one missing thing from my previous PR:

Since the old Query object is now deprecated, this helper eases migration to the new structure.

Quick follow up to #1871 

Code before:
```java
Query<E> query = currentSession().createQuery(hql, getEntityClass());
```

Code after:
```java
Query<E> query = query(hibernateQuery);
```

btw for our pretty large app the migration has been fairly smooth, `HashLoginService` changed in Jetty, the Hibernate upgrade needs a few things here and there, and Liquibase now forces a default schema, otherwise it seems much much easier than 0.9 -> 1.0