### PR TITLE
Enable setting context path programmatically 

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/server/DefaultServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/DefaultServerFactory.java
@@ -152,9 +152,6 @@ public class DefaultServerFactory extends AbstractServerFactory {
 
     @Override
     public Server build(Environment environment) {
-        // ensures that the environment is configured before the server is built
-        configure(environment);
-
         printBanner(environment.getName());
         final ThreadPool threadPool = createThreadPool(environment.metrics());
         final Server server = buildServer(environment.lifecycle(), threadPool);

--- a/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
@@ -153,6 +153,7 @@ public class DefaultServerFactoryTest {
         environment.jersey().register(new TestResource(requestReceived, shutdownInvoked));
 
         final ScheduledExecutorService executor = Executors.newScheduledThreadPool(3);
+        http.configure(environment);
         final Server server = http.build(environment);
 
         ((AbstractNetworkConnector) server.getConnectors()[0]).setPort(0);


### PR DESCRIPTION
As mentioned in #1546, setting the context path programmatically in an application's `run` method is being ignored.
`environment.getApplicationContext().setContextPath(somePath);`

This is due to DefaultServerFactory's `build` method (which executes after the application's `run`) reapplying the default (`/`). However, since #1504, the context path information has been getting set prior to the application's run method being invoked, so the configuration being performed in `build` is redundant. Here's the execution flow:

[EnvironmentCommand.run](https://github.com/dropwizard/dropwizard/blob/v1.0.6/dropwizard-core/src/main/java/io/dropwizard/cli/EnvironmentCommand.java#L40-L44)
1. calls `configure` which sets the context paths
2. calls the application's `run` method (where I'm attempting to set context path)
3. calls `run` which ends up executing ServerCommand's `run` method

[ServerCommand's `run` method]( https://github.com/dropwizard/dropwizard/blob/v1.0.6/dropwizard-core/src/main/java/io/dropwizard/cli/ServerCommand.java#L49)
1. calls ServerFactory's `build` method which calls `configure` again, wiping out the what the application set.

I'm proposing removing the call to `configure` in DefaultServerFactory's `build` method, as it is redundant and overwrites attempts to set the context path.