### PR TITLE
Correctly set up SO_LINGER for the HTTP connector

### DIFF
--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
@@ -555,7 +555,7 @@ public class HttpConnectorFactory implements ConnectorFactory {
 
         connector.setReuseAddress(reuseAddress);
         if (soLingerTime != null) {
-            connector.setSoLingerTime((int) soLingerTime.toSeconds());
+            connector.setSoLingerTime((int) soLingerTime.toMilliseconds());
         }
         connector.setIdleTimeout(idleTimeout.toMilliseconds());
         connector.setName(name);

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
@@ -130,7 +130,7 @@ public class HttpConnectorFactoryTest {
         assertThat(connector.getHost()).isEqualTo("127.0.0.1");
         assertThat(connector.getAcceptQueueSize()).isEqualTo(1024);
         assertThat(connector.getReuseAddress()).isTrue();
-        assertThat(connector.getSoLingerTime()).isEqualTo(30);
+        assertThat(connector.getSoLingerTime()).isEqualTo(30000);
         assertThat(connector.getIdleTimeout()).isEqualTo(30000);
         assertThat(connector.getName()).isEqualTo("test-http-connector");
 


### PR DESCRIPTION
Jetty's `ServerConnector` accepts `soLingerTime` in milliseconds, rather
than in seconds as `Socket.setSoLinger` does [1]. Dropwizard on the other
hand after parsing the YML configuration and extracting the `soLingerTime` parameter
passes it to Jetty in seconds. As a result, the configuration gets really
confusing for users, because the configuration value is more than the actual
SO_LINGER timeout by 1000 times.

The fix is to pass the configuration value to Jetty's `ServerConnector`
in milliseconds.

[1]: http://www.eclipse.org/jetty/documentation/9.4.x/configuring-connectors.html

Fixes #2175 