### PR TITLE
Migrate deprecated classes from commons-lang to commons-text

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -46,6 +46,11 @@
                 <version>3.6</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>1.1</version>
+            </dependency>
+            <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>

--- a/dropwizard-configuration/pom.xml
+++ b/dropwizard-configuration/pom.xml
@@ -40,6 +40,10 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationParsingException.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationParsingException.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.dataformat.yaml.snakeyaml.error.Mark;
 import com.google.common.collect.ImmutableSet;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.similarity.LevenshteinDistance;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -311,6 +311,7 @@ public class ConfigurationParsingException extends ConfigurationException {
 
         protected static class LevenshteinComparator implements Comparator<String>, Serializable {
             private static final long serialVersionUID = 1L;
+            private static final LevenshteinDistance LEVENSHTEIN_DISTANCE = new LevenshteinDistance();
 
             private String base;
 
@@ -343,8 +344,8 @@ public class ConfigurationParsingException extends ConfigurationException {
                 }
 
                 // determine which of the two is closer to the base and order it first
-                return Integer.compare(StringUtils.getLevenshteinDistance(a, base),
-                        StringUtils.getLevenshteinDistance(b, base));
+                return Integer.compare(LEVENSHTEIN_DISTANCE.apply(a, base),
+                    LEVENSHTEIN_DISTANCE.apply(b, base));
             }
 
             private void writeObject(ObjectOutputStream stream) throws IOException {

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/EnvironmentVariableLookup.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/EnvironmentVariableLookup.java
@@ -1,9 +1,9 @@
 package io.dropwizard.configuration;
 
-import org.apache.commons.lang3.text.StrLookup;
+import org.apache.commons.text.StrLookup;
 
 /**
- * A custom {@link org.apache.commons.lang3.text.StrLookup} implementation using environment variables as lookup source.
+ * A custom {@link org.apache.commons.text.StrLookup} implementation using environment variables as lookup source.
  */
 public class EnvironmentVariableLookup extends StrLookup<Object> {
     private final boolean strict;

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/EnvironmentVariableSubstitutor.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/EnvironmentVariableSubstitutor.java
@@ -1,6 +1,6 @@
 package io.dropwizard.configuration;
 
-import org.apache.commons.lang3.text.StrSubstitutor;
+import org.apache.commons.text.StrSubstitutor;
 
 /**
  * A custom {@link StrSubstitutor} using environment variables as lookup source.
@@ -19,7 +19,7 @@ public class EnvironmentVariableSubstitutor extends StrSubstitutor {
      *                                {@link UndefinedEnvironmentVariableException}, {@code false} otherwise.
      * @param substitutionInVariables a flag whether substitution is done in variable names.
      * @see io.dropwizard.configuration.EnvironmentVariableLookup#EnvironmentVariableLookup(boolean)
-     * @see org.apache.commons.lang3.text.StrSubstitutor#setEnableSubstitutionInVariables(boolean)
+     * @see org.apache.commons.text.StrSubstitutor#setEnableSubstitutionInVariables(boolean)
      */
     public EnvironmentVariableSubstitutor(boolean strict, boolean substitutionInVariables) {
         super(new EnvironmentVariableLookup(strict));

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/SubstitutingSourceProvider.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/SubstitutingSourceProvider.java
@@ -1,7 +1,7 @@
 package io.dropwizard.configuration;
 
 import com.google.common.io.ByteStreams;
-import org.apache.commons.lang3.text.StrSubstitutor;
+import org.apache.commons.text.StrSubstitutor;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -22,7 +22,7 @@ public class SubstitutingSourceProvider implements ConfigurationSourceProvider {
      * Create a new instance.
      *
      * @param delegate    The underlying {@link io.dropwizard.configuration.ConfigurationSourceProvider}.
-     * @param substitutor The custom {@link org.apache.commons.lang3.text.StrSubstitutor} implementation.
+     * @param substitutor The custom {@link org.apache.commons.text.StrSubstitutor} implementation.
      */
     public SubstitutingSourceProvider(ConfigurationSourceProvider delegate, StrSubstitutor substitutor) {
         this.delegate = requireNonNull(delegate);

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/SubstitutingSourceProviderTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/SubstitutingSourceProviderTest.java
@@ -1,8 +1,8 @@
 package io.dropwizard.configuration;
 
 import com.google.common.io.ByteStreams;
-import org.apache.commons.lang3.text.StrLookup;
-import org.apache.commons.lang3.text.StrSubstitutor;
+import org.apache.commons.text.StrLookup;
+import org.apache.commons.text.StrSubstitutor;
 import org.junit.Test;
 
 import javax.annotation.Nullable;

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/DefaultLoggingFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/DefaultLoggingFactoryTest.java
@@ -20,7 +20,7 @@ import io.dropwizard.jackson.Jackson;
 import io.dropwizard.logging.filter.FilterFactory;
 import io.dropwizard.validation.BaseValidator;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.text.StrSubstitutor;
+import org.apache.commons.text.StrSubstitutor;
 import org.assertj.core.data.MapEntry;
 import org.junit.Before;
 import org.junit.Rule;


### PR DESCRIPTION
Several classes and methods from the `commons-lang` package like `StrSubstitutor` and `StringUtils.getLevenshteinDistance` have been moved to a separate library `commons-text`. We should follow this deprecation warning and move our dependencies to the new library.

Unfortunately, it's not possible to make this change for the 1.2.1 version, because it changes the public API.

References #2171 