### PR TITLE
improves getting started doc by explaining where to save yml file

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -265,8 +265,8 @@ Our YAML file will then look like the below, full `example yml here`_:
 Dropwizard has *many* more configuration parameters than that, but they all have sane defaults so
 you can keep your configuration files small and focused.
 
-So save that YAML file as ``hello-world.yml``, because we'll be getting up and running pretty soon,
-and we'll need it. Next up, we're creating our application class!
+So save that YAML file in the directory you plan to run the fat jar from (see below) as ``hello-world.yml``, because 
+we'll be getting up and running pretty soon, and we'll need it. Next up, we're creating our application class!
 
 .. _gs-application:
 


### PR DESCRIPTION
When reading the getting started guidance on my first ever exposure to DropWizard, I was confused about where the YML file was supposed to go. At first I put it in the src/main/resources directory expecting the far jar execution to pick it up when I named it on the command line execution arguments. This tiny pull request seeks to clarify that the YML file can be saved anywhere and referenced later. 