### PR TITLE
docs: Fix broken link in user manual to Hibernate grouped constraints docs

### DIFF
--- a/docs/source/manual/validation.rst
+++ b/docs/source/manual/validation.rst
@@ -368,7 +368,7 @@ The ``@Validated`` annotation allows for `validation groups`_ to be specifically
 default group. This is useful when different endpoints share the same entity but may have different
 validation requirements.
 
-.. _validation groups: https://docs.jboss.org/hibernate/validator/5.2/reference/en-US/html/chapter-groups.html
+.. _validation groups: https://docs.jboss.org/hibernate/stable/validator/reference/en-US/html_single/?v=6.0#chapter-groups
 
 Going back to our favorite ``Person`` class. Let's say in the initial version of our API, ``name``
 has to be non-empty, but realized that business requirements changed and a name can't be longer than


### PR DESCRIPTION
I noticed today that a link in the user manual to a section of Hibernate Validator's user manual is broken. This change updates the link to point to the appropriate section of Hibernate's stable docs.

Not sure if we care about pinning the user manual to a specific version of the docs. The only past version of their docs that I can find online is [5.1](https://docs.jboss.org/hibernate/validator/5.1/reference/en-US/html/chapter-groups.html#chapter-groups), which is a few minor versions behind where Dropwizard is, at 5.4.