### PR TITLE
Upgrade to metrics 3.2.2

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -50,7 +50,7 @@ v1.1.0: Unreleased
 * Upgraded to Objenesis 2.5.1
 * Upgraded to AssertJ 3.6.2
 * Upgraded to classmate 1.3.3
-* Upgraded to Metrics 3.2.1 `#1936 <https://github.com/dropwizard/dropwizard/pull/1936>`_
+* Upgraded to Metrics 3.2.2 `#1970 <https://github.com/dropwizard/dropwizard/pull/1970>`_
 * Upgraded to Mustache 0.9.4 `#1766 <https://github.com/dropwizard/dropwizard/pull/1766>`_
 * Upgraded to Mockito 2.7.12
 * Upgraded to Liquibase 3.5.3

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -27,7 +27,7 @@
         <jackson.version>2.8.7</jackson.version>
         <jetty.version>9.4.2.v20170220</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
-        <metrics3.version>3.2.1</metrics3.version>
+        <metrics3.version>3.2.2</metrics3.version>
         <slf4j.version>1.7.24</slf4j.version>
         <logback.version>1.2.1</logback.version>
         <h2.version>1.4.193</h2.version>


### PR DESCRIPTION
Release notes: https://github.com/dropwizard/metrics/releases/tag/v3.2.2

This release fixes a nasty bug during creating a snapshot which was introduced in the 3.2.*  branch: https://github.com/dropwizard/metrics/pull/1111. The bug affects only `SlidingTimeWindowReservoir`, so its impact not so big, but anyway it would be great to ship the fix in the Dropwizard release.