### PR TITLE
Update 1.1.x branch jackson to 2.8.9

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -24,7 +24,7 @@
         <dropwizard.version>${project.version}</dropwizard.version>
         <guava.version>21.0</guava.version>
         <jersey.version>2.25.1</jersey.version>
-        <jackson.version>2.8.7</jackson.version>
+        <jackson.version>2.8.9</jackson.version>
         <jetty.version>9.4.2.v20170220</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics3.version>3.2.2</metrics3.version>


### PR DESCRIPTION
Update jackson version from 2.8.7 to 2.8.9 to address Deserializer security vulnerability, per #2085