### PR TITLE
Set database config '@MinDuration' to 1 millisecond

### DIFF
--- a/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
+++ b/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
@@ -373,22 +373,22 @@ public class DataSourceFactory implements PooledDataSourceFactory {
 
     private boolean logValidationErrors = false;
 
-    @MinDuration(value = 1, unit = TimeUnit.SECONDS)
+    @MinDuration(value = 0, unit = TimeUnit.MILLISECONDS, inclusive = false)
     @Nullable
     private Duration maxConnectionAge;
 
     @NotNull
-    @MinDuration(value = 1, unit = TimeUnit.SECONDS)
+    @MinDuration(value = 0, unit = TimeUnit.MILLISECONDS, inclusive = false)
     private Duration maxWaitForConnection = Duration.seconds(30);
 
     @NotNull
-    @MinDuration(value = 1, unit = TimeUnit.SECONDS)
+    @MinDuration(value = 0, unit = TimeUnit.MILLISECONDS, inclusive = false)
     private Duration minIdleTime = Duration.minutes(1);
 
     @NotNull
     private String validationQuery = "/* Health Check */ SELECT 1";
 
-    @MinDuration(value = 1, unit = TimeUnit.SECONDS)
+    @MinDuration(value = 0, unit = TimeUnit.MILLISECONDS, inclusive = false)
     @Nullable
     private Duration validationQueryTimeout;
 
@@ -403,11 +403,11 @@ public class DataSourceFactory implements PooledDataSourceFactory {
     private boolean autoCommentsEnabled = true;
 
     @NotNull
-    @MinDuration(1)
+    @MinDuration(value = 0, unit = TimeUnit.MILLISECONDS, inclusive = false)
     private Duration evictionInterval = Duration.seconds(5);
 
     @NotNull
-    @MinDuration(value = 50, unit = TimeUnit.MILLISECONDS)
+    @MinDuration(value = 0, unit = TimeUnit.MILLISECONDS, inclusive = false)
     private Duration validationInterval = Duration.seconds(30);
 
     private Optional<String> validatorClassName = Optional.empty();
@@ -415,7 +415,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
     private boolean removeAbandoned = false;
 
     @NotNull
-    @MinDuration(1)
+    @MinDuration(value = 0, unit = TimeUnit.MILLISECONDS, inclusive = false)
     private Duration removeAbandonedTimeout = Duration.seconds(60L);
 
     private Optional<String> jdbcInterceptors = Optional.empty();


### PR DESCRIPTION
Fixes #2130, more info in #2167.

This actually makes it to be >= 1 of any TimeUnit (the unit specified in the annotation is irrelevant when the value is 0), I just set them to milliseconds to be clearer that it can be a low value.