### PR TITLE
Update Validation annotation documentation

### DIFF
--- a/docs/source/manual/validation.rst
+++ b/docs/source/manual/validation.rst
@@ -366,20 +366,23 @@ Validating Grouped Constraints with ``@Validated``
 
 The ``@Validated`` annotation allows for `validation groups`_ to be specifically set, instead of the
 default group. This is useful when different endpoints share the same entity but may have different
-requirements.
+validation requirements.
 
 .. _validation groups: https://docs.jboss.org/hibernate/validator/5.2/reference/en-US/html/chapter-groups.html
 
-Going back to our favorite ``Person`` class. Let's say we initially coded it such that ``name`` has
-to be non-empty, but realized that business requirements needs the max length to be no more than 5.
-Instead of blowing away our current version of our API and creating angry clients, we can accept
-both versions of the API but at different endpoints.
+Going back to our favorite ``Person`` class. Let's say in the initial version of our API, ``name``
+has to be non-empty, but realized that business requirements changed and a name can't be longer than
+5 letters.  Instead of switching out the API from unsuspecting clients, we can accept both versions
+of the API but at different endpoints.
 
 .. code-block:: java
 
+    // We're going to create a group of validations for each version of our API
     public interface Version1Checks { }
 
-    public interface Version2Checks { }
+    // Our second version will extend Hibernate Validator Default class so that any validation
+    // annotation without an explicit group will also be validated with this version
+    public interface Version2Checks extends Default { }
 
     public class Person {
         @NotEmpty(groups = Version1Checks.class)
@@ -400,26 +403,44 @@ both versions of the API but at different endpoints.
     @Path("/person")
     @Produces(MediaType.APPLICATION_JSON)
     public class PersonResource {
+
+        // For the v1 endpoint, we'll validate with the version1 class, so we'll need to change the
+        // group of the NotNull annotation from the default of Default.class to Version1Checks.class
         @POST
         @Path("/v1")
-        public void createPersonV1(@Valid @Validated(Version1Checks.class) Person person) {
+        public void createPersonV1(
+            @NotNull(groups = Version1Checks.class)
+            @Valid
+            @Validated(Version1Checks.class)
+            Person person
+        ) {
+            // implementation ...
         }
 
+        // For the v2 endpoint, we'll validate with version1 and version2, which implicitly
+        // adds in the Default.class.
         @POST
         @Path("/v2")
-        public void createPersonV2(@Valid @Validated({Version1Checks.class, Version2Checks.class}) Person person) {
+        public void createPersonV2(
+            @NotNull
+            @Valid
+            @Validated({Version1Checks.class, Version2Checks.class})
+            Person person
+        ) {
+            // implementation ...
         }
     }
 
-Now, when clients hit ``/person/v1`` the ``Person`` entity will be checked by all the constraints
-that are a part of the ``Version1Checks`` group. If ``/person/v2`` is hit, then all the validations
+Now when clients hit ``/person/v1`` the ``Person`` entity will be checked by all the constraints
+that are a part of the ``Version1Checks`` group. If ``/person/v2`` is hit, then all validations
 are performed.
 
-.. note::
+.. warning::
 
-    Since interfaces can inherit other interfaces, ``Version2Checks`` can extend ``Version1Checks``
-    and wherever ``@Validated(Version2Checks.class)`` is used, version 1 constraints are checked
-    too.
+   If the `Version1Checks` group wasn't set for the `@NotNull` annotation for the v1 endpoint, the
+   annotation would not have had any effect and a null pointer exception would have occurred when a
+   property of a person is accessed. Dropwizard tries to protect against this class of bug by
+   disallowing multiple `@Validated` annotations on an endpoint that contain different groups.
 
 .. _man-validation-testing:
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProviderTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+import javax.validation.groups.Default;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedHashMap;
@@ -76,7 +77,7 @@ public class JacksonMessageBodyProviderTest {
     public interface Partial1 {
     }
 
-    public interface Partial2 {
+    public interface Partial2 extends Default {
     }
 
     public static class PartialExample {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
@@ -372,6 +372,16 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
+    public void invalidNullPartialValidatedRequestEntities() {
+        final Response response = target("/valid/validatedPartialExample")
+            .request().post(Entity.json(null));
+
+        assertThat(response.getStatus()).isEqualTo(422);
+        assertThat(response.readEntity(String.class))
+            .isEqualTo("{\"errors\":[\"The request body may not be null\"]}");
+    }
+
+    @Test
     public void invalidEntityExceptionForPartialValidatedRequestEntities() {
         final Response response = target("/valid/validatedPartialExampleBoth")
                 .request().post(Entity.json("{\"id\":1}"));
@@ -379,6 +389,16 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
         assertThat(response.getStatus()).isEqualTo(422);
         assertThat(response.readEntity(String.class))
                 .isEqualTo("{\"errors\":[\"text may not be null\"]}");
+    }
+
+    @Test
+    public void invalidNullPartialBothValidatedRequestEntities() {
+        final Response response = target("/valid/validatedPartialExampleBoth")
+            .request().post(Entity.json(null));
+
+        assertThat(response.getStatus()).isEqualTo(422);
+        assertThat(response.readEntity(String.class))
+            .isEqualTo("{\"errors\":[\"The request body may not be null\"]}");
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
@@ -91,7 +91,11 @@ public class ValidatingResource {
     @POST
     @Path("validatedPartialExampleBoth")
     public PartialExample validatedPartialExampleBoth(
-            @Validated({Partial1.class, Partial2.class}) @Valid PartialExample obj) {
+            @NotNull
+            @Valid
+            @Validated({Partial1.class, Partial2.class})
+            PartialExample obj
+    ) {
         return obj;
     }
 
@@ -134,7 +138,11 @@ public class ValidatingResource {
     @POST
     @Path("validatedPartialExample")
     public PartialExample validatedPartialExample(
-            @Validated({Partial1.class}) @Valid PartialExample obj) {
+            @NotNull(groups = Partial1.class)
+            @Valid
+            @Validated({Partial1.class})
+            PartialExample obj
+    ) {
         return obj;
     }
 


### PR DESCRIPTION
The current docs did not make it clear that annotations that were a part
of the Default group had no affect if the Validation annotation did not
contain the Default group (explicitly or implicitly through
inheritance). See PR #2052 for more information.

This commit also adds test cases to make the current behavior explicit
so any regressions can be caught in the future.

Closes #2049
Closes #2052