### PR TITLE
Add time zone to Java 8 datetime mappers

### DIFF
--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/DBIFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/DBIFactory.java
@@ -146,11 +146,11 @@ public class DBIFactory {
         dbi.registerArgumentFactory(new OptionalZonedDateTimeArgumentFactory(timeZone));
 
         dbi.registerColumnMapper(new JodaDateTimeMapper(timeZone));
-        dbi.registerColumnMapper(new InstantMapper(timeZone));
         dbi.registerColumnMapper(new LocalDateMapper());
         dbi.registerColumnMapper(new LocalDateTimeMapper());
-        dbi.registerColumnMapper(new OffsetDateTimeMapper());
-        dbi.registerColumnMapper(new ZonedDateTimeMapper());
+        dbi.registerColumnMapper(new InstantMapper(timeZone));
+        dbi.registerColumnMapper(new OffsetDateTimeMapper(timeZone));
+        dbi.registerColumnMapper(new ZonedDateTimeMapper(timeZone));
 
         return dbi;
     }


### PR DESCRIPTION
Unless I'm missing something this seems like a bug. I ran into it today while playing with JDBI.

Is there a good reason to keep around the default constructor? It looks like it is only used in tests right now. Those could easily pass an empty optional and get the same result, and that would have made this impossible to miss.