### PR TITLE
fixed error of not using given factory in JsonConfigurationFactory

### DIFF
--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/JsonConfigurationFactory.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/JsonConfigurationFactory.java
@@ -25,6 +25,6 @@ public class JsonConfigurationFactory<T> extends BaseConfigurationFactory<T> {
                                     Validator validator,
                                     ObjectMapper objectMapper,
                                     String propertyPrefix) {
-        super(new JsonFactory(), JsonFactory.FORMAT_NAME_JSON, klass, validator, objectMapper, propertyPrefix);
+        super(objectMapper.getFactory(), JsonFactory.FORMAT_NAME_JSON, klass, validator, objectMapper, propertyPrefix);
     }
 }


### PR DESCRIPTION
This was an oversight on my part in the JsonConfigurationFactory. I created a new JsonParser like the YamlConfigurationFactory does. But it is better to use the one given in the ObjectMapper because the user might have changed the settings of this one in the bootstrapping phase.