### PR TITLE
jersey-client: Add possibility to mark an HTTP entity as repeatable

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
@@ -414,13 +414,19 @@ public class JerseyClientBuilder {
         if (connectorProvider == null) {
             final ConfiguredCloseableHttpClient apacheHttpClient =
                     apacheHttpClientBuilder.buildWithDefaultRequestConfiguration(name);
-            connectorProvider = (client, runtimeConfig) -> new DropwizardApacheConnector(
-                    apacheHttpClient.getClient(),
-                    apacheHttpClient.getDefaultRequestConfig(),
-                    configuration.isChunkedEncodingEnabled());
+            connectorProvider = (client, runtimeConfig) -> createDropwizardApacheConnector(apacheHttpClient);
         }
         config.connectorProvider(connectorProvider);
 
         return config;
+    }
+
+    /**
+     * Builds {@link DropwizardApacheConnector} based on the configured Apache HTTP client
+     * as {@link ConfiguredCloseableHttpClient} and the chunked encoding configuration set by the user.
+     */
+    protected DropwizardApacheConnector createDropwizardApacheConnector(ConfiguredCloseableHttpClient configuredClient) {
+        return new DropwizardApacheConnector(configuredClient.getClient(), configuredClient.getDefaultRequestConfig(),
+                configuration.isChunkedEncodingEnabled());
     }
 }

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
@@ -331,6 +331,17 @@ public class JerseyClientBuilderTest {
         verify(apacheHttpClientBuilder).using(customCredentialsProvider);
     }
 
+    @Test
+    public void apacheConnectorCanOverridden() {
+        assertThat(new JerseyClientBuilder(new MetricRegistry()) {
+            @Override
+            protected DropwizardApacheConnector createDropwizardApacheConnector(ConfiguredCloseableHttpClient configuredClient) {
+                return new DropwizardApacheConnector(configuredClient.getClient(), configuredClient.getDefaultRequestConfig(),
+                    true, (clientRequest -> true));
+            }
+        }.using(environment).build("test")).isNotNull();
+    }
+
     @Provider
     @Consumes(MediaType.APPLICATION_SVG_XML)
     public static class FakeMessageBodyReader implements MessageBodyReader<JerseyClientBuilderTest> {


### PR DESCRIPTION
###### Problem:
Currently, `DropwizardApacheConnector` when configured with the chuncked encoding always assumes that the source entity from the Jersey client is not repeatable. That's true in the default case when we don't know from where the source of the input. Unfortunately, the Apache HTTP client can't retry unrepeatable entities, which poses challenges in environments where retries are common (e.g. microservices). The only alternative is to disable the chunked encoding which is not always desirable, because it requires additional buffering of the entity in memory.

###### Solution:
The solution of this issue to add a parameter which allows to configure the connector to use chunked encoding, but mark them as repeatable. In this case the caller is responsible to make sure that entites are
coming from a retriable source (e.g memory array, file on disk).

###### Result:
As a result users can use the Jersey client for sending POST requests with retries and chunked encoding.