### PR TITLE
Support disabled and enabled attributes for metrics

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -36,6 +36,7 @@ v1.1.0: Unreleased
 * Register Jackson parameter-names modules `#1908 <https://github.com/dropwizard/dropwizard/pull/1908>`_
 * Native Jackson deserialization of enums when Jackson annotations are present `#1909 <https://github.com/dropwizard/dropwizard/pull/1909>`_
 * Add `JsonConfigurationFactory` for first-class support of the JSON configuration `#1897 <https://github.com/dropwizard/dropwizard/pull/1897>`_
+* Support disabled and enabled attributes for metrics `#1957 <https://github.com/dropwizard/dropwizard/pull/1957>`_
 * Upgraded to Jackson 2.8.6
 * Upgraded to Hibernate Validator 5.3.4.Final
 * Upgraded to Hibernate ORM 5.2.8.Final

--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -789,6 +789,8 @@ The following options are available for all metrics reporters.
           rateUnit: seconds
           excludes: (none)
           includes: (all)
+          excludesAttributes: (none)
+          includesAttributes: (all)
           useRegexFilters: false
           frequency: 1 minute
 
@@ -800,6 +802,10 @@ durationUnit           milliseconds   The unit to report durations as. Overrides
 rateUnit               seconds        The unit to report rates as. Overrides per-metric rate units.
 excludes               (none)         Metrics to exclude from reports, by name. When defined, matching metrics will not be reported.
 includes               (all)          Metrics to include in reports, by name. When defined, only these metrics will be reported.
+excludesAttributes     (none)         Metric attributes to exclude from reports, by name (e.g ``p98``, ``m15_rate``, ``stddev``).
+                                      When defined, matching metrics attributes will not be reported.
+includesAttributes     (all)          Metrics attributes to include in reports, by name (e.g ``p98``, ```m15_rate``, ``stddev``).
+                                      When defined, only these attributes will be reported.
 useRegexFilters        false          Indicates whether the values of the 'includes' and 'excludes' fields should be treated as regular expressions or not.
 frequency              (none)         The frequency to report metrics. Overrides the default.
 ====================== =============  ===========

--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -802,9 +802,9 @@ durationUnit           milliseconds   The unit to report durations as. Overrides
 rateUnit               seconds        The unit to report rates as. Overrides per-metric rate units.
 excludes               (none)         Metrics to exclude from reports, by name. When defined, matching metrics will not be reported.
 includes               (all)          Metrics to include in reports, by name. When defined, only these metrics will be reported.
-excludesAttributes     (none)         Metric attributes to exclude from reports, by name (e.g ``p98``, ``m15_rate``, ``stddev``).
+excludesAttributes     (none)         Metric attributes to exclude from reports, by name (e.g. ``p98``, ``m15_rate``, ``stddev``).
                                       When defined, matching metrics attributes will not be reported.
-includesAttributes     (all)          Metrics attributes to include in reports, by name (e.g ``p98``, ```m15_rate``, ``stddev``).
+includesAttributes     (all)          Metrics attributes to include in reports, by name (e.g. ``p98``, ``m15_rate``, ``stddev``).
                                       When defined, only these attributes will be reported.
 useRegexFilters        false          Indicates whether the values of the 'includes' and 'excludes' fields should be treated as regular expressions or not.
 frequency              (none)         The frequency to report metrics. Overrides the default.

--- a/dropwizard-metrics-ganglia/src/main/java/io/dropwizard/metrics/ganglia/GangliaReporterFactory.java
+++ b/dropwizard-metrics-ganglia/src/main/java/io/dropwizard/metrics/ganglia/GangliaReporterFactory.java
@@ -203,6 +203,7 @@ public class GangliaReporterFactory extends BaseReporterFactory {
                                   .prefixedWith(getPrefix())
                                   .withDMax((int) dmax.toSeconds())
                                   .withTMax((int) tmax.toSeconds())
+                                  .disabledMetricAttributes(getDisabledAttributes())
                                   .build(ganglia);
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/dropwizard-metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteReporterFactory.java
+++ b/dropwizard-metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteReporterFactory.java
@@ -1,5 +1,6 @@
 package io.dropwizard.metrics.graphite;
 
+import com.codahale.metrics.MetricAttribute;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.ScheduledReporter;
 import com.codahale.metrics.graphite.Graphite;
@@ -8,12 +9,16 @@ import com.codahale.metrics.graphite.GraphiteUDP;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import io.dropwizard.metrics.BaseReporterFactory;
 import io.dropwizard.validation.OneOf;
 import io.dropwizard.validation.PortRange;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.validation.constraints.NotNull;
+import java.util.EnumSet;
+import java.util.Set;
 
 /**
  * A factory for {@link GraphiteReporter} instances.
@@ -120,6 +125,7 @@ public class GraphiteReporterFactory extends BaseReporterFactory {
                 .convertDurationsTo(getDurationUnit())
                 .convertRatesTo(getRateUnit())
                 .filter(getFilter())
-                .prefixedWith(getPrefix());
+                .prefixedWith(getPrefix())
+                .disabledMetricAttributes(getDisabledAttributes());
     }
 }

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/MetricAttributesTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/MetricAttributesTest.java
@@ -1,0 +1,58 @@
+package io.dropwizard.metrics;
+
+import com.codahale.metrics.MetricAttribute;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.ScheduledReporter;
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.EnumSet;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class MetricAttributesTest {
+
+    private static final EnumSet<MetricAttribute> ALL = EnumSet.allOf(MetricAttribute.class);
+    private static final EnumSet<MetricAttribute> NONE = EnumSet.noneOf(MetricAttribute.class);
+
+    @Parameters(name = "{index} !({0}-{1})={2}")
+    public static List<Object[]> data() {
+        return ImmutableList.of(
+            new Object[]{NONE, NONE, ALL},
+            new Object[]{ALL, NONE, NONE},
+            new Object[]{ALL, EnumSet.of(MetricAttribute.STDDEV, MetricAttribute.M15_RATE), EnumSet.of(MetricAttribute.STDDEV, MetricAttribute.M15_RATE)},
+            new Object[]{EnumSet.of(MetricAttribute.STDDEV, MetricAttribute.M15_RATE), NONE, EnumSet.complementOf(EnumSet.of(MetricAttribute.STDDEV, MetricAttribute.M15_RATE))},
+            new Object[]{EnumSet.of(MetricAttribute.STDDEV, MetricAttribute.M15_RATE, MetricAttribute.P95), EnumSet.of(MetricAttribute.P95), EnumSet.complementOf(EnumSet.of(MetricAttribute.STDDEV, MetricAttribute.M15_RATE))}
+        );
+    }
+
+    private final BaseReporterFactory factory = new BaseReporterFactory() {
+        @Override
+        public ScheduledReporter build(MetricRegistry registry) {
+            throw new UnsupportedOperationException("not implemented");
+        }
+    };
+
+    @Parameter
+    public EnumSet<MetricAttribute> includes;
+
+    @Parameter(1)
+    public EnumSet<MetricAttribute> excludes;
+
+    @Parameter(2)
+    public EnumSet<MetricAttribute> expectedResult;
+
+    @Test
+    public void testGetDisabledAttributes() {
+        factory.setIncludesAttributes(includes);
+        factory.setExcludesAttributes(excludes);
+        assertThat(factory.getDisabledAttributes()).isEqualTo(expectedResult);
+    }
+
+}

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/MetricsFactoryTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/MetricsFactoryTest.java
@@ -1,5 +1,6 @@
 package io.dropwizard.metrics;
 
+import com.codahale.metrics.MetricAttribute;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;
 import io.dropwizard.configuration.YamlConfigurationFactory;
@@ -11,6 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.EnumSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -46,5 +48,26 @@ public class MetricsFactoryTest {
         CsvReporterFactory csvReporter = new CsvReporterFactory();
         csvReporter.setFile(new File("metrics"));
         assertThat(config.getReporters()).hasSize(3);
+    }
+
+    @Test
+    public void canReadExcludedAndIncludedAttributes(){
+        assertThat(config.getReporters()).hasSize(3);
+        final ReporterFactory reporterFactory = config.getReporters().get(0);
+        assertThat(reporterFactory).isInstanceOf(ConsoleReporterFactory.class);
+        final ConsoleReporterFactory consoleReporterFactory = (ConsoleReporterFactory) reporterFactory;
+        assertThat(consoleReporterFactory.getIncludesAttributes()).isEqualTo(EnumSet.of(
+            MetricAttribute.P50, MetricAttribute.P95, MetricAttribute.P98, MetricAttribute.P99));
+        assertThat(consoleReporterFactory.getExcludesAttributes()).isEqualTo(EnumSet.of(MetricAttribute.P98));
+    }
+
+    @Test
+    public void canReadDefaultExcludedAndIncludedAttributes(){
+        assertThat(config.getReporters()).hasSize(3);
+        final ReporterFactory reporterFactory = config.getReporters().get(1);
+        assertThat(reporterFactory).isInstanceOf(CsvReporterFactory.class);
+        final CsvReporterFactory csvReporterFactory = (CsvReporterFactory) reporterFactory;
+        assertThat(csvReporterFactory.getIncludesAttributes()).isEqualTo(EnumSet.allOf(MetricAttribute.class));
+        assertThat(csvReporterFactory.getExcludesAttributes()).isEmpty();
     }
 }

--- a/dropwizard-metrics/src/test/resources/yaml/metrics.yml
+++ b/dropwizard-metrics/src/test/resources/yaml/metrics.yml
@@ -5,6 +5,8 @@ reporters:
     timeZone: PST
     durationUnit: milliseconds
     rateUnit: seconds
+    includesAttributes: [p50, p95, p98, p99]
+    excludesAttributes: [p98]
   - type: csv
     file: metrics
   - type: log


### PR DESCRIPTION
Metrics 3.2.* allows to configure the set of attributes which can be disabled for a reporter. It would be nice to provide the ability to set them via the YAML config the same way we provide that for
metric names.