### PR TITLE
Update 1.1.x branch Jetty  to 9.4.5.v20170502

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -25,7 +25,7 @@
         <guava.version>21.0</guava.version>
         <jersey.version>2.25.1</jersey.version>
         <jackson.version>2.8.9</jackson.version>
-        <jetty.version>9.4.2.v20170220</jetty.version>
+        <jetty.version>9.4.6.v20170531</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics3.version>3.2.2</metrics3.version>
         <slf4j.version>1.7.24</slf4j.version>


### PR DESCRIPTION
Update Jetty version from 9.4.5.v20170502 to 9.4.6.v20170531 to address CVE-2017-9735 per #2113