### PR TITLE
Use random UUID for database names in tests

### DIFF
--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OptionalDoubleTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OptionalDoubleTest.java
@@ -18,6 +18,7 @@ import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 
 import java.io.IOException;
 import java.util.OptionalDouble;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,7 +32,7 @@ public class OptionalDoubleTest {
     public void setupTests() throws IOException {
         final DataSourceFactory dataSourceFactory = new DataSourceFactory();
         dataSourceFactory.setDriverClass("org.h2.Driver");
-        dataSourceFactory.setUrl("jdbc:h2:mem:optional-double-" + System.currentTimeMillis() + "?user=sa");
+        dataSourceFactory.setUrl("jdbc:h2:mem:optional-double-" + UUID.randomUUID() + "?user=sa");
         dataSourceFactory.setInitialSize(1);
         final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
         try (Handle h = dbi.open()) {

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OptionalIntTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OptionalIntTest.java
@@ -18,6 +18,7 @@ import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 
 import java.io.IOException;
 import java.util.OptionalInt;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,7 +32,7 @@ public class OptionalIntTest {
     public void setupTests() throws IOException {
         final DataSourceFactory dataSourceFactory = new DataSourceFactory();
         dataSourceFactory.setDriverClass("org.h2.Driver");
-        dataSourceFactory.setUrl("jdbc:h2:mem:optional-int-" + System.currentTimeMillis() + "?user=sa");
+        dataSourceFactory.setUrl("jdbc:h2:mem:optional-int-" + UUID.randomUUID() + "?user=sa");
         dataSourceFactory.setInitialSize(1);
         final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
         try (Handle h = dbi.open()) {

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OptionalLongTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OptionalLongTest.java
@@ -18,6 +18,7 @@ import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 
 import java.io.IOException;
 import java.util.OptionalLong;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,7 +32,7 @@ public class OptionalLongTest {
     public void setupTests() throws IOException {
         final DataSourceFactory dataSourceFactory = new DataSourceFactory();
         dataSourceFactory.setDriverClass("org.h2.Driver");
-        dataSourceFactory.setUrl("jdbc:h2:mem:optional-long-" + System.currentTimeMillis() + "?user=sa");
+        dataSourceFactory.setUrl("jdbc:h2:mem:optional-long-" + UUID.randomUUID() + "?user=sa");
         dataSourceFactory.setInitialSize(1);
         final DBI dbi = new DBIFactory().build(env, dataSourceFactory, "test");
         try (Handle h = dbi.open()) {


### PR DESCRIPTION
The OS could return the same value for `System.currentTimeMillis()` for a long
time span, that means several tests may share the same database during a test run.
This could lead to sporadic test failures which we would like to avoid.