### PR TITLE
Make sure that supported cipher suite is used, but not at the expense of others

### DIFF
--- a/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2ConnectorFactory.java
+++ b/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2ConnectorFactory.java
@@ -21,7 +21,9 @@ import org.eclipse.jetty.util.thread.ThreadPool;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -100,7 +102,9 @@ public class Http2ConnectorFactory extends HttpsConnectorFactory {
         // HTTP/2 requires that a server MUST support TLSv1.2 and TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 cipher
         // See http://http2.github.io/http2-spec/index.html#rfc.section.9.2.2
         setSupportedProtocols(ImmutableList.of("TLSv1.2"));
-        setSupportedCipherSuites(addIfNotPresent(getSupportedCipherSuites(), "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"));
+        setSupportedCipherSuites(addIfNotPresent(
+            Optional.ofNullable(getSupportedCipherSuites()).orElse(Collections.emptyList()),
+            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"));
 
         // Setup connection factories
         final HttpConfiguration httpConfig = buildHttpConfiguration();


### PR DESCRIPTION
HTTP/2 demands that "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256" is
supported. Dropwizard provides for this by _only_ letting users utilise
that cipher suite.

However, there are many other HTTP/2 supported cipher suites, which
at present Dropwizard does not let people use.

Here, we simply make sure that cipher exists in the supported list.