### PR TITLE
Add support for HTML error responses and other non-JSON content types

### DIFF
--- a/docs/source/manual/views.rst
+++ b/docs/source/manual/views.rst
@@ -124,7 +124,7 @@ Template Errors
 ===============
 
 By default, if there is an error with the template (eg. the template file is not found or there is a
-compilation error with the template), the user will receive a ``500 Internal Sever Error`` with a
+compilation error with the template), the user will receive a ``500 Internal Server Error`` with a
 generic HTML message. The exact error will logged under error mode.
 
 To customize the behavior, create an exception mapper that will override the default one by looking
@@ -163,7 +163,7 @@ mustache templates can't be found:
 
 
 Caching
-===============
+=======
 By default templates are cached to improve loading time. If you want to disable it during the development mode,
 set the ``cache`` property to ``false`` in the view configuration.
 
@@ -172,3 +172,31 @@ set the ``cache`` property to ``false`` in the view configuration.
     views:
       .mustache:
         cache: false
+
+Custom Error Pages
+==================
+
+To get HTML error pages that fit in with your application, you can use a custom error view. Create a ``View`` that
+takes an ``ErrorMessage`` parameter in its constructor, and hook it up by registering a instance of
+``ErrorEntityWriter``.
+
+.. code-block:: java
+
+    env.jersey().register(new ErrorEntityWriter<ErrorMessage,View>(MediaType.TEXT_HTML_TYPE, View.class) {
+        @Override
+        protected View getRepresentation(ErrorMessage errorMessage) {
+            return new ErrorView(errorMessage);
+        }
+    });
+
+For validation error messages, you'll need to register another ``ErrorEntityWriter`` that handles
+``ValidationErrorMessage`` objects.
+
+.. code-block:: java
+
+    env.jersey().register(new ErrorEntityWriter<ValidationErrorMessage,View>(MediaType.TEXT_HTML_TYPE, View.class) {
+        @Override
+        protected View getRepresentation(ValidationErrorMessage message) {
+            return new ValidationErrorView(message);
+        }
+    });

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/ErrorEntityWriter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/ErrorEntityWriter.java
@@ -58,7 +58,7 @@ public abstract class ErrorEntityWriter<T, U> implements MessageBodyWriter<T> {
         responseHeaders.putSingle(HttpHeaders.CONTENT_TYPE, contentType);
 
         writer.writeTo(getRepresentation(entity), representation, representation, annotations,
-            MediaType.TEXT_HTML_TYPE, responseHeaders, entityStream);
+            contentType, responseHeaders, entityStream);
     }
 
     protected abstract U getRepresentation(T entity);

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/ErrorEntityWriter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/ErrorEntityWriter.java
@@ -20,7 +20,7 @@ import java.lang.reflect.Type;
  * @param <T> The entity type to handle
  * @param <U> The response type to produce
  */
-public abstract class ErrorEntityWriter<T,U> implements MessageBodyWriter<T> {
+public abstract class ErrorEntityWriter<T, U> implements MessageBodyWriter<T> {
 
     /**
      * @param contentType Content type the writer will produce

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/ErrorEntityWriter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/ErrorEntityWriter.java
@@ -1,0 +1,74 @@
+package io.dropwizard.jersey.errors;
+
+import org.glassfish.jersey.message.MessageBodyWorkers;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+/**
+ * This class allows producing non-JSON responses for particular entities. For example, register a instance with the
+ * {@link ErrorMessage} entity and the TEXT_HTML MediaType to produce custom HTML error messages.
+ *
+ * @param <T> The entity type to handle
+ * @param <U> The response type to produce
+ */
+public abstract class ErrorEntityWriter<T,U> implements MessageBodyWriter<T> {
+
+    /**
+     * @param contentType Content type the writer will produce
+     * @param representation Response type the writer will produce
+     */
+    public ErrorEntityWriter(MediaType contentType, Class<U> representation) {
+        this.contentType = contentType;
+        this.representation = representation;
+    }
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return headers.getAcceptableMediaTypes().contains(contentType);
+    }
+
+    @Override
+    public long getSize(T entity, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return 0;
+    }
+
+    @Override
+    public void writeTo(T entity,
+                        Class<?> type,
+                        Type genericType,
+                        Annotation[] annotations,
+                        MediaType mediaType,
+                        MultivaluedMap<String, Object> responseHeaders,
+                        OutputStream entityStream)
+        throws IOException, WebApplicationException {
+
+        final MessageBodyWriter<U> writer = mbw.get().getMessageBodyWriter(representation,
+            representation, annotations, contentType);
+
+        // Fix the headers, because Dropwizard error mappers always set the content type to APPLICATION_JSON
+        responseHeaders.putSingle(HttpHeaders.CONTENT_TYPE, contentType);
+
+        writer.writeTo(getRepresentation(entity), representation, representation, annotations,
+            MediaType.TEXT_HTML_TYPE, responseHeaders, entityStream);
+    }
+
+    protected abstract U getRepresentation(T entity);
+
+    private MediaType contentType;
+    private Class<U> representation;
+
+    @Context
+    private HttpHeaders headers;
+
+    @Context
+    private javax.inject.Provider<MessageBodyWorkers> mbw;
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/ErrorEntityWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/ErrorEntityWriterTest.java
@@ -1,0 +1,71 @@
+package io.dropwizard.jersey.errors;
+
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.jersey.AbstractJerseyTest;
+import io.dropwizard.jersey.DropwizardResourceConfig;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.servlet.ServletProperties;
+import org.glassfish.jersey.test.DeploymentContext;
+import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
+import org.glassfish.jersey.test.spi.TestContainerException;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
+import org.junit.Test;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+public class ErrorEntityWriterTest extends AbstractJerseyTest {
+
+    public static class ErrorEntityWriterTestResourceConfig extends DropwizardResourceConfig {
+        public ErrorEntityWriterTestResourceConfig() {
+            super(true, new MetricRegistry());
+
+            register(DefaultLoggingExceptionMapper.class);
+            register(DefaultJacksonMessageBodyProvider.class);
+            register(ExceptionResource.class);
+            register(new ErrorEntityWriter<ErrorMessage, String>(MediaType.TEXT_HTML_TYPE, String.class) {
+                @Override
+                protected String getRepresentation(ErrorMessage entity) {
+                    return "Uh oh: " + entity.getMessage();
+                }
+            });
+        }
+    }
+
+    @Override
+    protected TestContainerFactory getTestContainerFactory() throws TestContainerException {
+        return new GrizzlyWebTestContainerFactory();
+    }
+
+    @Override
+    protected DeploymentContext configureDeployment() {
+        final ResourceConfig rc = new ErrorEntityWriterTestResourceConfig();
+        return ServletDeploymentContext.builder(rc)
+            .initParam(ServletProperties.JAXRS_APPLICATION_CLASS, ErrorEntityWriterTestResourceConfig.class.getName())
+            .build();
+    }
+
+    @Test
+    public void formatsErrorsAsHtml() {
+
+        try {
+            target("/exception/html-exception")
+                .request(MediaType.TEXT_HTML_TYPE)
+                .get(String.class);
+
+            failBecauseExceptionWasNotThrown(WebApplicationException.class);
+
+        } catch (WebApplicationException e) {
+            final Response response = e.getResponse();
+            assertThat(response.getStatus()).isEqualTo(400);
+            assertThat(response.getMediaType()).isEqualTo(MediaType.TEXT_HTML_TYPE);
+            assertThat(response.readEntity(String.class)).isEqualTo("Uh oh: BIFF");
+        }
+    }
+
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/ErrorEntityWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/ErrorEntityWriterTest.java
@@ -31,7 +31,7 @@ public class ErrorEntityWriterTest extends AbstractJerseyTest {
             register(new ErrorEntityWriter<ErrorMessage, String>(MediaType.TEXT_HTML_TYPE, String.class) {
                 @Override
                 protected String getRepresentation(ErrorMessage entity) {
-                    return "Uh oh: " + entity.getMessage();
+                    return "<!DOCTYPE html><html><body>" + entity.getMessage() + "</body></html>";
                 }
             });
         }
@@ -64,7 +64,7 @@ public class ErrorEntityWriterTest extends AbstractJerseyTest {
             final Response response = e.getResponse();
             assertThat(response.getStatus()).isEqualTo(400);
             assertThat(response.getMediaType()).isEqualTo(MediaType.TEXT_HTML_TYPE);
-            assertThat(response.readEntity(String.class)).isEqualTo("Uh oh: BIFF");
+            assertThat(response.readEntity(String.class)).isEqualTo("<!DOCTYPE html><html><body>BIFF</body></html>");
         }
     }
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/ExceptionResource.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/ExceptionResource.java
@@ -45,4 +45,11 @@ public class ExceptionResource {
     public Response redirectTarget() {
         return Response.ok().entity("{\"status\":\"OK\"}").build();
     }
+
+    @GET
+    @Path("html-exception")
+    @Produces(MediaType.TEXT_HTML)
+    public void htmlException() throws WebApplicationException {
+        throw new WebApplicationException("BIFF", Response.Status.BAD_REQUEST);
+    }
 }


### PR DESCRIPTION
Fixes #2038 .

This adds `ErrorEntityWriter`, a generic class that works for HTML error responses but also for other content types. Unit test + docs included.