### PR TITLE
Use version 3.2.5 of dropwizard metrics

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -27,7 +27,7 @@
         <jackson.version>2.8.10</jackson.version>
         <jetty.version>9.4.6.v20170531</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
-        <metrics3.version>3.2.2</metrics3.version>
+        <metrics3.version>3.2.5</metrics3.version>
         <slf4j.version>1.7.24</slf4j.version>
         <logback.version>1.2.1</logback.version>
         <h2.version>1.4.193</h2.version>


### PR DESCRIPTION
Don't see any reason not to stay up to date on metrics version in 1.1.x