### PR TITLE
Add possibility to possibility to extend `DropwizardApacheConnector`

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardApacheConnector.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardApacheConnector.java
@@ -172,7 +172,7 @@ public class DropwizardApacheConnector implements Connector {
      * @param jerseyRequest representation of an HTTP request in Jersey
      * @return a correct {@link org.apache.http.HttpEntity} implementation
      */
-    private HttpEntity getHttpEntity(ClientRequest jerseyRequest) {
+    protected HttpEntity getHttpEntity(ClientRequest jerseyRequest) {
         if (jerseyRequest.getEntity() == null) {
             return null;
         }

--- a/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
@@ -414,13 +414,19 @@ public class JerseyClientBuilder {
         if (connectorProvider == null) {
             final ConfiguredCloseableHttpClient apacheHttpClient =
                     apacheHttpClientBuilder.buildWithDefaultRequestConfiguration(name);
-            connectorProvider = (client, runtimeConfig) -> new DropwizardApacheConnector(
-                    apacheHttpClient.getClient(),
-                    apacheHttpClient.getDefaultRequestConfig(),
-                    configuration.isChunkedEncodingEnabled());
+            connectorProvider = (client, runtimeConfig) -> createDropwizardApacheConnector(apacheHttpClient);
         }
         config.connectorProvider(connectorProvider);
 
         return config;
+    }
+
+    /**
+     * Builds {@link DropwizardApacheConnector} based on the configured Apache HTTP client
+     * as {@link ConfiguredCloseableHttpClient} and the chunked encoding configuration set by the user.
+     */
+    protected DropwizardApacheConnector createDropwizardApacheConnector(ConfiguredCloseableHttpClient configuredClient) {
+        return new DropwizardApacheConnector(configuredClient.getClient(), configuredClient.getDefaultRequestConfig(),
+                configuration.isChunkedEncodingEnabled());
     }
 }

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
@@ -12,7 +12,9 @@ import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.lifecycle.setup.ExecutorServiceBuilder;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import io.dropwizard.setup.Environment;
+import org.apache.http.HttpEntity;
 import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.entity.GzipCompressingEntity;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.DnsResolver;
@@ -21,10 +23,12 @@ import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.conn.socket.PlainConnectionSocketFactory;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 import org.apache.http.impl.client.SystemDefaultCredentialsProvider;
 import org.apache.http.impl.conn.SystemDefaultDnsResolver;
 import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
+import org.glassfish.jersey.client.ClientRequest;
 import org.glassfish.jersey.client.rx.RxClient;
 import org.glassfish.jersey.client.rx.java8.RxCompletionStageInvoker;
 import org.junit.After;
@@ -329,6 +333,22 @@ public class JerseyClientBuilderTest {
         CredentialsProvider customCredentialsProvider = new SystemDefaultCredentialsProvider();
         builder.using(customCredentialsProvider);
         verify(apacheHttpClientBuilder).using(customCredentialsProvider);
+    }
+
+    @Test
+    public void apacheConnectorCanOverridden() {
+        assertThat(new JerseyClientBuilder(new MetricRegistry()) {
+            @Override
+            protected DropwizardApacheConnector createDropwizardApacheConnector(ConfiguredCloseableHttpClient configuredClient) {
+                return new DropwizardApacheConnector(configuredClient.getClient(), configuredClient.getDefaultRequestConfig(),
+                    true) {
+                    @Override
+                    protected HttpEntity getHttpEntity(ClientRequest jerseyRequest) {
+                        return new GzipCompressingEntity(new ByteArrayEntity((byte[]) jerseyRequest.getEntity()));
+                    }
+                };
+            }
+        }.using(environment).build("test")).isNotNull();
     }
 
     @Provider


### PR DESCRIPTION
###### Problem:
Some users want to have more fine-grained Jersey-Apache HTTP client integration. For example, more elaborate behavior during retrying of with the chunked encoding enabled. 

###### Solution:
Make the `getEntity` method of `DropwizardApacheConnector` protected and provide a new method for creating an own implementation of `DropwizardApacheConnector` in `JerseyClientBuilder`.

###### Result:
Powerful users are more happy with Dropwizard and don't need to copy-past classes to customize them.