### PR TITLE
Implement TaskServlet::doGet to list tasks lexically.

### DIFF
--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/TaskServlet.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/TaskServlet.java
@@ -7,9 +7,13 @@ import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.base.Charsets;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.io.CharStreams;
 import com.google.common.net.MediaType;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,6 +92,25 @@ public class TaskServlet extends HttpServlet {
         }
 
         taskExecutors.put(task, taskExecutor);
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req,
+                         HttpServletResponse resp) throws ServletException, IOException {
+        if (Strings.isNullOrEmpty(req.getPathInfo())) {
+            try (final PrintWriter output = resp.getWriter()) {
+                resp.setContentType(MediaType.PLAIN_TEXT_UTF_8.toString());
+                final ArrayList<Task> tasks = new ArrayList<>(getTasks());
+                Collections.sort(tasks, Comparator.comparing(Task::getName));
+                for (final Task task : tasks) {
+                    output.println(task.getName());
+                }
+            }
+        } else if (tasks.containsKey(req.getPathInfo())) {
+            resp.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+        } else {
+            resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+        }
     }
 
     @Override

--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/TaskServlet.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/TaskServlet.java
@@ -11,9 +11,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.io.CharStreams;
 import com.google.common.net.MediaType;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,11 +97,10 @@ public class TaskServlet extends HttpServlet {
         if (Strings.isNullOrEmpty(req.getPathInfo())) {
             try (final PrintWriter output = resp.getWriter()) {
                 resp.setContentType(MediaType.PLAIN_TEXT_UTF_8.toString());
-                final ArrayList<Task> tasks = new ArrayList<>(getTasks());
-                Collections.sort(tasks, Comparator.comparing(Task::getName));
-                for (final Task task : tasks) {
-                    output.println(task.getName());
-                }
+                getTasks().stream()
+                    .map(Task::getName)
+                    .sorted()
+                    .forEach(output::println);
             }
         } else if (tasks.containsKey(req.getPathInfo())) {
             resp.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);


### PR DESCRIPTION
Tasks are logged on startup but aren't easily accessible otherwise. Implement `TaskServlet::doGet` to print tasks lexically by name.

Example:
```
$ curl http://localhost:8081/tasks
echo
gc
log-level
```
TaskServlet is mapped on "/tasks/*" and any GET request not matching root 
will yield 404 or 405.

404: Task name is unknown.  
405: Task name is registered but must be invoked with POST.