### PR TITLE
Improve error handling for Jersey's Exception that caused by client

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/setup/ExceptionMapperBinder.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/ExceptionMapperBinder.java
@@ -1,6 +1,7 @@
 package io.dropwizard.setup;
 
 import io.dropwizard.jersey.errors.EarlyEofExceptionMapper;
+import io.dropwizard.jersey.errors.IllegalStateExceptionMapper;
 import io.dropwizard.jersey.errors.LoggingExceptionMapper;
 import io.dropwizard.jersey.jackson.JsonProcessingExceptionMapper;
 import io.dropwizard.jersey.optional.EmptyOptionalExceptionMapper;
@@ -28,6 +29,7 @@ public class ExceptionMapperBinder extends AbstractBinder {
         bind(new JsonProcessingExceptionMapper(isShowDetails())).to(ExceptionMapper.class);
         bind(new EarlyEofExceptionMapper()).to(ExceptionMapper.class);
         bind(new EmptyOptionalExceptionMapper()).to(ExceptionMapper.class);
+        bind(new IllegalStateExceptionMapper()).to(ExceptionMapper.class);
     }
 
     public boolean isShowDetails() {

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/IllegalStateExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/IllegalStateExceptionMapper.java
@@ -1,0 +1,47 @@
+package io.dropwizard.jersey.errors;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+
+import org.glassfish.jersey.server.internal.LocalizationMessages;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.NotSupportedException;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * {@link javax.ws.rs.ext.ExceptionMapper ExceptionMapper} for {@link IllegalStateException}.
+ */
+@Provider
+public class IllegalStateExceptionMapper extends LoggingExceptionMapper<IllegalStateException> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(IllegalStateExceptionMapper.class);
+
+    @Override
+    public Response toResponse(final IllegalStateException exception) {
+        final String message = exception.getMessage();
+
+        if (LocalizationMessages.FORM_PARAM_CONTENT_TYPE_ERROR().equals(message)) {
+            /*
+             * If a POST request contains a Content-Type that is not application/x-www-form-urlencoded, Jersey throws
+             * IllegalStateException with or without @Consumes. See: https://java.net/jira/browse/JERSEY-2636
+             */
+            // Logs exception with additional information for developers.
+            LOGGER.debug("If the HTTP method is POST and using @FormParam in a resource method"
+                    + ", Content-Type should be application/x-www-form-urlencoded.", exception);
+            // Returns the same response as if NotSupportedException was thrown.
+            return createResponse(new NotSupportedException());
+        }
+
+        // LoggingExceptionMapper will log exception
+        return super.toResponse(exception);
+    }
+
+    private Response createResponse(final WebApplicationException exception) {
+        final ErrorMessage errorMessage =
+                new ErrorMessage(exception.getResponse().getStatus(), exception.getLocalizedMessage());
+        return Response.status(errorMessage.getCode()).type(APPLICATION_JSON_TYPE).entity(errorMessage).build();
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/IllegalStateExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/IllegalStateExceptionMapperTest.java
@@ -1,0 +1,33 @@
+package io.dropwizard.jersey.errors;
+
+import static javax.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.glassfish.jersey.server.internal.LocalizationMessages;
+import org.junit.Test;
+
+import javax.ws.rs.NotSupportedException;
+import javax.ws.rs.core.Response;
+
+public class IllegalStateExceptionMapperTest {
+
+    private final IllegalStateExceptionMapper mapper = new IllegalStateExceptionMapper();
+
+    @Test
+    public void delegatesToParentClass() {
+        @SuppressWarnings("serial")
+        final Response reponse = mapper.toResponse(new IllegalStateException(getClass().getName()) {});
+        assertThat(reponse.getStatusInfo()).isEqualTo(INTERNAL_SERVER_ERROR);
+    }
+
+    @Test
+    public void handlesFormParamContentTypeError() {
+        final Response reponse =
+                mapper.toResponse(new IllegalStateException(LocalizationMessages.FORM_PARAM_CONTENT_TYPE_ERROR()));
+        assertThat(reponse.getStatusInfo()).isEqualTo(UNSUPPORTED_MEDIA_TYPE);
+        assertThat(reponse.getEntity()).isInstanceOf(ErrorMessage.class);
+        assertThat(((ErrorMessage) reponse.getEntity()).getMessage())
+                .isEqualTo(new NotSupportedException().getLocalizedMessage());
+    }
+}


### PR DESCRIPTION
If sending a POST request with a `Content-Type` header that is not `application/x-www-form-urlencoded` and using `@FormParam` in resource method, an `IllegalStateException` will be thrown by Jersey and logged at ERROR level by `LoggingExceptionMapper`. Also, this is the same behavior as https://java.net/jira/browse/JERSEY-2636.

This indicates that **users can easily output ERROR level logs in server side**. Therefore, I would like to prevent this.

### Steps to reproduce

1. Create a new resource class and method that given the `@POST` and `@FormParam`.
Note: `@Consumes` is optional because ignoring.

```java
@Path("/")
public class EchoResource {
    @POST
    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
    public String echo(@FormParam("msg") String msg) {
        return msg;
    }
}
```

2. Send the POST request without a `Content-Type` header, the *500 Internal Server Error* is returned and logged at ERROR level.

```
$ curl -i -XPOST localhost:8080/
HTTP/1.1 500 Internal Server Error
Date: Sun, 26 Mar 2017 03:20:17 GMT
Content-Type: application/json
Content-Length: 110

{"code":500,"message":"There was an error processing your request. It has been logged (ID 76abeb6446b86576)."}
```

```
ERROR [2017-03-26 03:20:17,068] io.dropwizard.jersey.errors.LoggingExceptionMapper: Error handling a request: 76abeb6446b86576
! java.lang.IllegalStateException: The @FormParam is utilized when the content type of the request entity is not application/x-www-form-urlencoded
! at org.glassfish.jersey.server.internal.inject.FormParamValueFactoryProvider$FormParamValueFactory.ensureValidRequest(FormParamValueFactoryProvider.java:183)
! at org.glassfish.jersey.server.internal.inject.FormParamValueFactoryProvider$FormParamValueFactory.getForm(FormParamValueFactoryProvider.java:167)
! at org.glassfish.jersey.server.internal.inject.FormParamValueFactoryProvider$FormParamValueFactory.provide(FormParamValueFactoryProvider.java:118)
! at org.glassfish.jersey.server.spi.internal.ParamValueFactoryWithSource.provide(ParamValueFactoryWithSource.java:71)
! at org.glassfish.jersey.server.spi.internal.ParameterValueHelper.getParameterValues(ParameterValueHelper.java:90)
! at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$AbstractMethodParamInvoker.getParamValues(JavaResourceMethodDispatcherProvider.java:127)
...
```

### Impact

Probably, this change does not affected to users using the past version, because If bound an `ExceptionMapper<IllegalStateException>` at `Application#run(Configuration, Environment)`, this mappers register in the HK2 container before Dropwizard's ExceptionMapper(s) that is bound by the `ExceptionMapperBinder`.

Please refer to the following references for details.

Reference 1: [HK2 API documentation](https://hk2.java.net/2.5.0-b32/api-overview.html#Looking_up_services)
> Services are sorted by (in order) the service ranking, the largest locator id (so that services in children are picked before services in parents) and smallest service id (so that older services are picked prior to newer services). Therefore the best instance of a service is a service with the highest ranking or largest service locator id or the lowest service id. The ranking of a service is found in its Descriptor and can be changed at any time at run time. The locator id of a service is a system assigned value for the Descriptor when it is bound into the ServiceLocator and is the id of that ServiceLocator. The service id of a service is a system assigned value for the Descriptor when it is bound into the ServiceLocator. The system assigned value is a monotonically increasing value. Thus if two services have the same ranking the best service will be associated with the oldest Descriptor bound into the system.

Reference 2: [org.glassfish.jersey.internal.ExceptionMapperFactory#find(Class<T>, T)](https://github.com/jersey/jersey/blob/2.25.1/core-common/src/main/java/org/glassfish/jersey/internal/ExceptionMapperFactory.java#L122)
