### PR TITLE
Add flag to make ThreadNameFilter optional

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -61,6 +61,7 @@ rootPath                            ``/*``                                      
                                                                                      the JAX-RS resources will be served.
 registerDefaultExceptionMappers     true                                             Whether or not the default Jersey ExceptionMappers should be registered.
                                                                                      Set this to false if you want to register your own.
+enableThreadNameFilter              true                                             Whether or not to apply the ``ThreadNameFilter`` that adjusts thread names to include the request method and request URI.
 =================================== ===============================================  =============================================================================
 
 


### PR DESCRIPTION
Include a flag enableThreadNameFilter in AbstractServerFactory to allow
disabling of the ThreadNameFilter's installation. Existing default behavior
is preserved.

Fixes #2013.