### PR TITLE
Start the console appender after a logging reset

### DIFF
--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/DefaultLoggingFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/DefaultLoggingFactory.java
@@ -9,6 +9,7 @@ import ch.qos.logback.classic.jul.LevelChangePropagator;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.ConsoleAppender;
+import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
 import ch.qos.logback.core.util.StatusPrinter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.logback.InstrumentedAppender;
@@ -44,6 +45,7 @@ import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static java.util.Objects.requireNonNull;
@@ -203,8 +205,14 @@ public class DefaultLoggingFactory implements LoggingFactory {
             loggerContext.stop();
             final Logger logger = loggerContext.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
             logger.detachAndStopAllAppenders();
+            final DropwizardLayout formatter = new DropwizardLayout(loggerContext, TimeZone.getDefault());
+            formatter.start();
+            final LayoutWrappingEncoder<ILoggingEvent> layoutEncoder = new LayoutWrappingEncoder<>();
+            layoutEncoder.setLayout(formatter);
             final ConsoleAppender<ILoggingEvent> consoleAppender = new ConsoleAppender<>();
+            consoleAppender.setEncoder(layoutEncoder);
             consoleAppender.setContext(loggerContext);
+            consoleAppender.start();
             logger.addAppender(consoleAppender);
             loggerContext.start();
         } finally {

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/DefaultLoggingFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/DefaultLoggingFactory.java
@@ -210,6 +210,7 @@ public class DefaultLoggingFactory implements LoggingFactory {
             final LayoutWrappingEncoder<ILoggingEvent> layoutEncoder = new LayoutWrappingEncoder<>();
             layoutEncoder.setLayout(formatter);
             final ConsoleAppender<ILoggingEvent> consoleAppender = new ConsoleAppender<>();
+            consoleAppender.addFilter(new ThresholdLevelFilterFactory().build(Level.INFO));
             consoleAppender.setEncoder(layoutEncoder);
             consoleAppender.setContext(loggerContext);
             consoleAppender.start();


### PR DESCRIPTION
When resetting logging, configure a layout and start the appender. Otherwise, using the appender logs a warning to the Logback StatusManager:

> WARN in ch.qos.logback.core.ConsoleAppender[null] - Attempted to append to non started appender [null].

Uses the same layout as bootstrap.

This is related to #1973.