### PR TITLE
Add `@Nullable` annotations or initialize nonnull fields

### DIFF
--- a/dropwizard-assets/src/test/java/io/dropwizard/assets/AssetsBundleTest.java
+++ b/dropwizard-assets/src/test/java/io/dropwizard/assets/AssetsBundleTest.java
@@ -24,8 +24,8 @@ public class AssetsBundleTest {
     private final ServletEnvironment servletEnvironment = mock(ServletEnvironment.class);
     private final Environment environment = mock(Environment.class);
 
-    private AssetServlet servlet;
-    private String servletPath;
+    private AssetServlet servlet = new AssetServlet("/", "/", null, null);
+    private String servletPath = "";
 
     @Before
     public void setUp() throws Exception {

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthDynamicFeature.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthDynamicFeature.java
@@ -3,6 +3,7 @@ package io.dropwizard.auth;
 import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
 import org.glassfish.jersey.server.model.AnnotatedMethod;
 
+import javax.annotation.Nullable;
 import javax.annotation.security.DenyAll;
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
@@ -30,8 +31,10 @@ import java.util.Optional;
  */
 public class AuthDynamicFeature implements DynamicFeature {
 
+    @Nullable
     private final ContainerRequestFilter authFilter;
 
+    @Nullable
     private final Class<? extends ContainerRequestFilter> authFilterClass;
 
     public AuthDynamicFeature(ContainerRequestFilter authFilter) {

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthFilter.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthFilter.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import javax.annotation.Priority;
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.Priorities;
@@ -18,11 +19,11 @@ public abstract class AuthFilter<C, P extends Principal> implements ContainerReq
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 
-    protected String prefix;
-    protected String realm;
-    protected Authenticator<C, P> authenticator;
-    protected Authorizer<P> authorizer;
-    protected UnauthorizedHandler unauthorizedHandler;
+    protected String prefix =  "Basic";
+    protected String realm = "realm";
+    protected Authenticator<C, P> authenticator = credentials -> Optional.empty();
+    protected Authorizer<P> authorizer = new PermitAllAuthorizer<>();
+    protected UnauthorizedHandler unauthorizedHandler = new DefaultUnauthorizedHandler();
 
     /**
      * Abstract builder for auth filters.
@@ -34,6 +35,7 @@ public abstract class AuthFilter<C, P extends Principal> implements ContainerReq
 
         private String realm = "realm";
         private String prefix = "Basic";
+        @Nullable
         private Authenticator<C, P> authenticator;
         private Authorizer<P> authorizer = new PermitAllAuthorizer<>();
         private UnauthorizedHandler unauthorizedHandler = new DefaultUnauthorizedHandler();
@@ -127,7 +129,7 @@ public abstract class AuthFilter<C, P extends Principal> implements ContainerReq
      *                       See {@link SecurityContext}
      * @return {@code true}, if the request is authenticated, otherwise {@code false}
      */
-    protected boolean authenticate(ContainerRequestContext requestContext, C credentials, String scheme) {
+    protected boolean authenticate(ContainerRequestContext requestContext, @Nullable C credentials, String scheme) {
         try {
             if (credentials == null) {
                 return false;

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthValueFactoryProvider.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthValueFactoryProvider.java
@@ -11,6 +11,7 @@ import org.glassfish.jersey.server.internal.inject.ParamInjectionResolver;
 import org.glassfish.jersey.server.model.Parameter;
 import org.glassfish.jersey.server.spi.internal.ValueFactoryProvider;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.lang.reflect.ParameterizedType;
@@ -53,6 +54,7 @@ public class AuthValueFactoryProvider<T extends Principal> extends AbstractValue
      * @return the factory if annotated parameter matched type
      */
     @Override
+    @Nullable
     public AbstractContainerRequestValueFactory<?> createValueFactory(Parameter parameter) {
         if (!parameter.isAnnotationPresent(Auth.class)) {
             return null;

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/PolymorphicAuthValueFactoryProvider.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/PolymorphicAuthValueFactoryProvider.java
@@ -11,6 +11,7 @@ import org.glassfish.jersey.server.internal.inject.ParamInjectionResolver;
 import org.glassfish.jersey.server.model.Parameter;
 import org.glassfish.jersey.server.spi.internal.ValueFactoryProvider;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.lang.reflect.ParameterizedType;
@@ -58,6 +59,7 @@ public class PolymorphicAuthValueFactoryProvider<T extends Principal> extends Ab
      * @return the factory if annotated parameter matched type
      */
     @Override
+    @Nullable
     public AbstractContainerRequestValueFactory<?> createValueFactory(Parameter parameter) {
         if (!parameter.isAnnotationPresent(Auth.class)) {
             return null;

--- a/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardApacheConnector.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardApacheConnector.java
@@ -20,6 +20,7 @@ import org.glassfish.jersey.client.spi.AsyncConnectorCallback;
 import org.glassfish.jersey.client.spi.Connector;
 import org.glassfish.jersey.message.internal.Statuses;
 
+import javax.annotation.Nullable;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.core.Response;
 import java.io.ByteArrayInputStream;
@@ -63,6 +64,7 @@ public class DropwizardApacheConnector implements Connector {
     /**
      * Default HttpUriRequestConfig
      */
+    @Nullable
     private final RequestConfig defaultRequestConfig;
 
     /**
@@ -70,7 +72,7 @@ public class DropwizardApacheConnector implements Connector {
      */
     private final boolean chunkedEncodingEnabled;
 
-    public DropwizardApacheConnector(CloseableHttpClient client, RequestConfig defaultRequestConfig,
+    public DropwizardApacheConnector(CloseableHttpClient client, @Nullable RequestConfig defaultRequestConfig,
                                      boolean chunkedEncodingEnabled) {
         this.client = client;
         this.defaultRequestConfig = defaultRequestConfig;
@@ -172,6 +174,7 @@ public class DropwizardApacheConnector implements Connector {
      * @param jerseyRequest representation of an HTTP request in Jersey
      * @return a correct {@link org.apache.http.HttpEntity} implementation
      */
+    @Nullable
     private HttpEntity getHttpEntity(ClientRequest jerseyRequest) {
         if (jerseyRequest.getEntity() == null) {
             return null;

--- a/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactory.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactory.java
@@ -9,6 +9,7 @@ import org.apache.http.ssl.PrivateKeyStrategy;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.ssl.TrustStrategy;
 
+import javax.annotation.Nullable;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import java.io.File;
@@ -17,16 +18,20 @@ import java.io.InputStream;
 import java.security.KeyStore;
 import java.util.List;
 
+import static java.util.Objects.requireNonNull;
+
 public class DropwizardSSLConnectionSocketFactory {
 
     private final TlsConfiguration configuration;
+
+    @Nullable
     private final HostnameVerifier verifier;
 
     public DropwizardSSLConnectionSocketFactory(TlsConfiguration configuration) {
         this(configuration, null);
     }
 
-    public DropwizardSSLConnectionSocketFactory(TlsConfiguration configuration, HostnameVerifier verifier) {
+    public DropwizardSSLConnectionSocketFactory(TlsConfiguration configuration, @Nullable HostnameVerifier verifier) {
         this.configuration = configuration;
         this.verifier = verifier;
     }
@@ -36,6 +41,7 @@ public class DropwizardSSLConnectionSocketFactory {
                 chooseHostnameVerifier());
     }
 
+    @Nullable
     private String[] getSupportedCiphers() {
         final List<String> supportedCiphers = configuration.getSupportedCiphers();
         if (supportedCiphers == null) {
@@ -44,6 +50,7 @@ public class DropwizardSSLConnectionSocketFactory {
         return supportedCiphers.toArray(new String[supportedCiphers.size()]);
     }
 
+    @Nullable
     private String[] getSupportedProtocols() {
         final List<String> supportedProtocols = configuration.getSupportedProtocols();
         if (supportedProtocols == null) {
@@ -74,6 +81,7 @@ public class DropwizardSSLConnectionSocketFactory {
         return sslContext;
     }
 
+    @Nullable
     private PrivateKeyStrategy choosePrivateKeyStrategy() {
         PrivateKeyStrategy privateKeyStrategy = null;
         if (configuration.getCertAlias() != null) {
@@ -89,9 +97,10 @@ public class DropwizardSSLConnectionSocketFactory {
     private void loadKeyMaterial(SSLContextBuilder sslContextBuilder) throws Exception {
         if (configuration.getKeyStorePath() != null) {
             final KeyStore keystore = loadKeyStore(configuration.getKeyStoreType(), configuration.getKeyStorePath(),
-                    configuration.getKeyStorePassword());
-            
-            sslContextBuilder.loadKeyMaterial(keystore, configuration.getKeyStorePassword().toCharArray(), choosePrivateKeyStrategy());
+                requireNonNull(configuration.getKeyStorePassword()));
+
+            sslContextBuilder.loadKeyMaterial(keystore,
+                requireNonNull(configuration.getKeyStorePassword()).toCharArray(), choosePrivateKeyStrategy());
         }
     }
 
@@ -99,7 +108,7 @@ public class DropwizardSSLConnectionSocketFactory {
         KeyStore trustStore = null;
         if (configuration.getTrustStorePath() != null) {
             trustStore = loadKeyStore(configuration.getTrustStoreType(), configuration.getTrustStorePath(),
-                    configuration.getTrustStorePassword());
+                    requireNonNull(configuration.getTrustStorePassword()));
         }
         TrustStrategy trustStrategy = null;
         if (configuration.isTrustSelfSignedCertificates()) {

--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
@@ -46,6 +46,7 @@ import org.apache.http.impl.conn.SystemDefaultDnsResolver;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.protocol.HttpProcessor;
 
+import javax.annotation.Nullable;
 import javax.net.ssl.HostnameVerifier;
 import java.util.List;
 
@@ -64,21 +65,43 @@ public class HttpClientBuilder {
     private static final HttpRequestRetryHandler NO_RETRIES = (exception, executionCount, context) -> false;
 
     private final MetricRegistry metricRegistry;
+
+    @Nullable
     private String environmentName;
+
+    @Nullable
     private Environment environment;
     private HttpClientConfiguration configuration = new HttpClientConfiguration();
     private DnsResolver resolver = new SystemDefaultDnsResolver();
+
+    @Nullable
     private HostnameVerifier verifier;
+
+    @Nullable
     private HttpRequestRetryHandler httpRequestRetryHandler;
+
+    @Nullable
     private Registry<ConnectionSocketFactory> registry;
 
-    private CredentialsProvider credentialsProvider = null;
+    @Nullable
+    private CredentialsProvider credentialsProvider;
+
     private HttpClientMetricNameStrategy metricNameStrategy = HttpClientMetricNameStrategies.METHOD_ONLY;
-    private HttpRoutePlanner routePlanner = null;
+
+    @Nullable
+    private HttpRoutePlanner routePlanner;
+
+    @Nullable
     private RedirectStrategy redirectStrategy;
     private boolean disableContentCompression;
+
+    @Nullable
     private List<? extends Header> defaultHeaders;
+
+    @Nullable
     private HttpProcessor httpProcessor;
+
+    @Nullable
     private ServiceUnavailableRetryStrategy serviceUnavailableRetryStrategy;
 
     public HttpClientBuilder(MetricRegistry metricRegistry) {

--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientConfiguration.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientConfiguration.java
@@ -163,6 +163,7 @@ public class HttpClientConfiguration {
     }
 
     @JsonProperty("proxy")
+    @Nullable
     public ProxyConfiguration getProxyConfiguration() {
         return proxyConfiguration;
     }
@@ -183,6 +184,7 @@ public class HttpClientConfiguration {
     }
 
     @JsonProperty("tls")
+    @Nullable
     public TlsConfiguration getTlsConfiguration() {
         return tlsConfiguration;
     }

--- a/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
@@ -25,6 +25,7 @@ import org.glassfish.jersey.client.rx.RxClient;
 import org.glassfish.jersey.client.rx.RxInvoker;
 import org.glassfish.jersey.client.spi.ConnectorProvider;
 
+import javax.annotation.Nullable;
 import javax.net.ssl.HostnameVerifier;
 import javax.validation.Validator;
 import javax.ws.rs.client.Client;
@@ -65,9 +66,17 @@ public class JerseyClientBuilder {
 
     private HttpClientBuilder apacheHttpClientBuilder;
     private Validator validator = Validators.newValidator();
+
+    @Nullable
     private Environment environment;
+
+    @Nullable
     private ObjectMapper objectMapper;
+
+    @Nullable
     private ExecutorService executorService;
+
+    @Nullable
     private ConnectorProvider connectorProvider;
     private Duration shutdownGracePeriod = Duration.seconds(5);
 
@@ -351,7 +360,7 @@ public class JerseyClientBuilder {
             // is used to ensure that the service is shut down if the
             // Jersey client disposes of it.
             executorService = new DropwizardExecutorProvider.DisposableExecutorService(
-                environment.lifecycle()
+                requireNonNull(environment).lifecycle()
                     .executorService("jersey-client-" + name + "-%d")
                     .minThreads(configuration.getMinThreads())
                     .maxThreads(configuration.getMaxThreads())
@@ -361,7 +370,7 @@ public class JerseyClientBuilder {
         }
 
         if (objectMapper == null) {
-            objectMapper = environment.getObjectMapper();
+            objectMapper = requireNonNull(environment).getObjectMapper();
         }
 
         if (environment != null) {

--- a/dropwizard-client/src/main/java/io/dropwizard/client/proxy/AuthConfiguration.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/proxy/AuthConfiguration.java
@@ -3,6 +3,7 @@ package io.dropwizard.client.proxy;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.hibernate.validator.constraints.NotEmpty;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.Pattern;
 
 /**
@@ -68,21 +69,26 @@ public class AuthConfiguration {
     public static final String NT_CREDS = "NT";
 
     @NotEmpty
-    private String username;
+    private String username = "";
 
     @NotEmpty
-    private String password;
+    private String password = "";
 
     @Pattern(regexp = BASIC_AUTH_SCHEME + "|" + NTLM_AUTH_SCHEME)
+    @Nullable
     private String authScheme;
 
+    @Nullable
     private String realm;
 
+    @Nullable
     private String hostname;
 
+    @Nullable
     private String domain;
 
     @Pattern(regexp = USERNAME_PASSWORD_CREDS + "|" + NT_CREDS, flags = {Pattern.Flag.CASE_INSENSITIVE})
+    @Nullable
     private String credentialType;
 
     public AuthConfiguration() {
@@ -124,6 +130,7 @@ public class AuthConfiguration {
     }
 
     @JsonProperty
+    @Nullable
     public String getAuthScheme() {
         return authScheme;
     }
@@ -134,6 +141,7 @@ public class AuthConfiguration {
     }
 
     @JsonProperty
+    @Nullable
     public String getRealm() {
         return realm;
     }
@@ -144,6 +152,7 @@ public class AuthConfiguration {
     }
 
     @JsonProperty
+    @Nullable
     public String getHostname() {
         return hostname;
     }
@@ -154,6 +163,7 @@ public class AuthConfiguration {
     }
 
     @JsonProperty
+    @Nullable
     public String getDomain() {
         return domain;
     }
@@ -164,6 +174,7 @@ public class AuthConfiguration {
     }
 
     @JsonProperty
+    @Nullable
     public String getCredentialType() {
         return credentialType;
     }

--- a/dropwizard-client/src/main/java/io/dropwizard/client/proxy/NonProxyListProxyRoutePlanner.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/proxy/NonProxyListProxyRoutePlanner.java
@@ -54,6 +54,7 @@ public class NonProxyListProxyRoutePlanner extends DefaultProxyRoutePlanner {
     }
 
     @Override
+    @Nullable
     protected HttpHost determineProxy(HttpHost target, HttpRequest request, HttpContext context) throws HttpException {
         for (Pattern nonProxyHostPattern : nonProxyHostPatterns) {
             if (nonProxyHostPattern.matcher(target.getHostName()).matches()) {

--- a/dropwizard-client/src/main/java/io/dropwizard/client/proxy/ProxyConfiguration.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/proxy/ProxyConfiguration.java
@@ -57,7 +57,7 @@ import java.util.List;
 public class ProxyConfiguration {
 
     @NotEmpty
-    private String host;
+    private String host = "";
 
     @PortRange(min = -1)
     private Integer port = -1;
@@ -121,6 +121,7 @@ public class ProxyConfiguration {
     }
 
     @JsonProperty
+    @Nullable
     public List<String> getNonProxyHosts() {
         return nonProxyHosts;
     }
@@ -130,6 +131,7 @@ public class ProxyConfiguration {
         this.nonProxyHosts = nonProxyHosts;
     }
 
+    @Nullable
     public AuthConfiguration getAuth() {
         return auth;
     }

--- a/dropwizard-client/src/main/java/io/dropwizard/client/ssl/TlsConfiguration.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/ssl/TlsConfiguration.java
@@ -15,15 +15,19 @@ public class TlsConfiguration {
     @NotEmpty
     private String protocol = "TLSv1.2";
 
+    @Nullable
     private File keyStorePath;
 
+    @Nullable
     private String keyStorePassword;
 
     @NotEmpty
     private String keyStoreType = "JKS";
 
+    @Nullable
     private File trustStorePath;
 
+    @Nullable
     private String trustStorePassword;
 
     @NotEmpty
@@ -53,6 +57,7 @@ public class TlsConfiguration {
     }
 
     @JsonProperty
+    @Nullable
     public File getKeyStorePath() {
         return keyStorePath;
     }
@@ -63,6 +68,7 @@ public class TlsConfiguration {
     }
 
     @JsonProperty
+    @Nullable
     public String getKeyStorePassword() {
         return keyStorePassword;
     }
@@ -91,8 +97,8 @@ public class TlsConfiguration {
         this.trustStoreType = trustStoreType;
     }
 
-
     @JsonProperty
+    @Nullable
     public File getTrustStorePath() {
         return trustStorePath;
     }
@@ -103,6 +109,7 @@ public class TlsConfiguration {
     }
 
     @JsonProperty
+    @Nullable
     public String getTrustStorePassword() {
         return trustStorePassword;
     }

--- a/dropwizard-client/src/test/java/io/dropwizard/client/ConfiguredCloseableHttpClientTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/ConfiguredCloseableHttpClientTest.java
@@ -4,19 +4,15 @@ import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(MockitoJUnitRunner.class)
 public class ConfiguredCloseableHttpClientTest {
-    public ConfiguredCloseableHttpClient configuredClient;
-    @Mock
-    private CloseableHttpClient closeableHttpClientMock;
-    @Mock
-    private RequestConfig defaultRequestConfigMock;
+    private ConfiguredCloseableHttpClient configuredClient;
+
+    private CloseableHttpClient closeableHttpClientMock = Mockito.mock(CloseableHttpClient.class);
+    private RequestConfig defaultRequestConfigMock = Mockito.mock(RequestConfig.class);
 
     @Before
     public void setUp() {

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
@@ -33,6 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import javax.annotation.Nullable;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
@@ -295,6 +296,7 @@ public class JerseyClientBuilderTest {
                 }
 
                 @Override
+                @Nullable
                 public X509Certificate[] getAcceptedIssuers() {
                     return null;
                 }
@@ -348,7 +350,11 @@ public class JerseyClientBuilderTest {
         }
 
         @Override
-        public JerseyClientBuilderTest readFrom(Class<JerseyClientBuilderTest> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
+        @Nullable
+        public JerseyClientBuilderTest readFrom(Class<JerseyClientBuilderTest> type, Type genericType,
+                                                Annotation[] annotations, MediaType mediaType,
+                                                MultivaluedMap<String, String> httpHeaders, InputStream entityStream)
+            throws IOException, WebApplicationException {
             return null;
         }
     }

--- a/dropwizard-client/src/test/java/io/dropwizard/client/proxy/HttpClientConfigurationTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/proxy/HttpClientConfigurationTest.java
@@ -13,13 +13,14 @@ import org.junit.Test;
 import java.io.File;
 import java.util.List;
 
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
 public class HttpClientConfigurationTest {
 
     private final ObjectMapper objectMapper = Jackson.newObjectMapper();
-    private HttpClientConfiguration configuration;
+    private HttpClientConfiguration configuration = new HttpClientConfiguration();
 
     private void load(String configLocation) throws Exception {
         configuration = new YamlConfigurationFactory<>(HttpClientConfiguration.class,
@@ -38,15 +39,13 @@ public class HttpClientConfigurationTest {
     public void testFullConfigBasicProxy() throws Exception {
         load("yaml/proxy.yml");
 
-        ProxyConfiguration proxy = configuration.getProxyConfiguration();
-        assertThat(proxy).isNotNull();
+        ProxyConfiguration proxy = requireNonNull(configuration.getProxyConfiguration());
 
         assertThat(proxy.getHost()).isEqualTo("192.168.52.11");
         assertThat(proxy.getPort()).isEqualTo(8080);
         assertThat(proxy.getScheme()).isEqualTo("https");
 
-        AuthConfiguration auth = proxy.getAuth();
-        assertThat(auth).isNotNull();
+        AuthConfiguration auth = requireNonNull(proxy.getAuth());
         assertThat(auth.getUsername()).isEqualTo("secret");
         assertThat(auth.getPassword()).isEqualTo("stuff");
 
@@ -58,15 +57,13 @@ public class HttpClientConfigurationTest {
     public void testFullConfigNtlmProxy() throws Exception {
         load("yaml/proxy_ntlm.yml");
 
-        ProxyConfiguration proxy = configuration.getProxyConfiguration();
-        assertThat(proxy).isNotNull();
+        ProxyConfiguration proxy = requireNonNull(configuration.getProxyConfiguration());
 
         assertThat(proxy.getHost()).isEqualTo("192.168.52.11");
         assertThat(proxy.getPort()).isEqualTo(8080);
         assertThat(proxy.getScheme()).isEqualTo("https");
 
-        AuthConfiguration auth = proxy.getAuth();
-        assertThat(auth).isNotNull();
+        AuthConfiguration auth = requireNonNull(proxy.getAuth());
         assertThat(auth.getUsername()).isEqualTo("secret");
         assertThat(auth.getPassword()).isEqualTo("stuff");
         assertThat(auth.getAuthScheme()).isEqualTo("NTLM");
@@ -83,8 +80,7 @@ public class HttpClientConfigurationTest {
     public void testNoScheme() throws Exception {
         load("./yaml/no_scheme.yml");
 
-        ProxyConfiguration proxy = configuration.getProxyConfiguration();
-        assertThat(proxy).isNotNull();
+        ProxyConfiguration proxy = requireNonNull(configuration.getProxyConfiguration());
         assertThat(proxy.getHost()).isEqualTo("192.168.52.11");
         assertThat(proxy.getPort()).isEqualTo(8080);
         assertThat(proxy.getScheme()).isEqualTo("http");
@@ -94,8 +90,7 @@ public class HttpClientConfigurationTest {
     public void testNoAuth() throws Exception {
         load("./yaml/no_auth.yml");
 
-        ProxyConfiguration proxy = configuration.getProxyConfiguration();
-        assertThat(proxy).isNotNull();
+        ProxyConfiguration proxy = requireNonNull(configuration.getProxyConfiguration());
         assertThat(proxy.getHost()).isNotNull();
         assertThat(proxy.getAuth()).isNull();
     }
@@ -104,8 +99,7 @@ public class HttpClientConfigurationTest {
     public void testNoPort() throws Exception {
         load("./yaml/no_port.yml");
 
-        ProxyConfiguration proxy = configuration.getProxyConfiguration();
-        assertThat(proxy).isNotNull();
+        ProxyConfiguration proxy = requireNonNull(configuration.getProxyConfiguration());
         assertThat(proxy.getHost()).isNotNull();
         assertThat(proxy.getPort()).isEqualTo(-1);
     }
@@ -114,7 +108,7 @@ public class HttpClientConfigurationTest {
     public void testNoNonProxy() throws Exception {
         load("./yaml/no_port.yml");
 
-        ProxyConfiguration proxy = configuration.getProxyConfiguration();
+        ProxyConfiguration proxy = requireNonNull(configuration.getProxyConfiguration());
         assertThat(proxy.getNonProxyHosts()).isNull();
     }
 

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/BaseConfigurationFactory.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/BaseConfigurationFactory.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 
@@ -27,6 +28,7 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.databind.node.TreeTraversingParser;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
 
 /**
  * A generic factory class for loading configuration files, binding them to configuration objects, and
@@ -44,7 +46,10 @@ public abstract class BaseConfigurationFactory<T> implements ConfigurationFactor
     private final Class<T> klass;
     private final String propertyPrefix;
     protected final ObjectMapper mapper;
+
+    @Nullable
     private final Validator validator;
+
     private final String formatName;
     private final JsonFactory parserFactory;
 
@@ -60,21 +65,14 @@ public abstract class BaseConfigurationFactory<T> implements ConfigurationFactor
     public BaseConfigurationFactory(JsonFactory parserFactory,
                                     String formatName,
                                     Class<T> klass,
-                                    Validator validator,
+                                    @Nullable Validator validator,
                                     ObjectMapper objectMapper,
                                     String propertyPrefix) {
         this.klass = klass;
         this.formatName = formatName;
-        this.propertyPrefix = (propertyPrefix == null || propertyPrefix.endsWith("."))
-            ? propertyPrefix : (propertyPrefix + '.');
-        // Sub-classes may choose to omit data-binding; if so, null ObjectMapper passed:
-        if (objectMapper == null) { // sub-class has no need for mapper
-            this.mapper = null;
-            this.parserFactory = null;
-        } else {
-            this.mapper = objectMapper;
-            this.parserFactory = parserFactory;
-        }
+        this.propertyPrefix = propertyPrefix.endsWith(".") ? propertyPrefix : propertyPrefix + '.';
+        this.mapper = objectMapper;
+        this.parserFactory = parserFactory;
         this.validator = validator;
     }
 

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationParsingException.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationParsingException.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.dataformat.yaml.snakeyaml.error.Mark;
 import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.StringUtils;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -16,6 +17,8 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * A {@link ConfigurationException} for errors parsing a configuration file.
@@ -31,9 +34,13 @@ public class ConfigurationParsingException extends ConfigurationException {
         private List<JsonMappingException.Reference> fieldPath = Collections.emptyList();
         private int line = -1;
         private int column = -1;
-        private Exception cause = null;
+
+        @Nullable
+        private Exception cause;
         private List<String> suggestions = new ArrayList<>();
-        private String suggestionBase = null;
+
+        @Nullable
+        private String suggestionBase;
         private boolean suggestionsSorted = false;
 
         Builder(String summary) {
@@ -134,7 +141,7 @@ public class ConfigurationParsingException extends ConfigurationException {
                 return suggestions;
             }
 
-            suggestions.sort(new LevenshteinComparator(getSuggestionBase()));
+            suggestions.sort(new LevenshteinComparator(requireNonNull(getSuggestionBase())));
             suggestionsSorted = true;
 
             return suggestions;
@@ -156,6 +163,7 @@ public class ConfigurationParsingException extends ConfigurationException {
          *
          * @return the base for suggestions.
          */
+        @Nullable
         public String getSuggestionBase() {
             return suggestionBase;
         }
@@ -176,6 +184,7 @@ public class ConfigurationParsingException extends ConfigurationException {
          *
          * @return an Exception representing the cause of the problem, or null if there is none.
          */
+        @Nullable
         public Exception getCause() {
             return cause;
         }
@@ -273,7 +282,7 @@ public class ConfigurationParsingException extends ConfigurationException {
             }
 
             return hasCause()
-                    ? new ConfigurationParsingException(path, sb.toString(), getCause())
+                    ? new ConfigurationParsingException(path, sb.toString(), requireNonNull(getCause()))
                     : new ConfigurationParsingException(path, sb.toString());
         }
 

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/JsonConfigurationFactory.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/JsonConfigurationFactory.java
@@ -1,9 +1,10 @@
 package io.dropwizard.configuration;
 
-import javax.validation.Validator;
-
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.annotation.Nullable;
+import javax.validation.Validator;
 
 /**
  * A factory class for loading JSON configuration files, binding them to configuration objects, and

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/YamlConfigurationFactory.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/YamlConfigurationFactory.java
@@ -1,5 +1,6 @@
 package io.dropwizard.configuration;
 
+import javax.annotation.Nullable;
 import javax.validation.Validator;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -22,7 +23,7 @@ public class YamlConfigurationFactory<T> extends BaseConfigurationFactory<T> {
      * @param propertyPrefix the system property name prefix used by overrides
      */
     public YamlConfigurationFactory(Class<T> klass,
-                                    Validator validator,
+                                    @Nullable Validator validator,
                                     ObjectMapper objectMapper,
                                     String propertyPrefix) {
         super(new YAMLFactory(), YAMLFactory.FORMAT_NAME_YAML, klass, validator, objectMapper, propertyPrefix);

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/BaseConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/BaseConfigurationFactoryTest.java
@@ -17,6 +17,7 @@ import javax.validation.Validator;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import java.io.File;
+import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -56,12 +57,12 @@ public abstract class BaseConfigurationFactoryTest {
 
         @NotNull
         @Pattern(regexp = "[\\w]+[\\s]+[\\w]+([\\s][\\w]+)?")
-        private String name;
+        private String name = "";
 
         @JsonProperty
         private int age = 1;
 
-        List<String> type;
+        List<String> type = ImmutableList.of();
 
         @JsonProperty
         private Map<String, String> properties = new LinkedHashMap<>();
@@ -136,14 +137,24 @@ public abstract class BaseConfigurationFactoryTest {
     }
 
     protected final Validator validator = BaseValidator.newValidator();
-    protected ConfigurationFactory<Example> factory;
-    protected File malformedFile;
-    protected File emptyFile;
-    protected File invalidFile;
-    protected File validFile;
-    protected File typoFile;
-    protected File wrongTypeFile;
-    protected File malformedAdvancedFile;
+    protected ConfigurationFactory<Example> factory = new ConfigurationFactory<Example>() {
+        @Override
+        public Example build(ConfigurationSourceProvider provider, String path) throws IOException, ConfigurationException {
+            return new Example();
+        }
+
+        @Override
+        public Example build() throws IOException, ConfigurationException {
+            return new Example();
+        }
+    };
+    protected File malformedFile = new File("/");
+    protected File emptyFile = new File("/");
+    protected File invalidFile = new File("/");
+    protected File validFile = new File("/");
+    protected File typoFile = new File("/");
+    protected File wrongTypeFile = new File("/");
+    protected File malformedAdvancedFile = new File("/");
 
     protected static File resourceFileName(String resourceName) throws URISyntaxException {
         return new File(Resources.getResource(resourceName).toURI());

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationValidationExceptionTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationValidationExceptionTest.java
@@ -4,6 +4,7 @@ import io.dropwizard.validation.BaseValidator;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.annotation.Nullable;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 import javax.validation.constraints.NotNull;
@@ -17,6 +18,7 @@ import static org.junit.Assume.assumeThat;
 public class ConfigurationValidationExceptionTest {
     private static class Example {
         @NotNull
+        @Nullable // Weird combination, but Hibernate Validator is not good with the compile nullable checks
         String woo;
     }
 

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/SubstitutingSourceProviderTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/SubstitutingSourceProviderTest.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.text.StrLookup;
 import org.apache.commons.lang3.text.StrSubstitutor;
 import org.junit.Test;
 
+import javax.annotation.Nullable;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -42,6 +43,7 @@ public class SubstitutingSourceProviderTest {
     public void shouldSubstituteOnlyExistingVariables() throws IOException {
         StrLookup<?> dummyLookup = new StrLookup<Object>() {
             @Override
+            @Nullable
             public String lookup(String key) {
                 return null;
             }
@@ -56,6 +58,7 @@ public class SubstitutingSourceProviderTest {
     public void shouldSubstituteWithDefaultValue() throws IOException {
         StrLookup<?> dummyLookup = new StrLookup<Object>() {
             @Override
+            @Nullable
             public String lookup(String key) {
                 return null;
             }
@@ -67,7 +70,7 @@ public class SubstitutingSourceProviderTest {
     }
 
     private static class DummySourceProvider implements ConfigurationSourceProvider {
-        public InputStream lastStream;
+        public InputStream lastStream = new ByteArrayInputStream(new byte[]{});
 
         @Override
         public InputStream open(String s) throws IOException {

--- a/dropwizard-core/src/main/java/io/dropwizard/Configuration.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/Configuration.java
@@ -8,6 +8,7 @@ import io.dropwizard.metrics.MetricsFactory;
 import io.dropwizard.server.DefaultServerFactory;
 import io.dropwizard.server.ServerFactory;
 
+import javax.annotation.Nullable;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
@@ -65,6 +66,7 @@ public class Configuration {
     private ServerFactory server = new DefaultServerFactory();
 
     @Valid
+    @Nullable
     private LoggingFactory logging;
 
     @Valid

--- a/dropwizard-core/src/main/java/io/dropwizard/cli/Cli.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/Cli.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * The command-line runner for Dropwizard application.
  */
@@ -70,7 +72,8 @@ public class Cli {
                 parser.printVersion(stdOut);
             } else {
                 final Namespace namespace = parser.parseArgs(arguments);
-                final Command command = commands.get(namespace.getString(COMMAND_NAME_ATTR));
+                final Command command = requireNonNull(commands.get(namespace.getString(COMMAND_NAME_ATTR)),
+                    "Command is not found");
                 try {
                     command.run(bootstrap, namespace);
                 } catch (Throwable e) {

--- a/dropwizard-core/src/main/java/io/dropwizard/cli/ConfiguredCommand.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/ConfiguredCommand.java
@@ -12,6 +12,7 @@ import net.sourceforge.argparse4j.inf.Argument;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 
+import javax.annotation.Nullable;
 import javax.validation.Validator;
 import java.io.IOException;
 
@@ -26,6 +27,7 @@ import java.io.IOException;
 public abstract class ConfiguredCommand<T extends Configuration> extends Command {
     private boolean asynchronous;
 
+    @Nullable
     private T configuration;
 
     protected ConfiguredCommand(String name, String description) {

--- a/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
@@ -213,6 +213,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
     private static final Pattern WINDOWS_NEWLINE = Pattern.compile("\\r\\n?");
 
     @Valid
+    @Nullable
     private RequestLogFactory requestLog;
 
     @Valid
@@ -235,21 +236,29 @@ public abstract class AbstractServerFactory implements ServerFactory {
     private Duration idleThreadTimeout = Duration.minutes(1);
 
     @Min(1)
+    @Nullable
     private Integer nofileSoftLimit;
 
     @Min(1)
+    @Nullable
     private Integer nofileHardLimit;
 
+    @Nullable
     private Integer gid;
 
+    @Nullable
     private Integer uid;
 
+    @Nullable
     private String user;
 
+    @Nullable
     private String group;
 
+    @Nullable
     private String umask;
 
+    @Nullable
     private Boolean startsAsRoot;
 
     private Boolean registerDefaultExceptionMappers = Boolean.TRUE;
@@ -346,6 +355,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
     }
 
     @JsonProperty
+    @Nullable
     public Integer getNofileSoftLimit() {
         return nofileSoftLimit;
     }
@@ -356,6 +366,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
     }
 
     @JsonProperty
+    @Nullable
     public Integer getNofileHardLimit() {
         return nofileHardLimit;
     }
@@ -366,6 +377,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
     }
 
     @JsonProperty
+    @Nullable
     public Integer getGid() {
         return gid;
     }
@@ -376,6 +388,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
     }
 
     @JsonProperty
+    @Nullable
     public Integer getUid() {
         return uid;
     }
@@ -386,6 +399,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
     }
 
     @JsonProperty
+    @Nullable
     public String getUser() {
         return user;
     }
@@ -396,6 +410,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
     }
 
     @JsonProperty
+    @Nullable
     public String getGroup() {
         return group;
     }
@@ -406,6 +421,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
     }
 
     @JsonProperty
+    @Nullable
     public String getUmask() {
         return umask;
     }
@@ -416,6 +432,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
     }
 
     @JsonProperty
+    @Nullable
     public Boolean getStartsAsRoot() {
         return startsAsRoot;
     }

--- a/dropwizard-core/src/main/java/io/dropwizard/setup/Environment.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/Environment.java
@@ -14,6 +14,7 @@ import io.dropwizard.jetty.MutableServletContextHandler;
 import io.dropwizard.jetty.setup.ServletEnvironment;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 
+import javax.annotation.Nullable;
 import javax.servlet.Servlet;
 import javax.validation.Validator;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -56,7 +57,7 @@ public class Environment {
                        ObjectMapper objectMapper,
                        Validator validator,
                        MetricRegistry metricRegistry,
-                       ClassLoader classLoader,
+                       @Nullable ClassLoader classLoader,
                        HealthCheckRegistry healthCheckRegistry) {
         this.name = name;
         this.objectMapper = objectMapper;
@@ -107,7 +108,7 @@ public class Environment {
                        ObjectMapper objectMapper,
                        Validator validator,
                        MetricRegistry metricRegistry,
-                       ClassLoader classLoader) {
+                       @Nullable ClassLoader classLoader) {
         this(name, objectMapper, validator, metricRegistry, classLoader, new HealthCheckRegistry());
     }
 
@@ -196,6 +197,7 @@ public class Environment {
         return servletContext;
     }
 
+    @Nullable
     public Servlet getJerseyServletContainer() {
         return jerseyServletContainer.getContainer();
     }

--- a/dropwizard-core/src/main/java/io/dropwizard/sslreload/SslReloadTask.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/sslreload/SslReloadTask.java
@@ -1,6 +1,7 @@
 package io.dropwizard.sslreload;
 
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
 import io.dropwizard.jetty.SslReload;
 import io.dropwizard.servlets.tasks.Task;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
@@ -10,7 +11,7 @@ import java.util.Collection;
 
 /** A task that will refresh all ssl factories with up to date certificate information */
 public class SslReloadTask extends Task {
-    private Collection<SslReload> reloader;
+    private Collection<SslReload> reloader = ImmutableSet.of();
 
     protected SslReloadTask() {
         super("reload-ssl");

--- a/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
+++ b/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
@@ -8,7 +8,9 @@ import io.dropwizard.util.Duration;
 import io.dropwizard.validation.MinDuration;
 import io.dropwizard.validation.ValidationMethod;
 import org.apache.tomcat.jdbc.pool.PoolProperties;
+import org.hibernate.validator.constraints.NotEmpty;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -316,8 +318,8 @@ public class DataSourceFactory implements PooledDataSourceFactory {
         }
     }
 
-    @NotNull
-    private String driverClass = null;
+    @NotEmpty
+    private String driverClass = "";
 
     @Min(0)
     @Max(100)
@@ -329,20 +331,25 @@ public class DataSourceFactory implements PooledDataSourceFactory {
 
     private boolean rollbackOnReturn = false;
 
+    @Nullable
     private Boolean autoCommitByDefault;
 
+    @Nullable
     private Boolean readOnlyByDefault;
 
-    private String user = null;
+    @Nullable
+    private String user;
 
-    private String password = null;
+    @Nullable
+    private String password;
 
-    @NotNull
-    private String url = null;
+    @NotEmpty
+    private String url = "";
 
     @NotNull
     private Map<String, String> properties = new LinkedHashMap<>();
 
+    @Nullable
     private String defaultCatalog;
 
     @NotNull
@@ -359,6 +366,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
     @Min(1)
     private int maxSize = 100;
 
+    @Nullable
     private String initializationQuery;
 
     private boolean logAbandonedConnections = false;
@@ -366,6 +374,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
     private boolean logValidationErrors = false;
 
     @MinDuration(value = 1, unit = TimeUnit.SECONDS)
+    @Nullable
     private Duration maxConnectionAge;
 
     @NotNull
@@ -380,6 +389,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
     private String validationQuery = "/* Health Check */ SELECT 1";
 
     @MinDuration(value = 1, unit = TimeUnit.SECONDS)
+    @Nullable
     private Duration validationQueryTimeout;
 
     private boolean checkConnectionWhileIdle = true;
@@ -433,6 +443,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
     }
 
     @JsonProperty
+    @Nullable
     public String getUser() {
         return user;
     }
@@ -443,6 +454,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
     }
 
     @JsonProperty
+    @Nullable
     public String getPassword() {
         return password;
     }
@@ -603,6 +615,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
     }
 
     @JsonProperty
+    @Nullable
     public Boolean getAutoCommitByDefault() {
         return autoCommitByDefault;
     }
@@ -613,6 +626,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
     }
 
     @JsonProperty
+    @Nullable
     public String getDefaultCatalog() {
         return defaultCatalog;
     }
@@ -623,6 +637,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
     }
 
     @JsonProperty
+    @Nullable
     public Boolean getReadOnlyByDefault() {
         return readOnlyByDefault;
     }
@@ -663,6 +678,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
     }
 
     @JsonProperty
+    @Nullable
     public String getInitializationQuery() {
         return initializationQuery;
     }
@@ -855,7 +871,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
         poolConfig.setMinIdle(minSize);
 
         if (getMaxConnectionAge().isPresent()) {
-            poolConfig.setMaxAge(maxConnectionAge.toMilliseconds());
+            poolConfig.setMaxAge(getMaxConnectionAge().get().toMilliseconds());
         }
 
         poolConfig.setMaxWait((int) maxWaitForConnection.toMilliseconds());
@@ -876,7 +892,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
         poolConfig.setValidationInterval(validationInterval.toMilliseconds());
 
         if (getValidationQueryTimeout().isPresent()) {
-            poolConfig.setValidationQueryTimeout((int) validationQueryTimeout.toSeconds());
+            poolConfig.setValidationQueryTimeout((int) getValidationQueryTimeout().get().toSeconds());
         }
         validatorClassName.ifPresent(poolConfig::setValidatorClassName);
         jdbcInterceptors.ifPresent(poolConfig::setJdbcInterceptors);

--- a/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceFactoryTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceFactoryTest.java
@@ -12,6 +12,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.annotation.Nullable;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -24,6 +25,8 @@ public class DataSourceFactoryTest {
     private final MetricRegistry metricRegistry = new MetricRegistry();
 
     private DataSourceFactory factory;
+
+    @Nullable
     private ManagedDataSource dataSource;
 
     @Before

--- a/dropwizard-forms/src/test/java/io/dropwizard/forms/MultiPartBundleTest.java
+++ b/dropwizard-forms/src/test/java/io/dropwizard/forms/MultiPartBundleTest.java
@@ -2,20 +2,25 @@ package io.dropwizard.forms;
 
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jackson.Jackson;
+import io.dropwizard.logging.BootstrapLogging;
 import io.dropwizard.setup.Environment;
+import io.dropwizard.validation.BaseValidator;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MultiPartBundleTest {
+    static {
+        BootstrapLogging.bootstrap();
+    }
 
     @Test
     public void testRun() throws Exception {
         final Environment environment = new Environment(
                 "multipart-test",
                 Jackson.newObjectMapper(),
-                null,
+                BaseValidator.newValidator(),
                 new MetricRegistry(),
                 getClass().getClassLoader()
         );

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/HibernateBundle.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/HibernateBundle.java
@@ -12,9 +12,14 @@ import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Duration;
 import org.hibernate.SessionFactory;
 
+import javax.annotation.Nullable;
+
+import static java.util.Objects.requireNonNull;
+
 public abstract class HibernateBundle<T extends Configuration> implements ConfiguredBundle<T>, DatabaseConfiguration<T> {
     public static final String DEFAULT_NAME = "hibernate";
 
+    @Nullable
     private SessionFactory sessionFactory;
     private boolean lazyLoadingEnabled = true;
 
@@ -59,7 +64,8 @@ public abstract class HibernateBundle<T extends Configuration> implements Config
     @Override
     public final void run(T configuration, Environment environment) throws Exception {
         final PooledDataSourceFactory dbConfig = getDataSourceFactory(configuration);
-        this.sessionFactory = sessionFactoryFactory.build(this, environment, dbConfig, entities, name());
+        this.sessionFactory = requireNonNull(sessionFactoryFactory.build(this, environment, dbConfig,
+            entities, name()));
         registerUnitOfWorkListerIfAbsent(environment).registerSessionFactory(name(), sessionFactory);
         environment.healthChecks().register(name(),
                                             new SessionFactoryHealthCheck(
@@ -89,7 +95,7 @@ public abstract class HibernateBundle<T extends Configuration> implements Config
     }
 
     public SessionFactory getSessionFactory() {
-        return sessionFactory;
+        return requireNonNull(sessionFactory);
     }
 
     protected void configure(org.hibernate.cfg.Configuration configuration) {

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/Dog.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/Dog.java
@@ -2,6 +2,7 @@ package io.dropwizard.hibernate;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.annotation.Nullable;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.Id;
@@ -13,13 +14,16 @@ import javax.persistence.Table;
 @Table(name = "dogs")
 public class Dog {
     @Id
+    @Nullable
     private String name;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "owner")
+    @Nullable
     private Person owner;
 
     @JsonProperty
+    @Nullable
     public String getName() {
         return name;
     }
@@ -30,6 +34,7 @@ public class Dog {
     }
 
     @JsonProperty
+    @Nullable
     public Person getOwner() {
         return owner;
     }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
@@ -22,6 +22,7 @@ import org.joda.time.DateTimeZone;
 import org.junit.After;
 import org.junit.Test;
 
+import javax.annotation.Nullable;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -82,6 +83,7 @@ public class JerseyIntegrationTest extends JerseyTest {
         }
     }
 
+    @Nullable
     private SessionFactory sessionFactory;
 
     @Override

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/LazyLoadingTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/LazyLoadingTest.java
@@ -23,10 +23,10 @@ import org.junit.After;
 import org.junit.Test;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.PUT;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.HttpHeaders;
@@ -37,6 +37,7 @@ import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class LazyLoadingTest {
 
@@ -150,7 +151,7 @@ public class LazyLoadingTest {
         }
     }
 
-    private DropwizardTestSupport dropwizardTestSupport;
+    private DropwizardTestSupport dropwizardTestSupport = mock(DropwizardTestSupport.class);
     private Client client = new JerseyClientBuilder().build();
 
     public void setup(Class<? extends Application<TestConfiguration>> applicationClass) {
@@ -181,7 +182,7 @@ public class LazyLoadingTest {
         assertThat(raf.getOwner())
             .isNotNull();
 
-        assertThat(raf.getOwner().getName())
+        assertThat(requireNonNull(raf.getOwner()).getName())
             .isEqualTo("Coda");
     }
 

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/PersistenceExceptionMapper.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/PersistenceExceptionMapper.java
@@ -5,6 +5,7 @@ import org.hibernate.exception.DataException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import javax.persistence.PersistenceException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
@@ -12,12 +13,15 @@ import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 import javax.ws.rs.ext.Providers;
 
+import static java.util.Objects.requireNonNull;
+
 @Provider
 public class PersistenceExceptionMapper implements ExtendedExceptionMapper<PersistenceException> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DataException.class);
 
     @Context
+    @Nullable
     private Providers providers;
 
     @Override
@@ -30,13 +34,14 @@ public class PersistenceExceptionMapper implements ExtendedExceptionMapper<Persi
         // Cast is necessary since the return type is ExceptionMapper<? extends Throwable> and Java
         // does not allow calling toResponse on the method with a Throwable
         @SuppressWarnings("unchecked")
-        final ExceptionMapper<Throwable> exceptionMapper = (ExceptionMapper<Throwable>) providers.getExceptionMapper(t.getClass());
+        final ExceptionMapper<Throwable> exceptionMapper = (ExceptionMapper<Throwable>)
+            requireNonNull(providers).getExceptionMapper(t.getClass());
 
         return exceptionMapper.toResponse(t);
     }
 
     @Override
     public boolean isMappable(PersistenceException e) {
-        return providers.getExceptionMapper(e.getCause().getClass()) != null;
+        return requireNonNull(providers).getExceptionMapper(e.getCause().getClass()) != null;
     }
 }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/Person.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/Person.java
@@ -3,6 +3,7 @@ package io.dropwizard.hibernate;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.joda.time.DateTime;
 
+import javax.annotation.Nullable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -12,15 +13,17 @@ import javax.persistence.Table;
 @Table(name = "people")
 public class Person {
     @Id
-    private String name;
+    private String name = "";
 
     @Column
-    private String email;
+    private String email = "";
 
     @Column
+    @Nullable
     private DateTime birthday;
 
     @JsonProperty
+    @Nullable
     public String getName() {
         return name;
     }
@@ -41,6 +44,7 @@ public class Person {
     }
 
     @JsonProperty
+    @Nullable
     public DateTime getBirthday() {
         return birthday;
     }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SubResourcesTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SubResourcesTest.java
@@ -16,9 +16,9 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.POST;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.Entity;
@@ -27,6 +27,7 @@ import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.Optional;
 
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SubResourcesTest {
@@ -212,7 +213,7 @@ public class SubResourcesTest {
 
         assertThat(dog.getName()).isEqualTo("Bello");
         assertThat(dog.getOwner()).isNotNull();
-        assertThat(dog.getOwner().getName()).isEqualTo("Greg");
+        assertThat(requireNonNull(dog.getOwner()).getName()).isEqualTo("Greg");
     }
 
     @Test
@@ -224,7 +225,7 @@ public class SubResourcesTest {
 
         assertThat(dog.getName()).isEqualTo("Bandit");
         assertThat(dog.getOwner()).isNotNull();
-        assertThat(dog.getOwner().getName()).isEqualTo("Greg");
+        assertThat(requireNonNull(dog.getOwner()).getName()).isEqualTo("Greg");
     }
 
     @Test

--- a/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2CConnectorFactory.java
+++ b/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2CConnectorFactory.java
@@ -15,6 +15,7 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
 import org.eclipse.jetty.util.thread.ThreadPool;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 
@@ -81,7 +82,7 @@ public class Http2CConnectorFactory extends HttpConnectorFactory {
     }
 
     @Override
-    public Connector build(Server server, MetricRegistry metrics, String name, ThreadPool threadPool) {
+    public Connector build(Server server, MetricRegistry metrics, String name, @Nullable ThreadPool threadPool) {
 
         // Prepare connection factories for HTTP/2c
         final HttpConfiguration httpConfig = buildHttpConfiguration();

--- a/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2ConnectorFactory.java
+++ b/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2ConnectorFactory.java
@@ -20,6 +20,7 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
 import org.eclipse.jetty.util.thread.ThreadPool;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 
@@ -95,7 +96,7 @@ public class Http2ConnectorFactory extends HttpsConnectorFactory {
     }
 
     @Override
-    public Connector build(Server server, MetricRegistry metrics, String name, ThreadPool threadPool) {
+    public Connector build(Server server, MetricRegistry metrics, String name, @Nullable ThreadPool threadPool) {
         // HTTP/2 requires that a server MUST support TLSv1.2 and TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 cipher
         // See http://http2.github.io/http2-spec/index.html#rfc.section.9.2.2
         setSupportedProtocols(ImmutableList.of("TLSv1.2"));

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/FuzzyEnumModule.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/FuzzyEnumModule.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
 import io.dropwizard.util.Enums;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
@@ -62,6 +63,7 @@ public class FuzzyEnumModule extends Module {
     private static class PermissiveEnumDeserializers extends Deserializers.Base {
         @Override
         @SuppressWarnings("unchecked")
+        @Nullable
         public JsonDeserializer<?> findEnumDeserializer(Class<?> type,
                                                         DeserializationConfig config,
                                                         BeanDescription desc) throws JsonMappingException {

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 
+import javax.annotation.Nullable;
+
 /**
  * A utility class for Jackson.
  */
@@ -33,7 +35,7 @@ public class Jackson {
      * @param jsonFactory instance of {@link com.fasterxml.jackson.core.JsonFactory} to use
      *                    for the created {@link com.fasterxml.jackson.databind.ObjectMapper} instance.
      */
-    public static ObjectMapper newObjectMapper(JsonFactory jsonFactory) {
+    public static ObjectMapper newObjectMapper(@Nullable JsonFactory jsonFactory) {
         final ObjectMapper mapper = new ObjectMapper(jsonFactory);
 
         return configure(mapper);

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/AnnotationSensitivePropertyNamingStrategyTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/AnnotationSensitivePropertyNamingStrategyTest.java
@@ -6,11 +6,14 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.annotation.Nullable;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AnnotationSensitivePropertyNamingStrategyTest {
     public static class RegularExample {
         @JsonProperty
+        @Nullable
         String firstName;
 
         @SuppressWarnings("UnusedDeclaration") // Jackson
@@ -24,6 +27,7 @@ public class AnnotationSensitivePropertyNamingStrategyTest {
     @JsonSnakeCase
     public static class SnakeCaseExample {
         @JsonProperty
+        @Nullable
         String firstName;
 
         @SuppressWarnings("UnusedDeclaration") // Jackson

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/Issue1627.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/Issue1627.java
@@ -2,23 +2,30 @@ package io.dropwizard.jackson;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.annotation.Nullable;
 import java.util.UUID;
 
 public class Issue1627 {
+
+    @Nullable
     private final String string;
+
+    @Nullable
     private final UUID uuid;
 
-    public Issue1627(final String string, final UUID uuid) {
+    public Issue1627(@Nullable String string, @Nullable UUID uuid) {
         this.string = string;
         this.uuid = uuid;
     }
 
     @JsonProperty
+    @Nullable
     public String getString() {
         return this.string;
     }
 
     @JsonProperty
+    @Nullable
     public UUID getUuid() {
         return this.uuid;
     }

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -47,6 +48,7 @@ public class JacksonTest {
 
     static class LogMetadata {
 
+        @Nullable
         public Path path;
     }
 

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/InstantArgument.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/InstantArgument.java
@@ -3,6 +3,7 @@ package io.dropwizard.jdbi.args;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.Argument;
 
+import javax.annotation.Nullable;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -15,10 +16,12 @@ import java.util.Optional;
  * An {@link Argument} for {@link Instant} objects.
  */
 public class InstantArgument implements Argument {
+
+    @Nullable
     private final Instant instant;
     private final Optional<Calendar> calendar;
 
-    protected InstantArgument(final Instant instant, final Optional<Calendar> calendar) {
+    protected InstantArgument(@Nullable final Instant instant, final Optional<Calendar> calendar) {
         this.instant = instant;
         this.calendar = calendar;
     }

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/InstantMapper.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/InstantMapper.java
@@ -3,6 +3,7 @@ package io.dropwizard.jdbi.args;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultColumnMapper;
 
+import javax.annotation.Nullable;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -34,6 +35,7 @@ public class InstantMapper implements ResultColumnMapper<Instant> {
     }
 
     @Override
+    @Nullable
     public Instant mapColumn(ResultSet r, int columnNumber, StatementContext ctx) throws SQLException {
         final Timestamp timestamp = calendar.isPresent() ?
                 r.getTimestamp(columnNumber, cloneCalendar()) :
@@ -42,6 +44,7 @@ public class InstantMapper implements ResultColumnMapper<Instant> {
     }
 
     @Override
+    @Nullable
     public Instant mapColumn(ResultSet r, String columnLabel, StatementContext ctx) throws SQLException {
         final Timestamp timestamp = calendar.isPresent() ?
                 r.getTimestamp(columnLabel, cloneCalendar()) :

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/JodaDateTimeArgument.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/JodaDateTimeArgument.java
@@ -4,6 +4,7 @@ import org.joda.time.DateTime;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.Argument;
 
+import javax.annotation.Nullable;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -16,10 +17,11 @@ import java.util.Optional;
  */
 public class JodaDateTimeArgument implements Argument {
 
+    @Nullable
     private final DateTime value;
     private final Optional<Calendar> calendar;
 
-    JodaDateTimeArgument(final DateTime value, final Optional<Calendar> calendar) {
+    JodaDateTimeArgument(@Nullable final DateTime value, final Optional<Calendar> calendar) {
         this.value = value;
         this.calendar = calendar;
     }

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/JodaDateTimeMapper.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/JodaDateTimeMapper.java
@@ -4,6 +4,7 @@ import org.joda.time.DateTime;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultColumnMapper;
 
+import javax.annotation.Nullable;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -50,6 +51,7 @@ public class JodaDateTimeMapper implements ResultColumnMapper<DateTime> {
     }
 
     @Override
+    @Nullable
     public DateTime mapColumn(ResultSet r, int columnNumber, StatementContext ctx) throws SQLException {
         final Timestamp timestamp = calendar.isPresent() ? r.getTimestamp(columnNumber, cloneCalendar()) :
             r.getTimestamp(columnNumber);
@@ -59,6 +61,7 @@ public class JodaDateTimeMapper implements ResultColumnMapper<DateTime> {
         return new DateTime(timestamp.getTime());    }
 
     @Override
+    @Nullable
     public DateTime mapColumn(ResultSet r, String columnLabel, StatementContext ctx) throws SQLException {
         final Timestamp timestamp = calendar.isPresent() ? r.getTimestamp(columnLabel, cloneCalendar()) :
             r.getTimestamp(columnLabel);

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/LocalDateArgument.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/LocalDateArgument.java
@@ -3,6 +3,7 @@ package io.dropwizard.jdbi.args;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.Argument;
 
+import javax.annotation.Nullable;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -14,9 +15,10 @@ import java.time.LocalDate;
  */
 public class LocalDateArgument implements Argument {
 
+    @Nullable
     private final LocalDate value;
 
-    public LocalDateArgument(LocalDate value) {
+    public LocalDateArgument(@Nullable LocalDate value) {
         this.value = value;
     }
 

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/LocalDateMapper.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/LocalDateMapper.java
@@ -3,6 +3,7 @@ package io.dropwizard.jdbi.args;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultColumnMapper;
 
+import javax.annotation.Nullable;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -13,6 +14,7 @@ import java.time.LocalDate;
  */
 public class LocalDateMapper implements ResultColumnMapper<LocalDate> {
     @Override
+    @Nullable
     public LocalDate mapColumn(ResultSet r, String columnLabel, StatementContext ctx) throws SQLException {
         final Timestamp timestamp = r.getTimestamp(columnLabel);
         if (timestamp == null) {
@@ -22,6 +24,7 @@ public class LocalDateMapper implements ResultColumnMapper<LocalDate> {
     }
 
     @Override
+    @Nullable
     public LocalDate mapColumn(ResultSet r, int columnNumber, StatementContext ctx) throws SQLException {
         final Timestamp timestamp = r.getTimestamp(columnNumber);
         if (timestamp == null) {

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/LocalDateTimeArgument.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/LocalDateTimeArgument.java
@@ -3,6 +3,7 @@ package io.dropwizard.jdbi.args;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.Argument;
 
+import javax.annotation.Nullable;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -14,9 +15,10 @@ import java.time.LocalDateTime;
  */
 public class LocalDateTimeArgument implements Argument {
 
+    @Nullable
     private final LocalDateTime value;
 
-    LocalDateTimeArgument(final LocalDateTime value) {
+    LocalDateTimeArgument(@Nullable final LocalDateTime value) {
         this.value = value;
     }
 

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/LocalDateTimeMapper.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/LocalDateTimeMapper.java
@@ -3,6 +3,7 @@ package io.dropwizard.jdbi.args;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultColumnMapper;
 
+import javax.annotation.Nullable;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -14,6 +15,7 @@ import java.time.LocalDateTime;
 public class LocalDateTimeMapper implements ResultColumnMapper<LocalDateTime> {
 
     @Override
+    @Nullable
     public LocalDateTime mapColumn(ResultSet r, String columnLabel, StatementContext ctx) throws SQLException {
         final Timestamp timestamp = r.getTimestamp(columnLabel);
         if (timestamp == null) {
@@ -23,6 +25,7 @@ public class LocalDateTimeMapper implements ResultColumnMapper<LocalDateTime> {
     }
 
     @Override
+    @Nullable
     public LocalDateTime mapColumn(ResultSet r, int columnNumber, StatementContext ctx) throws SQLException {
         final Timestamp timestamp = r.getTimestamp(columnNumber);
         if (timestamp == null) {

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OffsetDateTimeArgument.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OffsetDateTimeArgument.java
@@ -3,6 +3,7 @@ package io.dropwizard.jdbi.args;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.Argument;
 
+import javax.annotation.Nullable;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -16,10 +17,11 @@ import java.util.Optional;
  */
 public class OffsetDateTimeArgument implements Argument {
 
+    @Nullable
     private final OffsetDateTime value;
     private final Optional<Calendar> calendar;
 
-    OffsetDateTimeArgument(final OffsetDateTime value, final Optional<Calendar> calendar) {
+    OffsetDateTimeArgument(@Nullable final OffsetDateTime value, final Optional<Calendar> calendar) {
         this.value = value;
         this.calendar = calendar;
     }

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OffsetDateTimeMapper.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OffsetDateTimeMapper.java
@@ -3,6 +3,7 @@ package io.dropwizard.jdbi.args;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultColumnMapper;
 
+import javax.annotation.Nullable;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -52,6 +53,7 @@ public class OffsetDateTimeMapper implements ResultColumnMapper<OffsetDateTime> 
     }
 
     @Override
+    @Nullable
     public OffsetDateTime mapColumn(ResultSet r, int columnNumber, StatementContext ctx) throws SQLException {
         final Timestamp timestamp = calendar.isPresent() ? r.getTimestamp(columnNumber, cloneCalendar()) :
             r.getTimestamp(columnNumber);
@@ -59,12 +61,14 @@ public class OffsetDateTimeMapper implements ResultColumnMapper<OffsetDateTime> 
     }
 
     @Override
+    @Nullable
     public OffsetDateTime mapColumn(ResultSet r, String columnLabel, StatementContext ctx) throws SQLException {
         final Timestamp timestamp = calendar.isPresent() ? r.getTimestamp(columnLabel, cloneCalendar()) :
             r.getTimestamp(columnLabel);
         return convertToOffsetDateTime(timestamp);
     }
 
+    @Nullable
     private OffsetDateTime convertToOffsetDateTime(Timestamp timestamp) {
         if (timestamp == null) {
             return null;

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/ZonedDateTimeArgument.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/ZonedDateTimeArgument.java
@@ -3,6 +3,7 @@ package io.dropwizard.jdbi.args;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.Argument;
 
+import javax.annotation.Nullable;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -16,10 +17,11 @@ import java.util.Optional;
  */
 public class ZonedDateTimeArgument implements Argument {
 
+    @Nullable
     private final ZonedDateTime value;
     private final Optional<Calendar> calendar;
 
-    ZonedDateTimeArgument(final ZonedDateTime value, final Optional<Calendar> calendar) {
+    ZonedDateTimeArgument(@Nullable final ZonedDateTime value, final Optional<Calendar> calendar) {
         this.value = value;
         this.calendar = calendar;
     }

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/ZonedDateTimeMapper.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/ZonedDateTimeMapper.java
@@ -3,6 +3,7 @@ package io.dropwizard.jdbi.args;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultColumnMapper;
 
+import javax.annotation.Nullable;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -52,6 +53,7 @@ public class ZonedDateTimeMapper implements ResultColumnMapper<ZonedDateTime> {
     }
 
     @Override
+    @Nullable
     public ZonedDateTime mapColumn(ResultSet r, int columnNumber, StatementContext ctx) throws SQLException {
         final Timestamp timestamp = calendar.isPresent() ? r.getTimestamp(columnNumber, cloneCalendar()) :
             r.getTimestamp(columnNumber);
@@ -59,12 +61,14 @@ public class ZonedDateTimeMapper implements ResultColumnMapper<ZonedDateTime> {
     }
 
     @Override
+    @Nullable
     public ZonedDateTime mapColumn(ResultSet r, String columnLabel, StatementContext ctx) throws SQLException {
         final Timestamp timestamp = calendar.isPresent() ? r.getTimestamp(columnLabel, cloneCalendar()) :
             r.getTimestamp(columnLabel);
         return convertToZonedDateTime(timestamp);
     }
 
+    @Nullable
     private ZonedDateTime convertToZonedDateTime(Timestamp timestamp) {
         if (timestamp == null) {
             return null;

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/GuavaJDBITest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/GuavaJDBITest.java
@@ -48,7 +48,7 @@ public class GuavaJDBITest {
     private final DBIFactory factory = new DBIFactory();
     private final List<Managed> managed = new ArrayList<>();
     private final MetricRegistry metricRegistry = new MetricRegistry();
-    private DBI dbi;
+    private DBI dbi = mock(DBI.class);
 
     @Before
     public void setUp() throws Exception {
@@ -102,7 +102,6 @@ public class GuavaJDBITest {
         for (Managed obj : managed) {
             obj.stop();
         }
-        this.dbi = null;
     }
 
     @Test

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/JDBITest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/JDBITest.java
@@ -48,7 +48,7 @@ public class JDBITest {
     private final DBIFactory factory = new DBIFactory();
     private final List<Managed> managed = new ArrayList<>();
     private final MetricRegistry metricRegistry = new MetricRegistry();
-    private DBI dbi;
+    private DBI dbi = mock(DBI.class);
 
     @Before
     public void setUp() throws Exception {
@@ -102,7 +102,6 @@ public class JDBITest {
         for (Managed obj : managed) {
             obj.stop();
         }
-        this.dbi = null;
     }
 
     @Test

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/InstantMapperTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/InstantMapperTest.java
@@ -2,6 +2,7 @@ package io.dropwizard.jdbi.args;
 
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.skife.jdbi.v2.StatementContext;
 
 import java.sql.ResultSet;
 import java.sql.Timestamp;
@@ -10,11 +11,13 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class InstantMapperTest {
 
     private final ResultSet resultSet = Mockito.mock(ResultSet.class);
+    private final StatementContext ctx = mock(StatementContext.class);
 
     @Test
     public void mapColumnByName() throws Exception {
@@ -22,7 +25,7 @@ public class InstantMapperTest {
         ZonedDateTime stored = expected.withZoneSameInstant(ZoneId.systemDefault());
         when(resultSet.getTimestamp("instant")).thenReturn(Timestamp.from(stored.toInstant()));
 
-        Instant actual = new InstantMapper().mapColumn(resultSet, "instant", null);
+        Instant actual = new InstantMapper().mapColumn(resultSet, "instant", ctx);
 
         assertThat(actual).isEqualTo(expected.toInstant());
     }
@@ -31,7 +34,7 @@ public class InstantMapperTest {
     public void mapColumnByName_TimestampIsNull() throws Exception {
         when(resultSet.getTimestamp("instant")).thenReturn(null);
 
-        Instant actual = new InstantMapper().mapColumn(resultSet, "instant", null);
+        Instant actual = new InstantMapper().mapColumn(resultSet, "instant", ctx);
 
         assertThat(actual).isNull();
     }
@@ -42,7 +45,7 @@ public class InstantMapperTest {
         ZonedDateTime stored = expected.withZoneSameInstant(ZoneId.systemDefault());
         when(resultSet.getTimestamp(1)).thenReturn(Timestamp.from(stored.toInstant()));
 
-        Instant actual = new InstantMapper().mapColumn(resultSet, 1, null);
+        Instant actual = new InstantMapper().mapColumn(resultSet, 1, ctx);
 
         assertThat(actual).isEqualTo(expected.toInstant());
     }
@@ -51,7 +54,7 @@ public class InstantMapperTest {
     public void mapColumnByIndex_TimestampIsNull() throws Exception {
         when(resultSet.getTimestamp(1)).thenReturn(null);
 
-        Instant actual = new InstantMapper().mapColumn(resultSet, 1, null);
+        Instant actual = new InstantMapper().mapColumn(resultSet, 1, ctx);
 
         assertThat(actual).isNull();
     }

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/JodaDateTimeMapperTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/JodaDateTimeMapperTest.java
@@ -3,22 +3,25 @@ package io.dropwizard.jdbi.args;
 import org.joda.time.DateTime;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.skife.jdbi.v2.StatementContext;
 
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class JodaDateTimeMapperTest {
 
-    private final ResultSet resultSet = Mockito.mock(ResultSet.class);
+    private final ResultSet resultSet = mock(ResultSet.class);
+    private final StatementContext ctx = mock(StatementContext.class);
 
     @Test
     public void mapColumnByName() throws Exception {
         when(resultSet.getTimestamp("name")).thenReturn(Timestamp.valueOf("2007-12-03 10:15:30.375"));
 
-        DateTime actual = new JodaDateTimeMapper().mapColumn(resultSet, "name", null);
+        DateTime actual = new JodaDateTimeMapper().mapColumn(resultSet, "name", ctx);
 
         assertThat(actual).isEqualTo(DateTime.parse("2007-12-03T10:15:30.375"));
     }
@@ -27,7 +30,7 @@ public class JodaDateTimeMapperTest {
     public void mapColumnByName_TimestampIsNull() throws Exception {
         when(resultSet.getTimestamp("name")).thenReturn(null);
 
-        DateTime actual = new JodaDateTimeMapper().mapColumn(resultSet, "name", null);
+        DateTime actual = new JodaDateTimeMapper().mapColumn(resultSet, "name", ctx);
 
         assertThat(actual).isNull();
     }
@@ -36,7 +39,7 @@ public class JodaDateTimeMapperTest {
     public void mapColumnByIndex() throws Exception {
         when(resultSet.getTimestamp(1)).thenReturn(Timestamp.valueOf("2007-12-03 10:15:30.375"));
 
-        DateTime actual = new JodaDateTimeMapper().mapColumn(resultSet, 1, null);
+        DateTime actual = new JodaDateTimeMapper().mapColumn(resultSet, 1, ctx);
 
         assertThat(actual).isEqualTo(DateTime.parse("2007-12-03T10:15:30.375"));
     }
@@ -45,7 +48,7 @@ public class JodaDateTimeMapperTest {
     public void mapColumnByIndex_TimestampIsNull() throws Exception {
         when(resultSet.getTimestamp(1)).thenReturn(null);
 
-        DateTime actual = new JodaDateTimeMapper().mapColumn(resultSet, 1, null);
+        DateTime actual = new JodaDateTimeMapper().mapColumn(resultSet, 1, ctx);
 
         assertThat(actual).isNull();
     }

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/LocalDateMapperTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/LocalDateMapperTest.java
@@ -1,24 +1,26 @@
 package io.dropwizard.jdbi.args;
 
 import org.junit.Test;
-import org.mockito.Mockito;
+import org.skife.jdbi.v2.StatementContext;
 
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class LocalDateMapperTest {
 
-    private final ResultSet resultSet = Mockito.mock(ResultSet.class);
+    private final ResultSet resultSet = mock(ResultSet.class);
+    private final StatementContext ctx = mock(StatementContext.class);
 
     @Test
     public void mapColumnByName() throws Exception {
         when(resultSet.getTimestamp("name")).thenReturn(Timestamp.valueOf("2007-12-03 00:00:00.000"));
 
-        LocalDate actual = new LocalDateMapper().mapColumn(resultSet, "name", null);
+        LocalDate actual = new LocalDateMapper().mapColumn(resultSet, "name", ctx);
 
         assertThat(actual).isEqualTo(LocalDate.parse("2007-12-03"));
     }
@@ -27,7 +29,7 @@ public class LocalDateMapperTest {
     public void mapColumnByName_TimestampIsNull() throws Exception {
         when(resultSet.getTimestamp("name")).thenReturn(null);
 
-        LocalDate actual = new LocalDateMapper().mapColumn(resultSet, "name", null);
+        LocalDate actual = new LocalDateMapper().mapColumn(resultSet, "name", ctx);
 
         assertThat(actual).isNull();
     }
@@ -36,7 +38,7 @@ public class LocalDateMapperTest {
     public void mapColumnByIndex() throws Exception {
         when(resultSet.getTimestamp(1)).thenReturn(Timestamp.valueOf("2007-12-03 00:00:00.000"));
 
-        LocalDate actual = new LocalDateMapper().mapColumn(resultSet, 1, null);
+        LocalDate actual = new LocalDateMapper().mapColumn(resultSet, 1, ctx);
 
         assertThat(actual).isEqualTo(LocalDate.parse("2007-12-03"));
     }
@@ -45,7 +47,7 @@ public class LocalDateMapperTest {
     public void mapColumnByIndex_TimestampIsNull() throws Exception {
         when(resultSet.getTimestamp(1)).thenReturn(null);
 
-        LocalDate actual = new LocalDateMapper().mapColumn(resultSet, 1, null);
+        LocalDate actual = new LocalDateMapper().mapColumn(resultSet, 1, ctx);
 
         assertThat(actual).isNull();
     }

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/LocalDateTimeMapperTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/LocalDateTimeMapperTest.java
@@ -1,24 +1,26 @@
 package io.dropwizard.jdbi.args;
 
 import org.junit.Test;
-import org.mockito.Mockito;
+import org.skife.jdbi.v2.StatementContext;
 
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class LocalDateTimeMapperTest {
 
-    private final ResultSet resultSet = Mockito.mock(ResultSet.class);
+    private final ResultSet resultSet = mock(ResultSet.class);
+    private final StatementContext ctx = mock(StatementContext.class);
 
     @Test
     public void mapColumnByName() throws Exception {
         when(resultSet.getTimestamp("name")).thenReturn(Timestamp.valueOf("2007-12-03 10:15:30.375"));
 
-        LocalDateTime actual = new LocalDateTimeMapper().mapColumn(resultSet, "name", null);
+        LocalDateTime actual = new LocalDateTimeMapper().mapColumn(resultSet, "name", ctx);
 
         assertThat(actual).isEqualTo(LocalDateTime.parse("2007-12-03T10:15:30.375"));
     }
@@ -27,7 +29,7 @@ public class LocalDateTimeMapperTest {
     public void mapColumnByName_TimestampIsNull() throws Exception {
         when(resultSet.getTimestamp("name")).thenReturn(null);
 
-        LocalDateTime actual = new LocalDateTimeMapper().mapColumn(resultSet, "name", null);
+        LocalDateTime actual = new LocalDateTimeMapper().mapColumn(resultSet, "name", ctx);
 
         assertThat(actual).isNull();
     }
@@ -36,7 +38,7 @@ public class LocalDateTimeMapperTest {
     public void mapColumnByIndex() throws Exception {
         when(resultSet.getTimestamp(1)).thenReturn(Timestamp.valueOf("2007-12-03 10:15:30.375"));
 
-        LocalDateTime actual = new LocalDateTimeMapper().mapColumn(resultSet, 1, null);
+        LocalDateTime actual = new LocalDateTimeMapper().mapColumn(resultSet, 1, ctx);
 
         assertThat(actual).isEqualTo(LocalDateTime.parse("2007-12-03T10:15:30.375"));
     }
@@ -45,7 +47,7 @@ public class LocalDateTimeMapperTest {
     public void mapColumnByIndex_TimestampIsNull() throws Exception {
         when(resultSet.getTimestamp(1)).thenReturn(null);
 
-        LocalDateTime actual = new LocalDateTimeMapper().mapColumn(resultSet, 1, null);
+        LocalDateTime actual = new LocalDateTimeMapper().mapColumn(resultSet, 1, ctx);
 
         assertThat(actual).isNull();
     }

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OffsetDateTimeMapperTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OffsetDateTimeMapperTest.java
@@ -2,6 +2,7 @@ package io.dropwizard.jdbi.args;
 
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.skife.jdbi.v2.StatementContext;
 
 import java.sql.ResultSet;
 import java.sql.Timestamp;
@@ -10,11 +11,13 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class OffsetDateTimeMapperTest {
 
-    private final ResultSet resultSet = Mockito.mock(ResultSet.class);
+    private final ResultSet resultSet = mock(ResultSet.class);
+    private final StatementContext ctx = mock(StatementContext.class);
 
     @Test
     public void mapColumnByName() throws Exception {
@@ -22,7 +25,7 @@ public class OffsetDateTimeMapperTest {
 
         when(resultSet.getTimestamp("name")).thenReturn(Timestamp.from(now));
 
-        OffsetDateTime actual = new OffsetDateTimeMapper().mapColumn(resultSet, "name", null);
+        OffsetDateTime actual = new OffsetDateTimeMapper().mapColumn(resultSet, "name", ctx);
 
         assertThat(actual).isEqualTo(OffsetDateTime.ofInstant(now, ZoneId.systemDefault()));
     }
@@ -31,7 +34,7 @@ public class OffsetDateTimeMapperTest {
     public void mapColumnByName_TimestampIsNull() throws Exception {
         when(resultSet.getTimestamp("name")).thenReturn(null);
 
-        OffsetDateTime actual = new OffsetDateTimeMapper().mapColumn(resultSet, "name", null);
+        OffsetDateTime actual = new OffsetDateTimeMapper().mapColumn(resultSet, "name", ctx);
 
         assertThat(actual).isNull();
     }
@@ -42,7 +45,7 @@ public class OffsetDateTimeMapperTest {
 
         when(resultSet.getTimestamp(1)).thenReturn(Timestamp.from(now));
 
-        OffsetDateTime actual = new OffsetDateTimeMapper().mapColumn(resultSet, 1, null);
+        OffsetDateTime actual = new OffsetDateTimeMapper().mapColumn(resultSet, 1, ctx);
 
         assertThat(actual).isEqualTo(OffsetDateTime.ofInstant(now, ZoneId.systemDefault()));
     }
@@ -51,7 +54,7 @@ public class OffsetDateTimeMapperTest {
     public void mapColumnByIndex_TimestampIsNull() throws Exception {
         when(resultSet.getTimestamp(1)).thenReturn(null);
 
-        OffsetDateTime actual = new OffsetDateTimeMapper().mapColumn(resultSet, 1, null);
+        OffsetDateTime actual = new OffsetDateTimeMapper().mapColumn(resultSet, 1, ctx);
 
         assertThat(actual).isNull();
     }

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/ZonedDateTimeMapperTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/ZonedDateTimeMapperTest.java
@@ -2,6 +2,7 @@ package io.dropwizard.jdbi.args;
 
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.skife.jdbi.v2.StatementContext;
 
 import java.sql.ResultSet;
 import java.sql.Timestamp;
@@ -9,17 +10,19 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class ZonedDateTimeMapperTest {
 
-    private final ResultSet resultSet = Mockito.mock(ResultSet.class);
+    private final ResultSet resultSet = mock(ResultSet.class);
+    private final StatementContext ctx = mock(StatementContext.class);
 
     @Test
     public void mapColumnByName() throws Exception {
         when(resultSet.getTimestamp("name")).thenReturn(Timestamp.valueOf("2007-12-03 10:15:30.375"));
 
-        ZonedDateTime actual = new ZonedDateTimeMapper().mapColumn(resultSet, "name", null);
+        ZonedDateTime actual = new ZonedDateTimeMapper().mapColumn(resultSet, "name", ctx);
 
         assertThat(actual).isEqualTo(ZonedDateTime.of(2007, 12, 3, 10, 15, 30, 375_000_000, ZoneId.systemDefault()));
     }
@@ -28,7 +31,7 @@ public class ZonedDateTimeMapperTest {
     public void mapColumnByName_TimestampIsNull() throws Exception {
         when(resultSet.getTimestamp("name")).thenReturn(null);
 
-        ZonedDateTime actual = new ZonedDateTimeMapper().mapColumn(resultSet, "name", null);
+        ZonedDateTime actual = new ZonedDateTimeMapper().mapColumn(resultSet, "name", ctx);
 
         assertThat(actual).isNull();
     }
@@ -37,7 +40,7 @@ public class ZonedDateTimeMapperTest {
     public void mapColumnByIndex() throws Exception {
         when(resultSet.getTimestamp(1)).thenReturn(Timestamp.valueOf("2007-12-03 10:15:30.375"));
 
-        ZonedDateTime actual = new ZonedDateTimeMapper().mapColumn(resultSet, 1, null);
+        ZonedDateTime actual = new ZonedDateTimeMapper().mapColumn(resultSet, 1, ctx);
 
         assertThat(actual).isEqualTo(ZonedDateTime.of(2007, 12, 3, 10, 15, 30, 375_000_000, ZoneId.systemDefault()));
     }
@@ -46,7 +49,7 @@ public class ZonedDateTimeMapperTest {
     public void mapColumnByIndex_TimestampIsNull() throws Exception {
         when(resultSet.getTimestamp(1)).thenReturn(null);
 
-        ZonedDateTime actual = new ZonedDateTimeMapper().mapColumn(resultSet, 1, null);
+        ZonedDateTime actual = new ZonedDateTimeMapper().mapColumn(resultSet, 1, ctx);
 
         assertThat(actual).isNull();
     }

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/DBIClient.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/DBIClient.java
@@ -1,6 +1,7 @@
 package io.dropwizard.jdbi.timestamps;
 
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableList;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jdbi.DBIFactory;
@@ -10,9 +11,12 @@ import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.rules.ExternalResource;
 import org.skife.jdbi.v2.DBI;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 import java.util.TimeZone;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Configured JDBI client for the database
@@ -21,15 +25,16 @@ public class DBIClient extends ExternalResource {
 
     private final TimeZone dbTimeZone;
 
+    @Nullable
     private DBI dbi;
-    private List<LifeCycle> managedObjects;
+    private List<LifeCycle> managedObjects = ImmutableList.of();
 
     public DBIClient(TimeZone dbTimeZone) {
         this.dbTimeZone = dbTimeZone;
     }
 
     public DBI getDbi() {
-        return dbi;
+        return requireNonNull(dbi);
     }
 
     @Override

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/DatabaseInTimeZone.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/DatabaseInTimeZone.java
@@ -8,6 +8,8 @@ import java.io.File;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
+import static org.mockito.Mockito.mock;
+
 /**
  * Run an instance of the H2 database in an another time zone
  */
@@ -16,7 +18,7 @@ public class DatabaseInTimeZone extends ExternalResource {
     private final TemporaryFolder temporaryFolder;
     private final TimeZone timeZone;
 
-    private Process process;
+    private Process process = mock(Process.class);
 
     public DatabaseInTimeZone(TemporaryFolder temporaryFolder, TimeZone timeZone) {
         this.temporaryFolder = temporaryFolder;

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/JodaDateTimeSqlTimestampTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/JodaDateTimeSqlTimestampTest.java
@@ -16,6 +16,7 @@ import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 
+import javax.annotation.Nullable;
 import java.util.Random;
 import java.util.TimeZone;
 
@@ -29,11 +30,11 @@ public class JodaDateTimeSqlTimestampTest {
 
     private static final DateTimeFormatter ISO_FMT = ISODateTimeFormat.dateTimeNoMillis();
 
-    private static TemporaryFolder temporaryFolder;
-    private static DatabaseInTimeZone databaseInTimeZone;
-    private static DateTimeZone dbTimeZone;
-    private static DBIClient dbiClient;
+    private static DateTimeZone dbTimeZone = DateTimeZone.UTC;
+    private static DBIClient dbiClient = new DBIClient(TimeZone.getDefault());
+
     @ClassRule
+    @Nullable
     public static TestRule chain;
 
     static {
@@ -42,11 +43,10 @@ public class JodaDateTimeSqlTimestampTest {
             try {
                 final TimeZone timeZone = getRandomTimeZone();
                 dbTimeZone = DateTimeZone.forTimeZone(timeZone);
-                temporaryFolder = new TemporaryFolder();
-                databaseInTimeZone = new DatabaseInTimeZone(temporaryFolder, timeZone);
+                final TemporaryFolder temporaryFolder = new TemporaryFolder();
                 dbiClient = new DBIClient(timeZone);
                 chain = RuleChain.outerRule(temporaryFolder)
-                        .around(databaseInTimeZone)
+                        .around(new DatabaseInTimeZone(temporaryFolder, timeZone))
                         .around(dbiClient);
                 done = true;
             } catch (IllegalArgumentException e) {

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -22,6 +22,7 @@ import org.glassfish.jersey.server.monitoring.RequestEventListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import javax.ws.rs.Path;
 import javax.ws.rs.ext.Provider;
 import java.io.Serializable;
@@ -36,7 +37,7 @@ public class DropwizardResourceConfig extends ResourceConfig {
     private static final Logger LOGGER = LoggerFactory.getLogger(DropwizardResourceConfig.class);
     private static final String NEWLINE = String.format("%n");
     private static final TypeResolver TYPE_RESOLVER = new TypeResolver();
-    
+
     private static final Pattern PATH_DIRTY_SLASHES = Pattern.compile("\\s*/\\s*/+\\s*");
 
     private String urlPattern = "/*";
@@ -49,7 +50,7 @@ public class DropwizardResourceConfig extends ResourceConfig {
         this(true, null);
     }
 
-    public DropwizardResourceConfig(boolean testOnly, MetricRegistry metricRegistry) {
+    public DropwizardResourceConfig(boolean testOnly, @Nullable MetricRegistry metricRegistry) {
         super();
 
         if (metricRegistry == null) {
@@ -135,7 +136,7 @@ public class DropwizardResourceConfig extends ResourceConfig {
         for (Class<?> klass : allResourcesClasses) {
             new EndpointLogger(urlPattern, klass).populate(endpointLogLines);
         }
-        
+
         final Set<Resource> allResources = this.getResources();
         for (Resource res : allResources) {
             for (Resource childRes : res.getChildResources()) {
@@ -143,7 +144,7 @@ public class DropwizardResourceConfig extends ResourceConfig {
                 //
                 // This code will never be reached because of ambiguous (sub-)resource methods
                 // related to the OPTIONS method and @Consumes/@Produces annotations.
-                
+
                 for (Class<?> childResHandlerClass : childRes.getHandlerClasses()) {
                     EndpointLogger epl = new EndpointLogger(urlPattern, childResHandlerClass);
                     epl.populate(cleanUpPath(res.getPath() + epl.rootPath), epl.klass, false, childRes, endpointLogLines);
@@ -161,7 +162,7 @@ public class DropwizardResourceConfig extends ResourceConfig {
 
         return msg.toString();
     }
-    
+
     @VisibleForTesting
     String cleanUpPath(String path) {
         return PATH_DIRTY_SLASHES.matcher(path).replaceAll("/").trim();
@@ -278,6 +279,7 @@ public class DropwizardResourceConfig extends ResourceConfig {
         }
 
         @Override
+        @Nullable
         public RequestEventListener onRequest(RequestEvent requestEvent) {
             return null;
         }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/ErrorEntityWriter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/ErrorEntityWriter.java
@@ -2,6 +2,7 @@ package io.dropwizard.jersey.errors;
 
 import org.glassfish.jersey.message.MessageBodyWorkers;
 
+import javax.annotation.Nullable;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
@@ -12,6 +13,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * This class allows producing non-JSON responses for particular entities. For example, register a instance with the
@@ -33,7 +36,7 @@ public abstract class ErrorEntityWriter<T, U> implements MessageBodyWriter<T> {
 
     @Override
     public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
-        return headers.getAcceptableMediaTypes().contains(contentType);
+        return requireNonNull(headers).getAcceptableMediaTypes().contains(contentType);
     }
 
     @Override
@@ -51,7 +54,7 @@ public abstract class ErrorEntityWriter<T, U> implements MessageBodyWriter<T> {
                         OutputStream entityStream)
         throws IOException, WebApplicationException {
 
-        final MessageBodyWriter<U> writer = mbw.get().getMessageBodyWriter(representation,
+        final MessageBodyWriter<U> writer = requireNonNull(mbw).get().getMessageBodyWriter(representation,
             representation, annotations, contentType);
 
         // Fix the headers, because Dropwizard error mappers always set the content type to APPLICATION_JSON
@@ -67,8 +70,10 @@ public abstract class ErrorEntityWriter<T, U> implements MessageBodyWriter<T> {
     private Class<U> representation;
 
     @Context
+    @Nullable
     private HttpHeaders headers;
 
     @Context
+    @Nullable
     private javax.inject.Provider<MessageBodyWorkers> mbw;
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/ErrorMessage.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/ErrorMessage.java
@@ -5,12 +5,15 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 
+import javax.annotation.Nullable;
 import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ErrorMessage {
     private final int code;
     private final String message;
+
+    @Nullable
     private final String details;
 
     public ErrorMessage(String message) {
@@ -23,7 +26,7 @@ public class ErrorMessage {
 
     @JsonCreator
     public ErrorMessage(@JsonProperty("code") int code, @JsonProperty("message") String message,
-                        @JsonProperty("details") String details) {
+                        @Nullable @JsonProperty("details") String details) {
         this.code = code;
         this.message = message;
         this.details = details;
@@ -40,6 +43,7 @@ public class ErrorMessage {
     }
 
     @JsonProperty("details")
+    @Nullable
     public String getDetails() {
         return details;
     }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/AllowedMethodsFilter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/AllowedMethodsFilter.java
@@ -24,7 +24,7 @@ public class AllowedMethodsFilter implements Filter {
 
     private static final Logger LOG = LoggerFactory.getLogger(AllowedMethodsFilter.class);
 
-    private ImmutableSet<String> allowedMethods;
+    private ImmutableSet<String> allowedMethods = ImmutableSet.of();
 
     @Override
     public void init(FilterConfig config) {

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/guava/OptionalMessageBodyWriter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/guava/OptionalMessageBodyWriter.java
@@ -4,6 +4,7 @@ import com.google.common.base.Optional;
 import io.dropwizard.jersey.optional.EmptyOptionalException;
 import org.glassfish.jersey.message.MessageBodyWorkers;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
@@ -16,11 +17,14 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 
+import static java.util.Objects.requireNonNull;
+
 @Provider
 @Produces(MediaType.WILDCARD)
 public class OptionalMessageBodyWriter implements MessageBodyWriter<Optional<?>> {
 
     @Inject
+    @Nullable
     private javax.inject.Provider<MessageBodyWorkers> mbw;
 
     // Jersey ignores this
@@ -52,7 +56,7 @@ public class OptionalMessageBodyWriter implements MessageBodyWriter<Optional<?>>
 
         final ParameterizedType actualGenericType = (ParameterizedType) genericType;
         final Type actualGenericTypeArgument = actualGenericType.getActualTypeArguments()[0];
-        final MessageBodyWriter writer = mbw.get().getMessageBodyWriter(entity.get().getClass(),
+        final MessageBodyWriter writer = requireNonNull(mbw).get().getMessageBodyWriter(entity.get().getClass(),
                 actualGenericTypeArgument, annotations, mediaType);
         writer.writeTo(entity.get(), entity.get().getClass(),
                 actualGenericTypeArgument,

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/guava/OptionalParamConverterProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/guava/OptionalParamConverterProvider.java
@@ -6,6 +6,7 @@ import org.glassfish.jersey.internal.inject.Providers;
 import org.glassfish.jersey.internal.util.ReflectionHelper;
 import org.glassfish.jersey.internal.util.collection.ClassTypePair;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.ws.rs.ext.ParamConverter;
@@ -27,6 +28,7 @@ public class OptionalParamConverterProvider implements ParamConverterProvider {
      * {@inheritDoc}
      */
     @Override
+    @Nullable
     public <T> ParamConverter<T> getConverter(final Class<T> rawType, final Type genericType, final Annotation[] annotations) {
         if (Optional.class.equals(rawType)) {
             final List<ClassTypePair> ctps = ReflectionHelper.getTypeArgumentAndClass(genericType);

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProvider.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
 
+import javax.annotation.Nullable;
 import javax.ws.rs.core.MediaType;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
@@ -24,17 +25,17 @@ public class JacksonMessageBodyProvider extends JacksonJaxbJsonProvider {
 
     @Override
     public boolean isReadable(Class<?> type,
-                              Type genericType,
-                              Annotation[] annotations,
-                              MediaType mediaType) {
+                              @Nullable Type genericType,
+                              @Nullable Annotation[] annotations,
+                              @Nullable MediaType mediaType) {
         return isProvidable(type) && super.isReadable(type, genericType, annotations, mediaType);
     }
 
     @Override
     public boolean isWriteable(Class<?> type,
-                               Type genericType,
-                               Annotation[] annotations,
-                               MediaType mediaType) {
+                               @Nullable Type genericType,
+                               @Nullable Annotation[] annotations,
+                               @Nullable MediaType mediaType) {
         return isProvidable(type) && super.isWriteable(type, genericType, annotations, mediaType);
     }
 

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/InstantParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/InstantParam.java
@@ -1,6 +1,8 @@
 package io.dropwizard.jersey.jsr310;
 
 import io.dropwizard.jersey.params.AbstractParam;
+
+import javax.annotation.Nullable;
 import java.time.Instant;
 
 /**
@@ -10,12 +12,12 @@ import java.time.Instant;
  * @see Instant
  */
 public class InstantParam extends AbstractParam<Instant> {
-    public InstantParam(final String input) {
+    public InstantParam(@Nullable final String input) {
         super(input);
     }
 
     @Override
-    protected Instant parse(final String input) throws Exception {
+    protected Instant parse(@Nullable final String input) throws Exception {
         return Instant.ofEpochMilli(Long.parseLong(input));
     }
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/InstantSecondParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/InstantSecondParam.java
@@ -1,6 +1,8 @@
 package io.dropwizard.jersey.jsr310;
 
 import io.dropwizard.jersey.params.AbstractParam;
+
+import javax.annotation.Nullable;
 import java.time.Instant;
 
 /**
@@ -10,12 +12,12 @@ import java.time.Instant;
  * @see Instant
  */
 public class InstantSecondParam extends AbstractParam<Instant> {
-    public InstantSecondParam(final String input) {
+    public InstantSecondParam(@Nullable final String input) {
         super(input);
     }
 
     @Override
-    protected Instant parse(final String input) throws Exception {
+    protected Instant parse(@Nullable final String input) throws Exception {
         return Instant.ofEpochSecond(Long.parseLong(input));
     }
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/LocalDateParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/LocalDateParam.java
@@ -2,6 +2,7 @@ package io.dropwizard.jersey.jsr310;
 
 import io.dropwizard.jersey.params.AbstractParam;
 
+import javax.annotation.Nullable;
 import java.time.LocalDate;
 
 /**
@@ -11,12 +12,12 @@ import java.time.LocalDate;
  * @see LocalDate
  */
 public class LocalDateParam extends AbstractParam<LocalDate> {
-    public LocalDateParam(final String input) {
+    public LocalDateParam(@Nullable final String input) {
         super(input);
     }
 
     @Override
-    protected LocalDate parse(final String input) throws Exception {
+    protected LocalDate parse(@Nullable final String input) throws Exception {
         return LocalDate.parse(input);
     }
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/LocalDateTimeParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/LocalDateTimeParam.java
@@ -2,6 +2,7 @@ package io.dropwizard.jersey.jsr310;
 
 import io.dropwizard.jersey.params.AbstractParam;
 
+import javax.annotation.Nullable;
 import java.time.LocalDateTime;
 
 /**
@@ -11,12 +12,12 @@ import java.time.LocalDateTime;
  * @see LocalDateTime
  */
 public class LocalDateTimeParam extends AbstractParam<LocalDateTime> {
-    public LocalDateTimeParam(final String input) {
+    public LocalDateTimeParam(@Nullable final String input) {
         super(input);
     }
 
     @Override
-    protected LocalDateTime parse(final String input) throws Exception {
+    protected LocalDateTime parse(@Nullable final String input) throws Exception {
         return LocalDateTime.parse(input);
     }
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/LocalTimeParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/LocalTimeParam.java
@@ -2,6 +2,7 @@ package io.dropwizard.jersey.jsr310;
 
 import io.dropwizard.jersey.params.AbstractParam;
 
+import javax.annotation.Nullable;
 import java.time.LocalTime;
 
 /**
@@ -11,12 +12,12 @@ import java.time.LocalTime;
  * @see LocalTime
  */
 public class LocalTimeParam extends AbstractParam<LocalTime> {
-    public LocalTimeParam(final String input) {
+    public LocalTimeParam(@Nullable final String input) {
         super(input);
     }
 
     @Override
-    protected LocalTime parse(final String input) throws Exception {
+    protected LocalTime parse(@Nullable final String input) throws Exception {
         return LocalTime.parse(input);
     }
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/OffsetDateTimeParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/OffsetDateTimeParam.java
@@ -2,6 +2,7 @@ package io.dropwizard.jersey.jsr310;
 
 import io.dropwizard.jersey.params.AbstractParam;
 
+import javax.annotation.Nullable;
 import java.time.OffsetDateTime;
 
 /**
@@ -11,12 +12,12 @@ import java.time.OffsetDateTime;
  * @see OffsetDateTime
  */
 public class OffsetDateTimeParam extends AbstractParam<OffsetDateTime> {
-    public OffsetDateTimeParam(final String input) {
+    public OffsetDateTimeParam(@Nullable final String input) {
         super(input);
     }
 
     @Override
-    protected OffsetDateTime parse(final String input) throws Exception {
+    protected OffsetDateTime parse(@Nullable final String input) throws Exception {
         return OffsetDateTime.parse(input);
     }
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/YearMonthParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/YearMonthParam.java
@@ -2,6 +2,7 @@ package io.dropwizard.jersey.jsr310;
 
 import io.dropwizard.jersey.params.AbstractParam;
 
+import javax.annotation.Nullable;
 import java.time.YearMonth;
 
 /**
@@ -11,12 +12,12 @@ import java.time.YearMonth;
  * @see YearMonth
  */
 public class YearMonthParam extends AbstractParam<YearMonth> {
-    public YearMonthParam(final String input) {
+    public YearMonthParam(@Nullable final String input) {
         super(input);
     }
 
     @Override
-    protected YearMonth parse(final String input) throws Exception {
+    protected YearMonth parse(@Nullable final String input) throws Exception {
         return YearMonth.parse(input);
     }
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/YearParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/YearParam.java
@@ -2,6 +2,7 @@ package io.dropwizard.jersey.jsr310;
 
 import io.dropwizard.jersey.params.AbstractParam;
 
+import javax.annotation.Nullable;
 import java.time.Year;
 
 /**
@@ -11,12 +12,12 @@ import java.time.Year;
  * @see java.time.YearMonth
  */
 public class YearParam extends AbstractParam<Year> {
-    public YearParam(final String input) {
+    public YearParam(@Nullable final String input) {
         super(input);
     }
 
     @Override
-    protected Year parse(final String input) throws Exception {
+    protected Year parse(@Nullable final String input) throws Exception {
         return Year.parse(input);
     }
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/ZoneIdParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/ZoneIdParam.java
@@ -2,6 +2,7 @@ package io.dropwizard.jersey.jsr310;
 
 import io.dropwizard.jersey.params.AbstractParam;
 
+import javax.annotation.Nullable;
 import java.time.ZoneId;
 
 /**
@@ -11,12 +12,12 @@ import java.time.ZoneId;
  * @see ZoneId
  */
 public class ZoneIdParam extends AbstractParam<ZoneId> {
-    public ZoneIdParam(final String input) {
+    public ZoneIdParam(@Nullable final String input) {
         super(input);
     }
 
     @Override
-    protected ZoneId parse(final String input) throws Exception {
+    protected ZoneId parse(@Nullable final String input) throws Exception {
         return ZoneId.of(input);
     }
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/ZonedDateTimeParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jsr310/ZonedDateTimeParam.java
@@ -2,6 +2,7 @@ package io.dropwizard.jersey.jsr310;
 
 import io.dropwizard.jersey.params.AbstractParam;
 
+import javax.annotation.Nullable;
 import java.time.ZonedDateTime;
 
 /**
@@ -11,12 +12,12 @@ import java.time.ZonedDateTime;
  * @see ZonedDateTime
  */
 public class ZonedDateTimeParam extends AbstractParam<ZonedDateTime> {
-    public ZonedDateTimeParam(final String input) {
+    public ZonedDateTimeParam(@Nullable final String input) {
         super(input);
     }
 
     @Override
-    protected ZonedDateTime parse(final String input) throws Exception {
+    protected ZonedDateTime parse(@Nullable final String input) throws Exception {
         return ZonedDateTime.parse(input);
     }
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalDoubleParamConverterProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalDoubleParamConverterProvider.java
@@ -1,5 +1,6 @@
 package io.dropwizard.jersey.optional;
 
+import javax.annotation.Nullable;
 import javax.inject.Singleton;
 import javax.ws.rs.ext.ParamConverter;
 import javax.ws.rs.ext.ParamConverterProvider;
@@ -18,6 +19,7 @@ public class OptionalDoubleParamConverterProvider implements ParamConverterProvi
      */
     @Override
     @SuppressWarnings("unchecked")
+    @Nullable
     public <T> ParamConverter<T> getConverter(final Class<T> rawType, final Type genericType,
                                               final Annotation[] annotations) {
         return OptionalDouble.class.equals(rawType) ? (ParamConverter<T>) paramConverter : null;

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalIntParamConverterProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalIntParamConverterProvider.java
@@ -1,5 +1,6 @@
 package io.dropwizard.jersey.optional;
 
+import javax.annotation.Nullable;
 import javax.inject.Singleton;
 import javax.ws.rs.ext.ParamConverter;
 import javax.ws.rs.ext.ParamConverterProvider;
@@ -18,6 +19,7 @@ public class OptionalIntParamConverterProvider implements ParamConverterProvider
      */
     @Override
     @SuppressWarnings("unchecked")
+    @Nullable
     public <T> ParamConverter<T> getConverter(final Class<T> rawType, final Type genericType,
                                               final Annotation[] annotations) {
         return OptionalInt.class.equals(rawType) ? (ParamConverter<T>) paramConverter : null;

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalLongParamConverterProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalLongParamConverterProvider.java
@@ -1,5 +1,6 @@
 package io.dropwizard.jersey.optional;
 
+import javax.annotation.Nullable;
 import javax.inject.Singleton;
 import javax.ws.rs.ext.ParamConverter;
 import javax.ws.rs.ext.ParamConverterProvider;
@@ -18,6 +19,7 @@ public class OptionalLongParamConverterProvider implements ParamConverterProvide
      */
     @Override
     @SuppressWarnings("unchecked")
+    @Nullable
     public <T> ParamConverter<T> getConverter(final Class<T> rawType, final Type genericType,
                                               final Annotation[] annotations) {
         return OptionalLong.class.equals(rawType) ? (ParamConverter<T>) paramConverter : null;

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalMessageBodyWriter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalMessageBodyWriter.java
@@ -2,6 +2,7 @@ package io.dropwizard.jersey.optional;
 
 import org.glassfish.jersey.message.MessageBodyWorkers;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
@@ -15,11 +16,14 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Optional;
 
+import static java.util.Objects.requireNonNull;
+
 @Provider
 @Produces(MediaType.WILDCARD)
 public class OptionalMessageBodyWriter implements MessageBodyWriter<Optional<?>> {
 
     @Inject
+    @Nullable
     private javax.inject.Provider<MessageBodyWorkers> mbw;
 
     // Jersey ignores this
@@ -52,7 +56,7 @@ public class OptionalMessageBodyWriter implements MessageBodyWriter<Optional<?>>
         final Type innerGenericType = (genericType instanceof ParameterizedType) ?
             ((ParameterizedType) genericType).getActualTypeArguments()[0] : entity.get().getClass();
 
-        final MessageBodyWriter writer = mbw.get().getMessageBodyWriter(entity.get().getClass(),
+        final MessageBodyWriter writer = requireNonNull(mbw).get().getMessageBodyWriter(entity.get().getClass(),
             innerGenericType, annotations, mediaType);
         writer.writeTo(entity.get(), entity.get().getClass(),
             innerGenericType, annotations, mediaType, httpHeaders, entityStream);

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalParamConverterProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalParamConverterProvider.java
@@ -5,6 +5,7 @@ import org.glassfish.jersey.internal.inject.Providers;
 import org.glassfish.jersey.internal.util.ReflectionHelper;
 import org.glassfish.jersey.internal.util.collection.ClassTypePair;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.ws.rs.ext.ParamConverter;
@@ -27,6 +28,7 @@ public class OptionalParamConverterProvider implements ParamConverterProvider {
      * {@inheritDoc}
      */
     @Override
+    @Nullable
     public <T> ParamConverter<T> getConverter(final Class<T> rawType, final Type genericType,
                                               final Annotation[] annotations) {
         if (Optional.class.equals(rawType)) {

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/AbstractParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/AbstractParam.java
@@ -4,6 +4,7 @@ import io.dropwizard.jersey.errors.ErrorMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -19,7 +20,7 @@ public abstract class AbstractParam<T> {
     private final String parameterName;
     private final T value;
 
-    protected AbstractParam(String input) {
+    protected AbstractParam(@Nullable String input) {
         this(input, "Parameter");
     }
 
@@ -29,7 +30,7 @@ public abstract class AbstractParam<T> {
      * @param input an input value from a client request
      */
     @SuppressWarnings({"AbstractMethodCallInConstructor", "OverriddenMethodCallDuringObjectConstruction"})
-    protected AbstractParam(String input, String parameterName) {
+    protected AbstractParam(@Nullable String input, String parameterName) {
         this.parameterName = parameterName;
         try {
             this.value = parse(input);
@@ -49,7 +50,7 @@ public abstract class AbstractParam<T> {
      * @param e the exception thrown while parsing {@code input}
      * @return the {@link Response} to be sent to the client
      */
-    protected Response error(String input, Exception e) {
+    protected Response error(@Nullable String input, Exception e) {
         LOGGER.debug("Invalid input received: {}", input);
         String errorMessage = errorMessage(e);
         if (errorMessage.contains("%s")) {
@@ -100,7 +101,7 @@ public abstract class AbstractParam<T> {
     * @return {@code input}, parsed as an instance of {@code T}
     * @throws Exception if there is an error parsing the input
     */
-    protected abstract T parse(String input) throws Exception;
+    protected abstract T parse(@Nullable String input) throws Exception;
 
     /**
      * Returns the underlying value.

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/AbstractParamConverterProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/AbstractParamConverterProvider.java
@@ -5,6 +5,7 @@ import io.dropwizard.jersey.validation.JerseyParameterNameProvider;
 import org.glassfish.jersey.internal.inject.ExtractorException;
 import org.glassfish.jersey.server.internal.LocalizationMessages;
 
+import javax.annotation.Nullable;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.ext.ParamConverter;
@@ -28,6 +29,7 @@ public class AbstractParamConverterProvider implements ParamConverterProvider {
     }
 
     @Override
+    @Nullable
     public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType, Annotation[] annotations) {
         if (AbstractParam.class.isAssignableFrom(rawType)) {
             final String parameterName = JerseyParameterNameProvider.getParameterNameFromAnnotations(annotations).orElse("Parameter");
@@ -42,6 +44,7 @@ public class AbstractParamConverterProvider implements ParamConverterProvider {
             return new ParamConverter<T>() {
                 @Override
                 @SuppressWarnings("unchecked")
+                @Nullable
                 public T fromString(String value) {
                     if (rawType != NonEmptyStringParam.class && Strings.isNullOrEmpty(value)) {
                         return null;

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/BooleanParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/BooleanParam.java
@@ -1,5 +1,7 @@
 package io.dropwizard.jersey.params;
 
+import javax.annotation.Nullable;
+
 /**
  * A parameter encapsulating boolean values. If the query parameter value is {@code "true"},
  * regardless of case, the returned value is {@link Boolean#TRUE}. If the query parameter value is
@@ -7,11 +9,11 @@ package io.dropwizard.jersey.params;
  * values will return a {@code 400 Bad Request} response.
  */
 public class BooleanParam extends AbstractParam<Boolean> {
-    public BooleanParam(String input) {
+    public BooleanParam(@Nullable String input) {
         super(input);
     }
 
-    public BooleanParam(String input, String parameterName) {
+    public BooleanParam(@Nullable String input, String parameterName) {
         super(input, parameterName);
     }
 
@@ -21,7 +23,7 @@ public class BooleanParam extends AbstractParam<Boolean> {
     }
 
     @Override
-    protected Boolean parse(String input) throws Exception {
+    protected Boolean parse(@Nullable String input) throws Exception {
         if ("true".equalsIgnoreCase(input)) {
             return Boolean.TRUE;
         }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/DateTimeParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/DateTimeParam.java
@@ -3,21 +3,23 @@ package io.dropwizard.jersey.params;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
+import javax.annotation.Nullable;
+
 /**
  * A parameter encapsulating date/time values. All non-parsable values will return a {@code 400 Bad
  * Request} response. All values returned are in UTC.
  */
 public class DateTimeParam extends AbstractParam<DateTime> {
-    public DateTimeParam(String input) {
+    public DateTimeParam(@Nullable String input) {
         super(input);
     }
 
-    public DateTimeParam(String input, String parameterName) {
+    public DateTimeParam(@Nullable String input, String parameterName) {
         super(input, parameterName);
     }
 
     @Override
-    protected DateTime parse(String input) throws Exception {
+    protected DateTime parse(@Nullable String input) throws Exception {
         return new DateTime(input, DateTimeZone.UTC);
     }
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/DurationParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/DurationParam.java
@@ -2,17 +2,21 @@ package io.dropwizard.jersey.params;
 
 import io.dropwizard.util.Duration;
 
+import javax.annotation.Nullable;
+
+import static java.util.Objects.requireNonNull;
+
 /**
  * A parameter encapsulating duration values. All non-parsable values will return a {@code 400 Bad
  * Request} response. Supports all input formats the {@link Duration} class supports.
  */
 public class DurationParam extends AbstractParam<Duration> {
 
-    public DurationParam(String input) {
+    public DurationParam(@Nullable String input) {
         super(input);
     }
 
-    public DurationParam(String input, String parameterName) {
+    public DurationParam(@Nullable String input, String parameterName) {
         super(input, parameterName);
     }
 
@@ -22,8 +26,8 @@ public class DurationParam extends AbstractParam<Duration> {
     }
 
     @Override
-    protected Duration parse(String input) throws Exception {
-        return Duration.parse(input);
+    protected Duration parse(@Nullable String input) throws Exception {
+        return Duration.parse(requireNonNull(input));
     }
 
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/InstantParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/InstantParam.java
@@ -1,16 +1,17 @@
 package io.dropwizard.jersey.params;
 
+import javax.annotation.Nullable;
 import java.time.Instant;
 
 /**
  * A parameter encapsulating date/time values. All non-parsable values will return a {@code 400 Bad Request} response.
  */
 public class InstantParam extends AbstractParam<Instant> {
-    public InstantParam(final String input) {
+    public InstantParam(@Nullable final String input) {
         super(input);
     }
 
-    public InstantParam(final String input, final String parameterName) {
+    public InstantParam(@Nullable final String input, final String parameterName) {
         super(input, parameterName);
     }
 
@@ -20,7 +21,7 @@ public class InstantParam extends AbstractParam<Instant> {
     }
 
     @Override
-    protected Instant parse(final String input) throws Exception {
+    protected Instant parse(@Nullable final String input) throws Exception {
         return Instant.parse(input);
     }
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/IntParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/IntParam.java
@@ -1,15 +1,17 @@
 package io.dropwizard.jersey.params;
 
+import javax.annotation.Nullable;
+
 /**
  * A parameter encapsulating integer values. All non-decimal values will return a
  * {@code 400 Bad Request} response.
  */
 public class IntParam extends AbstractParam<Integer> {
-    public IntParam(String input) {
+    public IntParam(@Nullable String input) {
         super(input);
     }
 
-    public IntParam(String input, String parameterName) {
+    public IntParam(@Nullable String input, String parameterName) {
         super(input, parameterName);
     }
 
@@ -19,7 +21,7 @@ public class IntParam extends AbstractParam<Integer> {
     }
 
     @Override
-    protected Integer parse(String input) {
+    protected Integer parse(@Nullable String input) {
         return Integer.valueOf(input);
     }
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/LocalDateParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/LocalDateParam.java
@@ -2,21 +2,23 @@ package io.dropwizard.jersey.params;
 
 import org.joda.time.LocalDate;
 
+import javax.annotation.Nullable;
+
 /**
  * A parameter encapsulating local date values. All non-parsable values will return a {@code 400 Bad
  * Request} response.
  */
 public class LocalDateParam extends AbstractParam<LocalDate> {
-    public LocalDateParam(String input) {
+    public LocalDateParam(@Nullable String input) {
         super(input);
     }
 
-    public LocalDateParam(String input, String parameterName) {
+    public LocalDateParam(@Nullable String input, String parameterName) {
         super(input, parameterName);
     }
 
     @Override
-    protected LocalDate parse(String input) throws Exception {
+    protected LocalDate parse(@Nullable String input) throws Exception {
         return new LocalDate(input);
     }
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/LongParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/LongParam.java
@@ -1,15 +1,17 @@
 package io.dropwizard.jersey.params;
 
+import javax.annotation.Nullable;
+
 /**
  * A parameter encapsulating long values. All non-decimal values will return a {@code 400 Bad
  * Request} response.
  */
 public class LongParam extends AbstractParam<Long> {
-    public LongParam(String input) {
+    public LongParam(@Nullable String input) {
         super(input);
     }
 
-    public LongParam(String input, String parameterName) {
+    public LongParam(@Nullable String input, String parameterName) {
         super(input, parameterName);
     }
 
@@ -19,7 +21,7 @@ public class LongParam extends AbstractParam<Long> {
     }
 
     @Override
-    protected Long parse(String input) {
+    protected Long parse(@Nullable String input) {
         return Long.valueOf(input);
     }
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/NonEmptyStringParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/NonEmptyStringParam.java
@@ -2,6 +2,7 @@ package io.dropwizard.jersey.params;
 
 import com.google.common.base.Strings;
 
+import javax.annotation.Nullable;
 import java.util.Optional;
 
 /**
@@ -11,16 +12,16 @@ import java.util.Optional;
  * {@code Optional.of("")}.
  */
 public class NonEmptyStringParam extends AbstractParam<Optional<String>> {
-    public NonEmptyStringParam(String input) {
+    public NonEmptyStringParam(@Nullable String input) {
         super(input);
     }
 
-    public NonEmptyStringParam(String input, String parameterName) {
+    public NonEmptyStringParam(@Nullable String input, String parameterName) {
         super(input, parameterName);
     }
 
     @Override
-    protected Optional<String> parse(String input) throws Exception {
+    protected Optional<String> parse(@Nullable String input) throws Exception {
         return Optional.ofNullable(Strings.emptyToNull(input));
     }
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/SizeParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/SizeParam.java
@@ -2,17 +2,21 @@ package io.dropwizard.jersey.params;
 
 import io.dropwizard.util.Size;
 
+import javax.annotation.Nullable;
+
+import static java.util.Objects.requireNonNull;
+
 /**
  * A parameter encapsulating size values. All non-parsable values will return a {@code 400 Bad
  * Request} response. Supports all input formats the {@link Size} class supports.
  */
 public class SizeParam extends AbstractParam<Size> {
 
-    public SizeParam(String input) {
+    public SizeParam(@Nullable String input) {
         super(input);
     }
 
-    public SizeParam(String input, String parameterName) {
+    public SizeParam(@Nullable String input, String parameterName) {
         super(input, parameterName);
     }
 
@@ -22,7 +26,7 @@ public class SizeParam extends AbstractParam<Size> {
     }
 
     @Override
-    protected Size parse(String input) throws Exception {
-        return Size.parse(input);
+    protected Size parse(@Nullable String input) throws Exception {
+        return Size.parse(requireNonNull(input));
     }
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/UUIDParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/UUIDParam.java
@@ -1,5 +1,6 @@
 package io.dropwizard.jersey.params;
 
+import javax.annotation.Nullable;
 import java.util.UUID;
 
 /**
@@ -8,11 +9,11 @@ import java.util.UUID;
  */
 public class UUIDParam extends AbstractParam<UUID> {
 
-    public UUIDParam(String input) {
+    public UUIDParam(@Nullable String input) {
         super(input);
     }
 
-    public UUIDParam(String input, String parameterName) {
+    public UUIDParam(@Nullable String input, String parameterName) {
         super(input, parameterName);
     }
 
@@ -22,7 +23,7 @@ public class UUIDParam extends AbstractParam<UUID> {
     }
 
     @Override
-    protected UUID parse(String input) throws Exception {
+    protected UUID parse(@Nullable String input) throws Exception {
         return UUID.fromString(input);
     }
 

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/sessions/FlashFactory.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/sessions/FlashFactory.java
@@ -2,13 +2,16 @@ package io.dropwizard.jersey.sessions;
 
 import org.glassfish.jersey.server.internal.inject.AbstractContainerRequestValueFactory;
 
+import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 import javax.ws.rs.core.Context;
 
 public final class FlashFactory extends AbstractContainerRequestValueFactory<Flash<?>> {
     @Context
+    @Nullable
     private HttpServletRequest request;
+
     private boolean doNotCreate;
 
     public FlashFactory(boolean doNotCreate) {
@@ -17,6 +20,7 @@ public final class FlashFactory extends AbstractContainerRequestValueFactory<Fla
 
     @Override
     @SuppressWarnings("rawtypes")
+    @Nullable
     public Flash<?> provide() {
         if (request == null) {
             return null;

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/sessions/HttpSessionFactory.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/sessions/HttpSessionFactory.java
@@ -2,12 +2,14 @@ package io.dropwizard.jersey.sessions;
 
 import org.glassfish.jersey.server.internal.inject.AbstractContainerRequestValueFactory;
 
+import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 import javax.ws.rs.core.Context;
 
 public final class HttpSessionFactory extends AbstractContainerRequestValueFactory<HttpSession> {
     @Context
+    @Nullable
     private HttpServletRequest request;
     private boolean doNotCreate;
 
@@ -16,6 +18,7 @@ public final class HttpSessionFactory extends AbstractContainerRequestValueFacto
     }
 
     @Override
+    @Nullable
     public HttpSession provide() {
         if (request == null) {
             return null;

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/sessions/SessionFactoryProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/sessions/SessionFactoryProvider.java
@@ -11,6 +11,7 @@ import org.glassfish.jersey.server.internal.inject.ParamInjectionResolver;
 import org.glassfish.jersey.server.model.Parameter;
 import org.glassfish.jersey.server.spi.internal.ValueFactoryProvider;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.servlet.http.HttpSession;
@@ -25,6 +26,7 @@ public class SessionFactoryProvider extends AbstractValueFactoryProvider {
     }
 
     @Override
+    @Nullable
     protected Factory<?> createValueFactory(final Parameter parameter) {
         final Class<?> classType = parameter.getRawType();
 

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/setup/JerseyContainerHolder.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/setup/JerseyContainerHolder.java
@@ -1,19 +1,23 @@
 package io.dropwizard.jersey.setup;
 
+import javax.annotation.Nullable;
 import javax.servlet.Servlet;
 
 public class JerseyContainerHolder {
+
+    @Nullable
     private Servlet container;
 
-    public JerseyContainerHolder(Servlet container) {
+    public JerseyContainerHolder(@Nullable Servlet container) {
         this.container = container;
     }
 
+    @Nullable
     public Servlet getContainer() {
         return container;
     }
 
-    public void setContainer(Servlet container) {
+    public void setContainer(@Nullable Servlet container) {
         this.container = container;
     }
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/setup/JerseyEnvironment.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/setup/JerseyEnvironment.java
@@ -94,6 +94,7 @@ public class JerseyEnvironment {
      * @see org.glassfish.jersey.server.ResourceConfig
      */
     @SuppressWarnings("unchecked")
+    @Nullable
     public <T> T getProperty(String name) {
         return (T) config.getProperties().get(name);
     }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/FuzzyEnumParamConverterProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/FuzzyEnumParamConverterProvider.java
@@ -4,9 +4,11 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import io.dropwizard.jersey.errors.ErrorMessage;
 import io.dropwizard.util.Enums;
+import org.glassfish.jersey.internal.util.ReflectionHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.lang.reflect.Method;
-import java.lang.reflect.InvocationTargetException;
+import javax.annotation.Nullable;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -14,14 +16,12 @@ import javax.ws.rs.ext.ParamConverter;
 import javax.ws.rs.ext.ParamConverterProvider;
 import javax.ws.rs.ext.Provider;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.security.AccessController;
 
 import static io.dropwizard.jersey.validation.JerseyParameterNameProvider.getParameterNameFromAnnotations;
-
-import org.glassfish.jersey.internal.util.ReflectionHelper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Provides converters to jersey for enums used as resource parameters.
@@ -39,7 +39,8 @@ public class FuzzyEnumParamConverterProvider implements ParamConverterProvider {
     private final static Joiner JOINER = Joiner.on(", ");
 
     @Override
-    public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType, Annotation[] annotations) {
+    @Nullable
+    public <T> ParamConverter<T> getConverter(Class<T> rawType, @Nullable Type genericType, Annotation[] annotations) {
         if (!rawType.isEnum()) {
             return null;
         }
@@ -51,6 +52,7 @@ public class FuzzyEnumParamConverterProvider implements ParamConverterProvider {
 
         return new ParamConverter<T>() {
             @Override
+            @Nullable
             public T fromString(String value) {
                 if (Strings.isNullOrEmpty(value)) {
                     return null;

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ParamValidatorUnwrapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ParamValidatorUnwrapper.java
@@ -5,6 +5,7 @@ import com.fasterxml.classmate.TypeResolver;
 import io.dropwizard.jersey.params.AbstractParam;
 import org.hibernate.validator.spi.valuehandling.ValidatedValueUnwrapper;
 
+import javax.annotation.Nullable;
 import java.lang.reflect.Type;
 
 /**
@@ -15,6 +16,7 @@ public class ParamValidatorUnwrapper extends ValidatedValueUnwrapper<AbstractPar
     private final TypeResolver resolver = new TypeResolver();
 
     @Override
+    @Nullable
     public Object handleValidatedValue(final AbstractParam<?> abstractParam) {
         return abstractParam == null ? null : abstractParam.get();
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/MyMessageParamConverterProvider.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/MyMessageParamConverterProvider.java
@@ -1,5 +1,6 @@
 package io.dropwizard.jersey;
 
+import javax.annotation.Nullable;
 import javax.ws.rs.ext.ParamConverter;
 import javax.ws.rs.ext.ParamConverterProvider;
 import javax.ws.rs.ext.Provider;
@@ -11,6 +12,7 @@ public class MyMessageParamConverterProvider implements ParamConverterProvider {
 
     @Override
     @SuppressWarnings("unchecked")
+    @Nullable
     public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType, Annotation[] annotations) {
         if (genericType.equals(MyMessage.class)) {
             return (ParamConverter<T>) new MyMessageParamConverter();

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/CharsetUtf8FilterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/CharsetUtf8FilterTest.java
@@ -2,9 +2,6 @@ package io.dropwizard.jersey.filter;
 
 import com.google.common.net.HttpHeaders;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
@@ -13,16 +10,13 @@ import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
 public class CharsetUtf8FilterTest {
 
-    @Mock
-    private ContainerRequestContext request;
-
-    @Mock
-    private ContainerResponseContext response;
+    private ContainerRequestContext request = mock(ContainerRequestContext.class);
+    private ContainerResponseContext response = mock(ContainerResponseContext.class);
 
     private CharsetUtf8Filter charsetUtf8Filter = new CharsetUtf8Filter();
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/RequestIdFilterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/RequestIdFilterTest.java
@@ -2,10 +2,7 @@ package io.dropwizard.jersey.filter;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 
 import javax.ws.rs.container.ContainerRequestContext;
@@ -16,20 +13,15 @@ import javax.ws.rs.core.UriInfo;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
 public class RequestIdFilterTest {
 
-    @Mock
-    private ContainerRequestContext request;
-
-    @Mock
-    private ContainerResponseContext response;
-
-    @Mock
-    private Logger logger;
+    private ContainerRequestContext request = mock(ContainerRequestContext.class);
+    private ContainerResponseContext response = mock(ContainerResponseContext.class);
+    private Logger logger = mock(Logger.class);
 
     private RequestIdFilter requestIdFilter = new RequestIdFilter();
     private MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/RuntimeFilterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/RuntimeFilterTest.java
@@ -1,10 +1,7 @@
 package io.dropwizard.jersey.filter;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
@@ -12,16 +9,13 @@ import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
 public class RuntimeFilterTest {
 
-    @Mock
-    private ContainerRequestContext request;
-
-    @Mock
-    private ContainerResponseContext response;
+    private ContainerRequestContext request = mock(ContainerRequestContext.class);
+    private ContainerResponseContext response = mock(ContainerResponseContext.class);
 
     private RuntimeFilter runtimeFilter = new RuntimeFilter();
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/gzip/ConfiguredGZipEncoderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/gzip/ConfiguredGZipEncoderTest.java
@@ -2,6 +2,7 @@ package io.dropwizard.jersey.gzip;
 
 import org.junit.Test;
 
+import javax.annotation.Nullable;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.core.HttpHeaders;
@@ -75,14 +76,6 @@ public class ConfiguredGZipEncoderTest {
         assertThat(context.isProceedCalled(), is(true));
     }
 
-
-    @Test(expected = NullPointerException.class)
-    public void contextMayNotBeNull() throws IOException {
-        ClientRequestContext context = null;
-        new ConfiguredGZipEncoder(false).filter(context);
-    }
-
-
     private class WriterInterceptorContextMock implements WriterInterceptorContext {
         private final MultivaluedMap<String, Object> headers;
         private OutputStream os = new OutputStream() {
@@ -103,6 +96,7 @@ public class ConfiguredGZipEncoderTest {
         }
 
         @Override
+        @Nullable
         public Object getEntity() {
             return null;
         }
@@ -128,11 +122,13 @@ public class ConfiguredGZipEncoderTest {
         }
 
         @Override
+        @Nullable
         public Object getProperty(String name) {
             return null;
         }
 
         @Override
+        @Nullable
         public Collection<String> getPropertyNames() {
             return null;
         }
@@ -158,6 +154,7 @@ public class ConfiguredGZipEncoderTest {
         }
 
         @Override
+        @Nullable
         public Class<?> getType() {
             return null;
         }
@@ -168,6 +165,7 @@ public class ConfiguredGZipEncoderTest {
         }
 
         @Override
+        @Nullable
         public Type getGenericType() {
             return null;
         }
@@ -178,6 +176,7 @@ public class ConfiguredGZipEncoderTest {
         }
 
         @Override
+        @Nullable
         public MediaType getMediaType() {
             return null;
         }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/CustomDeserialization.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/CustomDeserialization.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 
 /**
@@ -41,6 +42,7 @@ public class CustomDeserialization extends StdDeserializer<CustomRepresentation>
         }
 
         @Override
+        @Nullable
         public String getMessage() {
             return null;
         }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProviderTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreType;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
 import com.google.common.reflect.TypeToken;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.validation.Validated;
@@ -11,6 +12,7 @@ import org.hibernate.validator.constraints.NotEmpty;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.annotation.Nullable;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -71,7 +73,7 @@ public class JacksonMessageBodyProviderTest {
         @NotEmpty
         @Valid
         @JsonProperty
-        public List<Example> examples;
+        public List<Example> examples = ImmutableList.of();
     }
 
     public interface Partial1 {
@@ -86,6 +88,7 @@ public class JacksonMessageBodyProviderTest {
         public int id;
 
         @NotNull(groups = Partial2.class)
+        @Nullable
         @JsonProperty
         public String text;
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/OkRepresentation.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/OkRepresentation.java
@@ -2,10 +2,14 @@ package io.dropwizard.jersey.jackson;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.annotation.Nullable;
 import java.time.LocalDate;
 
 public class OkRepresentation {
-    private Integer message;
+
+    private Integer message = 0;
+
+    @Nullable
     private LocalDate date;
 
     @JsonProperty
@@ -14,6 +18,7 @@ public class OkRepresentation {
     }
 
     @JsonProperty
+    @Nullable
     public LocalDate getDate() {
         return date;
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/BeanParameter.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/BeanParameter.java
@@ -3,13 +3,15 @@ package io.dropwizard.jersey.validation;
 import io.dropwizard.validation.ValidationMethod;
 import org.hibernate.validator.constraints.NotEmpty;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.QueryParam;
+import java.util.Objects;
 
 public class BeanParameter {
     @QueryParam("name")
     @NotEmpty
-    private String name;
+    private String name = "";
 
     public String getName() {
         return name;
@@ -17,10 +19,11 @@ public class BeanParameter {
 
     @QueryParam("choice")
     @NotNull
+    @Nullable
     private Choice choice;
 
     public Choice getChoice() {
-        return choice;
+        return Objects.requireNonNull(choice);
     }
 
     @ValidationMethod(message = "name must be Coda")

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
@@ -1,29 +1,30 @@
-package io.dropwizard.jersey.validation;
+    package io.dropwizard.jersey.validation;
 
-import com.codahale.metrics.MetricRegistry;
-import io.dropwizard.jersey.AbstractJerseyTest;
-import io.dropwizard.jersey.DropwizardResourceConfig;
-import io.dropwizard.jersey.jackson.JacksonMessageBodyProviderTest.Example;
-import io.dropwizard.jersey.jackson.JacksonMessageBodyProviderTest.ListExample;
-import io.dropwizard.jersey.jackson.JacksonMessageBodyProviderTest.PartialExample;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+    import com.codahale.metrics.MetricRegistry;
+    import io.dropwizard.jersey.AbstractJerseyTest;
+    import io.dropwizard.jersey.DropwizardResourceConfig;
+    import io.dropwizard.jersey.jackson.JacksonMessageBodyProviderTest.Example;
+    import io.dropwizard.jersey.jackson.JacksonMessageBodyProviderTest.ListExample;
+    import io.dropwizard.jersey.jackson.JacksonMessageBodyProviderTest.PartialExample;
+    import org.junit.AfterClass;
+    import org.junit.BeforeClass;
+    import org.junit.Test;
 
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.Application;
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.util.Collection;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+    import javax.ws.rs.client.Entity;
+    import javax.ws.rs.core.Application;
+    import javax.ws.rs.core.Form;
+    import javax.ws.rs.core.GenericType;
+    import javax.ws.rs.core.MediaType;
+    import javax.ws.rs.core.Response;
+    import java.util.Collection;
+    import java.util.List;
+    import java.util.Locale;
+    import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assume.assumeThat;
+    import static java.util.Objects.requireNonNull;
+    import static org.assertj.core.api.Assertions.assertThat;
+    import static org.hamcrest.CoreMatchers.is;
+    import static org.junit.Assume.assumeThat;
 
 public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
 
@@ -525,8 +526,8 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
 
         Map<String, Example> map = response.readEntity(new GenericType<Map<String, Example>>() {
         });
-        assertThat(map.get("one").id).isEqualTo(1);
-        assertThat(map.get("two").id).isEqualTo(2);
+        assertThat(requireNonNull(map.get("one")).id).isEqualTo(1);
+        assertThat(requireNonNull(map.get("two")).id).isEqualTo(2);
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/SubBeanParameter.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/SubBeanParameter.java
@@ -11,7 +11,7 @@ import java.util.Locale;
 public class SubBeanParameter extends BeanParameter {
     @QueryParam("address")
     @NotEmpty
-    private String address;
+    private String address = "";
 
 
     @ValidationMethod(message = "address must not be uppercase",

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidRepresentation.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidRepresentation.java
@@ -5,7 +5,7 @@ import org.hibernate.validator.constraints.NotEmpty;
 
 public class ValidRepresentation {
     @NotEmpty
-    private String name;
+    private String name = "";
 
     @JsonProperty
     public String getName() {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
@@ -46,7 +46,7 @@ public class ValidatingResource {
 
     @QueryParam("sort")
     @Pattern(regexp = "^(asc|desc)$")
-    private String sortParam;
+    private String sortParam = "";
 
     @POST
     @Path("foo")

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/WrappedFailingExample.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/WrappedFailingExample.java
@@ -2,13 +2,16 @@ package io.dropwizard.jersey.validation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.annotation.Nullable;
 import javax.validation.Valid;
 
 public class WrappedFailingExample {
     @Valid
+    @Nullable
     private FailingExample example;
 
     @JsonProperty
+    @Nullable
     public FailingExample getExample() {
         return example;
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/WrappedValidRepresentation.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/WrappedValidRepresentation.java
@@ -2,13 +2,16 @@ package io.dropwizard.jersey.validation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.annotation.Nullable;
 import javax.validation.Valid;
 
 public class WrappedValidRepresentation {
     @Valid
+    @Nullable
     private ValidRepresentation representation;
 
     @JsonProperty
+    @Nullable
     public ValidRepresentation getRepresentation() {
         return representation;
     }

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/BiDiGzipHandler.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/BiDiGzipHandler.java
@@ -4,6 +4,7 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 
+import javax.annotation.Nullable;
 import javax.servlet.ReadListener;
 import javax.servlet.ServletException;
 import javax.servlet.ServletInputStream;
@@ -255,6 +256,7 @@ public class BiDiGzipHandler extends GzipHandler {
          * @param name a <code>String</code> specifying the name of a request header
          */
         @Override
+        @Nullable
         public String getHeader(final String name) {
             if (headerName.equalsIgnoreCase(name)) {
                 return null;

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/ConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/ConnectorFactory.java
@@ -7,6 +7,8 @@ import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.thread.ThreadPool;
 
+import javax.annotation.Nullable;
+
 /**
  * A factory for creating Jetty {@link Connector}s.
  */
@@ -24,5 +26,5 @@ public interface ConnectorFactory extends Discoverable {
     Connector build(Server server,
                     MetricRegistry metrics,
                     String name,
-                    ThreadPool threadPool);
+                    @Nullable ThreadPool threadPool);
 }

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/GzipHandlerFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/GzipHandlerFactory.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Iterables;
 import io.dropwizard.util.Size;
 import org.eclipse.jetty.server.Handler;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -83,7 +84,11 @@ public class GzipHandlerFactory {
 
     // By default compress responses for all user-agents
     private Set<String> excludedUserAgentPatterns = new HashSet<>();
+
+    @Nullable
     private Set<String> compressedMimeTypes;
+
+    @Nullable
     private Set<String> includedMethods;
 
     @Min(Deflater.DEFAULT_COMPRESSION)
@@ -93,7 +98,7 @@ public class GzipHandlerFactory {
     private boolean gzipCompatibleInflation = true;
 
     private boolean syncFlush = false;
-    
+
     @JsonProperty
     public boolean isEnabled() {
         return enabled;
@@ -125,6 +130,7 @@ public class GzipHandlerFactory {
     }
 
     @JsonProperty
+    @Nullable
     public Set<String> getCompressedMimeTypes() {
         return compressedMimeTypes;
     }
@@ -163,6 +169,7 @@ public class GzipHandlerFactory {
     }
 
     @JsonProperty
+    @Nullable
     public Set<String> getIncludedMethods() {
         return includedMethods;
     }
@@ -171,7 +178,7 @@ public class GzipHandlerFactory {
     public void setIncludedMethods(Set<String> methods) {
         this.includedMethods = methods;
     }
-    
+
     @JsonProperty
     public boolean isSyncFlush() {
         return syncFlush;
@@ -182,7 +189,7 @@ public class GzipHandlerFactory {
         this.syncFlush = syncFlush;
     }
 
-    public BiDiGzipHandler build(Handler handler) {
+    public BiDiGzipHandler build(@Nullable Handler handler) {
         final BiDiGzipHandler gzipHandler = new BiDiGzipHandler();
         gzipHandler.setHandler(handler);
         gzipHandler.setMinGzipSize((int) minimumEntitySize.toBytes());

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
@@ -24,6 +24,7 @@ import org.eclipse.jetty.util.thread.Scheduler;
 import org.eclipse.jetty.util.thread.ThreadPool;
 import org.hibernate.validator.valuehandling.UnwrapValidatedValue;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import java.util.Optional;
@@ -220,7 +221,8 @@ public class HttpConnectorFactory implements ConnectorFactory {
     @PortRange
     private int port = 8080;
 
-    private String bindHost = null;
+    @Nullable
+    private String bindHost;
 
     private boolean inheritChannel = false;
 
@@ -248,7 +250,8 @@ public class HttpConnectorFactory implements ConnectorFactory {
     @MinDuration(value = 1, unit = TimeUnit.MILLISECONDS)
     private Duration idleTimeout = Duration.seconds(30);
 
-    private Duration blockingTimeout = null;
+    @Nullable
+    private Duration blockingTimeout;
 
     @NotNull
     @MinSize(value = 1, unit = SizeUnit.BYTES)
@@ -273,10 +276,13 @@ public class HttpConnectorFactory implements ConnectorFactory {
     private Optional<Integer> selectorThreads = Optional.empty();
 
     @Min(0)
+    @Nullable
     private Integer acceptQueueSize;
 
     private boolean reuseAddress = true;
-    private Duration soLingerTime = null;
+
+    @Nullable
+    private Duration soLingerTime;
     private boolean useServerHeader = false;
     private boolean useDateHeader = true;
     private boolean useForwardedHeaders = true;
@@ -293,6 +299,7 @@ public class HttpConnectorFactory implements ConnectorFactory {
     }
 
     @JsonProperty
+    @Nullable
     public String getBindHost() {
         return bindHost;
     }
@@ -373,6 +380,7 @@ public class HttpConnectorFactory implements ConnectorFactory {
     }
 
     @JsonProperty
+    @Nullable
     public Duration getBlockingTimeout() {
         return blockingTimeout;
     }
@@ -443,6 +451,7 @@ public class HttpConnectorFactory implements ConnectorFactory {
     }
 
     @JsonProperty
+    @Nullable
     public Integer getAcceptQueueSize() {
         return acceptQueueSize;
     }
@@ -463,6 +472,7 @@ public class HttpConnectorFactory implements ConnectorFactory {
     }
 
     @JsonProperty
+    @Nullable
     public Duration getSoLingerTime() {
         return soLingerTime;
     }
@@ -517,7 +527,7 @@ public class HttpConnectorFactory implements ConnectorFactory {
     public Connector build(Server server,
                            MetricRegistry metrics,
                            String name,
-                           ThreadPool threadPool) {
+                           @Nullable ThreadPool threadPool) {
         final HttpConfiguration httpConfig = buildHttpConfiguration();
 
         final HttpConnectionFactory httpConnectionFactory = buildHttpConnectionFactory(httpConfig);
@@ -542,7 +552,7 @@ public class HttpConnectorFactory implements ConnectorFactory {
                                              Scheduler scheduler,
                                              ByteBufferPool bufferPool,
                                              String name,
-                                             ThreadPool threadPool,
+                                             @Nullable ThreadPool threadPool,
                                              ConnectionFactory... factories) {
         final ServerConnector connector = new ServerConnector(server,
                                                               threadPool,

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
@@ -24,6 +24,7 @@ import org.hibernate.validator.constraints.NotEmpty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import java.io.File;
@@ -224,42 +225,77 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpsConnectorFactory.class);
     private static final AtomicBoolean LOGGED = new AtomicBoolean(false);
 
+    @Nullable
     private String keyStorePath;
 
+    @Nullable
     private String keyStorePassword;
 
     @NotEmpty
     private String keyStoreType = "JKS";
 
+    @Nullable
     private String keyStoreProvider;
 
+    @Nullable
     private String trustStorePath;
 
+    @Nullable
     private String trustStorePassword;
 
     @NotEmpty
     private String trustStoreType = "JKS";
 
+    @Nullable
     private String trustStoreProvider;
 
+    @Nullable
     private String keyManagerPassword;
 
+    @Nullable
     private Boolean needClientAuth;
+
+    @Nullable
     private Boolean wantClientAuth;
+
+    @Nullable
     private String certAlias;
+
+    @Nullable
     private File crlPath;
+
+    @Nullable
     private Boolean enableCRLDP;
+
+    @Nullable
     private Boolean enableOCSP;
+
+    @Nullable
     private Integer maxCertPathLength;
+
+    @Nullable
     private URI ocspResponderUrl;
+
+    @Nullable
     private String jceProvider;
     private boolean validateCerts = false;
     private boolean validatePeers = false;
+
+    @Nullable
     private List<String> supportedProtocols;
+
+    @Nullable
     private List<String> excludedProtocols;
+
+    @Nullable
     private List<String> supportedCipherSuites;
+
+    @Nullable
     private List<String> excludedCipherSuites;
+
     private boolean allowRenegotiation = true;
+
+    @Nullable
     private String endpointIdentificationAlgorithm;
 
     @JsonProperty
@@ -273,6 +309,7 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
     }
 
     @JsonProperty
+    @Nullable
     public String getEndpointIdentificationAlgorithm() {
         return endpointIdentificationAlgorithm;
     }
@@ -283,6 +320,7 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
     }
 
     @JsonProperty
+    @Nullable
     public String getKeyStorePath() {
         return keyStorePath;
     }
@@ -293,6 +331,7 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
     }
 
     @JsonProperty
+    @Nullable
     public String getKeyStorePassword() {
         return keyStorePassword;
     }
@@ -313,6 +352,7 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
     }
 
     @JsonProperty
+    @Nullable
     public String getKeyStoreProvider() {
         return keyStoreProvider;
     }
@@ -333,6 +373,7 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
     }
 
     @JsonProperty
+    @Nullable
     public String getTrustStoreProvider() {
         return trustStoreProvider;
     }
@@ -343,6 +384,7 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
     }
 
     @JsonProperty
+    @Nullable
     public String getKeyManagerPassword() {
         return keyManagerPassword;
     }
@@ -353,6 +395,7 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
     }
 
     @JsonProperty
+    @Nullable
     public String getTrustStorePath() {
         return trustStorePath;
     }
@@ -363,16 +406,18 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
     }
 
     @JsonProperty
+    @Nullable
     public String getTrustStorePassword() {
         return trustStorePassword;
     }
 
     @JsonProperty
-    public void setTrustStorePassword(String trustStorePassword) {
+    public void setTrustStorePassword(@Nullable String trustStorePassword) {
         this.trustStorePassword = trustStorePassword;
     }
 
     @JsonProperty
+    @Nullable
     public Boolean getNeedClientAuth() {
         return needClientAuth;
     }
@@ -383,6 +428,7 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
     }
 
     @JsonProperty
+    @Nullable
     public Boolean getWantClientAuth() {
         return wantClientAuth;
     }
@@ -393,6 +439,7 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
     }
 
     @JsonProperty
+    @Nullable
     public String getCertAlias() {
         return certAlias;
     }
@@ -403,6 +450,7 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
     }
 
     @JsonProperty
+    @Nullable
     public File getCrlPath() {
         return crlPath;
     }
@@ -413,6 +461,7 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
     }
 
     @JsonProperty
+    @Nullable
     public Boolean getEnableCRLDP() {
         return enableCRLDP;
     }
@@ -423,6 +472,7 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
     }
 
     @JsonProperty
+    @Nullable
     public Boolean getEnableOCSP() {
         return enableOCSP;
     }
@@ -433,6 +483,7 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
     }
 
     @JsonProperty
+    @Nullable
     public Integer getMaxCertPathLength() {
         return maxCertPathLength;
     }
@@ -443,6 +494,7 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
     }
 
     @JsonProperty
+    @Nullable
     public URI getOcspResponderUrl() {
         return ocspResponderUrl;
     }
@@ -453,6 +505,7 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
     }
 
     @JsonProperty
+    @Nullable
     public String getJceProvider() {
         return jceProvider;
     }
@@ -473,6 +526,7 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
     }
 
     @JsonProperty
+    @Nullable
     public List<String> getSupportedProtocols() {
         return supportedProtocols;
     }
@@ -483,6 +537,7 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
     }
 
     @JsonProperty
+    @Nullable
     public List<String> getExcludedProtocols() {
         return excludedProtocols;
     }
@@ -493,11 +548,13 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
     }
 
     @JsonProperty
+    @Nullable
     public List<String> getSupportedCipherSuites() {
         return supportedCipherSuites;
     }
 
     @JsonProperty
+    @Nullable
     public List<String> getExcludedCipherSuites() {
         return excludedCipherSuites;
     }
@@ -534,7 +591,7 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
     }
 
     @Override
-    public Connector build(Server server, MetricRegistry metrics, String name, ThreadPool threadPool) {
+    public Connector build(Server server, MetricRegistry metrics, String name, @Nullable ThreadPool threadPool) {
         final HttpConfiguration httpConfig = buildHttpConfiguration();
 
         final HttpConnectionFactory httpConnectionFactory = buildHttpConnectionFactory(httpConfig);

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/Jetty93InstrumentedConnectionFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/Jetty93InstrumentedConnectionFactory.java
@@ -7,7 +7,10 @@ import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
 
+import javax.annotation.Nullable;
 import java.util.List;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * A version {@link com.codahale.metrics.jetty9.InstrumentedConnectionFactory}, which supports Jetty 9.3 API.
@@ -46,6 +49,8 @@ public class Jetty93InstrumentedConnectionFactory extends ContainerLifeCycle imp
     public Connection newConnection(Connector connector, EndPoint endPoint) {
         final Connection connection = connectionFactory.newConnection(connector, endPoint);
         connection.addListener(new Connection.Listener() {
+
+            @Nullable
             private Timer.Context context;
 
             @Override
@@ -55,7 +60,7 @@ public class Jetty93InstrumentedConnectionFactory extends ContainerLifeCycle imp
 
             @Override
             public void onClosed(Connection connection) {
-                context.stop();
+                requireNonNull(context).stop();
             }
         });
         return connection;

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/NetUtil.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/NetUtil.java
@@ -16,6 +16,7 @@
 package io.dropwizard.jetty;
 
 import com.google.common.io.Files;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -30,6 +31,8 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * This class is taken from the Netty project, and all credit goes to them.
@@ -96,6 +99,7 @@ public class NetUtil {
      * @param newLocalIpFilter the new local ip filter
      */
     public static void setLocalIpFilter(LocalIpFilter newLocalIpFilter) {
+        requireNonNull(newLocalIpFilter);
         LOCAL_IP_FILTER.set(newLocalIpFilter);
     }
 
@@ -105,7 +109,7 @@ public class NetUtil {
      * @return ip filter
      */
     public static LocalIpFilter getLocalIpFilter() {
-        return LOCAL_IP_FILTER.get();
+        return requireNonNull(LOCAL_IP_FILTER.get());
     }
 
     /**
@@ -142,7 +146,7 @@ public class NetUtil {
             final Enumeration<InetAddress> adrs = nif.getInetAddresses();
             while (adrs.hasMoreElements()) {
                 final InetAddress adr = adrs.nextElement();
-                if (LOCAL_IP_FILTER.get().use(nif, adr)) {
+                if (getLocalIpFilter().use(nif, adr)) {
                     listAdr.add(adr);
                 }
             }

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilderTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilderTest.java
@@ -1,26 +1,28 @@
 package io.dropwizard.lifecycle.setup;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import io.dropwizard.lifecycle.ExecutorServiceManager;
+import io.dropwizard.util.Duration;
+import org.junit.After;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
+import javax.annotation.Nullable;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.After;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-
-import io.dropwizard.lifecycle.ExecutorServiceManager;
-import io.dropwizard.util.Duration;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class ScheduledExecutorServiceBuilderTest {
 
     private static final Duration DEFAULT_SHUTDOWN_PERIOD = Duration.seconds(5L);
 
     private final LifecycleEnvironment le;
+
+    @Nullable
     private ScheduledExecutorService execTracker;
 
     public ScheduledExecutorServiceBuilderTest() {

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/AbstractAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/AbstractAppenderFactory.java
@@ -15,6 +15,7 @@ import io.dropwizard.logging.async.AsyncAppenderFactory;
 import io.dropwizard.logging.filter.FilterFactory;
 import io.dropwizard.logging.layout.LayoutFactory;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -88,6 +89,7 @@ public abstract class AbstractAppenderFactory<E extends DeferredProcessingAware>
     @NotNull
     protected Level threshold = Level.ALL;
 
+    @Nullable
     protected String logFormat;
 
     @NotNull
@@ -136,6 +138,7 @@ public abstract class AbstractAppenderFactory<E extends DeferredProcessingAware>
     }
 
     @JsonProperty
+    @Nullable
     public String getLogFormat() {
         return logFormat;
     }

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
@@ -22,7 +22,11 @@ import io.dropwizard.logging.layout.LayoutFactory;
 import io.dropwizard.util.Size;
 import io.dropwizard.validation.MinSize;
 import io.dropwizard.validation.ValidationMethod;
+
+import javax.annotation.Nullable;
 import javax.validation.constraints.Min;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * An {@link AppenderFactory} implementation which provides an appender that writes events to a file, archiving older
@@ -124,15 +128,18 @@ import javax.validation.constraints.Min;
 @JsonTypeName("file")
 public class FileAppenderFactory<E extends DeferredProcessingAware> extends AbstractAppenderFactory<E> {
 
+    @Nullable
     private String currentLogFilename;
 
     private boolean archive = true;
 
+    @Nullable
     private String archivedLogFilenamePattern;
 
     @Min(0)
     private int archivedFileCount = 5;
 
+    @Nullable
     private Size maxFileSize;
 
     @MinSize(1)
@@ -141,12 +148,13 @@ public class FileAppenderFactory<E extends DeferredProcessingAware> extends Abst
     private boolean immediateFlush = true;
 
     @JsonProperty
+    @Nullable
     public String getCurrentLogFilename() {
         return currentLogFilename;
     }
 
     @JsonProperty
-    public void setCurrentLogFilename(String currentLogFilename) {
+    public void setCurrentLogFilename(@Nullable String currentLogFilename) {
         this.currentLogFilename = currentLogFilename;
     }
 
@@ -161,6 +169,7 @@ public class FileAppenderFactory<E extends DeferredProcessingAware> extends Abst
     }
 
     @JsonProperty
+    @Nullable
     public String getArchivedLogFilenamePattern() {
         return archivedLogFilenamePattern;
     }
@@ -181,6 +190,7 @@ public class FileAppenderFactory<E extends DeferredProcessingAware> extends Abst
     }
 
     @JsonProperty
+    @Nullable
     public Size getMaxFileSize() {
         return maxFileSize;
     }
@@ -264,7 +274,7 @@ public class FileAppenderFactory<E extends DeferredProcessingAware> extends Abst
             appender.setFile(currentLogFilename);
             appender.setBufferSize(new FileSize(bufferSize.toBytes()));
 
-            if (maxFileSize != null && !archivedLogFilenamePattern.contains("%d")) {
+            if (maxFileSize != null && !requireNonNull(archivedLogFilenamePattern).contains("%d")) {
                 final FixedWindowRollingPolicy rollingPolicy = new FixedWindowRollingPolicy();
                 rollingPolicy.setContext(context);
                 rollingPolicy.setMaxIndex(getArchivedFileCount());

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/PrefixedRootCauseFirstThrowableProxyConverterTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/PrefixedRootCauseFirstThrowableProxyConverterTest.java
@@ -5,6 +5,7 @@ import com.google.common.base.Splitter;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.util.Collections;
@@ -23,6 +24,7 @@ public class PrefixedRootCauseFirstThrowableProxyConverterTest {
 
     private final ThrowableProxy proxy = new ThrowableProxy(getException());
 
+    @Nullable
     private Exception getException() {
         try {
             throwOuterWrapper();

--- a/dropwizard-metrics-ganglia/src/main/java/io/dropwizard/metrics/ganglia/GangliaReporterFactory.java
+++ b/dropwizard-metrics-ganglia/src/main/java/io/dropwizard/metrics/ganglia/GangliaReporterFactory.java
@@ -12,6 +12,7 @@ import io.dropwizard.validation.MinDuration;
 import org.hibernate.validator.constraints.NotEmpty;
 import org.hibernate.validator.constraints.Range;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import java.io.IOException;
 import java.util.Optional;
@@ -93,8 +94,13 @@ public class GangliaReporterFactory extends BaseReporterFactory {
     @Range(min = 0, max = 255)
     private int ttl = 1;
 
+    @Nullable
     private String prefix;
+
+    @Nullable
     private UUID uuid;
+
+    @Nullable
     private String spoof;
 
     @JsonProperty
@@ -157,6 +163,7 @@ public class GangliaReporterFactory extends BaseReporterFactory {
         this.ttl = ttl;
     }
 
+    @Nullable
     public String getPrefix() {
         return prefix;
     }

--- a/dropwizard-metrics/src/main/java/io/dropwizard/metrics/CsvReporterFactory.java
+++ b/dropwizard-metrics/src/main/java/io/dropwizard/metrics/CsvReporterFactory.java
@@ -6,8 +6,10 @@ import com.codahale.metrics.ScheduledReporter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import javax.validation.constraints.NotNull;
+import javax.annotation.Nullable;
 import java.io.File;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * A factory for configuring and building {@link CsvReporter} instances.
@@ -39,21 +41,23 @@ import java.io.File;
  */
 @JsonTypeName("csv")
 public class CsvReporterFactory extends BaseFormattedReporterFactory {
-    @NotNull
+    @Nullable
     private File file;
 
     @JsonProperty
+    @Nullable
     public File getFile() {
         return file;
     }
 
     @JsonProperty
-    public void setFile(File file) {
+    public void setFile(@Nullable File file) {
         this.file = file;
     }
 
     @Override
     public ScheduledReporter build(MetricRegistry registry) {
+        final File file = requireNonNull(this.file, "File is not set");
         final boolean creation = file.mkdirs();
         if (!creation && !file.exists()) {
             throw new RuntimeException("Failed to create" + file.getAbsolutePath());

--- a/dropwizard-metrics/src/main/java/io/dropwizard/metrics/Slf4jReporterFactory.java
+++ b/dropwizard-metrics/src/main/java/io/dropwizard/metrics/Slf4jReporterFactory.java
@@ -10,6 +10,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MarkerFactory;
 
+import javax.annotation.Nullable;
+
 /**
  * A {@link ReporterFactory} for {@link Slf4jReporter} instances.
  * <p/>
@@ -40,6 +42,7 @@ public class Slf4jReporterFactory extends BaseReporterFactory {
     @NotEmpty
     private String loggerName = "metrics";
 
+    @Nullable
     private String markerName;
 
     @JsonProperty("logger")
@@ -57,12 +60,13 @@ public class Slf4jReporterFactory extends BaseReporterFactory {
     }
 
     @JsonProperty
+    @Nullable
     public String getMarkerName() {
         return markerName;
     }
 
     @JsonProperty
-    public void setMarkerName(String markerName) {
+    public void setMarkerName(@Nullable String markerName) {
         this.markerName = markerName;
     }
 

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/BaseReporterFactoryTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/BaseReporterFactoryTest.java
@@ -82,13 +82,13 @@ public class BaseReporterFactoryTest {
     };
 
     @Parameterized.Parameter
-    public ImmutableSet<String> includes;
+    public ImmutableSet<String> includes = ImmutableSet.of();
 
     @Parameterized.Parameter(1)
-    public ImmutableSet<String> excludes;
+    public ImmutableSet<String> excludes = ImmutableSet.of();
 
     @Parameterized.Parameter(2)
-    public String name;
+    public String name = "";
 
     @Parameterized.Parameter(3)
     public boolean expectedDefaultResult;
@@ -100,7 +100,7 @@ public class BaseReporterFactoryTest {
     public boolean expectedSubstringResult;
 
     @Parameterized.Parameter(6)
-    public String msg;
+    public String msg = "";
 
     private final Metric metric = mock(Metric.class);
 

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/MetricAttributesTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/MetricAttributesTest.java
@@ -40,13 +40,13 @@ public class MetricAttributesTest {
     };
 
     @Parameter
-    public EnumSet<MetricAttribute> includes;
+    public EnumSet<MetricAttribute> includes = EnumSet.noneOf(MetricAttribute.class);
 
     @Parameter(1)
-    public EnumSet<MetricAttribute> excludes;
+    public EnumSet<MetricAttribute> excludes = EnumSet.noneOf(MetricAttribute.class);
 
     @Parameter(2)
-    public EnumSet<MetricAttribute> expectedResult;
+    public EnumSet<MetricAttribute> expectedResult = EnumSet.noneOf(MetricAttribute.class);
 
     @Test
     public void testGetDisabledAttributes() {

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/AbstractLiquibaseCommand.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/AbstractLiquibaseCommand.java
@@ -17,6 +17,7 @@ import liquibase.exception.ValidationFailedException;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 
+import javax.annotation.Nullable;
 import java.sql.SQLException;
 
 public abstract class AbstractLiquibaseCommand<T extends Configuration> extends ConfiguredCommand<T> {
@@ -59,7 +60,7 @@ public abstract class AbstractLiquibaseCommand<T extends Configuration> extends 
 
     @Override
     @SuppressWarnings("UseOfSystemOutOrSystemErr")
-    protected void run(Bootstrap<T> bootstrap, Namespace namespace, T configuration) throws Exception {
+    protected void run(@Nullable Bootstrap<T> bootstrap, Namespace namespace, T configuration) throws Exception {
         final PooledDataSourceFactory dbConfig = strategy.getDataSourceFactory(configuration);
         dbConfig.asSingleConnectionPool();
 

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbCommand.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbCommand.java
@@ -9,6 +9,8 @@ import net.sourceforge.argparse4j.inf.Subparser;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import static java.util.Objects.requireNonNull;
+
 public class DbCommand<T extends Configuration> extends AbstractLiquibaseCommand<T> {
     private static final String COMMAND_NAME_ATTR = "subcommand";
     private final SortedMap<String, AbstractLiquibaseCommand<T>> subcommands;
@@ -48,7 +50,8 @@ public class DbCommand<T extends Configuration> extends AbstractLiquibaseCommand
 
     @Override
     public void run(Namespace namespace, Liquibase liquibase) throws Exception {
-        final AbstractLiquibaseCommand<T> subcommand = subcommands.get(namespace.getString(COMMAND_NAME_ATTR));
+        final AbstractLiquibaseCommand<T> subcommand =
+            requireNonNull(subcommands.get(namespace.getString(COMMAND_NAME_ATTR)), "Unable find the command");
         subcommand.run(namespace, liquibase);
     }
 }

--- a/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/layout/SafeRequestParameterConverter.java
+++ b/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/layout/SafeRequestParameterConverter.java
@@ -4,6 +4,7 @@ import ch.qos.logback.access.pattern.AccessConverter;
 import ch.qos.logback.access.spi.IAccessEvent;
 import ch.qos.logback.core.util.OptionHelper;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
 
 /**
@@ -13,6 +14,7 @@ import java.util.Arrays;
  */
 public class SafeRequestParameterConverter extends AccessConverter {
 
+    @Nullable
     private String key;
 
     @Override

--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/assets/AssetServlet.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/assets/AssetServlet.java
@@ -9,6 +9,7 @@ import com.google.common.io.Resources;
 import com.google.common.net.HttpHeaders;
 import com.google.common.net.MediaType;
 
+import javax.annotation.Nullable;
 import javax.servlet.ServletException;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServlet;
@@ -54,7 +55,11 @@ public class AssetServlet extends HttpServlet {
 
     private final String resourcePath;
     private final String uriPath;
+
+    @Nullable
     private final String indexFile;
+
+    @Nullable
     private final Charset defaultCharset;
 
     /**
@@ -75,8 +80,8 @@ public class AssetServlet extends HttpServlet {
      */
     public AssetServlet(String resourcePath,
                         String uriPath,
-                        String indexFile,
-                        Charset defaultCharset) {
+                        @Nullable String indexFile,
+                        @Nullable Charset defaultCharset) {
         final String trimmedPath = SLASHES.trimFrom(resourcePath);
         this.resourcePath = trimmedPath.isEmpty() ? trimmedPath : trimmedPath + '/';
         final String trimmedUri = SLASHES.trimTrailingFrom(uriPath);
@@ -93,6 +98,7 @@ public class AssetServlet extends HttpServlet {
         return uriPath;
     }
 
+    @Nullable
     public String getIndexFile() {
         return indexFile;
     }
@@ -194,6 +200,7 @@ public class AssetServlet extends HttpServlet {
         }
     }
 
+    @Nullable
     private CachedAsset loadAsset(String key) throws URISyntaxException, IOException {
         checkArgument(key.startsWith(uriPath));
         final String requestedResourcePath = SLASHES.trimFrom(key.substring(uriPath.length()));

--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/LogConfigurationTask.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/LogConfigurationTask.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableMultimap;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.PrintWriter;
 import java.util.List;
 
@@ -67,6 +68,7 @@ public class LogConfigurationTask extends Task {
         return parameters.get("logger").asList();
     }
 
+    @Nullable
     private Level getLoggerLevel(ImmutableMultimap<String, String> parameters) {
         final List<String> loggerLevels = parameters.get("level").asList();
         return loggerLevels.isEmpty() ? null : Level.valueOf(loggerLevels.get(0));

--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/TaskServlet.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/TaskServlet.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import static com.codahale.metrics.MetricRegistry.name;
+import static java.util.Objects.requireNonNull;
 
 /**
  * A servlet which provides access to administrative {@link Task}s. It only responds to {@code POST}
@@ -118,7 +119,7 @@ public class TaskServlet extends HttpServlet {
             final PrintWriter output = resp.getWriter();
             try {
                 final TaskExecutor taskExecutor = taskExecutors.get(task);
-                taskExecutor.executeTask(getParams(req), getBody(req), output);
+                requireNonNull(taskExecutor).executeTask(getParams(req), getBody(req), output);
             } catch (Exception e) {
                 LOGGER.error("Error running {}", task.getName(), e);
                 resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/SlowRequestFilterTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/SlowRequestFilterTest.java
@@ -4,9 +4,6 @@ import io.dropwizard.util.Duration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 
 import javax.servlet.FilterChain;
@@ -15,27 +12,18 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SlowRequestFilterTest {
 
-    @Mock
-    private HttpServletRequest request;
-
-    @Mock
-    private HttpServletResponse response;
-
-    @Mock
-    private FilterChain chain;
-
-    @Mock
-    private FilterConfig filterConfig;
-
-    @Mock
-    private Logger logger;
+    private HttpServletRequest request = mock(HttpServletRequest.class);
+    private HttpServletResponse response = mock(HttpServletResponse.class);
+    private FilterChain chain = mock(FilterChain.class);
+    private FilterConfig filterConfig = mock(FilterConfig.class);
+    private Logger logger = mock(Logger.class);
 
     private SlowRequestFilter slowRequestFilter = new SlowRequestFilter(Duration.milliseconds(500));
 

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/ThreadNameFilterTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/ThreadNameFilterTest.java
@@ -3,9 +3,6 @@ package io.dropwizard.servlets;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -14,23 +11,19 @@ import javax.servlet.http.HttpServletResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
 public class ThreadNameFilterTest {
 
-    @Mock
-    private HttpServletRequest request;
+    private HttpServletRequest request = mock(HttpServletRequest.class);
 
-    @Mock
-    private HttpServletResponse response;
+    private HttpServletResponse response = mock(HttpServletResponse.class);
 
-    @Mock
-    private FilterChain chain;
+    private FilterChain chain = mock(FilterChain.class);
 
-    @Mock
-    private FilterConfig filterConfig;
+    private FilterConfig filterConfig = mock(FilterConfig.class);
 
     private ThreadNameFilter threadNameFilter = new ThreadNameFilter();
 

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/assets/AssetServletTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/assets/AssetServletTest.java
@@ -11,6 +11,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import javax.annotation.Nullable;
 import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -58,6 +59,7 @@ public class AssetServletTest {
 
     private static final ServletTester SERVLET_TESTER = new ServletTester();
     private final HttpTester.Request request = HttpTester.newRequest();
+    @Nullable
     private HttpTester.Response response;
 
     @BeforeClass

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/POJOConfigurationFactory.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/POJOConfigurationFactory.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.dropwizard.Configuration;
 import io.dropwizard.configuration.ConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.Jackson;
 
 import java.io.File;
 
@@ -13,7 +14,7 @@ public class POJOConfigurationFactory<C extends Configuration>
 
     @SuppressWarnings("unchecked")
     public POJOConfigurationFactory(C cfg) {
-        super((Class<C>) cfg.getClass(), null, null, null);
+        super((Class<C>) cfg.getClass(), null, Jackson.newObjectMapper(), "dw");
         configuration = cfg;
     }
 

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
@@ -75,6 +75,8 @@ public class DropwizardAppRule<C extends Configuration> extends ExternalResource
     private final DropwizardTestSupport<C> testSupport;
 
     private final AtomicInteger recursiveCallCount = new AtomicInteger(0);
+
+    @Nullable
     private Client client;
 
     public DropwizardAppRule(Class<? extends Application<C>> applicationClass) {
@@ -87,12 +89,12 @@ public class DropwizardAppRule<C extends Configuration> extends ExternalResource
         this(applicationClass, configPath, Optional.empty(), configOverrides);
     }
 
-    public DropwizardAppRule(Class<? extends Application<C>> applicationClass, String configPath,
+    public DropwizardAppRule(Class<? extends Application<C>> applicationClass, @Nullable String configPath,
                              Optional<String> customPropertyPrefix, ConfigOverride... configOverrides) {
         this(applicationClass, configPath, customPropertyPrefix, ServerCommand::new, configOverrides);
     }
 
-    public DropwizardAppRule(Class<? extends Application<C>> applicationClass, String configPath,
+    public DropwizardAppRule(Class<? extends Application<C>> applicationClass, @Nullable String configPath,
                              Optional<String> customPropertyPrefix, Function<Application<C>,
                              Command> commandInstantiator, ConfigOverride... configOverrides) {
         this(new DropwizardTestSupport<>(applicationClass, configPath, customPropertyPrefix, commandInstantiator,

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardTestResourceConfig.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardTestResourceConfig.java
@@ -49,6 +49,11 @@ class DropwizardTestResourceConfig extends DropwizardResourceConfig {
     }
 
     DropwizardTestResourceConfig(@Context ServletConfig servletConfig) {
-        this(CONFIGURATION_REGISTRY.get(requireNonNull(servletConfig.getInitParameter(CONFIGURATION_ID))));
+        this(getConfiguration(servletConfig));
+    }
+
+    private static ResourceTestJerseyConfiguration getConfiguration(@Context ServletConfig servletConfig) {
+        final String id = requireNonNull(servletConfig.getInitParameter(CONFIGURATION_ID), "No configuration id");
+        return requireNonNull(CONFIGURATION_REGISTRY.get(id), "No configuration");
     }
 }

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ResourceTestRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/ResourceTestRule.java
@@ -16,6 +16,7 @@ import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
+import javax.annotation.Nullable;
 import javax.validation.Validator;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.WebTarget;
@@ -24,6 +25,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * A JUnit {@link TestRule} for testing Jersey resources.
@@ -116,6 +119,8 @@ public class ResourceTestRule implements TestRule {
     }
 
     private ResourceTestJerseyConfiguration configuration;
+
+    @Nullable
     private JerseyTest test;
 
     private ResourceTestRule(ResourceTestJerseyConfiguration configuration) {
@@ -151,7 +156,7 @@ public class ResourceTestRule implements TestRule {
      * @return the {@link JerseyTest} configured {@link Client}
      */
     public Client client() {
-        return test.client();
+        return getJerseyTest().client();
     }
 
     /**
@@ -161,7 +166,7 @@ public class ResourceTestRule implements TestRule {
      * @return the underlying {@link JerseyTest}
      */
     public JerseyTest getJerseyTest() {
-        return test;
+        return requireNonNull(test);
     }
 
     @Override
@@ -198,7 +203,7 @@ public class ResourceTestRule implements TestRule {
                     base.evaluate();
                 } finally {
                     DropwizardTestResourceConfig.CONFIGURATION_REGISTRY.remove(configuration.getId());
-                    test.tearDown();
+                    requireNonNull(test).tearDown();
                 }
             }
         };

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportTest.java
@@ -116,11 +116,11 @@ public class DropwizardTestSupportTest {
     public static class TestConfiguration extends Configuration {
         @NotEmpty
         @JsonProperty
-        private String message;
+        private String message = "";
 
         @NotEmpty
         @JsonProperty
-        private String extra;
+        private String extra = "";
 
         public String getMessage() {
             return message;

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/Person.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/Person.java
@@ -5,8 +5,8 @@ import com.google.common.base.MoreObjects;
 import java.util.Objects;
 
 public class Person {
-    private String name;
-    private String email;
+    private String name = "";
+    private String email = "";
 
     public Person() { /* Jackson deserialization */ }
 

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResource.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResource.java
@@ -7,6 +7,7 @@ import io.dropwizard.testing.Person;
 import io.dropwizard.validation.Validated;
 import org.eclipse.jetty.io.EofException;
 
+import javax.annotation.Nullable;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import javax.validation.groups.Default;
@@ -19,6 +20,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
 
 @Path("/person/{name}")
 @Produces(MediaType.APPLICATION_JSON)
@@ -67,12 +70,13 @@ public class PersonResource {
     public String validationGroupsException(
         @Valid @Validated(Partial1.class) @BeanParam BeanParameter params,
         @Valid @Validated(Default.class) byte[] entity) {
-        return params.age.toString() + entity.length;
+        return requireNonNull(params.age).toString() + entity.length;
     }
 
     public interface Partial1 { }
     public static class BeanParameter {
         @QueryParam("age")
+        @Nullable
         public Integer age;
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleReentrantTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleReentrantTest.java
@@ -1,32 +1,21 @@
 package io.dropwizard.testing.junit;
 
 import io.dropwizard.testing.DropwizardTestSupport;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.mockito.InOrder;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 
 public class DropwizardAppRuleReentrantTest {
 
-    @Rule
-    public MockitoRule mockitoRule = MockitoJUnit.rule();
-
-    @Mock
-    DropwizardTestSupport<TestConfiguration> testSupport;
-
-    @Mock
-    Statement statement;
-
-    @Mock
-    Description description;
+    DropwizardTestSupport<TestConfiguration> testSupport = mock(DropwizardTestSupport.class);
+    Statement statement = mock(Statement.class);
+    Description description = mock(Description.class);
 
     @Test
     public void testReentrantRuleStartsApplicationOnlyOnce() throws Throwable {

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/TestConfiguration.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/TestConfiguration.java
@@ -8,11 +8,11 @@ public class TestConfiguration extends Configuration {
 
     @JsonProperty
     @NotEmpty
-    private String message;
+    private String message = "";
 
     @JsonProperty
     @NotEmpty
-    private String extra;
+    private String extra = "";
 
     public TestConfiguration() { }
 

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/TestEntity.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/TestEntity.java
@@ -1,5 +1,6 @@
 package io.dropwizard.testing.junit;
 
+import javax.annotation.Nullable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -7,6 +8,8 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
+
+import static java.util.Objects.requireNonNull;
 
 @Entity
 @Table(name = "test_entities")
@@ -19,13 +22,14 @@ class TestEntity {
 
     @NotNull
     @Column(name = "desc")
+    @Nullable
     private String description;
 
     protected TestEntity() {
         // for Hibernate
     }
 
-    TestEntity(final String description) {
+    TestEntity(@Nullable String description) {
         this.description = description;
     }
 
@@ -34,7 +38,7 @@ class TestEntity {
     }
 
     String getDescription() {
-        return description;
+        return requireNonNull(description);
     }
 
     void setDescription(final String description) {

--- a/dropwizard-util/src/main/java/io/dropwizard/util/Enums.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Enums.java
@@ -2,6 +2,8 @@ package io.dropwizard.util;
 
 import com.google.common.base.CharMatcher;
 
+import javax.annotation.Nullable;
+
 /**
  * Helper methods for enum types.
  */
@@ -20,6 +22,7 @@ public class Enums {
      * @param constants The list of constants for the {@link Enum} to which you wish to convert.
      * @return The enum or null, if no enum constant matched the input value.
      */
+    @Nullable
     public static Enum<?> fromStringFuzzy(String value, Enum<?>[] constants) {
         final String text = CharMatcher.whitespace()
             .removeFrom(value)

--- a/dropwizard-util/src/main/java/io/dropwizard/util/Generics.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Generics.java
@@ -1,5 +1,6 @@
 package io.dropwizard.util;
 
+import javax.annotation.Nullable;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
@@ -74,6 +75,7 @@ public class Generics {
     }
 
     @SuppressWarnings("unchecked")
+    @Nullable
     private static <T> Class<T> determineClass(Class<? super T> bound, Type candidate) {
         if (candidate instanceof Class<?>) {
             final Class<?> cls = (Class<?>) candidate;

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/MaxDurationValidator.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/MaxDurationValidator.java
@@ -12,8 +12,8 @@ import java.util.concurrent.TimeUnit;
  */
 public class MaxDurationValidator implements ConstraintValidator<MaxDuration, Duration> {
 
-    private long maxQty;
-    private TimeUnit maxUnit;
+    private long maxQty = 0;
+    private TimeUnit maxUnit = TimeUnit.MILLISECONDS;
 
     @Override
     public void initialize(MaxDuration constraintAnnotation) {

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/MaxSizeValidator.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/MaxSizeValidator.java
@@ -12,8 +12,8 @@ import javax.validation.ConstraintValidatorContext;
  */
 public class MaxSizeValidator implements ConstraintValidator<MaxSize, Size> {
 
-    private long maxQty;
-    private SizeUnit maxUnit;
+    private long maxQty = 0;
+    private SizeUnit maxUnit = SizeUnit.BYTES;
 
     @Override
     public void initialize(MaxSize constraintAnnotation) {

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/MinDurationValidator.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/MinDurationValidator.java
@@ -12,8 +12,8 @@ import java.util.concurrent.TimeUnit;
  */
 public class MinDurationValidator implements ConstraintValidator<MinDuration, Duration> {
 
-    private long minQty;
-    private TimeUnit minUnit;
+    private long minQty = 0;
+    private TimeUnit minUnit = TimeUnit.MILLISECONDS;
 
     @Override
     public void initialize(MinDuration constraintAnnotation) {

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/MinSizeValidator.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/MinSizeValidator.java
@@ -12,8 +12,8 @@ import javax.validation.ConstraintValidatorContext;
  */
 public class MinSizeValidator implements ConstraintValidator<MinSize, Size> {
 
-    private long minQty;
-    private SizeUnit minUnit;
+    private long minQty = 0;
+    private SizeUnit minUnit = SizeUnit.BYTES;
 
     @Override
     public void initialize(MinSize constraintAnnotation) {

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/OneOfValidator.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/OneOfValidator.java
@@ -4,7 +4,7 @@ import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
 public class OneOfValidator implements ConstraintValidator<OneOf, Object> {
-    private String[] values;
+    private String[] values = new String[]{};
     private boolean caseInsensitive;
     private boolean ignoreWhitespace;
 

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/ValidationCaller.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/ValidationCaller.java
@@ -1,5 +1,7 @@
 package io.dropwizard.validation.selfvalidating;
 
+import javax.annotation.Nullable;
+
 /**
  * This class represents a wrapper for calling validation methods annotated with <code>@SelfValidation</code>.
  * It is used as a base class for the code generation.
@@ -8,12 +10,14 @@ package io.dropwizard.validation.selfvalidating;
  */
 public abstract class ValidationCaller<T> {
 
+    @Nullable
     protected T validationObject;
 
     public void setValidationObject(T obj) {
         this.validationObject = obj;
     }
 
+    @Nullable
     public T getValidationObject() {
         return validationObject;
     }

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/valuehandling/OptionalDoubleValidatedValueUnwrapper.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/valuehandling/OptionalDoubleValidatedValueUnwrapper.java
@@ -2,6 +2,7 @@ package io.dropwizard.validation.valuehandling;
 
 import org.hibernate.validator.spi.valuehandling.ValidatedValueUnwrapper;
 
+import javax.annotation.Nullable;
 import java.lang.reflect.Type;
 import java.util.OptionalDouble;
 
@@ -12,6 +13,7 @@ import java.util.OptionalDouble;
  */
 public class OptionalDoubleValidatedValueUnwrapper extends ValidatedValueUnwrapper<OptionalDouble> {
     @Override
+    @Nullable
     public Object handleValidatedValue(final OptionalDouble optional) {
         return optional.isPresent() ? optional.getAsDouble() : null;
     }

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/valuehandling/OptionalIntValidatedValueUnwrapper.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/valuehandling/OptionalIntValidatedValueUnwrapper.java
@@ -2,6 +2,7 @@ package io.dropwizard.validation.valuehandling;
 
 import org.hibernate.validator.spi.valuehandling.ValidatedValueUnwrapper;
 
+import javax.annotation.Nullable;
 import java.lang.reflect.Type;
 import java.util.OptionalInt;
 
@@ -12,6 +13,7 @@ import java.util.OptionalInt;
  */
 public class OptionalIntValidatedValueUnwrapper extends ValidatedValueUnwrapper<OptionalInt> {
     @Override
+    @Nullable
     public Object handleValidatedValue(final OptionalInt optional) {
         return optional.isPresent() ? optional.getAsInt() : null;
     }

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/valuehandling/OptionalLongValidatedValueUnwrapper.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/valuehandling/OptionalLongValidatedValueUnwrapper.java
@@ -2,6 +2,7 @@ package io.dropwizard.validation.valuehandling;
 
 import org.hibernate.validator.spi.valuehandling.ValidatedValueUnwrapper;
 
+import javax.annotation.Nullable;
 import java.lang.reflect.Type;
 import java.util.OptionalLong;
 
@@ -12,6 +13,7 @@ import java.util.OptionalLong;
  */
 public class OptionalLongValidatedValueUnwrapper extends ValidatedValueUnwrapper<OptionalLong> {
     @Override
+    @Nullable
     public Object handleValidatedValue(final OptionalLong optional) {
         return optional.isPresent() ? optional.getAsLong() : null;
     }

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/ConstraintPerson.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/ConstraintPerson.java
@@ -5,7 +5,7 @@ import org.hibernate.validator.constraints.NotEmpty;
 
 public class ConstraintPerson {
     @NotEmpty
-    private String name;
+    private String name = "";
 
     @JsonProperty
     public String getName() {

--- a/dropwizard-views-mustache/src/main/java/io/dropwizard/views/mustache/PerClassMustacheResolver.java
+++ b/dropwizard-views-mustache/src/main/java/io/dropwizard/views/mustache/PerClassMustacheResolver.java
@@ -3,6 +3,7 @@ package io.dropwizard.views.mustache;
 import com.github.mustachejava.MustacheResolver;
 import io.dropwizard.views.View;
 
+import javax.annotation.Nullable;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -21,6 +22,7 @@ class PerClassMustacheResolver implements MustacheResolver {
     }
 
     @Override
+    @Nullable
     public Reader getReader(String resourceName) {
         final InputStream is = klass.getResourceAsStream(resourceName);
         if (is == null) {

--- a/dropwizard-views/src/main/java/io/dropwizard/views/View.java
+++ b/dropwizard-views/src/main/java/io/dropwizard/views/View.java
@@ -2,6 +2,7 @@ package io.dropwizard.views;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import javax.annotation.Nullable;
 import java.nio.charset.Charset;
 import java.util.Optional;
 
@@ -10,6 +11,8 @@ import java.util.Optional;
  */
 public abstract class View {
     private final String templateName;
+
+    @Nullable
     private final Charset charset;
 
     /**
@@ -27,7 +30,7 @@ public abstract class View {
      * @param templateName the name of the template resource
      * @param charset      the character set for {@code templateName}
      */
-    protected View(String templateName, Charset charset) {
+    protected View(String templateName, @Nullable Charset charset) {
         this.templateName = resolveName(templateName);
         this.charset = charset;
     }

--- a/dropwizard-views/src/main/java/io/dropwizard/views/ViewMessageBodyWriter.java
+++ b/dropwizard-views/src/main/java/io/dropwizard/views/ViewMessageBodyWriter.java
@@ -5,6 +5,7 @@ import com.codahale.metrics.Timer;
 import com.google.common.annotations.VisibleForTesting;
 import org.glassfish.jersey.message.internal.HeaderValueException;
 
+import javax.annotation.Nullable;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
@@ -23,13 +24,20 @@ import java.util.Locale;
 import java.util.ServiceLoader;
 
 import static com.codahale.metrics.MetricRegistry.name;
+import static java.util.Objects.requireNonNull;
 
 @Provider
-@Produces({ MediaType.TEXT_HTML, MediaType.APPLICATION_XHTML_XML })
+@Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_XHTML_XML})
 public class ViewMessageBodyWriter implements MessageBodyWriter<View> {
 
     @Context
+    @Nullable
     private HttpHeaders headers;
+
+    @VisibleForTesting
+    void setHeaders(HttpHeaders headers) {
+        this.headers = headers;
+    }
 
     private final Iterable<ViewRenderer> renderers;
     private final MetricRegistry metricRegistry;
@@ -70,7 +78,7 @@ public class ViewMessageBodyWriter implements MessageBodyWriter<View> {
         try {
             for (ViewRenderer renderer : renderers) {
                 if (renderer.isRenderable(t)) {
-                    renderer.render(t, detectLocale(headers), entityStream);
+                    renderer.render(t, detectLocale(requireNonNull(headers)), entityStream);
                     return;
                 }
             }

--- a/dropwizard-views/src/test/java/io/dropwizard/views/ViewBundleTest.java
+++ b/dropwizard-views/src/test/java/io/dropwizard/views/ViewBundleTest.java
@@ -6,12 +6,8 @@ import io.dropwizard.Configuration;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
 import io.dropwizard.setup.Environment;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.WebApplicationException;
@@ -28,12 +24,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class ViewBundleTest {
-    @Rule
-    public final MockitoRule mockitoRule = MockitoJUnit.rule();
-    @Mock
-    private JerseyEnvironment jerseyEnvironment;
-
-    private final Environment environment = mock(Environment.class);
+    private JerseyEnvironment jerseyEnvironment = mock(JerseyEnvironment.class);
+    private Environment environment = mock(Environment.class);
 
     private static class MyConfiguration extends Configuration {
         @NotNull
@@ -61,7 +53,7 @@ public class ViewBundleTest {
 
     @Test
     public void addsTheViewMessageBodyWriterToTheEnvironment() throws Exception {
-        new ViewBundle<>().run(null, environment);
+        new ViewBundle<>().run(new MyConfiguration(), environment);
 
         verify(jerseyEnvironment).register(any(ViewMessageBodyWriter.class));
     }

--- a/pom.xml
+++ b/pom.xml
@@ -356,6 +356,7 @@
                                 <arg>-XepDisableWarningsInGeneratedCode</arg>
                                 <arg>-Xep:NullAway:ERROR</arg>
                                 <arg>-XepOpt:NullAway:AnnotatedPackages=io.dropwizard</arg>
+                                <arg>-XepOpt:NullAway:UnannotatedSubPackages=io.dropwizard.benchmarks</arg>
                             </compilerArgs>
                         </configuration>
                         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -354,7 +354,7 @@
                             </annotationProcessorPaths>
                             <compilerArgs>
                                 <arg>-XepDisableWarningsInGeneratedCode</arg>
-                                <!-- Defaults to WARNING <arg>-Xep:NullAway:ERROR</arg> -->
+                                <arg>-Xep:NullAway:ERROR</arg>
                                 <arg>-XepOpt:NullAway:AnnotatedPackages=io.dropwizard</arg>
                             </compilerArgs>
                         </configuration>


### PR DESCRIPTION
We now run a static analyzer during our build (#2204) which helps us to catch NPE during compilation. To make it work, we should annotate actual nullable fields with the `@Nullable` annotation, otherwise the analyzer will always consider such fields as non-null by default and will report violations when a null value is assigned to them.