### PR TITLE
Add support for setting several cipher suites for HTTP/2

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -486,7 +486,8 @@ The correct library version depends on a JVM version. Consult Jetty ALPN guide__
 
 Note that your JVM also must provide ``TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`` cipher. The specification states__
 that HTTP/2 deployments must support it to avoid handshake failures. It's the single supported cipher in HTTP/2
-connector by default.
+connector by default. In case you want to support more strong ciphers, you should specify them in the
+``supportedCipherSuites`` parameter along with ``TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256``.
 
 .. __: http://http2.github.io/http2-spec/index.html#rfc.section.9.2.2
 
@@ -504,7 +505,9 @@ This connector extends the attributes that are available to the :ref:`HTTPS conn
           keyStorePassword: changeit
           trustStorePath: /path/to/file # required
           trustStorePassword: changeit
-          supportedCipherSuites: TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+          supportedCipherSuites: # optional
+            - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+            - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 
 
 ========================  ========  ===================================================================================

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2ConnectorFactoryTest.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2ConnectorFactoryTest.java
@@ -1,0 +1,39 @@
+package io.dropwizard.http2;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+public class Http2ConnectorFactoryTest {
+
+    private Http2ConnectorFactory http2ConnectorFactory = new Http2ConnectorFactory();
+
+    @Test
+    public void testSetDefaultHttp2Cipher() {
+        http2ConnectorFactory.checkSupportedCipherSuites();
+
+        assertThat(http2ConnectorFactory.getSupportedCipherSuites()).containsExactly(
+            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
+    }
+
+    @Test
+    public void testCustomCiphersAreSupported() {
+        http2ConnectorFactory.setSupportedCipherSuites(ImmutableList.of("TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"));
+
+        http2ConnectorFactory.checkSupportedCipherSuites();
+
+        assertThat(http2ConnectorFactory.getSupportedCipherSuites()).containsExactly(
+            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
+    }
+
+    @Test
+    public void testThrowExceptionIfDefaultCipherIsNotSet() {
+        http2ConnectorFactory.setSupportedCipherSuites(ImmutableList.of("TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"));
+
+        assertThatIllegalArgumentException().isThrownBy(() -> http2ConnectorFactory.checkSupportedCipherSuites())
+            .withMessage("HTTP/2 server configuration must include cipher: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
+    }
+}

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2WithCustomCipherTest.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2WithCustomCipherTest.java
@@ -1,0 +1,54 @@
+package io.dropwizard.http2;
+
+import io.dropwizard.Configuration;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.eclipse.jetty.http2.client.http.HttpClientTransportOverHTTP2;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+
+public class Http2WithCustomCipherTest extends AbstractHttp2Test {
+
+    private static final String PREFIX = "tls_custom_http2";
+
+    @Rule
+    public final DropwizardAppRule<Configuration> appRule = new DropwizardAppRule<>(
+        FakeApplication.class, resourceFilePath("test-http2-with-custom-cipher.yml"),
+        Optional.of(PREFIX),
+        config(PREFIX, "server.connector.keyStorePath", resourceFilePath("stores/http2_server.jks")),
+        config(PREFIX, "server.connector.trustStorePath", resourceFilePath("stores/http2_client.jts"))
+    );
+
+    private final SslContextFactory sslContextFactory = new SslContextFactory();
+    private HttpClient client;
+
+    @Before
+    public void setUp() throws Exception {
+        sslContextFactory.setTrustStorePath(resourceFilePath("stores/http2_client.jts"));
+        sslContextFactory.setTrustStorePassword("http2_client");
+        sslContextFactory.start();
+
+        client = new HttpClient(new HttpClientTransportOverHTTP2(new HTTP2Client()), sslContextFactory);
+        client.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        client.stop();
+    }
+
+    @Test
+    public void testHttp2WithCustomCipher() throws Exception {
+        assertResponse(client.GET("https://localhost:" + appRule.getLocalPort() + "/api/test"));
+    }
+
+}

--- a/dropwizard-http2/src/test/resources/test-http2-with-custom-cipher.yml
+++ b/dropwizard-http2/src/test/resources/test-http2-with-custom-cipher.yml
@@ -1,0 +1,12 @@
+server:
+  type: simple
+  connector:
+    type: h2
+    port: 0
+    keyStorePassword: http2_server
+    validateCerts: false
+    supportedCipherSuites:
+      - 'TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384'
+      - 'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256'
+  applicationContextPath: /api
+  adminContextPath: /admin


### PR DESCRIPTION
There are many SSL ciphers which are supported by HTTP/2 clients (see https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility) and the user should have the ability to use them in Dropwizard
applications. Currently it's not possible because Dropwizard forces the default cipher `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256` defined in the HTTP2 spec.

This change allows users to provide a custom list of supported ciphers, so clients who support more strong ciphers, can use them. The provided list of ciphers MUST contain the `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256` cipher as defined in the HTTP2 spec.

Redux of #1978.