### PR TITLE
Decrease allowable tomcat jdbc validation interval to 50ms

### DIFF
--- a/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
+++ b/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
@@ -397,7 +397,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
     private Duration evictionInterval = Duration.seconds(5);
 
     @NotNull
-    @MinDuration(1)
+    @MinDuration(value = 50, unit = TimeUnit.MILLISECONDS)
     private Duration validationInterval = Duration.seconds(30);
 
     private Optional<String> validatorClassName = Optional.empty();


### PR DESCRIPTION
The minimum should be lowered because it's sensible to allow for
validation intervals of less than a second. For instance, the default
validation interval for HikariCP is 500ms. The lower bound of 50ms
was chosen as a compromise between a nonsensically low number
and 500ms