### PR TITLE
dropwizard-auth: Add support for optional resource protection

### DIFF
--- a/docs/source/manual/auth.rst
+++ b/docs/source/manual/auth.rst
@@ -216,9 +216,36 @@ If there are no provided credentials for the request, or if the credentials are 
 provider will return a scheme-appropriate ``401 Unauthorized`` response without calling your
 resource method.
 
-If you have a resource which is optionally protected (e.g., you want to display a logged-in user's
-name but not require login), you need to implement a custom filter which injects a security context
-containing the principal if it exists, without performing authentication.
+Optional protection
+-------------------
+
+Resource methods can be _optionally_ protected by representing the
+principal as an ``Optional``. In such cases, the ``Optional`` resource
+method argument will be populated with the principal, if
+present. Otherwise, the argument will be ``Optional.empty``.
+
+For instance, say you have an endpoint that should display a logged-in
+user's name, but return an anonymous reply for unauthenticated
+requests. You need to implement a custom filter which injects a
+security context containing the principal if it exists, without
+performing authentication.
+
+.. code-block:: java
+
+    @GET
+    public String getGreeting(@Auth Optional<User> userOpt) {
+        if (userOpt.isPresent()) {
+            return "Hello, " + userOpt.get().getName() + "!";
+        } else {
+            return "Greetings, anonymous visitor!"
+        }
+    }
+
+For optionally-protected resources, requests with invalid auth will be
+treated the same as those with no provided auth credentials. That is
+to say, requests that _fail_ to meet an authenticator or authorizer's
+requirements result in an empty principal being passed to the resource
+method.
 
 Testing Protected Resources
 ===========================
@@ -380,6 +407,3 @@ Now we can do
 
 .. note::
     The polymorphic auth feature *SHOULD NOT* be used with any other ``AuthDynamicFeature``. Doing so may have undesired effects.
-
-
-

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthDynamicFeature.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthDynamicFeature.java
@@ -11,7 +11,6 @@ import javax.ws.rs.container.DynamicFeature;
 import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.FeatureContext;
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Type;
 import java.util.Optional;
 
 /**

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthDynamicFeature.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthDynamicFeature.java
@@ -54,13 +54,15 @@ public class AuthDynamicFeature implements DynamicFeature {
         // First, check for any @Auth annotations on the method.
         for (int i = 0; i < parameterAnnotations.length; i++) {
             for (final Annotation annotation : parameterAnnotations[i]) {
-                // Optional auth requires that a concrete AuthFilter be provided.
-                if (annotation instanceof Auth && parameterTypes[i].equals(Optional.class) && authFilter != null) {
-                    context.register(new WebApplicationExceptionCatchingFilter(authFilter));
-                    return;
-                } else if (annotation instanceof Auth) {
-                    registerAuthFilter(context);
-                    return;
+                if (annotation instanceof Auth) {
+                    // Optional auth requires that a concrete AuthFilter be provided.
+                    if (parameterTypes[i].equals(Optional.class) && authFilter != null) {
+                        context.register(new WebApplicationExceptionCatchingFilter(authFilter));
+                        return;
+                    } else {
+                        registerAuthFilter(context);
+                        return;
+                    }
                 }
             }
         }

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthFilter.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthFilter.java
@@ -100,11 +100,11 @@ public abstract class AuthFilter<C, P extends Principal> implements ContainerReq
          * @return a new instance of the filter
          */
         public T buildAuthFilter() {
-            Preconditions.checkArgument(realm != null, "Realm is not set");
-            Preconditions.checkArgument(prefix != null, "Prefix is not set");
-            Preconditions.checkArgument(authenticator != null, "Authenticator is not set");
-            Preconditions.checkArgument(authorizer != null, "Authorizer is not set");
-            Preconditions.checkArgument(unauthorizedHandler != null, "Unauthorized handler is not set");
+            Preconditions.checkNotNull(realm, "Realm is not set");
+            Preconditions.checkNotNull(prefix, "Prefix is not set");
+            Preconditions.checkNotNull(authenticator, "Authenticator is not set");
+            Preconditions.checkNotNull(authorizer, "Authorizer is not set");
+            Preconditions.checkNotNull(unauthorizedHandler, "Unauthorized handler is not set");
 
             final T authFilter = newInstance();
             authFilter.authorizer = authorizer;
@@ -140,7 +140,7 @@ public abstract class AuthFilter<C, P extends Principal> implements ContainerReq
 
             final SecurityContext securityContext = requestContext.getSecurityContext();
             final boolean secure = securityContext != null && securityContext.isSecure();
-            
+
             requestContext.setSecurityContext(new SecurityContext() {
                 @Override
                 public Principal getUserPrincipal() {

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthValueFactoryProvider.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthValueFactoryProvider.java
@@ -54,17 +54,16 @@ public class AuthValueFactoryProvider<T extends Principal> extends AbstractValue
      */
     @Override
     public AbstractContainerRequestValueFactory<?> createValueFactory(Parameter parameter) {
-        final boolean isOptionalPrincipal = parameter.getRawType().equals(Optional.class)
-            && ParameterizedType.class.isAssignableFrom(parameter.getType().getClass())
-            && principalClass.equals(((ParameterizedType) parameter.getType()).getActualTypeArguments()[0]);
-
-        if (!parameter.isAnnotationPresent(Auth.class)
-           || !(principalClass.equals(parameter.getRawType()) || isOptionalPrincipal)) {
+        if (!parameter.isAnnotationPresent(Auth.class)) {
             return null;
-        } else if (isOptionalPrincipal) {
-            return new OptionalPrincipalContainerRequestValueFactory();
-        } else {
+        } else if (principalClass.equals(parameter.getRawType())) {
             return new PrincipalContainerRequestValueFactory();
+        } else {
+            final boolean isOptionalPrincipal = parameter.getRawType() == Optional.class
+                && ParameterizedType.class.isAssignableFrom(parameter.getType().getClass())
+                && principalClass == ((ParameterizedType) parameter.getType()).getActualTypeArguments()[0];
+
+            return isOptionalPrincipal ? new OptionalPrincipalContainerRequestValueFactory() : null;
         }
     }
 

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/OptionalPrincipalContainerRequestValueFactory.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/OptionalPrincipalContainerRequestValueFactory.java
@@ -1,0 +1,31 @@
+package io.dropwizard.auth;
+
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.internal.inject.AbstractContainerRequestValueFactory;
+
+import java.util.Optional;
+import java.security.Principal;
+
+/**
+ * A value factory which extracts an {@link Optional optional} {@link
+ * Principal} from the current {@link ContainerRequest} instance.
+ */
+class OptionalPrincipalContainerRequestValueFactory
+    extends AbstractContainerRequestValueFactory<Optional<Principal>>
+{
+    /**
+     * @return {@link Optional}{@code <}{@link Principal}{@code >}
+     *         stored on the request, or {@code Optional.empty()} if
+     *         no object was found.
+     */
+    @Override
+    public Optional<Principal> provide() {
+        final Principal principal = getContainerRequest().getSecurityContext().getUserPrincipal();
+
+        if (principal == null) {
+            return Optional.empty();
+        } else {
+            return Optional.of(principal);
+        }
+    }
+}

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/OptionalPrincipalContainerRequestValueFactory.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/OptionalPrincipalContainerRequestValueFactory.java
@@ -20,12 +20,6 @@ class OptionalPrincipalContainerRequestValueFactory
      */
     @Override
     public Optional<Principal> provide() {
-        final Principal principal = getContainerRequest().getSecurityContext().getUserPrincipal();
-
-        if (principal == null) {
-            return Optional.empty();
-        } else {
-            return Optional.of(principal);
-        }
+        return Optional.ofNullable(getContainerRequest().getSecurityContext().getUserPrincipal());
     }
 }

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/OptionalPrincipalContainerRequestValueFactory.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/OptionalPrincipalContainerRequestValueFactory.java
@@ -11,8 +11,7 @@ import java.security.Principal;
  * Principal} from the current {@link ContainerRequest} instance.
  */
 class OptionalPrincipalContainerRequestValueFactory
-    extends AbstractContainerRequestValueFactory<Optional<Principal>>
-{
+    extends AbstractContainerRequestValueFactory<Optional<Principal>> {
     /**
      * @return {@link Optional}{@code <}{@link Principal}{@code >}
      *         stored on the request, or {@code Optional.empty()} if

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/PolymorphicAuthDynamicFeature.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/PolymorphicAuthDynamicFeature.java
@@ -3,12 +3,15 @@ package io.dropwizard.auth;
 import com.google.common.collect.ImmutableMap;
 import org.glassfish.jersey.server.model.AnnotatedMethod;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.security.Principal;
+import java.util.Optional;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.DynamicFeature;
 import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.FeatureContext;
-import java.lang.annotation.Annotation;
-import java.security.Principal;
 
 /**
  * A {@link DynamicFeature} that registers the provided auth filters
@@ -30,12 +33,24 @@ public class PolymorphicAuthDynamicFeature<T extends Principal> implements Dynam
         final AnnotatedMethod am = new AnnotatedMethod(resourceInfo.getResourceMethod());
         final Annotation[][] parameterAnnotations = am.getParameterAnnotations();
         final Class<?>[] parameterTypes = am.getParameterTypes();
+        final Type[] parameterGenericTypes = am.getGenericParameterTypes();
 
         for (int i = 0; i < parameterAnnotations.length; i++) {
             for (final Annotation annotation : parameterAnnotations[i]) {
-                if (annotation instanceof Auth && authFilterMap.containsKey(parameterTypes[i])) {
-                    context.register(authFilterMap.get(parameterTypes[i]));
-                    return;
+                // If the parameter type is an Optional, extract its type
+                // parameter. Otherwise, use the parameter type itself.
+                final Type paramType = (parameterTypes[i].equals(Optional.class))
+                    ? ((ParameterizedType) parameterGenericTypes[i]).getActualTypeArguments()[0]
+                    : parameterTypes[i];
+
+                if (annotation instanceof Auth && authFilterMap.containsKey(paramType)) {
+                    if (parameterTypes[i].equals(Optional.class)) {
+                        context.register(new WebApplicationExceptionCatchingFilter(authFilterMap.get(paramType)));
+                        return;
+                    } else {
+                        context.register(authFilterMap.get(parameterTypes[i]));
+                        return;
+                    }
                 }
             }
         }

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/PolymorphicAuthValueFactoryProvider.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/PolymorphicAuthValueFactoryProvider.java
@@ -59,17 +59,16 @@ public class PolymorphicAuthValueFactoryProvider<T extends Principal> extends Ab
      */
     @Override
     public AbstractContainerRequestValueFactory<?> createValueFactory(Parameter parameter) {
-        final boolean isOptionalPrincipal = parameter.getRawType().equals(Optional.class)
-            && ParameterizedType.class.isAssignableFrom(parameter.getType().getClass())
-            && principalClassSet.contains(((ParameterizedType) parameter.getType()).getActualTypeArguments()[0]);
-
-        if (!parameter.isAnnotationPresent(Auth.class)
-           || !(principalClassSet.contains(parameter.getRawType()) || isOptionalPrincipal)) {
+        if (!parameter.isAnnotationPresent(Auth.class)) {
             return null;
-        } else if (isOptionalPrincipal) {
-            return new OptionalPrincipalContainerRequestValueFactory();
-        } else {
+        } else if (principalClassSet.contains(parameter.getRawType())) {
             return new PrincipalContainerRequestValueFactory();
+        } else {
+            final boolean isOptionalPrincipal = parameter.getRawType() == Optional.class
+                && ParameterizedType.class.isAssignableFrom(parameter.getType().getClass())
+                && principalClassSet.contains(((ParameterizedType) parameter.getType()).getActualTypeArguments()[0]);
+
+            return isOptionalPrincipal ? new OptionalPrincipalContainerRequestValueFactory() : null;
         }
     }
 

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/WebApplicationExceptionCatchingFilter.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/WebApplicationExceptionCatchingFilter.java
@@ -3,8 +3,6 @@ package io.dropwizard.auth;
 import com.google.common.base.Preconditions;
 
 import java.io.IOException;
-import java.security.Principal;
-import java.util.Optional;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/WebApplicationExceptionCatchingFilter.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/WebApplicationExceptionCatchingFilter.java
@@ -1,0 +1,30 @@
+package io.dropwizard.auth;
+
+import java.io.IOException;
+import java.security.Principal;
+import java.util.Optional;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+
+/**
+ * A {@link ContainerRequestFilter} decorator which catches any {@link
+ * WebApplicationException WebApplicationExceptions} thrown by an
+ * underlying {@code ContextRequestFilter}.
+ */
+class WebApplicationExceptionCatchingFilter implements ContainerRequestFilter {
+    private final ContainerRequestFilter underlying;
+
+    public WebApplicationExceptionCatchingFilter(ContainerRequestFilter underlying) {
+        this.underlying = underlying;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        try {
+            underlying.filter(requestContext);
+        } catch (WebApplicationException err) {
+            // Pass through.
+        }
+    }
+}

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/WebApplicationExceptionCatchingFilter.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/WebApplicationExceptionCatchingFilter.java
@@ -1,5 +1,7 @@
 package io.dropwizard.auth;
 
+import com.google.common.base.Preconditions;
+
 import java.io.IOException;
 import java.security.Principal;
 import java.util.Optional;
@@ -16,6 +18,7 @@ class WebApplicationExceptionCatchingFilter implements ContainerRequestFilter {
     private final ContainerRequestFilter underlying;
 
     public WebApplicationExceptionCatchingFilter(ContainerRequestFilter underlying) {
+        Preconditions.checkNotNull(underlying, "Underlying ContainerRequestFilter is not set");
         this.underlying = underlying;
     }
 

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthBaseTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthBaseTest.java
@@ -95,6 +95,29 @@ public abstract class AuthBaseTest<T extends DropwizardResourceConfig> extends J
     }
 
     @Test
+    public void resourceWithValidOptionalAuthentication200() {
+        assertThat(target("/test/optional").request()
+            .header(HttpHeaders.AUTHORIZATION, getPrefix() + " " + getOrdinaryGuyValidToken())
+            .get(String.class))
+            .isEqualTo("principal was present");
+    }
+
+    @Test
+    public void resourceWithInvalidOptionalAuthentication200() {
+        assertThat(target("/test/optional").request()
+            .header(HttpHeaders.AUTHORIZATION, getPrefix() + " " + getBadGuyToken())
+            .get(String.class))
+            .isEqualTo("principal was not present");
+    }
+
+    @Test
+    public void resourceWithoutOptionalAuthentication200() {
+        assertThat(target("/test/optional").request()
+            .get(String.class))
+            .isEqualTo("principal was not present");
+    }
+
+    @Test
     public void resourceWithAuthorizationPrincipalIsNotAuthorized403() {
         try {
             target("/test/admin").request()

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthResource.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthResource.java
@@ -1,6 +1,5 @@
 package io.dropwizard.auth;
 
-
 import javax.annotation.security.DenyAll;
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
@@ -9,6 +8,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import java.security.Principal;
+import java.util.Optional;
 
 @Path("/test/")
 @Produces(MediaType.TEXT_PLAIN)
@@ -26,6 +26,13 @@ public class AuthResource {
     @Path("profile")
     public String showForEveryUser(@Auth Principal principal) {
         return "'" + principal.getName() + "' has user privileges";
+    }
+
+    @PermitAll
+    @GET
+    @Path("optional")
+    public String checkOptionalAuth(@Auth Optional<Principal> principalOpt) {
+        return "principal was " + ((principalOpt.isPresent()) ? "" : "not ") + "present";
     }
 
     @GET

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthResource.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthResource.java
@@ -32,7 +32,7 @@ public class AuthResource {
     @GET
     @Path("optional")
     public String checkOptionalAuth(@Auth Optional<Principal> principalOpt) {
-        return "principal was " + ((principalOpt.isPresent()) ? "" : "not ") + "present";
+        return "principal was " + (principalOpt.isPresent() ? "" : "not ") + "present";
     }
 
     @GET

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/PolymorphicPrincipalEntityResource.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/PolymorphicPrincipalEntityResource.java
@@ -7,6 +7,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,5 +31,11 @@ public class PolymorphicPrincipalEntityResource {
     public String principalEntityWithoutAuth(@Auth NullPrincipal principal) {
         assertThat(principal).isNotNull();
         return principal.getName();
+    }
+
+    @GET
+    @Path("optional")
+    public String checkOptionalAuth(@Auth Optional<NullPrincipal> principalOpt) {
+        return "principal was " + ((principalOpt.isPresent()) ? "" : "not ") + "present";
     }
 }

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/PolymorphicPrincipalEntityTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/PolymorphicPrincipalEntityTest.java
@@ -140,4 +140,35 @@ public class PolymorphicPrincipalEntityTest extends JerseyTest {
             assertThat(e.getResponse().getStatus()).isEqualTo(401);
         }
     }
+
+    @Test
+    public void resourceWithValidOptionalAuthentication200() {
+        assertThat(target("/auth-test/optional").request()
+            .header(HttpHeaders.AUTHORIZATION, "Basic " + NULL_USERNAME_ENCODED_TOKEN)
+            .get(String.class))
+            .isEqualTo("principal was present");
+    }
+
+    @Test
+    public void resourceWithInvalidOptionalAuthentication200() {
+        assertThat(target("/auth-test/optional").request()
+            .header(HttpHeaders.AUTHORIZATION, "Basic cats")
+            .get(String.class))
+            .isEqualTo("principal was not present");
+    }
+
+    @Test
+    public void resourceWithoutOptionalAuthentication200() {
+        assertThat(target("/auth-test/optional").request()
+            .get(String.class))
+            .isEqualTo("principal was not present");
+    }
+
+    @Test
+    public void resourceWithDifferentOptionalAuthentication200() {
+        assertThat(target("/auth-test/optional").request()
+            .header(HttpHeaders.AUTHORIZATION, "Basic " + JSON_USERNAME_ENCODED_TOKEN)
+            .get(String.class))
+            .isEqualTo("principal was not present");
+    }
 }


### PR DESCRIPTION
The current support for optionally-protected resources isn't great. We require users to implement a custom auth filter to inject a dummy `SecurityContext` for unauth'd requests.

I had occasion to write such an endpoint at work and decided to take a stab at supporting `Optional` principals with the `@Auth` annotation. With this patch, I'm able to do things like this:

```
@GET
public String getGreeting(@Auth Optional<User> userOpt) {
  if (userOpt.isPresent()) {
    return "Hello, " + userOpt.get().getName() + "!";
  } else {
    return "Greetings, anonymous visitor!"
  }
}
```
This change breaks down into two steps:

1. A new `ContainerRequestFilter` decorator is used to silence exceptions thrown by failed `AuthFilter` invocations. This results in every request succeeding and principals being injected into the `SecurityContext` of auth'd requests.
2. An `OptionalPrincipalContainerRequestValueFactory` class is used to return the optional principal rather than throwing on its absence.

These two new classes are wired into `AuthDynamicFeature` and `AuthValueFactoryProvider` and their polymorphic equivalents. Tests are added to verify the behavior of each combination and the auth section of the used manual is updated to reflect this new capability.
