### PR TITLE
Update 1.0.x branch jackson to 2.7.9.1

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -24,7 +24,7 @@
         <dropwizard.version>${project.version}</dropwizard.version>
         <guava.version>19.0</guava.version>
         <jersey.version>2.23.2</jersey.version>
-        <jackson.api.version>2.7.8</jackson.api.version>
+        <jackson.api.version>2.7.9.1</jackson.api.version>
         <jackson.version>2.7.8</jackson.version>
         <jetty.version>9.3.9.v20160517</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>


### PR DESCRIPTION
Update jackson version from 2.7.8 to 2.7.9.1 to address Deserializer security vulnerability, per #2085