### PR TITLE
Improve unhandled exception logging in Cli.run

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/cli/Cli.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/Cli.java
@@ -84,7 +84,7 @@ public class Cli {
             return false;
         } catch (Throwable t) {
             // Unexpected exceptions should result in non-zero exit status of the process
-            stdErr.println(t.getMessage());
+            t.printStackTrace(stdErr);
             return false;
         }
     }

--- a/dropwizard-core/src/test/java/io/dropwizard/cli/CliTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/cli/CliTest.java
@@ -12,12 +12,14 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
 import java.util.Locale;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -34,6 +36,21 @@ public class CliTest {
         public void run(Configuration configuration, Environment environment) throws Exception {
         }
     };
+
+    private static final class BadAppException extends Exception {
+        private static final long serialVersionUID = 1L;
+
+        public static final String BAD_APP_EXCEPTION_STACK_TRACE = "BadAppException stack trace";
+
+        public BadAppException() {
+        }
+
+        @Override
+        public void printStackTrace(PrintWriter writer) {
+            writer.println(BAD_APP_EXCEPTION_STACK_TRACE);
+        }
+    }
+
     private final Bootstrap<Configuration> bootstrap = new Bootstrap<>(app);
     private final ByteArrayOutputStream stdOut = new ByteArrayOutputStream();
     private final ByteArrayOutputStream stdErr = new ByteArrayOutputStream();
@@ -294,5 +311,20 @@ public class CliTest {
                 .isEmpty();
 
         verify(command).run(eq(bootstrap), any(Namespace.class), any(Configuration.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void unhandledExceptionsAreLoggedAppropriately() throws Exception {
+        doThrow(new BadAppException()).when(command).run(any(Bootstrap.class), any(Namespace.class), any(Configuration.class));
+
+        assertThat(cli.run("check"))
+                .isFalse();
+
+        assertThat(stdOut.toString())
+                .isEmpty();
+
+        assertThat(stdErr.toString())
+                .isEqualTo(String.format("%s%n", BadAppException.BAD_APP_EXCEPTION_STACK_TRACE));
     }
 }


### PR DESCRIPTION
Only log the exception message if there is one and
always print the exceptiopn stack trace when Cli.run
receives an unhandled exception when invoking Command.run.

Fixes #2003