### PR TITLE
Add JDBC interceptor configuration

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -1298,6 +1298,7 @@ validationInterval              30 seconds               To avoid excess validat
 
 validatorClassName              none                     Name of a class of a custom validator implementation, which
                                                          will be used for validating connections.
+jdbcInterceptors                none                       A semicolon separated list of JDBC interceptor classnames.
 ============================    =====================    ===============================================================
 
 .. _man-configuration-polymorphic:

--- a/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
+++ b/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
@@ -285,9 +285,25 @@ import java.util.concurrent.TimeUnit;
  *             implementation, which will be used for validating connections.
  *         </td>
  *     </tr>
+ *     <tr>
+ *         <td>{@code jdbcInterceptors}</td>
+ *         <td>(none)</td>
+ *         <td>
+ *             A semicolon separated list of classnames extending
+ *             {@link org.apache.tomcat.jdbc.pool.JdbcInterceptor}
+ *         </td>
+ *     </tr>
  * </table>
  */
 public class DataSourceFactory implements PooledDataSourceFactory {
+    public Optional<String> getJdbcInterceptors() {
+        return jdbcInterceptors;
+    }
+
+    public void setJdbcInterceptors(Optional<String> jdbcInterceptors) {
+        this.jdbcInterceptors = jdbcInterceptors;
+    }
+
     @SuppressWarnings("UnusedDeclaration")
     public enum TransactionIsolation {
         NONE(Connection.TRANSACTION_NONE),
@@ -399,6 +415,8 @@ public class DataSourceFactory implements PooledDataSourceFactory {
     @NotNull
     @MinDuration(1)
     private Duration removeAbandonedTimeout = Duration.seconds(60L);
+
+    private Optional<String> jdbcInterceptors = Optional.empty();
 
     @JsonProperty
     @Override
@@ -859,7 +877,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
             poolConfig.setValidationQueryTimeout((int) validationQueryTimeout.toSeconds());
         }
         validatorClassName.ifPresent(poolConfig::setValidatorClassName);
-
+        jdbcInterceptors.ifPresent(poolConfig::setJdbcInterceptors);
         return new ManagedPooledDataSource(poolConfig, metricRegistry);
     }
 }

--- a/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceConfigurationTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceConfigurationTest.java
@@ -54,6 +54,7 @@ public class DataSourceConfigurationTest {
         assertThat(ds.getCheckConnectionOnReturn()).isEqualTo(true);
         assertThat(ds.getValidationQueryTimeout()).isEqualTo(Optional.of(Duration.seconds(3)));
         assertThat(ds.getValidatorClassName()).isEqualTo(Optional.of("io.dropwizard.db.CustomConnectionValidator"));
+        assertThat(ds.getJdbcInterceptors()).isEqualTo(Optional.of("StatementFinalizer;SlowQueryReport"));
     }
 
     @Test

--- a/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceFactoryTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceFactoryTest.java
@@ -6,6 +6,8 @@ import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.util.Duration;
 import io.dropwizard.validation.BaseValidator;
+import org.apache.tomcat.jdbc.pool.interceptor.ConnectionState;
+import org.apache.tomcat.jdbc.pool.interceptor.StatementFinalizer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -106,6 +108,16 @@ public class DataSourceFactoryTest {
             }
         }
         assertThat(CustomConnectionValidator.loaded).isTrue();
+    }
+
+    @Test
+    public void testJdbcInterceptors() throws Exception {
+        factory.setJdbcInterceptors(Optional.of("StatementFinalizer;ConnectionState"));
+        final ManagedPooledDataSource source = (ManagedPooledDataSource) dataSource();
+
+        assertThat(source.getPoolProperties().getJdbcInterceptorsAsArray())
+            .extracting("interceptorClass")
+            .contains(StatementFinalizer.class, ConnectionState.class);
     }
 
     @Test

--- a/dropwizard-db/src/test/resources/yaml/full_db_pool.yml
+++ b/dropwizard-db/src/test/resources/yaml/full_db_pool.yml
@@ -44,3 +44,4 @@ checkConnectionOnConnect: false
 checkConnectionOnReturn: true
 
 validatorClassName: io.dropwizard.db.CustomConnectionValidator
+jdbcInterceptors: "StatementFinalizer;SlowQueryReport"


### PR DESCRIPTION
Had a conversation with the author or hikaricp where tomcat jdbc should have various interceptors on by default like `ConnectionState`, and I realized that one can't specify interceptors through the db yaml. This is a good first step.

Closes #1960

CC @ololoken of #1960