### PR TITLE
Use LoadingCache in CachingAuthorizer

### DIFF
--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/CachingAuthorizerTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/CachingAuthorizerTest.java
@@ -10,6 +10,7 @@ import org.mockito.InOrder;
 import java.security.Principal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.inOrder;
@@ -119,8 +120,18 @@ public class CachingAuthorizerTest {
 
     @Test
     public void calculatesCacheStats() throws Exception {
-        cached.authorize(principal, role);
         assertThat(cached.stats().loadCount()).isEqualTo(0);
+        cached.authorize(principal, role);
+        assertThat(cached.stats().loadCount()).isEqualTo(1);
         assertThat(cached.size()).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldPropagateRuntimeException() throws AuthenticationException {
+        final RuntimeException e = new NullPointerException();
+        when(underlying.authorize(principal, role)).thenThrow(e);
+        assertThatNullPointerException()
+            .isThrownBy(() -> cached.authorize(principal, role))
+            .isSameAs(e);
     }
 }


### PR DESCRIPTION
As done in #1615 for CachingAuthenticator. Since `Authorizer::authorize` doesn't have a `throws` clause, I've only handled `UncheckedExecutionException`s.

Result when `null` is returned by the authorizer will differ from previously, where a `NullPointerException` would have been thrown by the cache's `put` method, whereas now a `InvalidCacheLoadException` will be thrown by the cache itself when the loader returns null. There might be a way to have the same result as previously, let me know if you want me to look into it (but personally I don't think it really matters as most users won't be catching those exceptions anyway, and it might even be clearer as to what happened).

EDIT: Looking at this again, `Authorizer::authorize` returns a `boolean` and not a `Boolean` so null returns shouldn't happen anyway.