### PR TITLE
Add missing @UnwrapValidatedValue annotations

### DIFF
--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
@@ -22,6 +22,7 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
 import org.eclipse.jetty.util.thread.Scheduler;
 import org.eclipse.jetty.util.thread.ThreadPool;
+import org.hibernate.validator.valuehandling.UnwrapValidatedValue;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -262,9 +263,11 @@ public class HttpConnectorFactory implements ConnectorFactory {
     private Size maxBufferPoolSize = Size.kilobytes(64);
 
     @Min(1)
+    @UnwrapValidatedValue
     private Optional<Integer> acceptorThreads = Optional.empty();
 
     @Min(1)
+    @UnwrapValidatedValue
     private Optional<Integer> selectorThreads = Optional.empty();
 
     @Min(0)

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/valuehandling/GuavaOptionalValidatedValueUnwrapperTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/valuehandling/GuavaOptionalValidatedValueUnwrapperTest.java
@@ -19,6 +19,7 @@ public class GuavaOptionalValidatedValueUnwrapperTest {
     public static class Example {
 
         @Min(3)
+        @UnwrapValidatedValue
         public Optional<Integer> three = Optional.absent();
 
         @NotNull


### PR DESCRIPTION
Some classes/fields were missing the `@UnwrapValidatedValue` annotations in combination with javax.validation annotations.