### PR TITLE
Fixed violation of Comparable contract in Size

### DIFF
--- a/dropwizard-util/src/main/java/io/dropwizard/util/Size.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Size.java
@@ -120,7 +120,7 @@ public class Size implements Comparable<Size> {
             return false;
         }
         final Size size = (Size) obj;
-        return (count == size.count) && (unit == size.unit);
+        return this.compareTo(size) == 0;
     }
 
     @Override

--- a/dropwizard-util/src/test/java/io/dropwizard/util/SizeTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/SizeTest.java
@@ -546,4 +546,17 @@ public class SizeTest {
         assertThat(mapper.readValue("\"1 terabytes\"", Size.class)).isEqualTo(Size.terabytes(1L));
         assertThat(mapper.readValue("\"2 terabytes\"", Size.class)).isEqualTo(Size.terabytes(2L));
     }
+    
+    @Test
+    public void verifyComparableContract() {
+        final Size kb = Size.kilobytes(1024L);
+        final Size bytes = Size.bytes(kb.toBytes());
+
+        assertThat(bytes.compareTo(kb)).isEqualTo(0);
+        assertThat(kb.compareTo(bytes)).isEqualTo(0);
+
+        // If comparator == 0, then the following must be true
+        assertThat(bytes.equals(kb)).isTrue();
+        assertThat(kb.equals(bytes)).isTrue();
+    }
 }


### PR DESCRIPTION
Added unit test to verify comparable contract.

This addresses the bug alluded to in #2153. It turns out that the reporter of the issue uncovered a violation of a rule set forth when implementing the Comparable interface.