### PR TITLE
Make AllowedMethodsFilter immutable

### DIFF
--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OptionalDoubleTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OptionalDoubleTest.java
@@ -6,6 +6,8 @@ import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jdbi.DBIFactory;
 import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.setup.Environment;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.skife.jdbi.v2.DBI;
@@ -36,6 +38,13 @@ public class OptionalDoubleTest {
             h.execute("CREATE TABLE test (id INT PRIMARY KEY, optional DOUBLE)");
         }
         dao = dbi.onDemand(TestDao.class);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        for (LifeCycle managedObject : env.lifecycle().getManagedObjects()) {
+            managedObject.stop();
+        }
     }
 
     @Test

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OptionalIntTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OptionalIntTest.java
@@ -6,6 +6,8 @@ import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jdbi.DBIFactory;
 import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.setup.Environment;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.skife.jdbi.v2.DBI;
@@ -36,6 +38,13 @@ public class OptionalIntTest {
             h.execute("CREATE TABLE test (id INT PRIMARY KEY, optional INT)");
         }
         dao = dbi.onDemand(TestDao.class);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        for (LifeCycle managedObject : env.lifecycle().getManagedObjects()) {
+            managedObject.stop();
+        }
     }
 
     @Test

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OptionalLongTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OptionalLongTest.java
@@ -6,6 +6,8 @@ import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jdbi.DBIFactory;
 import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.setup.Environment;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.skife.jdbi.v2.DBI;
@@ -36,6 +38,13 @@ public class OptionalLongTest {
             h.execute("CREATE TABLE test (id INT PRIMARY KEY, optional BIGINT)");
         }
         dao = dbi.onDemand(TestDao.class);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        for (LifeCycle managedObject : env.lifecycle().getManagedObjects()) {
+            managedObject.stop();
+        }
     }
 
     @Test

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/AllowedMethodsFilter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/AllowedMethodsFilter.java
@@ -13,29 +13,24 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.Optional;
 
 public class AllowedMethodsFilter implements Filter {
 
     public static final String ALLOWED_METHODS_PARAM = "allowedMethods";
-    public static final Set<String> DEFAULT_ALLOWED_METHODS = ImmutableSet.of(
+    public static final ImmutableSet<String> DEFAULT_ALLOWED_METHODS = ImmutableSet.of(
             "GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH"
     );
 
     private static final Logger LOG = LoggerFactory.getLogger(AllowedMethodsFilter.class);
 
-    private Set<String> allowedMethods = new HashSet<>();
+    private ImmutableSet<String> allowedMethods;
 
     @Override
     public void init(FilterConfig config) {
-        final String allowedMethodsConfig = config.getInitParameter(ALLOWED_METHODS_PARAM);
-        if (allowedMethodsConfig == null) {
-            allowedMethods.addAll(DEFAULT_ALLOWED_METHODS);
-        } else {
-            allowedMethods.addAll(Arrays.asList(allowedMethodsConfig.split(",")));
-        }
+        allowedMethods = Optional.ofNullable(config.getInitParameter(ALLOWED_METHODS_PARAM))
+            .map(p -> ImmutableSet.copyOf(p.split(",")))
+            .orElse(DEFAULT_ALLOWED_METHODS);
     }
 
     @Override
@@ -56,6 +51,5 @@ public class AllowedMethodsFilter implements Filter {
 
     @Override
     public void destroy() {
-        allowedMethods.clear();
     }
 }


### PR DESCRIPTION
It looks like that the set of allowed methods in `AllowedMethodsFilter` is not modified after it was created. We could embrace it and make immutable during the creation time. This also should provide some performance benefits, because immutable hash tables could be optimized during construction times (e.g. they can use linear probing instead chaining) 