### PR TITLE
Update 1.0.x branch jetty to 9.3.20.v20170531

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -27,7 +27,7 @@
         <jackson.api.version>2.7.9</jackson.api.version>
         <jackson.version>2.7.9</jackson.version>
         <jackson.databind.version>2.7.9.1</jackson.databind.version>
-        <jetty.version>9.3.9.v20160517</jetty.version>
+        <jetty.version>9.3.20.v20170531</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics3.version>3.1.4</metrics3.version>
         <slf4j.version>1.7.21</slf4j.version>


### PR DESCRIPTION
Update Jetty version from 9.3.9.v20160517 to 9.3.20.v20170531 to address CVE-2017-9735 per #2113