### PR TITLE
Fixed typo in javax.el exclusion

### DIFF
--- a/dropwizard-jersey/pom.xml
+++ b/dropwizard-jersey/pom.xml
@@ -50,7 +50,7 @@
             <!-- dropwizard-validation has a newer version of these -->
             <exclusions>
             	<exclusion>
-            		<groupId>org.glassfish.web</groupId>
+            		<groupId>org.glassfish</groupId>
             		<artifactId>javax.el</artifactId>
             	</exclusion>
             	<exclusion>


### PR DESCRIPTION
The 1.1.0 release introduced a maven dependency conflict which has already been corrected in the 1.1.x branch. However, the fix itself has a typo. This fixes that typo. This will need to be merged into master as well. I have worked around this by forcing the javax.el and javax.el-api versions to 3.0.0 in my own pom for the time being.