### PR TITLE
Set logging context for file appenders before setting the buffer size

### DIFF
--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
@@ -239,6 +239,7 @@ public class FileAppenderFactory<E extends DeferredProcessingAware> extends Abst
     protected FileAppender<E> buildAppender(LoggerContext context) {
         if (archive) {
             final RollingFileAppender<E> appender = new RollingFileAppender<>();
+            appender.setContext(context);
             appender.setFile(currentLogFilename);
             appender.setBufferSize(new FileSize(bufferSize.toBytes()));
 
@@ -287,6 +288,7 @@ public class FileAppenderFactory<E extends DeferredProcessingAware> extends Abst
         }
 
         final FileAppender<E> appender = new FileAppender<>();
+        appender.setContext(context);
         appender.setFile(currentLogFilename);
         appender.setBufferSize(new FileSize(bufferSize.toBytes()));
         return appender;


### PR DESCRIPTION
Setting buffer size results in writing an internal log message: `Setting bufferSize to ...`.
If the context is not set, then Logback writes a log message: `LOGBACK: No context given for ch.qos.logback.core.FileAppender[null]` to the console log. It's a little bit annoying and we can avoid by setting the context right after instantiating the appenders.

This is related to #1951.