### PR TITLE
Add setting system/default timezone in logging configuration

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -614,6 +614,7 @@ discardingThreshold    51           When the blocking queue has only the capacit
                                     If no discarding threshold is specified, then a default of queueSize / 5 is used.
                                     To keep all events, set discardingThreshold to 0.
 timeZone               UTC          The time zone to which event timestamps will be converted.
+                                    To use the system/default time zone, set it to ``system``.
 target                 stdout       The name of the standard stream to which events will be written.
                                     Can be ``stdout`` or ``stderr``.
 logFormat              default      The Logback pattern with which events will be formatted. See

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/AbstractAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/AbstractAppenderFactory.java
@@ -21,6 +21,8 @@ import javax.validation.constraints.NotNull;
 import java.util.List;
 import java.util.TimeZone;
 
+import static com.google.common.base.Strings.nullToEmpty;
+
 /**
  * A base implementation of {@link AppenderFactory}.
  * <p/>
@@ -100,7 +102,7 @@ public abstract class AbstractAppenderFactory<E extends DeferredProcessingAware>
     private boolean includeCallerData = false;
 
     private ImmutableList<FilterFactory<E>> filterFactories = ImmutableList.of();
-    
+
     private boolean neverBlock = false;
 
     @JsonProperty
@@ -149,6 +151,12 @@ public abstract class AbstractAppenderFactory<E extends DeferredProcessingAware>
     }
 
     @JsonProperty
+    public void setTimeZone(String zoneId) {
+        this.timeZone = nullToEmpty(zoneId).equalsIgnoreCase("system") ? TimeZone.getDefault() :
+            TimeZone.getTimeZone(zoneId);
+    }
+
+    @JsonProperty
     public void setTimeZone(TimeZone timeZone) {
         this.timeZone = timeZone;
     }
@@ -172,7 +180,7 @@ public abstract class AbstractAppenderFactory<E extends DeferredProcessingAware>
     public void setFilterFactories(List<FilterFactory<E>> appenders) {
         this.filterFactories = ImmutableList.copyOf(appenders);
     }
-    
+
     @JsonProperty
     public void setNeverBlock(boolean neverBlock) {
         this.neverBlock = neverBlock;

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/AppenderFactoryCustomTimeZone.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/AppenderFactoryCustomTimeZone.java
@@ -1,0 +1,64 @@
+package io.dropwizard.logging;
+
+import com.google.common.io.Resources;
+import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.validation.BaseValidator;
+import org.junit.Test;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.util.TimeZone;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AppenderFactoryCustomTimeZone {
+
+    static {
+        BootstrapLogging.bootstrap();
+    }
+
+    private final YamlConfigurationFactory<ConsoleAppenderFactory> factory = new YamlConfigurationFactory<>(
+        ConsoleAppenderFactory.class, BaseValidator.newValidator(), Jackson.newObjectMapper(), "dw");
+
+    private static File loadResource(String resourceName) throws URISyntaxException {
+        return new File(Resources.getResource(resourceName).toURI());
+    }
+
+    @Test
+    public void testLoadAppenderWithTimeZoneInFullFormat() throws Exception {
+        final ConsoleAppenderFactory appender = factory.build(loadResource("yaml/appender_with_time_zone_in_full_format.yml"));
+        assertThat(appender.getTimeZone().getID()).isEqualTo("America/Los_Angeles");
+    }
+
+    @Test
+    public void testLoadAppenderWithTimeZoneInCustomFormat() throws Exception {
+        final ConsoleAppenderFactory appender = factory.build(loadResource("yaml/appender_with_custom_time_zone_format.yml"));
+        assertThat(appender.getTimeZone().getID()).isEqualTo("GMT-02:00");
+    }
+
+    @Test
+    public void testLoadAppenderWithNoTimeZone() throws Exception {
+        final ConsoleAppenderFactory appender = factory.build(loadResource("yaml/appender_with_no_time_zone.yml"));
+        assertThat(appender.getTimeZone().getID()).isEqualTo("UTC");
+    }
+
+    @Test
+    public void testLoadAppenderWithUtcTimeZone() throws Exception {
+        final ConsoleAppenderFactory appender = factory.build(loadResource("yaml/appender_with_utc_time_zone.yml"));
+        assertThat(appender.getTimeZone().getID()).isEqualTo("UTC");
+    }
+
+    @Test
+    public void testLoadAppenderWithWrongTimeZone() throws Exception {
+        final ConsoleAppenderFactory appender = factory.build(loadResource("yaml/appender_with_wrong_time_zone.yml"));
+        assertThat(appender.getTimeZone().getID()).isEqualTo("GMT");
+    }
+
+    @Test
+    public void testLoadAppenderWithSystemTimeZone() throws Exception {
+        final ConsoleAppenderFactory appender = factory.build(loadResource("yaml/appender_with_system_time_zone.yml"));
+        assertThat(appender.getTimeZone()).isEqualTo(TimeZone.getDefault());
+    }
+
+}

--- a/dropwizard-logging/src/test/resources/yaml/appender_with_custom_time_zone_format.yml
+++ b/dropwizard-logging/src/test/resources/yaml/appender_with_custom_time_zone_format.yml
@@ -1,0 +1,2 @@
+type: console
+timeZone: GMT-02:00

--- a/dropwizard-logging/src/test/resources/yaml/appender_with_no_time_zone.yml
+++ b/dropwizard-logging/src/test/resources/yaml/appender_with_no_time_zone.yml
@@ -1,0 +1,1 @@
+type: console

--- a/dropwizard-logging/src/test/resources/yaml/appender_with_system_time_zone.yml
+++ b/dropwizard-logging/src/test/resources/yaml/appender_with_system_time_zone.yml
@@ -1,0 +1,2 @@
+type: console
+timeZone: system

--- a/dropwizard-logging/src/test/resources/yaml/appender_with_time_zone_in_full_format.yml
+++ b/dropwizard-logging/src/test/resources/yaml/appender_with_time_zone_in_full_format.yml
@@ -1,0 +1,2 @@
+type: console
+timeZone: America/Los_Angeles

--- a/dropwizard-logging/src/test/resources/yaml/appender_with_utc_time_zone.yml
+++ b/dropwizard-logging/src/test/resources/yaml/appender_with_utc_time_zone.yml
@@ -1,0 +1,2 @@
+type: console
+timeZone: UTC

--- a/dropwizard-logging/src/test/resources/yaml/appender_with_wrong_time_zone.yml
+++ b/dropwizard-logging/src/test/resources/yaml/appender_with_wrong_time_zone.yml
@@ -1,0 +1,2 @@
+type: console
+timeZone: Narnia


### PR DESCRIPTION
Users should have the ability to use the system timezone in the logging configuration. It allows administrators to take advantage of the operation system/JVM time zone management tools and use the same configuration for Dropwizard applications in different time zones.

Resolves #1980.