### PR TITLE
Move disabling Javadoc linter from profile to main build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <dropwizard.url>http://www.dropwizard.io/${project.version}</dropwizard.url>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <javadoc.doclint.none>-Xdoclint:none</javadoc.doclint.none>
         <maven.site.deploy.skip>true</maven.site.deploy.skip>
         <junit.version>4.12</junit.version>
         <assertj.version>3.6.2</assertj.version>
@@ -271,15 +272,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-            <id>java8-disable-strict-javadoc</id>
-            <activation>
-                <jdk>[1.8,)</jdk>
-            </activation>
-            <properties>
-                <javadoc.doclint.none>-Xdoclint:none</javadoc.doclint.none>
-            </properties>
         </profile>
         <profile>
             <id>dev</id>


### PR DESCRIPTION
Since Dropwizard is using Java 8 as a baseline, it's not necessary to "hide" disabling the Javadoc linter in a profile (`java8-disable-strict-javadoc`).

Additionally, this change enables users of Gradle to use the Dropwizard BOM with the [Nebula Dependency Recommender plugin](https://github.com/nebula-plugins/nebula-dependency-recommender-plugin).

## Gradle Example

**build.gradle**
```
plugins {
    id 'java'
    id "nebula.dependency-recommender" version "4.1.0"
}

sourceCompatibility = '1.8'
targetCompatibility = '1.8'

// UTF-8 should be standard by now. So use it!
[compileJava, compileTestJava]*.options*.encoding = 'UTF-8'

repositories {
    mavenCentral()
}

dependencyRecommendations {
   mavenBom module: "io.dropwizard:dropwizard-bom:1.1.0-rc3"
}

dependencies {
    compile "io.dropwizard:dropwizard-core"
}
```

**Error without this change**
```
$ gradle build
:compileJava
Exception while polling provider recommender-9 for version
java.lang.IllegalArgumentException: neither model source nor input file are specified
        at org.apache.maven.model.building.DefaultModelBuilder.readModel(DefaultModelBuilder.java:439)
        [long stack trace shortened for clarity]
:compileJava FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Could not resolve all dependencies for configuration ':compileClasspath'.
> Could not find io.dropwizard:dropwizard-core:.
  Searched in the following locations:
      https://repo1.maven.org/maven2/io/dropwizard/dropwizard-core//dropwizard-core-.pom
      https://repo1.maven.org/maven2/io/dropwizard/dropwizard-core//dropwizard-core-.jar
  Required by:
      project :

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 1.868 secs
```

**Example with this change**
```
$ gradle build
:compileJava
:processResources NO-SOURCE
:classes
:jar
:assemble
:compileTestJava NO-SOURCE
:processTestResources NO-SOURCE
:testClasses UP-TO-DATE
:test NO-SOURCE
:check UP-TO-DATE
:build

BUILD SUCCESSFUL

Total time: 2.167 secs
```