### PR TITLE
Document caveat of bean-spec compliant endpoints

### DIFF
--- a/docs/source/manual/validation.rst
+++ b/docs/source/manual/validation.rst
@@ -207,6 +207,43 @@ knows the server failed through no fault of their own.
 Analogous to an empty request body, an empty entity annotated with ``@NotNull`` will return ``server
 response may not be null``
 
+.. warning::
+
+   Be careful when using return value constraints when endpoints satisfy all of the following:
+
+   - Function name starts with ``get``
+   - No arguments
+   - The return value has validation constraints
+
+   If an endpoint satisfies these conditions, whenever a request is processed by the resource that
+   endpoint will be additionally invoked. To give a concrete example:
+
+    .. code-block:: java
+
+        @Path("/")
+        public class ValidatedResource {
+            private AtomicLong counter = new AtomicLong();
+
+            @GET
+            @Path("/foo")
+            @NotEmpty
+            public String getFoo() {
+                counter.getAndIncrement();
+                return "";
+            }
+
+            @GET
+            @Path("/bar")
+            public String getBar() {
+                return "";
+            }
+        }
+
+
+    If a ``/foo`` is requested then ``counter`` will have increment by 2, and if ``/bar`` is
+    requested then ``counter`` will increment by 1. It is our hope that such endpoints are few, far
+    between, and documented thoroughly.
+
 .. _man-validation-limitations:
 
 Limitations


### PR DESCRIPTION
If endpoints are written in a way that comply with bean-spec property and have validation annotations on them, they will be additionally executed as part of the validation logic.

I dug into the code and there is very little we can do in this regard. I tried coding a way to exclude certain properties that are annotated with `javax.ws.rs` annotations, but I had no luck -- we'd have to write our own `Validator`, so I thought the best solution would be to just document this small downside.

Only 1.0.0 and 1.1.0 users should be affected.

CC @scottaj 

Closes #2008