### PR TITLE
Update to Jackson 2.9

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -24,7 +24,7 @@
         <dropwizard.version>${project.version}</dropwizard.version>
         <guava.version>22.0</guava.version>
         <jersey.version>2.25.1</jersey.version>
-        <jackson.version>2.8.9</jackson.version>
+        <jackson.version>2.9.0</jackson.version>
         <jetty.version>9.4.6.v20170531</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics3.version>3.2.3</metrics3.version>

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/YamlConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/YamlConfigurationFactoryTest.java
@@ -17,17 +17,17 @@ public class YamlConfigurationFactoryTest extends BaseConfigurationFactoryTest {
         this.wrongTypeFile = resourceFileName("factory-test-wrong-type.yml");
         this.malformedAdvancedFile = resourceFileName("factory-test-malformed-advanced.yml");
     }
-    
+
     @Override
     public void throwsAnExceptionOnMalformedFiles() throws Exception {
         try {
             super.throwsAnExceptionOnMalformedFiles();
         } catch (ConfigurationParsingException e) {
             assertThat(e)
-                .hasMessageContaining(" * Failed to parse configuration; Can not construct instance of io.dropwizard.configuration.BaseConfigurationFactoryTest$Example");
+                .hasMessageContaining(" * Failed to parse configuration; Cannot construct instance of `io.dropwizard.configuration.BaseConfigurationFactoryTest$Example`");
         }
     }
-    
+
     @Override
     public void printsDetailedInformationOnMalformedContent() throws Exception {
         try {

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapper.java
@@ -2,10 +2,7 @@ package io.dropwizard.jersey.jackson;
 
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.exc.InvalidFormatException;
-import com.fasterxml.jackson.databind.exc.PropertyBindingException;
-import com.google.common.base.Throwables;
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
 import io.dropwizard.jersey.errors.ErrorMessage;
 import io.dropwizard.jersey.errors.LoggingExceptionMapper;
 import org.slf4j.Logger;
@@ -14,15 +11,9 @@ import org.slf4j.LoggerFactory;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
-import java.util.regex.Pattern;
 
 @Provider
 public class JsonProcessingExceptionMapper extends LoggingExceptionMapper<JsonProcessingException> {
-    // Pattern to match jackson error messages where a class lacks a single argument constructor
-    // or factory to handle a given type. For example:
-    // "no boolean/Boolean-argument constructor/factory method to deserialize from boolean value"
-    private static final Pattern WRONG_TYPE_REGEX = Pattern.compile("factory method to deserialize from \\w+ value");
-
     private static final Logger LOGGER = LoggerFactory.getLogger(JsonProcessingExceptionMapper.class);
     private final boolean showDetails;
 
@@ -41,40 +32,13 @@ public class JsonProcessingExceptionMapper extends LoggingExceptionMapper<JsonPr
     @Override
     public Response toResponse(JsonProcessingException exception) {
         /*
-         * If the error is in the JSON generation, it's a server error.
+         * If the error is in the JSON generation or an invalid definition, it's a server error.
          */
-        if (exception instanceof JsonGenerationException) {
+        if (exception instanceof JsonGenerationException || exception instanceof InvalidDefinitionException) {
             return super.toResponse(exception); // LoggingExceptionMapper will log exception
         }
 
         final String message = exception.getOriginalMessage();
-
-        /*
-         * If we can't deserialize the JSON because someone forgot a no-arg
-         * constructor, or it is not known how to serialize the type it's
-         * a server error and we should inform the developer.
-         */
-        if (exception instanceof JsonMappingException) {
-            final JsonMappingException ex = (JsonMappingException) exception;
-            final Throwable cause = Throwables.getRootCause(ex);
-
-            // Exceptions that denote an error on the client side
-            final boolean clientCause = cause instanceof InvalidFormatException ||
-                cause instanceof PropertyBindingException;
-
-            // Until completely foolproof mechanism can be worked out in coordination
-            // with Jackson on how to communicate client vs server fault, compare
-            // start of message with known server faults.
-            final boolean beanError = cause.getMessage() == null ||
-                (cause.getMessage().startsWith("No suitable constructor found") ||
-                cause.getMessage().startsWith("No serializer found for class") ||
-                (cause.getMessage().startsWith("Can not construct instance") &&
-                    !WRONG_TYPE_REGEX.matcher(cause.getMessage()).find()));
-
-            if (beanError && !clientCause) {
-                return super.toResponse(exception); // LoggingExceptionMapper will log exception
-            }
-        }
 
         /*
          * Otherwise, it's those pesky users.

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/CustomDeserialization.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/CustomDeserialization.java
@@ -23,7 +23,12 @@ public class CustomDeserialization extends StdDeserializer<CustomRepresentation>
         JsonParser jsonParser,
         DeserializationContext deserializationContext
     ) throws IOException {
-        throw new MyNastyException(jsonParser);
+        final Object ss = jsonParser.readValueAs(Object.class);
+        if (ss.equals("SQL_INECTION")) {
+            throw new RuntimeException("Database fell over due to sql injection");
+        } else {
+            throw new MyNastyException(jsonParser);
+        }
     }
 
     /**


### PR DESCRIPTION
Jackson 2.9 greatly simplifies exception handling with the new exception,
`InvalidDefinitionException`.

This PR technically breaks behavior for custom deserializers, but I
believe it is now the correct behavior. If a deserializer fails to to deserialize
input then a 400 should be returned as it denotes unexpected input. A 500
should only be returned if a deserializer encountered an error unrelated
to the input (if it read from a non-existant file or db...(not saying it's
a good design)). Added a test case to assert this.

Do not merge this PR as Jackson 2.9 is not actually released. I'm not sure when it will
be released, but I figured it would be a good idea to know what to expect.