### PR TITLE
Test for #2046

### DIFF
--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/JsonConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/JsonConfigurationFactoryTest.java
@@ -47,8 +47,8 @@ public class JsonConfigurationFactoryTest extends BaseConfigurationFactoryTest {
             assertThat(e)
                     .hasMessageContaining(String.format(
                             "%s has an error:%n" +
-	                            "  * Malformed JSON at line: 7, column: 3; Unexpected close marker '}': expected ']'",
-	                            malformedAdvancedFile.getName()));
+                                "  * Malformed JSON at line: 7, column: 3; Unexpected close marker '}': expected ']'",
+                                malformedAdvancedFile.getName()));
         }
     }
     
@@ -60,8 +60,8 @@ public class JsonConfigurationFactoryTest extends BaseConfigurationFactoryTest {
             assertThat(e)
             .hasMessageContaining(String.format(
                     "%s has an error:%n" +
-	                    "  * Malformed JSON at line: 4, column: 4; Unexpected character ('/' (code 47)): maybe a (non-standard) comment? (not recognized as one since Feature 'ALLOW_COMMENTS' not enabled for parser)",
-	                    commentFile.getName()));
+                        "  * Malformed JSON at line: 4, column: 4; Unexpected character ('/' (code 47)): maybe a (non-standard) comment? (not recognized as one since Feature 'ALLOW_COMMENTS' not enabled for parser)",
+                        commentFile.getName()));
             throw e;
         }
     }

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/JsonConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/JsonConfigurationFactoryTest.java
@@ -58,7 +58,7 @@ public class JsonConfigurationFactoryTest extends BaseConfigurationFactoryTest {
             factory.build(commentFile);
         } catch (ConfigurationParsingException e) {
             assertThat(e)
-            .hasMessageContaining(String.format(
+                .hasMessageContaining(String.format(
                     "%s has an error:%n" +
                         "  * Malformed JSON at line: 4, column: 4; Unexpected character ('/' (code 47)): maybe a (non-standard) comment? (not recognized as one since Feature 'ALLOW_COMMENTS' not enabled for parser)",
                         commentFile.getName()));

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/JsonConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/JsonConfigurationFactoryTest.java
@@ -16,7 +16,7 @@ public class JsonConfigurationFactoryTest extends BaseConfigurationFactoryTest {
 
     private File commentFile;
 
-	@Override
+    @Override
     public void setUp() throws Exception {
         this.factory = new JsonConfigurationFactory<>(Example.class, validator, Jackson.newObjectMapper(), "dw");
         this.malformedFile = resourceFileName("factory-test-malformed.json");
@@ -47,32 +47,32 @@ public class JsonConfigurationFactoryTest extends BaseConfigurationFactoryTest {
             assertThat(e)
                     .hasMessageContaining(String.format(
                             "%s has an error:%n" +
-                            "  * Malformed JSON at line: 7, column: 3; Unexpected close marker '}': expected ']'",
-                            malformedAdvancedFile.getName()));
+	                            "  * Malformed JSON at line: 7, column: 3; Unexpected close marker '}': expected ']'",
+	                            malformedAdvancedFile.getName()));
         }
     }
     
-    @Test(expected=ConfigurationParsingException.class)
+    @Test(expected = ConfigurationParsingException.class)
     public void defaultJsonFactoryFailsOnComment() throws IOException, ConfigurationException {
-    	try {
-    		factory.build(commentFile);
-    	} catch(ConfigurationParsingException e) {
-    		assertThat(e)
+        try {
+            factory.build(commentFile);
+        } catch (ConfigurationParsingException e) {
+            assertThat(e)
             .hasMessageContaining(String.format(
                     "%s has an error:%n" +
-                    "  * Malformed JSON at line: 4, column: 4; Unexpected character ('/' (code 47)): maybe a (non-standard) comment? (not recognized as one since Feature 'ALLOW_COMMENTS' not enabled for parser)",
-                    commentFile.getName()));
-    		throw e;
-    	}
+	                    "  * Malformed JSON at line: 4, column: 4; Unexpected character ('/' (code 47)): maybe a (non-standard) comment? (not recognized as one since Feature 'ALLOW_COMMENTS' not enabled for parser)",
+	                    commentFile.getName()));
+            throw e;
+        }
     }
     
     @Test
     public void configuredMapperAllowsComment() throws IOException, ConfigurationException {
-    	ObjectMapper mapper = Jackson
-    		.newObjectMapper()
-    		.configure(Feature.ALLOW_COMMENTS, true);
-    	
-    	JsonConfigurationFactory<Example> factory = new JsonConfigurationFactory<>(Example.class, validator, mapper, "dw");
-    	factory.build(commentFile);
+        ObjectMapper mapper = Jackson
+            .newObjectMapper()
+            .configure(Feature.ALLOW_COMMENTS, true);
+        
+        JsonConfigurationFactory<Example> factory = new JsonConfigurationFactory<>(Example.class, validator, mapper, "dw");
+        factory.build(commentFile);
     }
 }

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/JsonConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/JsonConfigurationFactoryTest.java
@@ -2,17 +2,28 @@ package io.dropwizard.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.JsonParser.Feature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.dropwizard.jackson.Jackson;
 
 public class JsonConfigurationFactoryTest extends BaseConfigurationFactoryTest {
 
-    @Override
+    private File commentFile;
+
+	@Override
     public void setUp() throws Exception {
         this.factory = new JsonConfigurationFactory<>(Example.class, validator, Jackson.newObjectMapper(), "dw");
         this.malformedFile = resourceFileName("factory-test-malformed.json");
         this.emptyFile = resourceFileName("factory-test-empty.json");
         this.invalidFile = resourceFileName("factory-test-invalid.json");
         this.validFile = resourceFileName("factory-test-valid.json");
+        this.commentFile = resourceFileName("factory-test-comment.json");
         this.typoFile = resourceFileName("factory-test-typo.json");
         this.wrongTypeFile = resourceFileName("factory-test-wrong-type.json");
         this.malformedAdvancedFile = resourceFileName("factory-test-malformed-advanced.json");
@@ -36,8 +47,32 @@ public class JsonConfigurationFactoryTest extends BaseConfigurationFactoryTest {
             assertThat(e)
                     .hasMessageContaining(String.format(
                             "%s has an error:%n" +
-                                    "  * Malformed JSON at line: 7, column: 3; Unexpected close marker '}': expected ']'",
-                                    malformedAdvancedFile.getName()));
+                            "  * Malformed JSON at line: 7, column: 3; Unexpected close marker '}': expected ']'",
+                            malformedAdvancedFile.getName()));
         }
+    }
+    
+    @Test(expected=ConfigurationParsingException.class)
+    public void defaultJsonFactoryFailsOnComment() throws IOException, ConfigurationException {
+    	try {
+    		factory.build(commentFile);
+    	} catch(ConfigurationParsingException e) {
+    		assertThat(e)
+            .hasMessageContaining(String.format(
+                    "%s has an error:%n" +
+                    "  * Malformed JSON at line: 4, column: 4; Unexpected character ('/' (code 47)): maybe a (non-standard) comment? (not recognized as one since Feature 'ALLOW_COMMENTS' not enabled for parser)",
+                    commentFile.getName()));
+    		throw e;
+    	}
+    }
+    
+    @Test
+    public void configuredMapperAllowsComment() throws IOException, ConfigurationException {
+    	ObjectMapper mapper = Jackson
+    		.newObjectMapper()
+    		.configure(Feature.ALLOW_COMMENTS, true);
+    	
+    	JsonConfigurationFactory<Example> factory = new JsonConfigurationFactory<>(Example.class, validator, mapper, "dw");
+    	factory.build(commentFile);
     }
 }

--- a/dropwizard-configuration/src/test/resources/factory-test-comment.json
+++ b/dropwizard-configuration/src/test/resources/factory-test-comment.json
@@ -1,0 +1,15 @@
+{
+	"name": "Migty Wizard",
+	/*This is a comment*/
+	"type": [
+		"wizard"
+	],
+	"properties": {
+		"admin": true
+	},
+	"servers": [
+		{
+			"port": 8080
+		}
+	]
+}


### PR DESCRIPTION
Sorry for the late response. I had a lot to do the last few weeks. Here is a test for the problem in #2046 . I added an example json config that contains a comment and can only be parsed if the object mapper is configured accordingly.