### PR TITLE
Support configuring FileAppender#bufferSize.

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -647,6 +647,7 @@ File
           archivedFileCount: 5
           timeZone: UTC
           logFormat: # TODO
+          bufferSize: 8KB
           filterFactories:
             - type: URI
 
@@ -683,6 +684,8 @@ filterFactories              (none)       The list of filters to apply to the ap
                                           the thresold.
 neverBlock                   false        Prevent the wrapping asynchronous appender from blocking when its underlying queue is full.
                                           Set to true to disable blocking.
+bufferSize                   8KB          The buffer size of the underlying FileAppender (setting added in logback 1.1.10). Increasing this
+                                          from the default of 8KB to 256KB is reported to significantly reduce thread contention.
 ============================ ===========  ==================================================================================================
 
 

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/DefaultLoggingFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/DefaultLoggingFactoryTest.java
@@ -74,6 +74,7 @@ public class DefaultLoggingFactoryTest {
         assertThat(fileAppenderFactory.getCurrentLogFilename()).isEqualTo("${new_app}.log");
         assertThat(fileAppenderFactory.getArchivedLogFilenamePattern()).isEqualTo("${new_app}-%d.log.gz");
         assertThat(fileAppenderFactory.getArchivedFileCount()).isEqualTo(5);
+        assertThat(fileAppenderFactory.getBufferSize().toKilobytes()).isEqualTo(256);
         final ImmutableList<FilterFactory<ILoggingEvent>> filterFactories = fileAppenderFactory.getFilterFactories();
         assertThat(filterFactories).hasSize(2);
         assertThat(filterFactories.get(0)).isExactlyInstanceOf(TestFilterFactory.class);

--- a/dropwizard-logging/src/test/resources/yaml/logging_advanced.yml
+++ b/dropwizard-logging/src/test/resources/yaml/logging_advanced.yml
@@ -12,6 +12,7 @@ loggers:
         archivedLogFilenamePattern: '${new_app}-%d.log.gz'
         logFormat: "%-5level %logger: %msg%n"
         archivedFileCount: 5
+        bufferSize: 256KB
   "com.example.legacyApp":
     level: DEBUG
   "com.example.notAdditive":


### PR DESCRIPTION
Update FileAppenderFactory to support configuration of the
FileAppender#bufferSize setting. Introduced in logback 1.1.10, this
setting is reported to reduce thread contention in logging performance
tests.