### PR TITLE
Add test for javax.ws.rs annotations in interfaces

### DIFF
--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
@@ -34,6 +34,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     protected Application configure() {
         return DropwizardResourceConfig.forTesting(new MetricRegistry())
                 .packages("io.dropwizard.jersey.validation")
+                .register(new ValidatingResource2())
                 .register(new HibernateValidationFeature(Validators.newValidator()));
     }
 
@@ -76,6 +77,15 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
                 .post(Entity.entity("{}", MediaType.APPLICATION_JSON));
         assertThat(response.getStatus()).isEqualTo(422);
         assertThat(response.readEntity(String.class)).isEqualTo("{\"errors\":[\"name may not be empty\"]}");
+    }
+
+    @Test
+    public void postInvalidInterfaceEntityIs422() throws Exception {
+        final Response response = target("/valid2/repr").request(MediaType.APPLICATION_JSON)
+            .post(Entity.entity("{\"name\": \"a\"}", MediaType.APPLICATION_JSON));
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.readEntity(String.class))
+            .isEqualTo("{\"errors\":[\"query param interfaceVariable may not be null\"]}");
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource2.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource2.java
@@ -1,0 +1,10 @@
+package io.dropwizard.jersey.validation;
+
+import io.dropwizard.other.RestInterface;
+
+public class ValidatingResource2 implements RestInterface {
+    @Override
+    public ValidRepresentation repr(ValidRepresentation representation, String xer) {
+        return representation;
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/other/RestInterface.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/other/RestInterface.java
@@ -1,0 +1,31 @@
+package io.dropwizard.other;
+
+import io.dropwizard.jersey.validation.ValidRepresentation;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * Interface that holds all the javax.ws.rs annotations so we keep our
+ * implementation a little cleaner. This interface lives in a different
+ * package as the tests are set up to scan everything in io.dropwizard.jersey
+ * which will pick up this class. Jersey will then fail to instantiate this
+ * class. Users that typically register their classes directly will Jersey
+ * will not need to worry about this problem.
+ */
+@Path("/valid2/")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public interface RestInterface {
+    @POST
+    @Path("repr")
+    @Valid
+    ValidRepresentation repr(@NotNull @Valid ValidRepresentation representation,
+                             @NotNull @QueryParam("interfaceVariable") String xer);
+}


### PR DESCRIPTION
A test to ensure that we don't regress on our validation messages for resources which have all their annotations on their implemented interface. Reference: #1932