### PR TITLE
[ENHANCEMENT] SubstringMatchingStrategy for metrics

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -815,6 +815,7 @@ excludesAttributes     (none)         Metric attributes to exclude from reports,
 includesAttributes     (all)          Metrics attributes to include in reports, by name (e.g. ``p98``, ``m15_rate``, ``stddev``).
                                       When defined, only these attributes will be reported.
 useRegexFilters        false          Indicates whether the values of the 'includes' and 'excludes' fields should be treated as regular expressions or not.
+useSubstringMatching   false          Uses a substring matching strategy to determine whether a metric should be processed.
 frequency              (none)         The frequency to report metrics. Overrides the default.
 ====================== =============  ===========
 
@@ -825,6 +826,8 @@ The inclusion and exclusion rules are defined as:
 * If **excludes** is empty, no metrics are excluded;
 * If **excludes** is not empty, then exclusion rules take precedence over inclusion rules. Thus if a name matches the exclusion rules it will not be included in reports even if it also matches the inclusion rules.
 
+When neither **useRegexFilters** nor **useSubstringMatching** are enabled, a default exact matching strategy will be used to determine whether a metric should be processed.
+In case both **useRegexFilters** and **useSubstringMatching** are set, **useRegexFilters** takes precedence over **useSubstringMatching**.
 
 .. _man-configuration-metrics-formatted:
 

--- a/dropwizard-metrics/src/main/java/io/dropwizard/metrics/BaseReporterFactory.java
+++ b/dropwizard-metrics/src/main/java/io/dropwizard/metrics/BaseReporterFactory.java
@@ -5,10 +5,6 @@ import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.ScheduledReporter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Strings;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import io.dropwizard.util.Duration;
@@ -21,7 +17,6 @@ import java.util.EnumSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Pattern;
 
 /**
  * A base {@link ReporterFactory} for configuring metric reporters.

--- a/dropwizard-metrics/src/main/java/io/dropwizard/metrics/BaseReporterFactory.java
+++ b/dropwizard-metrics/src/main/java/io/dropwizard/metrics/BaseReporterFactory.java
@@ -89,6 +89,9 @@ public abstract class BaseReporterFactory implements ReporterFactory {
     private static final RegexStringMatchingStrategy REGEX_STRING_MATCHING_STRATEGY =
             new RegexStringMatchingStrategy();
 
+    private static final SubstringMatchingStrategy SUBSTRING_MATCHING_STRATEGY =
+        new SubstringMatchingStrategy();
+
     @NotNull
     private TimeUnit durationUnit = TimeUnit.MILLISECONDS;
 
@@ -107,6 +110,8 @@ public abstract class BaseReporterFactory implements ReporterFactory {
     private Optional<Duration> frequency = Optional.empty();
 
     private boolean useRegexFilters = false;
+
+    private boolean useSubstringMatching = false;
 
     private EnumSet<MetricAttribute> excludesAttributes = EnumSet.noneOf(MetricAttribute.class);
 
@@ -173,6 +178,16 @@ public abstract class BaseReporterFactory implements ReporterFactory {
     }
 
     @JsonProperty
+    public boolean getUseSubstringMatching() {
+        return useSubstringMatching;
+    }
+
+    @JsonProperty
+    public void setUseSubstringMatching(boolean useSubstringMatching) {
+        this.useSubstringMatching = useSubstringMatching;
+    }
+
+    @JsonProperty
     public EnumSet<MetricAttribute> getExcludesAttributes() {
         return excludesAttributes;
     }
@@ -216,7 +231,7 @@ public abstract class BaseReporterFactory implements ReporterFactory {
     @JsonIgnore
     public MetricFilter getFilter() {
         final StringMatchingStrategy stringMatchingStrategy = getUseRegexFilters() ?
-                REGEX_STRING_MATCHING_STRATEGY : DEFAULT_STRING_MATCHING_STRATEGY;
+                REGEX_STRING_MATCHING_STRATEGY : (getUseSubstringMatching() ? SUBSTRING_MATCHING_STRATEGY : DEFAULT_STRING_MATCHING_STRATEGY);
 
         return (name, metric) -> {
             // Include the metric if its name is not excluded and its name is included

--- a/dropwizard-metrics/src/main/java/io/dropwizard/metrics/DefaultStringMatchingStrategy.java
+++ b/dropwizard-metrics/src/main/java/io/dropwizard/metrics/DefaultStringMatchingStrategy.java
@@ -1,0 +1,16 @@
+package io.dropwizard.metrics;
+
+import com.google.common.collect.ImmutableSet;
+
+class DefaultStringMatchingStrategy implements StringMatchingStrategy {
+    @Override
+    public boolean containsMatch(ImmutableSet<String> matchExpressions, String metricName) {
+        for (String matchExpression : matchExpressions) {
+            if (metricName.contains(matchExpression)) {
+                // just need to match on a single value - return as soon as we do
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/dropwizard-metrics/src/main/java/io/dropwizard/metrics/DefaultStringMatchingStrategy.java
+++ b/dropwizard-metrics/src/main/java/io/dropwizard/metrics/DefaultStringMatchingStrategy.java
@@ -5,12 +5,6 @@ import com.google.common.collect.ImmutableSet;
 class DefaultStringMatchingStrategy implements StringMatchingStrategy {
     @Override
     public boolean containsMatch(ImmutableSet<String> matchExpressions, String metricName) {
-        for (String matchExpression : matchExpressions) {
-            if (metricName.contains(matchExpression)) {
-                // just need to match on a single value - return as soon as we do
-                return true;
-            }
-        }
-        return false;
+        return matchExpressions.contains(metricName);
     }
 }

--- a/dropwizard-metrics/src/main/java/io/dropwizard/metrics/RegexStringMatchingStrategy.java
+++ b/dropwizard-metrics/src/main/java/io/dropwizard/metrics/RegexStringMatchingStrategy.java
@@ -1,0 +1,35 @@
+package io.dropwizard.metrics;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+class RegexStringMatchingStrategy implements StringMatchingStrategy {
+    private final LoadingCache<String, Pattern> patternCache;
+
+    RegexStringMatchingStrategy() {
+        patternCache = CacheBuilder.newBuilder()
+            .expireAfterWrite(1, TimeUnit.HOURS)
+            .build(new CacheLoader<String, Pattern>() {
+                @Override
+                public Pattern load(String regex) throws Exception {
+                    return Pattern.compile(regex);
+                }
+            });
+    }
+
+    @Override
+    public boolean containsMatch(ImmutableSet<String> matchExpressions, String metricName) {
+        for (String regexExpression : matchExpressions) {
+            if (patternCache.getUnchecked(regexExpression).matcher(metricName).matches()) {
+                // just need to match on a single value - return as soon as we do
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/dropwizard-metrics/src/main/java/io/dropwizard/metrics/StringMatchingStrategy.java
+++ b/dropwizard-metrics/src/main/java/io/dropwizard/metrics/StringMatchingStrategy.java
@@ -1,0 +1,7 @@
+package io.dropwizard.metrics;
+
+import com.google.common.collect.ImmutableSet;
+
+interface StringMatchingStrategy {
+    boolean containsMatch(ImmutableSet<String> matchExpressions, String metricName);
+}

--- a/dropwizard-metrics/src/main/java/io/dropwizard/metrics/SubstringMatchingStrategy.java
+++ b/dropwizard-metrics/src/main/java/io/dropwizard/metrics/SubstringMatchingStrategy.java
@@ -7,8 +7,8 @@ class SubstringMatchingStrategy implements StringMatchingStrategy {
     public boolean containsMatch(ImmutableSet<String> matchExpressions, String metricName) {
         for (String matchExpression : matchExpressions) {
             if (metricName.contains(matchExpression)) {
-            // just need to match on a single value - return as soon as we do
-            return true;
+                // just need to match on a single value - return as soon as we do
+                return true;
             }
         }
         return false;

--- a/dropwizard-metrics/src/main/java/io/dropwizard/metrics/SubstringMatchingStrategy.java
+++ b/dropwizard-metrics/src/main/java/io/dropwizard/metrics/SubstringMatchingStrategy.java
@@ -1,0 +1,16 @@
+package io.dropwizard.metrics;
+
+import com.google.common.collect.ImmutableSet;
+
+class SubstringMatchingStrategy implements StringMatchingStrategy {
+    @Override
+    public boolean containsMatch(ImmutableSet<String> matchExpressions, String metricName) {
+        for (String matchExpression : matchExpressions) {
+            if (metricName.contains(matchExpression)) {
+            // just need to match on a single value - return as soon as we do
+            return true;
+            }
+        }
+        return false;
+    }
+}

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/BaseReporterFactoryTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/BaseReporterFactoryTest.java
@@ -17,10 +17,10 @@ import static org.mockito.Mockito.mock;
 @RunWith(Parameterized.class)
 public class BaseReporterFactoryTest {
     private static final ImmutableSet<String> INCLUDES = ImmutableSet.of("inc", "both", "inc.+");
-    private static final ImmutableSet<String> EXCLUDES = ImmutableSet.of("both", "exc", "exc.+");
+    private static final ImmutableSet<String> EXCLUDES = ImmutableSet.of("exc", "both", "exc.+");
     private static final ImmutableSet<String> EMPTY = ImmutableSet.of();
 
-    @Parameterized.Parameters(name = "{index} {4} {2}={3}")
+    @Parameterized.Parameters(name = "{index} {6} {2}")
     public static List<Object[]> data() {
 
         return ImmutableList.of(
@@ -28,49 +28,49 @@ public class BaseReporterFactoryTest {
                  * case1: If include list is empty and exclude list is empty, everything should be
                  * included.
                  */
-                new Object[]{EMPTY, EMPTY, "inc", true, true, "case1"},
-                new Object[]{EMPTY, EMPTY, "both", true, true, "case1"},
-                new Object[]{EMPTY, EMPTY, "exc", true, true, "case1"},
-                new Object[]{EMPTY, EMPTY, "any", true, true, "case1"},
-                new Object[]{EMPTY, EMPTY, "incWithSuffix", true, true, "case1"},
-                new Object[]{EMPTY, EMPTY, "excWithSuffix", true, true, "case1"},
-                new Object[]{EMPTY, EMPTY, "prefiXincSuffix", true, true, "case1"},
+                new Object[]{EMPTY, EMPTY, "inc", true, true, true, "case1"},
+                new Object[]{EMPTY, EMPTY, "both", true, true, true, "case1"},
+                new Object[]{EMPTY, EMPTY, "exc", true, true, true, "case1"},
+                new Object[]{EMPTY, EMPTY, "any", true, true, true, "case1"},
+                new Object[]{EMPTY, EMPTY, "incWithSuffix", true, true, true, "case1"},
+                new Object[]{EMPTY, EMPTY, "excWithSuffix", true, true, true, "case1"},
+                new Object[]{EMPTY, EMPTY, "prefiXincSuffix", true, true, true, "case1"},
 
                 /*
                  * case2: If include list is NOT empty and exclude list is empty, only the ones
                  * specified in the include list should be included.
                  */
-                new Object[]{INCLUDES, EMPTY, "inc", true, true, "case2"},
-                new Object[]{INCLUDES, EMPTY, "both", true, true, "case2"},
-                new Object[]{INCLUDES, EMPTY, "exc", false, false, "case2"},
-                new Object[]{INCLUDES, EMPTY, "any", false, false, "case2"},
-                new Object[]{INCLUDES, EMPTY, "incWithSuffix", true, true, "case2"},
-                new Object[]{INCLUDES, EMPTY, "excWithSuffix", false, false, "case2"},
-                new Object[]{INCLUDES, EMPTY, "prefiXincSuffix", true, false, "case2"},
+                new Object[]{INCLUDES, EMPTY, "inc", true, true, true, "case2"},
+                new Object[]{INCLUDES, EMPTY, "both", true, true, true, "case2"},
+                new Object[]{INCLUDES, EMPTY, "exc", false, false, false, "case2"},
+                new Object[]{INCLUDES, EMPTY, "any", false, false, false, "case2"},
+                new Object[]{INCLUDES, EMPTY, "incWithSuffix", false, true, true, "case2"},
+                new Object[]{INCLUDES, EMPTY, "excWithSuffix", false, false, false, "case2"},
+                new Object[]{INCLUDES, EMPTY, "prefiXincSuffix", false, false, true, "case2"},
 
                 /*
                  * case3: If include list is empty and exclude list is NOT empty, everything should be
                  * included except the ones in the exclude list.
                  */
-                new Object[]{EMPTY, EXCLUDES, "inc", true, true, "case3"},
-                new Object[]{EMPTY, EXCLUDES, "both", false, false, "case3"},
-                new Object[]{EMPTY, EXCLUDES, "exc", false, false, "case3"},
-                new Object[]{EMPTY, EXCLUDES, "any", true, true, "case3"},
-                new Object[]{EMPTY, EXCLUDES, "incWithSuffix", true, true, "case3"},
-                new Object[]{EMPTY, EXCLUDES, "excWithSuffix", false, false, "case3"},
-                new Object[]{EMPTY, EXCLUDES, "prefiXincSuffix", true, true, "case3"},
+                new Object[]{EMPTY, EXCLUDES, "inc", true, true, true, "case3"},
+                new Object[]{EMPTY, EXCLUDES, "both", false, false, false, "case3"},
+                new Object[]{EMPTY, EXCLUDES, "exc", false, false, false, "case3"},
+                new Object[]{EMPTY, EXCLUDES, "any", true, true, true, "case3"},
+                new Object[]{EMPTY, EXCLUDES, "incWithSuffix", true, true, true, "case3"},
+                new Object[]{EMPTY, EXCLUDES, "excWithSuffix", true, false, false, "case3"},
+                new Object[]{EMPTY, EXCLUDES, "prefiXincSuffix", true, true, true, "case3"},
 
                 /*
                  * case4: If include list is NOT empty and exclude list is NOT empty, only things not excluded
                  * and specifically included should show up. Excludes takes precedence.
                  */
-                new Object[]{INCLUDES, EXCLUDES, "inc", true, true, "case4"},
-                new Object[]{INCLUDES, EXCLUDES, "both", false, false, "case4"},
-                new Object[]{INCLUDES, EXCLUDES, "exc", false, false, "case4"},
-                new Object[]{INCLUDES, EXCLUDES, "any", false, false, "case4"},
-                new Object[]{INCLUDES, EXCLUDES, "incWithSuffix", true, true, "case4"},
-                new Object[]{INCLUDES, EXCLUDES, "excWithSuffix", false, false, "case4"},
-                new Object[]{INCLUDES, EXCLUDES, "prefiXincSuffix", true, false, "case3"}
+                new Object[]{INCLUDES, EXCLUDES, "inc", true, true, true, "case4"},
+                new Object[]{INCLUDES, EXCLUDES, "both", false, false, false, "case4"},
+                new Object[]{INCLUDES, EXCLUDES, "exc", false, false, false, "case4"},
+                new Object[]{INCLUDES, EXCLUDES, "any", false, false, false, "case4"},
+                new Object[]{INCLUDES, EXCLUDES, "incWithSuffix", false, true, true, "case4"},
+                new Object[]{INCLUDES, EXCLUDES, "excWithSuffix", false, false, false, "case4"},
+                new Object[]{INCLUDES, EXCLUDES, "prefiXincSuffix", false, false, true, "case4"}
         );
     }
 
@@ -97,6 +97,9 @@ public class BaseReporterFactoryTest {
     public boolean expectedRegexResult;
 
     @Parameterized.Parameter(5)
+    public boolean expectedSubstringResult;
+
+    @Parameterized.Parameter(6)
     public String msg;
 
     private final Metric metric = mock(Metric.class);
@@ -107,6 +110,7 @@ public class BaseReporterFactoryTest {
         factory.setExcludes(excludes);
 
         factory.setUseRegexFilters(false);
+        factory.setUseSubstringMatching(false);
         assertThat(factory.getFilter().matches(name, metric))
                 .overridingErrorMessage(msg + ": expected 'matches(%s)=%s' for default matcher", name, expectedDefaultResult)
                 .isEqualTo(expectedDefaultResult);
@@ -118,8 +122,21 @@ public class BaseReporterFactoryTest {
         factory.setExcludes(excludes);
 
         factory.setUseRegexFilters(true);
+        factory.setUseSubstringMatching(false);
         assertThat(factory.getFilter().matches(name, metric))
                 .overridingErrorMessage(msg + ": expected 'matches(%s)=%s' for regex matcher", name, expectedRegexResult)
                 .isEqualTo(expectedRegexResult);
+    }
+
+    @Test
+    public void tesSubstringMatching() {
+        factory.setIncludes(includes);
+        factory.setExcludes(excludes);
+
+        factory.setUseRegexFilters(false);
+        factory.setUseSubstringMatching(true);
+        assertThat(factory.getFilter().matches(name, metric))
+            .overridingErrorMessage(msg + ": expected 'matches(%s)=%s' for substring matcher", name, expectedSubstringResult)
+            .isEqualTo(expectedSubstringResult);
     }
 }

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/BaseReporterFactoryTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/BaseReporterFactoryTest.java
@@ -16,18 +16,15 @@ import static org.mockito.Mockito.mock;
 
 @RunWith(Parameterized.class)
 public class BaseReporterFactoryTest {
-
-
     private static final ImmutableSet<String> INCLUDES = ImmutableSet.of("inc", "both", "inc.+");
     private static final ImmutableSet<String> EXCLUDES = ImmutableSet.of("both", "exc", "exc.+");
     private static final ImmutableSet<String> EMPTY = ImmutableSet.of();
-
 
     @Parameterized.Parameters(name = "{index} {4} {2}={3}")
     public static List<Object[]> data() {
 
         return ImmutableList.of(
-                /**
+                /*
                  * case1: If include list is empty and exclude list is empty, everything should be
                  * included.
                  */
@@ -37,8 +34,9 @@ public class BaseReporterFactoryTest {
                 new Object[]{EMPTY, EMPTY, "any", true, true, "case1"},
                 new Object[]{EMPTY, EMPTY, "incWithSuffix", true, true, "case1"},
                 new Object[]{EMPTY, EMPTY, "excWithSuffix", true, true, "case1"},
+                new Object[]{EMPTY, EMPTY, "prefiXincSuffix", true, true, "case1"},
 
-                /**
+                /*
                  * case2: If include list is NOT empty and exclude list is empty, only the ones
                  * specified in the include list should be included.
                  */
@@ -46,10 +44,11 @@ public class BaseReporterFactoryTest {
                 new Object[]{INCLUDES, EMPTY, "both", true, true, "case2"},
                 new Object[]{INCLUDES, EMPTY, "exc", false, false, "case2"},
                 new Object[]{INCLUDES, EMPTY, "any", false, false, "case2"},
-                new Object[]{INCLUDES, EMPTY, "incWithSuffix", false, true, "case2"},
+                new Object[]{INCLUDES, EMPTY, "incWithSuffix", true, true, "case2"},
                 new Object[]{INCLUDES, EMPTY, "excWithSuffix", false, false, "case2"},
+                new Object[]{INCLUDES, EMPTY, "prefiXincSuffix", true, false, "case2"},
 
-                /**
+                /*
                  * case3: If include list is empty and exclude list is NOT empty, everything should be
                  * included except the ones in the exclude list.
                  */
@@ -58,9 +57,10 @@ public class BaseReporterFactoryTest {
                 new Object[]{EMPTY, EXCLUDES, "exc", false, false, "case3"},
                 new Object[]{EMPTY, EXCLUDES, "any", true, true, "case3"},
                 new Object[]{EMPTY, EXCLUDES, "incWithSuffix", true, true, "case3"},
-                new Object[]{EMPTY, EXCLUDES, "excWithSuffix", true, false, "case3"},
+                new Object[]{EMPTY, EXCLUDES, "excWithSuffix", false, false, "case3"},
+                new Object[]{EMPTY, EXCLUDES, "prefiXincSuffix", true, true, "case3"},
 
-                /**
+                /*
                  * case4: If include list is NOT empty and exclude list is NOT empty, only things not excluded
                  * and specifically included should show up. Excludes takes precedence.
                  */
@@ -68,8 +68,9 @@ public class BaseReporterFactoryTest {
                 new Object[]{INCLUDES, EXCLUDES, "both", false, false, "case4"},
                 new Object[]{INCLUDES, EXCLUDES, "exc", false, false, "case4"},
                 new Object[]{INCLUDES, EXCLUDES, "any", false, false, "case4"},
-                new Object[]{INCLUDES, EXCLUDES, "incWithSuffix", false, true, "case4"},
-                new Object[]{INCLUDES, EXCLUDES, "excWithSuffix", false, false, "case4"}
+                new Object[]{INCLUDES, EXCLUDES, "incWithSuffix", true, true, "case4"},
+                new Object[]{INCLUDES, EXCLUDES, "excWithSuffix", false, false, "case4"},
+                new Object[]{INCLUDES, EXCLUDES, "prefiXincSuffix", true, false, "case3"}
         );
     }
 
@@ -80,7 +81,7 @@ public class BaseReporterFactoryTest {
         }
     };
 
-    @Parameterized.Parameter(0)
+    @Parameterized.Parameter
     public ImmutableSet<String> includes;
 
     @Parameterized.Parameter(1)
@@ -121,5 +122,4 @@ public class BaseReporterFactoryTest {
                 .overridingErrorMessage(msg + ": expected 'matches(%s)=%s' for regex matcher", name, expectedRegexResult)
                 .isEqualTo(expectedRegexResult);
     }
-
 }


### PR DESCRIPTION
The reason I came across this `problem` (maybe it is meant to be used like the way it is now) is because I use datadog and use a thin library on top of dropwizard (https://raw.githubusercontent.com/coursera/metrics-datadog). Which gave the following description how includes work;

---

#### Filtering

If you want to filter only a few metrics, you can use the `includes` or 
`excludes` key to create a set of metrics to include or exclude respectively.

~~~yaml
metrics:
  frequency: 1 minute                       # Default is 1 second.
  reporters:
    - type: datadog
      host: <host>
      includes:
        - jvm.
        - ch.
~~~

The check is very simplistic so be as specific as possible. For example, if 
you have "jvm.", the filter will check if the includes has that value in any 
part of the metric name (not just the beginning).

---
After trying a lot of different configurations I checked the code to see if this was really the case. For now I used a regular expression to fix my problem, but I would like to improve the code to adhere to the description above.

Dropwizard's own documentation is very brief about the usage (should it be the complete string or not?);
```
includes	(all)	Metrics to include in reports, by name. When defined, only these metrics will be reported.
```