### PR TITLE
Remove a logback warning for the classic request logging

### DIFF
--- a/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/old/LogbackClassicRequestLogFactory.java
+++ b/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/old/LogbackClassicRequestLogFactory.java
@@ -3,6 +3,7 @@ package io.dropwizard.request.logging.old;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Context;
 import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.pattern.PatternLayoutBase;
 import ch.qos.logback.core.spi.AppenderAttachableImpl;
@@ -54,6 +55,12 @@ import java.util.TimeZone;
 @JsonTypeName("classic")
 public class LogbackClassicRequestLogFactory implements RequestLogFactory {
     private static class RequestLogLayout extends PatternLayoutBase<ILoggingEvent> {
+
+        private RequestLogLayout(Context context) {
+            super();
+            setContext(context);
+        }
+
         @Override
         public String doLayout(ILoggingEvent event) {
             return event.getFormattedMessage() + CoreConstants.LINE_SEPARATOR;
@@ -108,7 +115,7 @@ public class LogbackClassicRequestLogFactory implements RequestLogFactory {
         final LoggerContext context = logger.getLoggerContext();
         final LevelFilterFactory<ILoggingEvent> levelFilterFactory = new NullLevelFilterFactory<>();
         final AsyncAppenderFactory<ILoggingEvent> asyncAppenderFactory = new AsyncLoggingEventAppenderFactory();
-        final LayoutFactory<ILoggingEvent> layoutFactory = (c, tz) -> new RequestLogLayout();
+        final LayoutFactory<ILoggingEvent> layoutFactory = (c, tz) -> new RequestLogLayout(c);
         final AppenderAttachableImpl<ILoggingEvent> attachable = new AppenderAttachableImpl<>();
         for (AppenderFactory<ILoggingEvent> appender : appenders) {
             attachable.addAppender(appender.build(context, name, layoutFactory, levelFilterFactory, asyncAppenderFactory));

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/old/LogbackClassicRequestLogFactoryTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/old/LogbackClassicRequestLogFactoryTest.java
@@ -11,6 +11,7 @@ import io.dropwizard.logging.FileAppenderFactory;
 import io.dropwizard.logging.SyslogAppenderFactory;
 import io.dropwizard.request.logging.RequestLogFactory;
 import io.dropwizard.validation.BaseValidator;
+import org.eclipse.jetty.server.RequestLog;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -44,6 +45,12 @@ public class LogbackClassicRequestLogFactoryTest {
         assertThat(classicRequestLogFactory.getAppenders()).hasSize(3).extractingResultOf("getClass").contains(
             ConsoleAppenderFactory.class, FileAppenderFactory.class, SyslogAppenderFactory.class
         );
+    }
+
+    @Test
+    public void testBuild() {
+        final RequestLog requestLog = this.requestLog.build("classic-request-log");
+        assertThat(requestLog).isInstanceOf(DropwizardSlf4jRequestLog.class);
     }
 
     @Test


### PR DESCRIPTION
After the last update Logback issues the following warning when an application uses the classic request logging:
`LOGBACK: No context given for io.dropwizard.request.logging.old.LogbackClassicRequestLogFactory$RequestLogLayout("null")`

A fix is assign the context to the layout after its construction.