### PR TITLE
Update the URL's for grizzly and jax-rs-spec

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -1592,7 +1592,7 @@ the request is passed through.
 
 Filters can be dynamically bound to resource methods using `DynamicFeature`_:
 
-.. _DynamicFeature: http://jax-rs-spec.java.net/nonav/2.0-rev-a/apidocs/index.html
+.. _DynamicFeature: https://github.com/jax-rs 
 
 .. code-block:: java
 

--- a/docs/source/manual/testing.rst
+++ b/docs/source/manual/testing.rst
@@ -273,7 +273,7 @@ dependency for the Jersey Test Framework providers to your Maven POM and set ``G
     }
 
 .. __: https://jersey.github.io/documentation/latest/test-framework.html
-.. _Grizzly: https://grizzly.java.net/
+.. _Grizzly: https://javaee.github.io/grizzly/ 
 
 .. _man-testing-clients:
 


### PR DESCRIPTION
`java.net` has closed. 
Update the URL's for `grizzly` and `jax-rs-spec`
Unfortunately, `jax-rs-spec` API Docs are no longer published on their site.