### PR TITLE
Set the console logging context after a reset

### DIFF
--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/DefaultLoggingFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/DefaultLoggingFactory.java
@@ -202,7 +202,9 @@ public class DefaultLoggingFactory implements LoggingFactory {
             loggerContext.stop();
             final Logger logger = loggerContext.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
             logger.detachAndStopAllAppenders();
-            logger.addAppender(new ConsoleAppender<>());
+            final ConsoleAppender<ILoggingEvent> consoleAppender = new ConsoleAppender<>();
+            consoleAppender.setContext(loggerContext);
+            logger.addAppender(consoleAppender);
             loggerContext.start();
         } finally {
             CHANGE_LOGGER_CONTEXT_LOCK.unlock();


### PR DESCRIPTION
When resetting logging, we should set a context for the console appender. Otherwise, we get an annoying message: `LOGBACK: No context given for ch.qos.logback.core.ConsoleAppender[null]` in the tests which use `DropwizardAppRule`.

This is related to #1947.