### PR TITLE
Add some commonly used and useful jersey request/response filters

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/CharsetFilter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/CharsetFilter.java
@@ -14,7 +14,7 @@ import javax.ws.rs.ext.Provider;
 
 /**
  * This class ensures that any HTTP response that includes a Content-Type
- * response header, that it also includes the UTF-8 character set.
+ * response header, will also include the UTF-8 character set.
  */
 @Provider
 @Priority(Priorities.HEADER_DECORATOR)

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/CharsetFilter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/CharsetFilter.java
@@ -1,0 +1,35 @@
+package io.dropwizard.jersey.filter;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * This class ensures that any HTTP response that includes a Content-Type
+ * response header, that it also includes the UTF-8 character set.
+ */
+@Provider
+@Priority(Priorities.HEADER_DECORATOR)
+public class CharsetFilter implements ContainerResponseFilter {
+
+    private static final String UTF_8 = StandardCharsets.UTF_8.displayName(Locale.ENGLISH);
+
+    @Override
+    public void filter(final ContainerRequestContext request,
+            final ContainerResponseContext response) throws IOException {
+
+        final MediaType type = response.getMediaType();
+        if (type != null && !type.getParameters().containsKey(MediaType.CHARSET_PARAMETER)) {
+            final MediaType typeWithCharset = type.withCharset(UTF_8);
+            response.getHeaders().putSingle(HttpHeaders.CONTENT_TYPE, typeWithCharset);
+        }
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/CharsetUtf8Filter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/CharsetUtf8Filter.java
@@ -18,7 +18,7 @@ import javax.ws.rs.ext.Provider;
  */
 @Provider
 @Priority(Priorities.HEADER_DECORATOR)
-public class CharsetFilter implements ContainerResponseFilter {
+public class CharsetUtf8Filter implements ContainerResponseFilter {
 
     private static final String UTF_8 = StandardCharsets.UTF_8.displayName(Locale.ENGLISH);
 

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/RequestIdFilter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/RequestIdFilter.java
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory;
 /**
  * This class adds a "X-Request-Id" HTTP response header and logs the following
  * information: request method, request path, request ID, response status,
- * response bytes (or -1 if not known).
+ * response length (or -1 if not known).
  *
  * @see https://devcenter.heroku.com/articles/http-request-id
  */

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/RequestIdFilter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/RequestIdFilter.java
@@ -1,0 +1,36 @@
+package io.dropwizard.jersey.filter;
+
+import java.io.IOException;
+import java.util.UUID;
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.ext.Provider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class adds a "X-Request-Id" HTTP response header and logs the following
+ * information: request method, request path, request ID, response status,
+ * response bytes (or -1 if not known)
+ */
+@Provider
+@Priority(Priorities.USER)
+public class RequestIdFilter implements ContainerResponseFilter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RequestIdFilter.class);
+    private static final String REQUEST_ID = "X-Request-Id";
+
+    @Override
+    public void filter(final ContainerRequestContext request,
+            final ContainerResponseContext response) throws IOException {
+
+        final UUID id = UUID.randomUUID();
+        LOGGER.info("method={} path={} request_id={} status={} bytes={}",
+                request.getMethod(), request.getUriInfo().getPath(), id,
+                response.getStatus(), response.getLength());
+        response.getHeaders().add(REQUEST_ID, id);
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/RequestIdFilter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/RequestIdFilter.java
@@ -1,7 +1,9 @@
 package io.dropwizard.jersey.filter;
 
 import java.io.IOException;
+import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import javax.annotation.Priority;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.container.ContainerRequestContext;
@@ -10,6 +12,7 @@ import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.ext.Provider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.google.common.base.Strings;
 
 /**
  * This class adds a "X-Request-Id" HTTP response header and logs the following
@@ -29,10 +32,38 @@ public class RequestIdFilter implements ContainerResponseFilter {
     public void filter(final ContainerRequestContext request,
             final ContainerResponseContext response) throws IOException {
 
-        final UUID id = UUID.randomUUID();
+        String id = request.getHeaderString(REQUEST_ID);
+        if (Strings.isNullOrEmpty(id)) {
+            id = generateRandomUuid().toString();
+        }
+        
         LOGGER.info("method={} path={} request_id={} status={} length={}",
                 request.getMethod(), request.getUriInfo().getPath(), id,
                 response.getStatus(), response.getLength());
-        response.getHeaders().add(REQUEST_ID, id);
+        response.getHeaders().putSingle(REQUEST_ID, id);
+    }
+
+    /**
+     * Generate a random UUID v4 that will perform reasonably when used by
+     * multiple threads under load.
+     *
+     * @see https://github.com/Netflix/netflix-commons/blob/v0.3.0/netflix-commons-util/src/main/java/com/netflix/util/concurrent/ConcurrentUUIDFactory.java
+     * @return random UUID
+     */
+    private static UUID generateRandomUuid() {
+        final Random rnd = ThreadLocalRandom.current();
+        long mostSig  = rnd.nextLong();
+        long leastSig = rnd.nextLong();
+
+        // Identify this as a version 4 UUID, that is one based on a random value.
+        mostSig &= 0xffffffffffff0fffL;
+        mostSig |= 0x0000000000004000L;
+
+        // Set the variant identifier as specified for version 4 UUID values.  The two
+        // high order bits of the lower word are required to be one and zero, respectively.
+        leastSig &= 0x3fffffffffffffffL;
+        leastSig |= 0x8000000000000000L;
+
+        return new UUID(mostSig, leastSig);
     }
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/RequestIdFilter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/RequestIdFilter.java
@@ -37,7 +37,7 @@ public class RequestIdFilter implements ContainerResponseFilter {
             id = generateRandomUuid().toString();
         }
         
-        LOGGER.info("method={} path={} request_id={} status={} length={}",
+        LOGGER.trace("method={} path={} request_id={} status={} length={}",
                 request.getMethod(), request.getUriInfo().getPath(), id,
                 response.getStatus(), response.getLength());
         response.getHeaders().putSingle(REQUEST_ID, id);

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/RequestIdFilter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/RequestIdFilter.java
@@ -14,7 +14,9 @@ import org.slf4j.LoggerFactory;
 /**
  * This class adds a "X-Request-Id" HTTP response header and logs the following
  * information: request method, request path, request ID, response status,
- * response bytes (or -1 if not known)
+ * response bytes (or -1 if not known).
+ *
+ * @see https://devcenter.heroku.com/articles/http-request-id
  */
 @Provider
 @Priority(Priorities.USER)
@@ -28,7 +30,7 @@ public class RequestIdFilter implements ContainerResponseFilter {
             final ContainerResponseContext response) throws IOException {
 
         final UUID id = UUID.randomUUID();
-        LOGGER.info("method={} path={} request_id={} status={} bytes={}",
+        LOGGER.info("method={} path={} request_id={} status={} length={}",
                 request.getMethod(), request.getUriInfo().getPath(), id,
                 response.getStatus(), response.getLength());
         response.getHeaders().add(REQUEST_ID, id);

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/RuntimeFilter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/RuntimeFilter.java
@@ -11,8 +11,9 @@ import io.dropwizard.util.Duration;
 
 /**
  * This class adds an "X-Runtime" HTTP response header that includes the time
- * taken to execute the request, in seconds.
- * 
+ * taken to execute the request, in seconds (based on the implementation from
+ * Ruby on Rails).
+ *
  * @see https://github.com/rack/rack/blob/master/lib/rack/runtime.rb
  */
 @Provider

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/RuntimeFilter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/RuntimeFilter.java
@@ -36,7 +36,7 @@ public class RuntimeFilter implements ContainerRequestFilter, ContainerResponseF
         final Long startTime = (Long) request.getProperty(RUNTIME_PROPERTY);
         if (startTime != null) {
             final float seconds = (System.nanoTime() - startTime) / NANOS_IN_SECOND;
-            response.getHeaders().add(RUNTIME_HEADER, String.format("%.6f", seconds));
+            response.getHeaders().putSingle(RUNTIME_HEADER, String.format("%.6f", seconds));
         }
     }
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/RuntimeFilter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/RuntimeFilter.java
@@ -1,0 +1,41 @@
+package io.dropwizard.jersey.filter;
+
+import java.io.IOException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.ext.Provider;
+import io.dropwizard.util.Duration;
+
+/**
+ * This class adds an "X-Runtime" HTTP response header that includes the time
+ * taken to execute the request, in seconds.
+ * 
+ * @see https://github.com/rack/rack/blob/master/lib/rack/runtime.rb
+ */
+@Provider
+@PreMatching
+public class RuntimeFilter implements ContainerRequestFilter, ContainerResponseFilter {
+
+    private static final float NANOS_IN_SECOND = Duration.seconds(1).toNanoseconds();
+    private static final String RUNTIME_HEADER = "X-Runtime";
+    private static final String RUNTIME_PROPERTY = "io.dropwizard.jersey.filter.runtime";
+
+    @Override
+    public void filter(final ContainerRequestContext request) throws IOException {
+        request.setProperty(RUNTIME_PROPERTY, System.nanoTime());
+    }
+
+    @Override
+    public void filter(final ContainerRequestContext request,
+            final ContainerResponseContext response) throws IOException {
+
+        final Long startTime = (Long) request.getProperty(RUNTIME_PROPERTY);
+        if (startTime != null) {
+            final float seconds = (System.nanoTime() - startTime) / NANOS_IN_SECOND;
+            response.getHeaders().add(RUNTIME_HEADER, String.format("%.6f", seconds));
+        }
+    }
+}


### PR DESCRIPTION
* `X-Request-Id` filter is based upon https://devcenter.heroku.com/articles/http-request-id
* `X-Runtime` filter is based upon https://github.com/rack/rack/blob/master/lib/rack/runtime.rb

These are not registered by default.  They are merely provide for convenience if people want to opt-in to using them.