### PR TITLE
Add new criteriaQuery method to avoid hibernate criteria deprecations.

### DIFF
--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/AbstractDAO.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/AbstractDAO.java
@@ -12,7 +12,6 @@ import org.hibernate.query.internal.AbstractProducedQuery;
 import java.io.Serializable;
 import java.util.List;
 
-import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 
 import static java.util.Objects.requireNonNull;
@@ -61,8 +60,7 @@ public class AbstractDAO<E> {
      * @return a new {@link CriteriaQuery} query
      */
     protected CriteriaQuery<E> criteriaQuery() {
-        CriteriaBuilder builder = this.currentSession().getCriteriaBuilder();
-        return builder.createQuery(getEntityClass());
+        return this.currentSession().getCriteriaBuilder().createQuery(getEntityClass());
     }
 
     /**

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/AbstractDAO.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/AbstractDAO.java
@@ -12,6 +12,7 @@ import org.hibernate.query.internal.AbstractProducedQuery;
 import java.io.Serializable;
 import java.util.List;
 
+import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 
 import static java.util.Objects.requireNonNull;
@@ -52,6 +53,16 @@ public class AbstractDAO<E> {
      */
     protected Criteria criteria() {
         return currentSession().createCriteria(entityClass);
+    }
+
+    /**
+     * Creates a new {@link CriteriaQuery} for {@code <E>}.
+     *
+     * @return a new {@link CriteriaQuery} query
+     */
+    protected CriteriaQuery<E> criteriaQuery() {
+        CriteriaBuilder builder = this.currentSession().getCriteriaBuilder();
+        return builder.createQuery(getEntityClass());
     }
 
     /**

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/AbstractDAOTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/AbstractDAOTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import java.io.Serializable;
 import java.util.List;
 
+import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -88,6 +89,7 @@ public class AbstractDAOTest {
     }
 
     private final SessionFactory factory = mock(SessionFactory.class);
+    private final CriteriaBuilder criteriaBuilder = mock(CriteriaBuilder.class);
     private final Criteria criteria = mock(Criteria.class);
     @SuppressWarnings("unchecked")
     private final CriteriaQuery<String> criteriaQuery = mock(CriteriaQuery.class);
@@ -98,8 +100,10 @@ public class AbstractDAOTest {
 
     @Before
     public void setup() throws Exception {
+        when(criteriaBuilder.createQuery(same(String.class))).thenReturn(criteriaQuery);
         when(factory.getCurrentSession()).thenReturn(session);
         when(session.createCriteria(String.class)).thenReturn(criteria);
+        when(session.getCriteriaBuilder()).thenReturn(criteriaBuilder);
         when(session.getNamedQuery(anyString())).thenReturn(query);
         when(session.createQuery(anyString(), same(String.class))).thenReturn(query);
     }
@@ -133,11 +137,20 @@ public class AbstractDAOTest {
     }
 
     @Test
-    public void createsNewCriteriaQueries() throws Exception {
+    public void createsNewCriteria() throws Exception {
         assertThat(dao.criteria())
                 .isEqualTo(criteria);
 
         verify(session).createCriteria(String.class);
+    }
+
+    @Test
+    public void createsNewCriteriaQueries() throws Exception {
+        assertThat(dao.criteriaQuery())
+                .isEqualTo(criteriaQuery);
+
+        verify(session).getCriteriaBuilder();
+        verify(criteriaBuilder).createQuery(String.class);
     }
 
     @Test


### PR DESCRIPTION
Hibernate deprecated `session.createCriteria(<E>)`.

I added a `criteriaQuery()` method as a migration path away from `criteria()`. I considered `createCriteriaUpdate` and `createCriteriaDelete` methods as well, but wasn't sure if they would be wanted. Please let me know your thoughts.