### PR TITLE
Remove unnecessary use of varargs methods

### DIFF
--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
@@ -59,8 +59,8 @@ public class Jackson {
         mapper.registerModule(new AfterburnerModule());
         mapper.registerModule(new FuzzyEnumModule());
         mapper.registerModule(new ParameterNamesModule());
-        mapper.registerModules(new Jdk8Module());
-        mapper.registerModules(new JavaTimeModule());
+        mapper.registerModule(new Jdk8Module());
+        mapper.registerModule(new JavaTimeModule());
         mapper.setPropertyNamingStrategy(new AnnotationSensitivePropertyNamingStrategy());
         mapper.setSubtypeResolver(new DiscoverableSubtypeResolver());
 


### PR DESCRIPTION
Use `mapper#registerModule(Module)` instead of `mapper#registerModules(Modules...)` in `Jackson#configure(ObjectMapper)`.