### PR TITLE
Add support for parametrized commands with parametrized configurations

### DIFF
--- a/dropwizard-util/src/main/java/io/dropwizard/util/Generics.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Generics.java
@@ -59,6 +59,14 @@ public class Generics {
                             }
                         }
                     }
+                } else if (param instanceof ParameterizedType) {
+                    final Type rawType = ((ParameterizedType) param).getRawType();
+                    if (rawType instanceof Class<?>) {
+                        final Class<T> cls = determineClass(bound, rawType);
+                        if (cls != null) {
+                            return cls;
+                        }
+                    }
                 }
             }
         }

--- a/dropwizard-util/src/test/java/io/dropwizard/util/GenericsTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/GenericsTest.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Rule;
@@ -26,6 +27,7 @@ public class GenericsTest<T> {
             {IntegerList.class, Integer.class, Integer.class, Integer.class, null, null },
             {NumberList.class, Number.class, Number.class, Number.class, null, null },
             {IntegerValueMap.class, Object.class, Number.class, Integer.class, null, null },
+            {ListOfStringSets.class, Set.class, Set.class, Set.class, null, null },
         });
     }
 
@@ -53,13 +55,14 @@ public class GenericsTest<T> {
     public void testTypeParameter() {
         assertThat(Generics.getTypeParameter(klass)).isEqualTo(typeParameter);
     }
-    
+
     @Test
     public void testBoundTypeParameter() {
         assertThat(Generics.getTypeParameter(klass, bound)).isEqualTo(boundTypeParameter);
     }
-    
+
     public static class IntegerList extends ArrayList<Integer> { }
     public static class NumberList<V extends Number> extends ArrayList<V> { }
     public static class IntegerValueMap<K> extends HashMap<K, Integer> { }
+    public static class ListOfStringSets extends ArrayList<Set<String>> { }
 }


### PR DESCRIPTION
Jackson is able to deserialize parametrized configuration classes, so we should support configured commands with them. To figure out the type, we need to check the raw type one of the type arguments and check if it's can be cast to the `Configuration` class.

Simply put, for the class
`RunDbVacuum extends ConfiguredCommand<ReplicaConfig<Replica>>`, `Generics` should be able to figure out that we need to deserialize the config as `ReplicaConfig`.

Resolves #2187 