### PR TITLE
Exclude duplicated JTA 1.1 from dropwizard-hibernate dependencies

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -114,6 +114,10 @@
                         <groupId>org.joda</groupId>
                         <artifactId>joda-money</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.geronimo.specs</groupId>
+                        <artifactId>geronimo-jta_1.1_spec</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>

--- a/dropwizard-hibernate/pom.xml
+++ b/dropwizard-hibernate/pom.xml
@@ -31,6 +31,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-hibernate5</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.transaction</groupId>
+                    <artifactId>jta</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jadira.usertype</groupId>


### PR DESCRIPTION
`jackson-datatype-hibernate5` pulls a `javax.transaction.jta` artifact and Jadira pulls `geronimo-jta_1.1_spec`. They are outdated, because Hibernate already pulls JTA1.2.

This exclude affords to avoid warnings about duplicated classes from the `maven-shade-plugin` during assembling a fat jar.