### PR TITLE
Allow commands to customize exception handling

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/cli/CheckCommand.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/CheckCommand.java
@@ -37,4 +37,10 @@ public class CheckCommand<T extends Configuration> extends ConfiguredCommand<T> 
                        T configuration) throws Exception {
         LOGGER.info("Configuration is OK");
     }
+
+    /* The stacktrace is redundant as the message contains the yaml error location */
+    @Override
+    public void onError(Cli cli, Namespace namespace, Throwable e) {
+        cli.getStdErr().println(e.getMessage());
+    }
 }

--- a/dropwizard-core/src/main/java/io/dropwizard/cli/Command.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/Command.java
@@ -55,4 +55,17 @@ public abstract class Command {
      * @throws Exception if something goes wrong
      */
     public abstract void run(Bootstrap<?> bootstrap, Namespace namespace) throws Exception;
+
+    /**
+     * Method is called if there is an issue parsing configuration, setting up the
+     * environment, or running the command itself. The default is printing the stacktrace
+     * to facilitate debugging, but can be customized per command.
+     *
+     * @param cli contains the streams for stdout and stderr
+     * @param namespace the parsed arguments from the commandline
+     * @param e The exception that was thrown when setting up or running the command
+     */
+    public void onError(Cli cli, Namespace namespace, Throwable e) {
+        e.printStackTrace(cli.getStdErr());
+    }
 }

--- a/dropwizard-core/src/test/java/io/dropwizard/cli/CliTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/cli/CliTest.java
@@ -5,7 +5,9 @@ import io.dropwizard.Configuration;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.util.JarLocation;
+import net.sourceforge.argparse4j.impl.Arguments;
 import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparser;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -49,6 +51,37 @@ public class CliTest {
         public void printStackTrace(PrintWriter writer) {
             writer.println(BAD_APP_EXCEPTION_STACK_TRACE);
         }
+
+        @Override
+        public String getMessage() {
+            return "I'm a bad exception";
+        }
+    }
+
+    public static final class CustomCommand extends Command {
+        protected CustomCommand() {
+            super("custom", "I'm custom");
+        }
+
+        @Override
+        public void configure(Subparser subparser) {
+            subparser.addArgument("--debug")
+                .action(Arguments.storeTrue());
+        }
+
+        @Override
+        public void run(Bootstrap<?> bootstrap, Namespace namespace) throws Exception {
+            throw new RuntimeException("I did not expect this!");
+        }
+
+        @Override
+        public void onError(Cli cli, Namespace namespace, Throwable e) {
+            if (namespace.getBoolean("debug")) {
+                super.onError(cli, namespace, e);
+            } else {
+                cli.getStdOut().println(e.getMessage());
+            }
+        }
     }
 
     private final Bootstrap<Configuration> bootstrap = new Bootstrap<>(app);
@@ -74,6 +107,7 @@ public class CliTest {
         when(location.toString()).thenReturn("dw-thing.jar");
         when(location.getVersion()).thenReturn(Optional.of("1.0.0"));
         bootstrap.addCommand(command);
+        bootstrap.addCommand(new CustomCommand());
 
         doNothing().when(command).run(any(Bootstrap.class), any(Namespace.class), any(Configuration.class));
 
@@ -126,10 +160,10 @@ public class CliTest {
 
         assertThat(stdOut.toString())
                 .isEqualTo(String.format(
-                        "usage: java -jar dw-thing.jar [-h] [-v] {check} ...%n" +
+                        "usage: java -jar dw-thing.jar [-h] [-v] {check,custom} ...%n" +
                                 "%n" +
                                 "positional arguments:%n" +
-                                "  {check}                available commands%n" +
+                                "  {check,custom}         available commands%n" +
                                 "%n" +
                                 "optional arguments:%n" +
                                 "  -h, --help             show this help message and exit%n" +
@@ -147,10 +181,10 @@ public class CliTest {
 
         assertThat(stdOut.toString())
                 .isEqualTo(String.format(
-                        "usage: java -jar dw-thing.jar [-h] [-v] {check} ...%n" +
+                        "usage: java -jar dw-thing.jar [-h] [-v] {check,custom} ...%n" +
                                 "%n" +
                                 "positional arguments:%n" +
-                                "  {check}                available commands%n" +
+                                "  {check,custom}         available commands%n" +
                                 "%n" +
                                 "optional arguments:%n" +
                                 "  -h, --help             show this help message and exit%n" +
@@ -168,10 +202,10 @@ public class CliTest {
 
         assertThat(stdOut.toString())
                 .isEqualTo(String.format(
-                        "usage: java -jar dw-thing.jar [-h] [-v] {check} ...%n" +
+                        "usage: java -jar dw-thing.jar [-h] [-v] {check,custom} ...%n" +
                                 "%n" +
                                 "positional arguments:%n" +
-                                "  {check}                available commands%n" +
+                                "  {check,custom}         available commands%n" +
                                 "%n" +
                                 "optional arguments:%n" +
                                 "  -h, --help             show this help message and exit%n" +
@@ -243,10 +277,10 @@ public class CliTest {
         assertThat(stdErr.toString())
                 .isEqualTo(String.format(
                         "unrecognized arguments: '--yes'%n" +
-                                "usage: java -jar dw-thing.jar [-h] [-v] {check} ...%n" +
+                                "usage: java -jar dw-thing.jar [-h] [-v] {check,custom} ...%n" +
                                 "%n" +
                                 "positional arguments:%n" +
-                                "  {check}                available commands%n" +
+                                "  {check,custom}         available commands%n" +
                                 "%n" +
                                 "optional arguments:%n" +
                                 "  -h, --help             show this help message and exit%n" +
@@ -287,11 +321,11 @@ public class CliTest {
 
         assertThat(stdErr.toString())
                 .isEqualTo(String.format(
-                        "invalid choice: 'plop' (choose from 'check')%n" +
-                                "usage: java -jar dw-thing.jar [-h] [-v] {check} ...%n" +
+                        "invalid choice: 'plop' (choose from 'check', 'custom')%n" +
+                                "usage: java -jar dw-thing.jar [-h] [-v] {check,custom} ...%n" +
                                 "%n" +
                                 "positional arguments:%n" +
-                                "  {check}                available commands%n" +
+                                "  {check,custom}         available commands%n" +
                                 "%n" +
                                 "optional arguments:%n" +
                                 "  -h, --help             show this help message and exit%n" +
@@ -315,7 +349,7 @@ public class CliTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void unhandledExceptionsAreLoggedAppropriately() throws Exception {
+    public void unhandledExceptionsMessagesArePrintedForCheck() throws Exception {
         doThrow(new BadAppException()).when(command).run(any(Bootstrap.class), any(Namespace.class), any(Configuration.class));
 
         assertThat(cli.run("check"))
@@ -325,6 +359,37 @@ public class CliTest {
                 .isEmpty();
 
         assertThat(stdErr.toString())
-                .isEqualTo(String.format("%s%n", BadAppException.BAD_APP_EXCEPTION_STACK_TRACE));
+                .isEqualTo(String.format("I'm a bad exception%n"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void unhandledExceptionsCustomCommand() throws Exception {
+        doThrow(new BadAppException()).when(command).run(any(Bootstrap.class), any(Namespace.class), any(Configuration.class));
+
+        assertThat(cli.run("custom"))
+            .isFalse();
+
+        assertThat(stdOut.toString())
+            .isEqualTo(String.format("I did not expect this!%n"));
+
+        assertThat(stdErr.toString())
+            .isEmpty();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void unhandledExceptionsCustomCommandDebug() throws Exception {
+        doThrow(new BadAppException()).when(command).run(any(Bootstrap.class), any(Namespace.class), any(Configuration.class));
+
+        assertThat(cli.run("custom", "--debug"))
+            .isFalse();
+
+        assertThat(stdOut.toString())
+            .isEmpty();
+
+        assertThat(stdErr.toString())
+            .startsWith(String.format("java.lang.RuntimeException: I did not expect this!%n" +
+                "\tat io.dropwizard.cli.CliTest$CustomCommand.run(CliTest.java"));
     }
 }


### PR DESCRIPTION
Fix for #2122

Allows for commands to catch configuration, environment, and command exceptions in one place (eg. forcing all commands to print the stack trace is less than desirable)

Below is an example of a custom command that will print the stack trace to stderr if someone passed in `--debug`, else print the error message to stdout.

```java
public static final class CustomCommand extends Command {
    @Override
    public void configure(Subparser subparser) {
        subparser.addArgument("--debug").action(Arguments.storeTrue());
    }

    @Override
    public void run(Bootstrap<?> bootstrap, Namespace namespace) throws Exception {
        throw new RuntimeException("I did not expect this!");
    }

    @Override
    public void onError(Cli cli, Namespace namespace, Throwable e) {
        if (namespace.getBoolean("debug")) {
            super.onError(cli, namespace, e);
        } else {
            cli.getStdOut().println(e.getMessage());
        }
    }
}
```

Reviews, suggestions welcomed. Some things to think about:

- I am unsure whether to keep `Cli` argument in `onError` or replace it with `stdOut` and `stdErr` directly from `Cli`
- Should configured commands get another argument for onError, except it has configuration (if parsed correctly?). Same thing with environment commands.
- I decided to not allow customization of HelpScreenException logging

EDIT: I should clarify, this `onError` gets called before `onFatalError` so `onError` doesn't need to do `System.exit(1)`