### PR TITLE
Fix size and time rolling appender

### DIFF
--- a/dropwizard-example/src/test/java/com/example/helloworld/IntegrationTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/IntegrationTest.java
@@ -13,8 +13,12 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class IntegrationTest {
@@ -60,5 +64,16 @@ public class IntegrationTest {
         assertThat(newPerson.getId()).isNotNull();
         assertThat(newPerson.getFullName()).isEqualTo(person.getFullName());
         assertThat(newPerson.getJobTitle()).isEqualTo(person.getJobTitle());
+    }
+
+    @Test
+    public void testLogFileWritten() throws IOException {
+        // The log file is using a size and time based policy, which used to silently
+        // fail (and not write to a log file). This test ensures not only that the
+        // log file exists, but also contains the log line that jetty prints on startup
+        final Path log = Paths.get("./logs/application.log");
+        assertThat(log).exists();
+        final String actual = new String(Files.readAllBytes(log), UTF_8);
+        assertThat(actual).contains("0.0.0.0:" + RULE.getLocalPort());
     }
 }

--- a/dropwizard-example/src/test/resources/test-example.yml
+++ b/dropwizard-example/src/test/resources/test-example.yml
@@ -14,3 +14,16 @@ server:
   adminConnectors:
     - type: http
       port: 0
+
+# Logging settings.
+logging:
+  level: INFO
+  appenders:
+    - type: console
+    - type: file
+      currentLogFilename: './logs/application.log'
+      archivedLogFilenamePattern: './logs/application-%d-%i.log.gz'
+      archive: true
+      archivedFileCount: 7
+      maxFileSize: '1mb'
+

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
@@ -262,22 +262,24 @@ public class FileAppenderFactory<E extends DeferredProcessingAware> extends Abst
                 final TimeBasedRollingPolicy<E> rollingPolicy;
                 if (maxFileSize == null) {
                     rollingPolicy = new TimeBasedRollingPolicy<>();
+
+                    final TimeBasedFileNamingAndTriggeringPolicy<E> triggeringPolicy = new DefaultTimeBasedFileNamingAndTriggeringPolicy<>();
+                    triggeringPolicy.setContext(context);
+                    triggeringPolicy.setTimeBasedRollingPolicy(rollingPolicy);
+                    appender.setTriggeringPolicy(triggeringPolicy);
                 } else {
+                    // Creating a size and time policy does not need a separate triggering policy set
+                    // on the appender because this policy registers the trigger policy
                     final SizeAndTimeBasedRollingPolicy<E> sizeAndTimeBasedRollingPolicy = new SizeAndTimeBasedRollingPolicy<>();
                     sizeAndTimeBasedRollingPolicy.setMaxFileSize(new FileSize(maxFileSize.toBytes()));
                     rollingPolicy = sizeAndTimeBasedRollingPolicy;
                 }
 
-                final TimeBasedFileNamingAndTriggeringPolicy<E> triggeringPolicy = new DefaultTimeBasedFileNamingAndTriggeringPolicy<>();
-                triggeringPolicy.setContext(context);
                 rollingPolicy.setContext(context);
                 rollingPolicy.setFileNamePattern(archivedLogFilenamePattern);
-                rollingPolicy.setTimeBasedFileNamingAndTriggeringPolicy(triggeringPolicy);
-                triggeringPolicy.setTimeBasedRollingPolicy(rollingPolicy);
                 rollingPolicy.setMaxHistory(archivedFileCount);
 
                 appender.setRollingPolicy(rollingPolicy);
-                appender.setTriggeringPolicy(triggeringPolicy);
 
                 rollingPolicy.setParent(appender);
                 rollingPolicy.start();

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
@@ -6,7 +6,6 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.FileAppender;
-import ch.qos.logback.core.rolling.DefaultTimeBasedFileNamingAndTriggeringPolicy;
 import ch.qos.logback.core.rolling.FixedWindowRollingPolicy;
 import ch.qos.logback.core.rolling.RollingFileAppender;
 import ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy;
@@ -180,7 +179,7 @@ public class FileAppenderFactoryTest {
         fileAppenderFactory.setArchivedLogFilenamePattern(folder.newFile("example-%d-%i.log.gz").toString());
         RollingFileAppender<ILoggingEvent> appender = (RollingFileAppender<ILoggingEvent>) fileAppenderFactory.buildAppender(new LoggerContext());
 
-        assertThat(appender.getTriggeringPolicy()).isInstanceOf(DefaultTimeBasedFileNamingAndTriggeringPolicy.class);
+        assertThat(appender.getTriggeringPolicy()).isInstanceOf(SizeAndTimeBasedRollingPolicy.class);
         final Field maxFileSizeField = SizeAndTimeBasedRollingPolicy.class.getDeclaredField("maxFileSize");
         maxFileSizeField.setAccessible(true);
         final FileSize maxFileSize = (FileSize) maxFileSizeField.get(appender.getRollingPolicy());


### PR DESCRIPTION
Without this fix, file logging configurations that use time and size based rotations will not work (ie, no log file or logging statements). Added test case to guard against regressions.

cc @charbonnier666 who reported the issue and also reported this PR fixed the issue

Closes #2068