### PR TITLE
SelfValidation annotation as an alternative to ValidationMethod

### DIFF
--- a/dropwizard-benchmarks/pom.xml
+++ b/dropwizard-benchmarks/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <!-- see https://issues.apache.org/jira/browse/MCOMPILER-235 -->
         <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
-        <jmh.version>1.15</jmh.version>
+        <jmh.version>1.19</jmh.version>
         <!-- Skip deployment of this sub-module -->
         <maven.source.skip>true</maven.source.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>

--- a/dropwizard-benchmarks/src/main/java/io/dropwizard/benchmarks/jersey/SelfValidatingBenchmark.java
+++ b/dropwizard-benchmarks/src/main/java/io/dropwizard/benchmarks/jersey/SelfValidatingBenchmark.java
@@ -1,0 +1,112 @@
+package io.dropwizard.benchmarks.jersey;
+
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.concurrent.TimeUnit;
+
+import javax.validation.Validator;
+
+import org.glassfish.jersey.server.model.Invocable;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import io.dropwizard.jersey.validation.Validators;
+import io.dropwizard.logging.BootstrapLogging;
+import io.dropwizard.validation.ValidationMethod;
+import io.dropwizard.validation.selfvalidating.SelfValidating;
+import io.dropwizard.validation.selfvalidating.SelfValidation;
+import io.dropwizard.validation.selfvalidating.ViolationCollector;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class SelfValidatingBenchmark {
+
+    static {
+        BootstrapLogging.bootstrap();
+    }
+
+    public static class ValidationMethodUser {
+        @ValidationMethod
+        public boolean isValid1(String param1) {
+            return true;
+        }
+
+        @ValidationMethod
+        public boolean isValid2(String param1, int param2) {
+            return true;
+        }
+        
+        @ValidationMethod(message="invalid1")
+        public boolean isInvalid1(String param1) {
+            return false;
+        }
+        
+        @ValidationMethod(message="invalid2")
+        public boolean isInvalid2(String param1, int param2) {
+            return false;
+        }
+    }
+
+    @SelfValidating
+    public static class SelfValidatingMethodUser {
+        @SelfValidation
+        public void validateValid1(ViolationCollector collector) {
+        }
+
+        @SelfValidation
+        public void validateValid2(ViolationCollector collector) {
+        }
+        
+        @SelfValidation
+        public void validateInvalid1(ViolationCollector collector) {
+            collector.addViolation("invalid1");
+        }
+        
+        @SelfValidation
+        public void validateInvalid2(ViolationCollector collector) {
+            collector.addViolation("invalid2");
+        }
+    }
+
+    private ValidationMethodUser validationMethodUser;
+    private SelfValidatingMethodUser selfValidatingMethodUser;
+    private Validator validator;
+
+    final Invocable invocable = Invocable.create(request -> null);
+
+    @Setup
+    public void prepare() {
+        validator = Validators.newValidator();
+        validationMethodUser = new ValidationMethodUser();
+        selfValidatingMethodUser = new SelfValidatingMethodUser();
+    }
+
+    @Benchmark
+    public void validationMethod() {
+        validator.validate(validationMethodUser);
+    }
+
+    @Benchmark
+    public void selfValidating() {
+        validator.validate(selfValidatingMethodUser);
+    }
+
+    public static void main(String[] args) throws Exception {  
+        new Runner(new OptionsBuilder()
+                .include(SelfValidatingBenchmark.class.getSimpleName())
+                .forks(1)
+                .warmupIterations(5)
+                .measurementIterations(8)
+                .build())
+                .run();
+    }
+}

--- a/dropwizard-validation/pom.xml
+++ b/dropwizard-validation/pom.xml
@@ -41,5 +41,20 @@
             <artifactId>commons-lang3</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+        	<groupId>org.javassist</groupId>
+        	<artifactId>javassist</artifactId>
+        	
+        </dependency>
+        <dependency>
+        	<groupId>org.slf4j</groupId>
+        	<artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+        	<groupId>org.slf4j</groupId>
+        	<artifactId>slf4j-simple</artifactId>
+        	<version>1.7.25</version>
+        	<scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/SelfValidating.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/SelfValidating.java
@@ -20,8 +20,8 @@ import javax.validation.Payload;
 @Constraint(validatedBy =  SelfValidatingValidator.class)
 public @interface SelfValidating {
 
-	String message() default "";
-	
+    String message() default "";
+    
     Class<?>[] groups() default { };
 
     Class<? extends Payload>[] payload() default { };

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/SelfValidating.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/SelfValidating.java
@@ -1,0 +1,28 @@
+package io.dropwizard.validation.selfvalidating;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+/**
+ * The annotated element has methods annotated by 
+ * {@link io.dropwizard.validation.selfvalidating.SelfValidation}.
+ * Those methods are executed on validation.
+ */
+@Documented
+@Target({ ElementType.TYPE, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy =  SelfValidatingValidator.class)
+public @interface SelfValidating {
+
+	String message() default "";
+	
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default { };
+}

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/SelfValidatingValidator.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/SelfValidatingValidator.java
@@ -25,89 +25,89 @@ import javassist.NotFoundException;
  */
 public class SelfValidatingValidator implements ConstraintValidator<SelfValidating, Object>{
 
-	private static final Logger LOG = LoggerFactory.getLogger(SelfValidatingValidator.class);
-	private static final AtomicInteger COUNTER = new AtomicInteger();
-	
-	private HashMap<Class<?>, List<ValidationCaller<?>>> methodMap = new HashMap<>();
-	
-	@Override
-	public void initialize(SelfValidating constraintAnnotation) {}
+    private static final Logger LOG = LoggerFactory.getLogger(SelfValidatingValidator.class);
+    private static final AtomicInteger COUNTER = new AtomicInteger();
+    
+    private HashMap<Class<?>, List<ValidationCaller<?>>> methodMap = new HashMap<>();
+    
+    @Override
+    public void initialize(SelfValidating constraintAnnotation) {}
 
-	@SuppressWarnings({ "rawtypes", "unchecked" })
-	@Override
-	public boolean isValid(Object value, ConstraintValidatorContext context) {
-		List<ValidationCaller<?>> callers = findMethods(value.getClass());
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Override
+    public boolean isValid(Object value, ConstraintValidatorContext context) {
+        List<ValidationCaller<?>> callers = findMethods(value.getClass());
 
-		ViolationCollector collector = new ViolationCollector(context);
-		context.disableDefaultConstraintViolation();
-		for(ValidationCaller caller:callers) {
-			caller.setValidationObject(value);
-			caller.call(collector);
-		}
-		return !collector.hasViolationOccurred();
-	}
+        ViolationCollector collector = new ViolationCollector(context);
+        context.disableDefaultConstraintViolation();
+        for(ValidationCaller caller:callers) {
+            caller.setValidationObject(value);
+            caller.call(collector);
+        }
+        return !collector.hasViolationOccurred();
+    }
 
-	/**
-	 * This method generates and caches <code>ValidationCaller</code>s for each method annotated 
-	 * with <code>@SelfValidation</code> that adheres to required signature.
-	 * @param annotated
-	 * @return
-	 */
-	private synchronized List<ValidationCaller<?>> findMethods(Class<? extends Object> annotated) {
-		if(methodMap.containsKey(annotated))
-			return methodMap.get(annotated);
-	
-		synchronized (methodMap) {
-			if(methodMap.containsKey(annotated))
-				return methodMap.get(annotated);
-			
-			List<ValidationCaller<?>> l = new ArrayList<>();
-			
-			ClassPool cp;
-			CtClass callerSuperclass;
-			CtClass[] callingParameters;
-			try {
-				cp = ClassPool.getDefault();
-				callerSuperclass = cp.get(ValidationCaller.class.getName());
-				callingParameters = new CtClass[] {cp.get(ViolationCollector.class.getName())};
-			} catch(NotFoundException e) {
-				throw new IllegalStateException("Failed to load included class", e);
-			}
-				
-			for(Method m:annotated.getMethods()) {
-	    		if(m.isAnnotationPresent(SelfValidation.class)) {
-	    			if(!void.class.equals(m.getReturnType()))
-	    				LOG.error("The method {} is annotated with SelfValidation but does not return void. It is ignored.", m);
-	    			else if(m.getParameterTypes().length!=1 || !m.getParameterTypes()[0].equals(ViolationCollector.class))
-	    				LOG.error("The method {} is annotated with SelfValidation but does not have a single parameter of type {}", m, ViolationCollector.class);
-	    			else if((m.getModifiers() & Modifier.PUBLIC) == 0)
-	    				LOG.error("The method {} is annotated with SelfValidation but is not public", m);
-	    			else {
-	    				try {
-			    			CtClass cc = cp.makeClass("ValidationCallerGeneratedImpl"+COUNTER.getAndIncrement());
-			    			cc.setSuperclass(callerSuperclass);
-			 
-			    			CtMethod method = new CtMethod(CtClass.voidType, "call", callingParameters, cc);
-			    			cc.addMethod(method);
-			    			method.setBody("{ return (("+annotated.getName()+")getValidationObject())."+m.getName()+"($1); }");
-			    			
-			    			cc.setModifiers(Modifier.PUBLIC);
-			    			ValidationCaller<?> caller = (ValidationCaller<?>)cc.toClass().newInstance();
-			    			l.add(caller);
-	    				} catch(Exception e) {
-	    					LOG.error("Failed to generate ValidationCaller for method "+m.toString(), e);
-	    				}
-	    			}
-	    		}
-	    	}
-			if(l.isEmpty())
-				LOG.error("The class {} is annotated with SelfValidating but contains no valid methods that are annotated with SelfValidation", annotated);
-				
-			methodMap.put(annotated, l);
-			return l;
-		}
-		
-		
-	}
+    /**
+     * This method generates and caches <code>ValidationCaller</code>s for each method annotated 
+     * with <code>@SelfValidation</code> that adheres to required signature.
+     * @param annotated
+     * @return
+     */
+    private synchronized List<ValidationCaller<?>> findMethods(Class<? extends Object> annotated) {
+        if(methodMap.containsKey(annotated))
+            return methodMap.get(annotated);
+    
+        synchronized (methodMap) {
+            if(methodMap.containsKey(annotated))
+                return methodMap.get(annotated);
+            
+            List<ValidationCaller<?>> l = new ArrayList<>();
+            
+            ClassPool cp;
+            CtClass callerSuperclass;
+            CtClass[] callingParameters;
+            try {
+                cp = ClassPool.getDefault();
+                callerSuperclass = cp.get(ValidationCaller.class.getName());
+                callingParameters = new CtClass[] {cp.get(ViolationCollector.class.getName())};
+            } catch(NotFoundException e) {
+                throw new IllegalStateException("Failed to load included class", e);
+            }
+                
+            for(Method m:annotated.getMethods()) {
+                if(m.isAnnotationPresent(SelfValidation.class)) {
+                    if(!void.class.equals(m.getReturnType()))
+                        LOG.error("The method {} is annotated with SelfValidation but does not return void. It is ignored.", m);
+                    else if(m.getParameterTypes().length!=1 || !m.getParameterTypes()[0].equals(ViolationCollector.class))
+                        LOG.error("The method {} is annotated with SelfValidation but does not have a single parameter of type {}", m, ViolationCollector.class);
+                    else if((m.getModifiers() & Modifier.PUBLIC) == 0)
+                        LOG.error("The method {} is annotated with SelfValidation but is not public", m);
+                    else {
+                        try {
+                            CtClass cc = cp.makeClass("ValidationCallerGeneratedImpl"+COUNTER.getAndIncrement());
+                            cc.setSuperclass(callerSuperclass);
+             
+                            CtMethod method = new CtMethod(CtClass.voidType, "call", callingParameters, cc);
+                            cc.addMethod(method);
+                            method.setBody("{ return (("+annotated.getName()+")getValidationObject())."+m.getName()+"($1); }");
+                            
+                            cc.setModifiers(Modifier.PUBLIC);
+                            ValidationCaller<?> caller = (ValidationCaller<?>)cc.toClass().newInstance();
+                            l.add(caller);
+                        } catch(Exception e) {
+                            LOG.error("Failed to generate ValidationCaller for method "+m.toString(), e);
+                        }
+                    }
+                }
+            }
+            if(l.isEmpty())
+                LOG.error("The class {} is annotated with SelfValidating but contains no valid methods that are annotated with SelfValidation", annotated);
+                
+            methodMap.put(annotated, l);
+            return l;
+        }
+        
+        
+    }
 
 }

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/SelfValidatingValidator.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/SelfValidatingValidator.java
@@ -28,7 +28,7 @@ public class SelfValidatingValidator implements ConstraintValidator<SelfValidati
     private static final Logger LOG = LoggerFactory.getLogger(SelfValidatingValidator.class);
     private static final AtomicInteger COUNTER = new AtomicInteger();
     
-    private HashMap<Class<?>, List<ValidationCaller<?>>> methodMap = new HashMap<>();
+    private final HashMap<Class<?>, List<ValidationCaller<?>>> methodMap = new HashMap<>();
     
     @Override
     public void initialize(SelfValidating constraintAnnotation) {}
@@ -92,7 +92,8 @@ public class SelfValidatingValidator implements ConstraintValidator<SelfValidati
                             method.setBody("{ return ((" + annotated.getName() + ")getValidationObject())." + m.getName() + "($1); }");
                             
                             cc.setModifiers(Modifier.PUBLIC);
-                            ValidationCaller<?> caller = (ValidationCaller<?>) cc.toClass().newInstance();
+                            @SuppressWarnings("unchecked")
+                            ValidationCaller<?> caller = (ValidationCaller<?>) cc.toClass().getConstructor().newInstance();
                             l.add(caller);
                         } catch (Exception e) {
                             LOG.error("Failed to generate ValidationCaller for method " + m.toString(), e);

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/SelfValidatingValidator.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/SelfValidatingValidator.java
@@ -1,0 +1,113 @@
+package io.dropwizard.validation.selfvalidating;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javassist.ClassPool;
+import javassist.CtClass;
+import javassist.CtMethod;
+import javassist.NotFoundException;
+
+/**
+ * This class is the base validator for the <code>@SelfValidating</code> annotation. It
+ * initiates the self validation process on an object, generating wrapping methods to call
+ * the validation methods efficiently and then calls them.
+ */
+public class SelfValidatingValidator implements ConstraintValidator<SelfValidating, Object>{
+
+	private static final Logger LOG = LoggerFactory.getLogger(SelfValidatingValidator.class);
+	private static final AtomicInteger COUNTER = new AtomicInteger();
+	
+	private HashMap<Class<?>, List<ValidationCaller<?>>> methodMap = new HashMap<>();
+	
+	@Override
+	public void initialize(SelfValidating constraintAnnotation) {}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Override
+	public boolean isValid(Object value, ConstraintValidatorContext context) {
+		List<ValidationCaller<?>> callers = findMethods(value.getClass());
+
+		ViolationCollector collector = new ViolationCollector(context);
+		context.disableDefaultConstraintViolation();
+		for(ValidationCaller caller:callers) {
+			caller.setValidationObject(value);
+			caller.call(collector);
+		}
+		return !collector.hasViolationOccurred();
+	}
+
+	/**
+	 * This method generates and caches <code>ValidationCaller</code>s for each method annotated 
+	 * with <code>@SelfValidation</code> that adheres to required signature.
+	 * @param annotated
+	 * @return
+	 */
+	private synchronized List<ValidationCaller<?>> findMethods(Class<? extends Object> annotated) {
+		if(methodMap.containsKey(annotated))
+			return methodMap.get(annotated);
+	
+		synchronized (methodMap) {
+			if(methodMap.containsKey(annotated))
+				return methodMap.get(annotated);
+			
+			List<ValidationCaller<?>> l = new ArrayList<>();
+			
+			ClassPool cp;
+			CtClass callerSuperclass;
+			CtClass[] callingParameters;
+			try {
+				cp = ClassPool.getDefault();
+				callerSuperclass = cp.get(ValidationCaller.class.getName());
+				callingParameters = new CtClass[] {cp.get(ViolationCollector.class.getName())};
+			} catch(NotFoundException e) {
+				throw new IllegalStateException("Failed to load included class", e);
+			}
+				
+			for(Method m:annotated.getMethods()) {
+	    		if(m.isAnnotationPresent(SelfValidation.class)) {
+	    			if(!void.class.equals(m.getReturnType()))
+	    				LOG.error("The method {} is annotated with SelfValidation but does not return void. It is ignored.", m);
+	    			else if(m.getParameterTypes().length!=1 || !m.getParameterTypes()[0].equals(ViolationCollector.class))
+	    				LOG.error("The method {} is annotated with SelfValidation but does not have a single parameter of type {}", m, ViolationCollector.class);
+	    			else if((m.getModifiers() & Modifier.PUBLIC) == 0)
+	    				LOG.error("The method {} is annotated with SelfValidation but is not public", m);
+	    			else {
+	    				try {
+			    			CtClass cc = cp.makeClass("ValidationCallerGeneratedImpl"+COUNTER.getAndIncrement());
+			    			cc.setSuperclass(callerSuperclass);
+			 
+			    			CtMethod method = new CtMethod(CtClass.voidType, "call", callingParameters, cc);
+			    			cc.addMethod(method);
+			    			method.setBody("{ return (("+annotated.getName()+")getValidationObject())."+m.getName()+"($1); }");
+			    			
+			    			cc.setModifiers(Modifier.PUBLIC);
+			    			ValidationCaller<?> caller = (ValidationCaller<?>)cc.toClass().newInstance();
+			    			l.add(caller);
+	    				} catch(Exception e) {
+	    					LOG.error("Failed to generate ValidationCaller for method "+m.toString(), e);
+	    				}
+	    			}
+	    		}
+	    	}
+			if(l.isEmpty())
+				LOG.error("The class {} is annotated with SelfValidating but contains no valid methods that are annotated with SelfValidation", annotated);
+				
+			methodMap.put(annotated, l);
+			return l;
+		}
+		
+		
+	}
+
+}

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/SelfValidatingValidator.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/SelfValidatingValidator.java
@@ -78,9 +78,9 @@ public class SelfValidatingValidator implements ConstraintValidator<SelfValidati
                 if (m.isAnnotationPresent(SelfValidation.class)) {
                     if (!void.class.equals(m.getReturnType()))
                         LOG.error("The method {} is annotated with SelfValidation but does not return void. It is ignored.", m);
-                    else if(m.getParameterTypes().length != 1 || !m.getParameterTypes()[0].equals(ViolationCollector.class))
+                    else if (m.getParameterTypes().length != 1 || !m.getParameterTypes()[0].equals(ViolationCollector.class))
                         LOG.error("The method {} is annotated with SelfValidation but does not have a single parameter of type {}", m, ViolationCollector.class);
-                    else if((m.getModifiers() & Modifier.PUBLIC) == 0)
+                    else if ((m.getModifiers() & Modifier.PUBLIC) == 0)
                         LOG.error("The method {} is annotated with SelfValidation but is not public", m);
                     else {
                         try {

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/SelfValidation.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/SelfValidation.java
@@ -15,4 +15,4 @@ import java.lang.annotation.Target;
 @Documented
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface SelfValidation {}
+public @interface SelfValidation { }

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/SelfValidation.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/SelfValidation.java
@@ -1,0 +1,18 @@
+package io.dropwizard.validation.selfvalidating;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This method, if used in conjunction with 
+ * {@link io.dropwizard.validation.selfvalidating.SelfValidating},
+ * will be executed to check if the object itself is valid.
+ * For that it requires the signature <code>public void methodName(ViolationCollector)</code>.
+ */
+@Documented
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SelfValidation {}

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/ValidationCaller.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/ValidationCaller.java
@@ -6,16 +6,16 @@ package io.dropwizard.validation.selfvalidating;
  * @param <T> the object type that contains the validation method
  */
 public abstract class ValidationCaller<T> {
-	
-	protected T validationObject;
-	
-	public void setValidationObject(T obj) {
-		this.validationObject = obj;
-	}
-	
-	public T getValidationObject() {
-		return validationObject;
-	}
+    
+    protected T validationObject;
+    
+    public void setValidationObject(T obj) {
+        this.validationObject = obj;
+    }
+    
+    public T getValidationObject() {
+        return validationObject;
+    }
 
-	public abstract void call(ViolationCollector vc);
+    public abstract void call(ViolationCollector vc);
 }

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/ValidationCaller.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/ValidationCaller.java
@@ -1,0 +1,21 @@
+package io.dropwizard.validation.selfvalidating;
+
+/**
+ * This class represents a wrapper for calling validation methods annotated with <code>@SelfValidation</code>.
+ * It is used as a base class for the code generation.
+ * @param <T> the object type that contains the validation method
+ */
+public abstract class ValidationCaller<T> {
+	
+	protected T validationObject;
+	
+	public void setValidationObject(T obj) {
+		this.validationObject = obj;
+	}
+	
+	public T getValidationObject() {
+		return validationObject;
+	}
+
+	public abstract void call(ViolationCollector vc);
+}

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/ViolationCollector.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/ViolationCollector.java
@@ -1,0 +1,54 @@
+package io.dropwizard.validation.selfvalidating;
+
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * This class is a simple wrapper around the ConstraintValidatorContext of hibernate validation.
+ * It collects all the violations of the SelfValidation methods of an object.
+ */
+public class ViolationCollector {
+	
+	private boolean violationOccurred = false;
+	private ConstraintValidatorContext context;
+	
+	
+	public ViolationCollector(ConstraintValidatorContext context) {
+		this.context = context;
+	}
+	
+	/**
+	 * Adds a new violation to this collector. This also sets violationOccurred to true.
+	 * @param msg the message of the violation
+	 */
+	public void addViolation(String msg) {
+		violationOccurred = true;
+		context
+			.buildConstraintViolationWithTemplate(msg)
+			.addConstraintViolation();
+	}
+	
+	/**
+	 * This method returns the wrapped context for raw access to the validation framework. If you use 
+	 * the context to add violations make sure to call <code>setViolationOccurred(true)</code>.
+	 * @return the wrapped Hibernate ConstraintValidatorContext
+	 */
+	public ConstraintValidatorContext getContext() {
+		return context;
+	}
+	
+	/**
+	 * @return if any violation was collected
+	 */
+	public boolean hasViolationOccurred() {
+		return violationOccurred;
+	}
+	
+	/**
+	 * Manually sets if a violation occurred. This is automatically set if <code>addViolation</code> is called.
+	 * @param violationOccurred if any violation was collected
+	 */
+	public void setViolationOccurred(boolean violationOccurred) {
+		this.violationOccurred = violationOccurred;
+	}
+
+}

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/ViolationCollector.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/ViolationCollector.java
@@ -7,48 +7,48 @@ import javax.validation.ConstraintValidatorContext;
  * It collects all the violations of the SelfValidation methods of an object.
  */
 public class ViolationCollector {
-	
-	private boolean violationOccurred = false;
-	private ConstraintValidatorContext context;
-	
-	
-	public ViolationCollector(ConstraintValidatorContext context) {
-		this.context = context;
-	}
-	
-	/**
-	 * Adds a new violation to this collector. This also sets violationOccurred to true.
-	 * @param msg the message of the violation
-	 */
-	public void addViolation(String msg) {
-		violationOccurred = true;
-		context
-			.buildConstraintViolationWithTemplate(msg)
-			.addConstraintViolation();
-	}
-	
-	/**
-	 * This method returns the wrapped context for raw access to the validation framework. If you use 
-	 * the context to add violations make sure to call <code>setViolationOccurred(true)</code>.
-	 * @return the wrapped Hibernate ConstraintValidatorContext
-	 */
-	public ConstraintValidatorContext getContext() {
-		return context;
-	}
-	
-	/**
-	 * @return if any violation was collected
-	 */
-	public boolean hasViolationOccurred() {
-		return violationOccurred;
-	}
-	
-	/**
-	 * Manually sets if a violation occurred. This is automatically set if <code>addViolation</code> is called.
-	 * @param violationOccurred if any violation was collected
-	 */
-	public void setViolationOccurred(boolean violationOccurred) {
-		this.violationOccurred = violationOccurred;
-	}
+    
+    private boolean violationOccurred = false;
+    private ConstraintValidatorContext context;
+    
+    
+    public ViolationCollector(ConstraintValidatorContext context) {
+        this.context = context;
+    }
+    
+    /**
+     * Adds a new violation to this collector. This also sets violationOccurred to true.
+     * @param msg the message of the violation
+     */
+    public void addViolation(String msg) {
+        violationOccurred = true;
+        context
+            .buildConstraintViolationWithTemplate(msg)
+            .addConstraintViolation();
+    }
+    
+    /**
+     * This method returns the wrapped context for raw access to the validation framework. If you use 
+     * the context to add violations make sure to call <code>setViolationOccurred(true)</code>.
+     * @return the wrapped Hibernate ConstraintValidatorContext
+     */
+    public ConstraintValidatorContext getContext() {
+        return context;
+    }
+    
+    /**
+     * @return if any violation was collected
+     */
+    public boolean hasViolationOccurred() {
+        return violationOccurred;
+    }
+    
+    /**
+     * Manually sets if a violation occurred. This is automatically set if <code>addViolation</code> is called.
+     * @param violationOccurred if any violation was collected
+     */
+    public void setViolationOccurred(boolean violationOccurred) {
+        this.violationOccurred = violationOccurred;
+    }
 
 }

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/SelfValidationTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/SelfValidationTest.java
@@ -23,10 +23,43 @@ public class SelfValidationTest {
     }
     
     @SelfValidating
+    public static class DirectContextExample {
+        @SelfValidation
+        public void validateFail(ViolationCollector col) {
+            col.getContext().buildConstraintViolationWithTemplate(FAILED).addConstraintViolation();
+            col.setViolationOccurred(true);
+        }
+    }
+    
+    @SelfValidating
     public static class CorrectExample {
         @SuppressWarnings("unused")
         @SelfValidation
         public void validateCorrect(ViolationCollector col) {}
+    }
+    
+    @SelfValidating
+    public static class InvalidExample {
+    	@SuppressWarnings("unused")
+		@SelfValidation
+        public void validateCorrect(ViolationCollector col) {}
+    	
+    	@SuppressWarnings("unused")
+		@SelfValidation
+        public void validateFailAdditionalParameters(ViolationCollector col, int a) {
+            col.addViolation(FAILED);
+        }
+    	
+    	@SelfValidation
+        public boolean validateFailReturn(ViolationCollector col) {
+            col.addViolation(FAILED);
+            return true;
+        }
+    	
+    	@SelfValidation
+        private void validateFailPrivate(ViolationCollector col) {
+            col.addViolation(FAILED);
+        }
     }
     
     @SelfValidating
@@ -74,6 +107,12 @@ public class SelfValidationTest {
     }
     
     @Test
+    public void testDirectContextUsage() throws Exception {
+        assertThat(ConstraintViolations.format(validator.validate(new DirectContextExample())))
+                .containsOnly(" " + FAILED);
+    }
+    
+    @Test
     public void complexExample() throws Exception {
         assertThat(ConstraintViolations.format(validator.validate(new ComplexExample())))
                 .containsOnly(
@@ -81,5 +120,11 @@ public class SelfValidationTest {
                         " " + FAILED + "2",
                         " " + FAILED + "3"
             );
+    }
+    
+    @Test
+    public void invalidExample() throws Exception {
+        assertThat(ConstraintViolations.format(validator.validate(new InvalidExample())))
+                .isEmpty();
     }
 }

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/SelfValidationTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/SelfValidationTest.java
@@ -1,0 +1,77 @@
+package io.dropwizard.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.validation.Validator;
+
+import org.junit.Test;
+
+import io.dropwizard.validation.selfvalidating.SelfValidating;
+import io.dropwizard.validation.selfvalidating.SelfValidation;
+import io.dropwizard.validation.selfvalidating.ViolationCollector;
+
+public class SelfValidationTest {
+	
+	private static final String FAILED = "failed";
+	
+	@SelfValidating
+    public static class FailingExample {
+		@SelfValidation
+        public void validateFail(ViolationCollector col) {
+			col.addViolation(FAILED);
+        }
+    }
+	
+	@SelfValidating
+    public static class CorrectExample {
+		@SuppressWarnings("unused")
+		@SelfValidation
+        public void validateCorrect(ViolationCollector col) {}
+    }
+	
+	@SelfValidating
+    public static class ComplexExample {
+		@SelfValidation
+        public void validateFail1(ViolationCollector col) {
+			col.addViolation(FAILED+"1");
+        }
+		
+		@SelfValidation
+        public void validateFail2(ViolationCollector col) {
+			col.addViolation(FAILED+"2");
+        }
+		
+		@SelfValidation
+        public void validateFail3(ViolationCollector col) {
+			col.addViolation(FAILED+"3");
+        }
+		
+		@SuppressWarnings("unused")
+		@SelfValidation
+		public void validateCorrect(ViolationCollector col) {}
+    }
+
+    private final Validator validator = BaseValidator.newValidator();
+
+    @Test
+    public void failingExample() throws Exception {
+        assertThat(ConstraintViolations.format(validator.validate(new FailingExample())))
+                .containsOnly(" "+FAILED);
+    }
+    
+    @Test
+    public void correctExample() throws Exception {
+        assertThat(ConstraintViolations.format(validator.validate(new CorrectExample())))
+        		.isEmpty();
+    }
+    
+    @Test
+    public void complexExample() throws Exception {
+        assertThat(ConstraintViolations.format(validator.validate(new ComplexExample())))
+                .containsOnly(
+                		" "+FAILED+"1",
+                		" "+FAILED+"2",
+                		" "+FAILED+"3"
+                );
+    }
+}

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/SelfValidationTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/SelfValidationTest.java
@@ -40,23 +40,23 @@ public class SelfValidationTest {
     
     @SelfValidating
     public static class InvalidExample {
-    	@SuppressWarnings("unused")
-		@SelfValidation
+        @SuppressWarnings("unused")
+        @SelfValidation
         public void validateCorrect(ViolationCollector col) {}
-    	
-    	@SuppressWarnings("unused")
-		@SelfValidation
+        
+        @SuppressWarnings("unused")
+        @SelfValidation
         public void validateFailAdditionalParameters(ViolationCollector col, int a) {
             col.addViolation(FAILED);
         }
-    	
-    	@SelfValidation
+        
+        @SelfValidation
         public boolean validateFailReturn(ViolationCollector col) {
             col.addViolation(FAILED);
             return true;
         }
-    	
-    	@SelfValidation
+        
+        @SelfValidation
         private void validateFailPrivate(ViolationCollector col) {
             col.addViolation(FAILED);
         }

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/SelfValidationTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/SelfValidationTest.java
@@ -11,44 +11,44 @@ import io.dropwizard.validation.selfvalidating.SelfValidation;
 import io.dropwizard.validation.selfvalidating.ViolationCollector;
 
 public class SelfValidationTest {
-	
-	private static final String FAILED = "failed";
-	
-	@SelfValidating
+    
+    private static final String FAILED = "failed";
+    
+    @SelfValidating
     public static class FailingExample {
-		@SelfValidation
+        @SelfValidation
         public void validateFail(ViolationCollector col) {
-			col.addViolation(FAILED);
+            col.addViolation(FAILED);
         }
     }
-	
-	@SelfValidating
+    
+    @SelfValidating
     public static class CorrectExample {
-		@SuppressWarnings("unused")
-		@SelfValidation
+        @SuppressWarnings("unused")
+        @SelfValidation
         public void validateCorrect(ViolationCollector col) {}
     }
-	
-	@SelfValidating
+    
+    @SelfValidating
     public static class ComplexExample {
-		@SelfValidation
+        @SelfValidation
         public void validateFail1(ViolationCollector col) {
-			col.addViolation(FAILED+"1");
+            col.addViolation(FAILED+"1");
         }
-		
-		@SelfValidation
+        
+        @SelfValidation
         public void validateFail2(ViolationCollector col) {
-			col.addViolation(FAILED+"2");
+            col.addViolation(FAILED+"2");
         }
-		
-		@SelfValidation
+        
+        @SelfValidation
         public void validateFail3(ViolationCollector col) {
-			col.addViolation(FAILED+"3");
+            col.addViolation(FAILED+"3");
         }
-		
-		@SuppressWarnings("unused")
-		@SelfValidation
-		public void validateCorrect(ViolationCollector col) {}
+        
+        @SuppressWarnings("unused")
+        @SelfValidation
+        public void validateCorrect(ViolationCollector col) {}
     }
 
     private final Validator validator = BaseValidator.newValidator();
@@ -62,16 +62,16 @@ public class SelfValidationTest {
     @Test
     public void correctExample() throws Exception {
         assertThat(ConstraintViolations.format(validator.validate(new CorrectExample())))
-        		.isEmpty();
+                .isEmpty();
     }
     
     @Test
     public void complexExample() throws Exception {
         assertThat(ConstraintViolations.format(validator.validate(new ComplexExample())))
                 .containsOnly(
-                		" "+FAILED+"1",
-                		" "+FAILED+"2",
-                		" "+FAILED+"3"
+                        " "+FAILED+"1",
+                        " "+FAILED+"2",
+                        " "+FAILED+"3"
                 );
     }
 }

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/SelfValidationTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/SelfValidationTest.java
@@ -33,17 +33,17 @@ public class SelfValidationTest {
     public static class ComplexExample {
         @SelfValidation
         public void validateFail1(ViolationCollector col) {
-            col.addViolation(FAILED+"1");
+            col.addViolation(FAILED + "1");
         }
         
         @SelfValidation
         public void validateFail2(ViolationCollector col) {
-            col.addViolation(FAILED+"2");
+            col.addViolation(FAILED + "2");
         }
         
         @SelfValidation
         public void validateFail3(ViolationCollector col) {
-            col.addViolation(FAILED+"3");
+            col.addViolation(FAILED + "3");
         }
         
         @SuppressWarnings("unused")
@@ -56,7 +56,7 @@ public class SelfValidationTest {
     @Test
     public void failingExample() throws Exception {
         assertThat(ConstraintViolations.format(validator.validate(new FailingExample())))
-                .containsOnly(" "+FAILED);
+                .containsOnly(" " + FAILED);
     }
     
     @Test
@@ -69,9 +69,9 @@ public class SelfValidationTest {
     public void complexExample() throws Exception {
         assertThat(ConstraintViolations.format(validator.validate(new ComplexExample())))
                 .containsOnly(
-                        " "+FAILED+"1",
-                        " "+FAILED+"2",
-                        " "+FAILED+"3"
-                );
+                        " " + FAILED + "1",
+                        " " + FAILED + "2",
+                        " " + FAILED + "3"
+            );
     }
 }

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/SelfValidationTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/SelfValidationTest.java
@@ -66,6 +66,14 @@ public class SelfValidationTest {
     }
     
     @Test
+    public void multipleTestingOfSameClass() throws Exception {
+        assertThat(ConstraintViolations.format(validator.validate(new CorrectExample())))
+                .isEmpty();
+        assertThat(ConstraintViolations.format(validator.validate(new CorrectExample())))
+                .isEmpty();
+    }
+    
+    @Test
     public void complexExample() throws Exception {
         assertThat(ConstraintViolations.format(validator.validate(new ComplexExample())))
                 .containsOnly(


### PR DESCRIPTION
This pull request solves my feature request issue #2140 .
It adds the two Annoations @SelfValidation and @SelfValidating. An example of how to use it:
```java
@SelfValidating
public class Example {
    private int a = 3;
    private int b = 6;

    @SelfValidation
    public void validOnlyIfEven(ViolationCollector col) {
        if(a+b % 2 != 0)
            col.addViolation("a+b must be an even value. At the moment it is "+a+"+"+b+"="+(a+b));
    }
}
```

What do you think of it? If this solution is okay with you (especially the names of annotations) I would write a paragraph for the documentation.