### PR TITLE
Fix HttpSessionListener.sessionDestroyed is not being called #2031

### DIFF
--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/RoutingHandler.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/RoutingHandler.java
@@ -3,7 +3,7 @@ package io.dropwizard.jetty;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.jetty.server.handler.HandlerCollection;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -11,7 +11,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Map;
 
-public class RoutingHandler extends AbstractHandler {
+public class RoutingHandler extends HandlerCollection {
     /**
      * We use an array of entries instead of a map here for performance reasons. We're only ever
      * comparing connectors by reference, not by equality, so avoiding the overhead of a map is
@@ -37,6 +37,7 @@ public class RoutingHandler extends AbstractHandler {
             this.entries[i++] = new Entry(entry.getKey(), entry.getValue());
             addBean(entry.getValue());
         }
+        setHandlers(handlers.values().toArray(new Handler[handlers.size()]));
     }
 
     @Override

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/RoutingHandlerTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/RoutingHandlerTest.java
@@ -77,14 +77,14 @@ public class RoutingHandlerTest {
     public void withSessionHandler() throws Exception {
         final ContextHandler handler1 = new ContextHandler();
         final ServletContextHandler handler2 = new ServletContextHandler();
-        final SessionHandler handler2_1 = new SessionHandler();
-        handler2.setSessionHandler(handler2_1);
+        final SessionHandler childHandler1 = new SessionHandler();
+        handler2.setSessionHandler(childHandler1);
         final RoutingHandler handler = new RoutingHandler(ImmutableMap.of(connector1, handler1, connector2, handler2));
         new Server().setHandler(handler);
 
         handler.start();
         try {
-            assertThat(getSessionHandlers(handler)).containsOnly(handler2_1);
+            assertThat(getSessionHandlers(handler)).containsOnly(childHandler1);
         } finally {
             handler.stop();
         }

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/RoutingHandlerTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/RoutingHandlerTest.java
@@ -7,7 +7,14 @@ import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.server.session.SessionHandler;
+import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -65,4 +72,40 @@ public class RoutingHandlerTest {
 
         verify(handler1).handle("target", baseRequest, request, response);
     }
+
+    @Test
+    public void withSessionHandler() throws Exception {
+        final ContextHandler handler1 = new ContextHandler();
+        final ServletContextHandler handler2 = new ServletContextHandler();
+        final SessionHandler handler2_1 = new SessionHandler();
+        handler2.setSessionHandler(handler2_1);
+        final RoutingHandler handler = new RoutingHandler(ImmutableMap.of(connector1, handler1, connector2, handler2));
+        new Server().setHandler(handler);
+
+        handler.start();
+        try {
+            assertThat(getSessionHandlers(handler)).containsOnly(handler2_1);
+        } finally {
+            handler.stop();
+        }
+    }
+
+    @Test
+    public void withoutSessionHandler() throws Exception {
+        new Server().setHandler(handler);
+
+        handler.start();
+        try {
+            assertThat(getSessionHandlers(handler)).isEmpty();
+        } finally {
+            handler.stop();
+        }
+    }
+
+    private Set<SessionHandler> getSessionHandlers(final RoutingHandler routingHandler) {
+        return Arrays.stream(routingHandler.getServer().getChildHandlersByClass(ContextHandler.class))
+                .map(handler -> ((ContextHandler) handler).getChildHandlerByClass(SessionHandler.class))
+                .filter(Objects::nonNull).collect(Collectors.toSet());
+    }
+
 }


### PR DESCRIPTION
Solves: #2031

Also, in order to make it possible to detect degradation caused by Jetty's version upgrade, I added several tests.
