### PR TITLE
Return a 400 when a request body can't be decompressed

### DIFF
--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/BiDiGzipHandler.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/BiDiGzipHandler.java
@@ -12,6 +12,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 import java.io.BufferedReader;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -22,6 +23,7 @@ import java.util.Enumeration;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
+import java.util.zip.ZipException;
 
 /**
  * An extension of {@link GzipHandler} which decompresses gzip- and deflate-encoded request
@@ -87,18 +89,33 @@ public class BiDiGzipHandler extends GzipHandler {
 
     private WrappedServletRequest wrapDeflatedRequest(HttpServletRequest request) throws IOException {
         final Inflater inflater = buildInflater();
-        final InflaterInputStream input = new InflaterInputStream(request.getInputStream(), inflater, inputBufferSize) {
-            @Override
-            public void close() throws IOException {
-                super.close();
-                localInflater.set(inflater);
-            }
-        };
-        return new WrappedServletRequest(request, input);
+        try {
+            final InflaterInputStream input = new InflaterInputStream(request.getInputStream(), inflater, inputBufferSize) {
+                @Override
+                public void close() throws IOException {
+                    super.close();
+                    localInflater.set(inflater);
+                }
+            };
+            InputStream exceptionHandlingInput = new ZipExceptionHandlingInputStream(input, DEFLATE);
+            return new WrappedServletRequest(request, exceptionHandlingInput);
+        } catch (ZipException e) {
+            throw ZipExceptionHandlingInputStream.buildBadDataException(DEFLATE, e);
+        } catch (EOFException e) {
+            throw ZipExceptionHandlingInputStream.buildPrematureEofException(DEFLATE, e);
+        }
     }
 
     private WrappedServletRequest wrapGzippedRequest(HttpServletRequest request) throws IOException {
-        return new WrappedServletRequest(request, new GZIPInputStream(request.getInputStream(), inputBufferSize));
+        try {
+            GZIPInputStream input = new GZIPInputStream(request.getInputStream(), inputBufferSize);
+            InputStream exceptionHandlingInput = new ZipExceptionHandlingInputStream(input, GZIP);
+            return new WrappedServletRequest(request, exceptionHandlingInput);
+        } catch (ZipException e) {
+            throw ZipExceptionHandlingInputStream.buildBadDataException(GZIP, e);
+        } catch (EOFException e) {
+            throw ZipExceptionHandlingInputStream.buildPrematureEofException(GZIP, e);
+        }
     }
 
     private HttpServletRequest removeContentEncodingHeader(final HttpServletRequest request) {

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/BiDiGzipHandler.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/BiDiGzipHandler.java
@@ -98,10 +98,8 @@ public class BiDiGzipHandler extends GzipHandler {
                 }
             };
             return new WrappedServletRequest(request, new ZipExceptionHandlingInputStream(input, DEFLATE));
-        } catch (ZipException e) {
-            throw ZipExceptionHandlingInputStream.buildBadDataException(DEFLATE, e);
-        } catch (EOFException e) {
-            throw ZipExceptionHandlingInputStream.buildPrematureEofException(DEFLATE, e);
+        } catch (IOException e) {
+            throw ZipExceptionHandlingInputStream.handleException(DEFLATE, e);
         }
     }
 
@@ -109,10 +107,8 @@ public class BiDiGzipHandler extends GzipHandler {
         try {
             final GZIPInputStream input = new GZIPInputStream(request.getInputStream(), inputBufferSize);
             return new WrappedServletRequest(request, new ZipExceptionHandlingInputStream(input, GZIP));
-        } catch (ZipException e) {
-            throw ZipExceptionHandlingInputStream.buildBadDataException(GZIP, e);
-        } catch (EOFException e) {
-            throw ZipExceptionHandlingInputStream.buildPrematureEofException(GZIP, e);
+        } catch (IOException e) {
+            throw ZipExceptionHandlingInputStream.handleException(GZIP, e);
         }
     }
 

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/BiDiGzipHandler.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/BiDiGzipHandler.java
@@ -97,8 +97,7 @@ public class BiDiGzipHandler extends GzipHandler {
                     localInflater.set(inflater);
                 }
             };
-            InputStream exceptionHandlingInput = new ZipExceptionHandlingInputStream(input, DEFLATE);
-            return new WrappedServletRequest(request, exceptionHandlingInput);
+            return new WrappedServletRequest(request, new ZipExceptionHandlingInputStream(input, DEFLATE));
         } catch (ZipException e) {
             throw ZipExceptionHandlingInputStream.buildBadDataException(DEFLATE, e);
         } catch (EOFException e) {
@@ -108,9 +107,8 @@ public class BiDiGzipHandler extends GzipHandler {
 
     private WrappedServletRequest wrapGzippedRequest(HttpServletRequest request) throws IOException {
         try {
-            GZIPInputStream input = new GZIPInputStream(request.getInputStream(), inputBufferSize);
-            InputStream exceptionHandlingInput = new ZipExceptionHandlingInputStream(input, GZIP);
-            return new WrappedServletRequest(request, exceptionHandlingInput);
+            final GZIPInputStream input = new GZIPInputStream(request.getInputStream(), inputBufferSize);
+            return new WrappedServletRequest(request, new ZipExceptionHandlingInputStream(input, GZIP));
         } catch (ZipException e) {
             throw ZipExceptionHandlingInputStream.buildBadDataException(GZIP, e);
         } catch (EOFException e) {

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/ZipExceptionHandlingInputStream.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/ZipExceptionHandlingInputStream.java
@@ -12,19 +12,20 @@ import org.eclipse.jetty.http.BadMessageException;
  * This InputStream is used to decorate a GZIPInputStream or InflaterInputStream, intercept decompression
  * exceptions, and rethrow them as BadMessageExceptions
  */
-class ZipExceptionHandlingInputStream extends FilterInputStream {
+class ZipExceptionHandlingInputStream extends InputStream {
 
+    private final InputStream delegate;
     private final String format;
 
     ZipExceptionHandlingInputStream(InputStream in, String format) {
-        super(in);
+        this.delegate = in;
         this.format = format;
     }
 
     @Override
     public int read(byte[] b, int off, int len) throws IOException {
         try {
-            return super.read(b, off, len);
+            return delegate.read(b, off, len);
         } catch (IOException e) {
             throw handleException(format, e);
         }
@@ -33,7 +34,7 @@ class ZipExceptionHandlingInputStream extends FilterInputStream {
     @Override
     public int read() throws IOException {
         try {
-            return super.read();
+            return delegate.read();
         } catch (IOException e) {
             throw handleException(format, e);
         }
@@ -42,7 +43,7 @@ class ZipExceptionHandlingInputStream extends FilterInputStream {
     @Override
     public long skip(long n) throws IOException {
         try {
-            return super.skip(n);
+            return delegate.skip(n);
         } catch (IOException e) {
             throw handleException(format, e);
         }
@@ -51,7 +52,7 @@ class ZipExceptionHandlingInputStream extends FilterInputStream {
     @Override
     public int available() throws IOException {
         try {
-            return super.available();
+            return delegate.available();
         } catch (IOException e) {
             throw handleException(format, e);
         }
@@ -60,16 +61,26 @@ class ZipExceptionHandlingInputStream extends FilterInputStream {
     @Override
     public void close() throws IOException {
         try {
-            super.close();
+            delegate.close();
         } catch (IOException e) {
             throw handleException(format, e);
         }
     }
 
     @Override
+    public synchronized void mark(int readlimit) {
+        delegate.mark(readlimit);
+    }
+
+    @Override
+    public boolean markSupported() {
+        return delegate.markSupported();
+    }
+
+    @Override
     synchronized public void reset() throws IOException {
         try {
-            super.reset();
+            delegate.reset();
         } catch (IOException e) {
             throw handleException(format, e);
         }

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/ZipExceptionHandlingInputStream.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/ZipExceptionHandlingInputStream.java
@@ -1,0 +1,97 @@
+package io.dropwizard.jetty;
+
+import java.io.EOFException;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.ZipException;
+
+import org.eclipse.jetty.http.BadMessageException;
+
+/**
+ * This InputStream is used to decorate a GZIPInputStream or InflaterInputStream, intercept decompression
+ * exceptions, and rethrow them as BadMessageExceptions
+ */
+class ZipExceptionHandlingInputStream extends FilterInputStream {
+
+    private final String format;
+
+    ZipExceptionHandlingInputStream(InputStream in, String format) {
+        super(in);
+        this.format = format;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        try {
+            return super.read(b, off, len);
+        } catch (ZipException e) {
+            throw buildBadDataException(format, e);
+        } catch (EOFException e) {
+            throw buildPrematureEofException(format, e);
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        try {
+            return super.read();
+        } catch (ZipException e) {
+            throw buildBadDataException(format, e);
+        } catch (EOFException e) {
+            throw buildPrematureEofException(format, e);
+        }
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        try {
+            return super.skip(n);
+        } catch (ZipException e) {
+            throw buildBadDataException(format, e);
+        } catch (EOFException e) {
+            throw buildPrematureEofException(format, e);
+        }
+    }
+
+    @Override
+    public int available() throws IOException {
+        try {
+            return super.available();
+        } catch (ZipException e) {
+            throw buildBadDataException(format, e);
+        } catch (EOFException e) {
+            throw buildPrematureEofException(format, e);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            super.close();
+        } catch (ZipException e) {
+            throw buildBadDataException(format, e);
+        } catch (EOFException e) {
+            throw buildPrematureEofException(format, e);
+        }
+    }
+
+    @Override
+    synchronized public void reset() throws IOException {
+        try {
+            super.reset();
+        } catch (ZipException e) {
+            throw buildBadDataException(format, e);
+        } catch (EOFException e) {
+            throw buildPrematureEofException(format, e);
+        }
+    }
+
+    static BadMessageException buildBadDataException(String format, Throwable cause) {
+        return new BadMessageException(400, "Invalid " + format + " data in request", cause);
+    }
+
+    static BadMessageException buildPrematureEofException(String format, Throwable cause) {
+        return new BadMessageException(400, "Premature end of " + format + " data", cause);
+    }
+}

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/ZipExceptionHandlingInputStream.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/ZipExceptionHandlingInputStream.java
@@ -25,10 +25,8 @@ class ZipExceptionHandlingInputStream extends FilterInputStream {
     public int read(byte[] b, int off, int len) throws IOException {
         try {
             return super.read(b, off, len);
-        } catch (ZipException e) {
-            throw buildBadDataException(format, e);
-        } catch (EOFException e) {
-            throw buildPrematureEofException(format, e);
+        } catch (IOException e) {
+            throw handleException(format, e);
         }
     }
 
@@ -36,10 +34,8 @@ class ZipExceptionHandlingInputStream extends FilterInputStream {
     public int read() throws IOException {
         try {
             return super.read();
-        } catch (ZipException e) {
-            throw buildBadDataException(format, e);
-        } catch (EOFException e) {
-            throw buildPrematureEofException(format, e);
+        } catch (IOException e) {
+            throw handleException(format, e);
         }
     }
 
@@ -47,10 +43,8 @@ class ZipExceptionHandlingInputStream extends FilterInputStream {
     public long skip(long n) throws IOException {
         try {
             return super.skip(n);
-        } catch (ZipException e) {
-            throw buildBadDataException(format, e);
-        } catch (EOFException e) {
-            throw buildPrematureEofException(format, e);
+        } catch (IOException e) {
+            throw handleException(format, e);
         }
     }
 
@@ -58,10 +52,8 @@ class ZipExceptionHandlingInputStream extends FilterInputStream {
     public int available() throws IOException {
         try {
             return super.available();
-        } catch (ZipException e) {
-            throw buildBadDataException(format, e);
-        } catch (EOFException e) {
-            throw buildPrematureEofException(format, e);
+        } catch (IOException e) {
+            throw handleException(format, e);
         }
     }
 
@@ -69,10 +61,8 @@ class ZipExceptionHandlingInputStream extends FilterInputStream {
     public void close() throws IOException {
         try {
             super.close();
-        } catch (ZipException e) {
-            throw buildBadDataException(format, e);
-        } catch (EOFException e) {
-            throw buildPrematureEofException(format, e);
+        } catch (IOException e) {
+            throw handleException(format, e);
         }
     }
 
@@ -80,18 +70,26 @@ class ZipExceptionHandlingInputStream extends FilterInputStream {
     synchronized public void reset() throws IOException {
         try {
             super.reset();
-        } catch (ZipException e) {
-            throw buildBadDataException(format, e);
-        } catch (EOFException e) {
-            throw buildPrematureEofException(format, e);
+        } catch (IOException e) {
+            throw handleException(format, e);
         }
     }
 
-    static BadMessageException buildBadDataException(String format, Throwable cause) {
+    static BadMessageException handleException(String format, IOException e) throws IOException {
+        if (e instanceof ZipException) {
+            return buildBadDataException(format, e);
+        } else if (e instanceof EOFException) {
+            return buildPrematureEofException(format, e);
+        } else {
+            throw e;
+        }
+    }
+
+    private static BadMessageException buildBadDataException(String format, Throwable cause) {
         return new BadMessageException(400, "Invalid " + format + " data in request", cause);
     }
 
-    static BadMessageException buildPrematureEofException(String format, Throwable cause) {
+    private static BadMessageException buildPrematureEofException(String format, Throwable cause) {
         return new BadMessageException(400, "Premature end of " + format + " data", cause);
     }
 }

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/ZipExceptionHandlingInputStreamTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/ZipExceptionHandlingInputStreamTest.java
@@ -9,6 +9,7 @@ import java.util.zip.ZipException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -75,6 +76,21 @@ public class ZipExceptionHandlingInputStreamTest {
         public void testClose() throws Exception {
             in.close();
             verify(delegate).close();
+            verifyNoMoreInteractions(delegate);
+        }
+
+        @Test
+        public void testMark() {
+            in.mark(42);
+            verify(delegate).mark(42);
+            verifyNoMoreInteractions(delegate);
+        }
+
+        @Test
+        public void testMarkSupported() {
+            doReturn(true).when(delegate).markSupported();
+            assertTrue(in.markSupported());
+            verify(delegate).markSupported();
             verifyNoMoreInteractions(delegate);
         }
 

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/ZipExceptionHandlingInputStreamTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/ZipExceptionHandlingInputStreamTest.java
@@ -1,0 +1,138 @@
+package io.dropwizard.jetty;
+
+import java.io.EOFException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.zip.ZipException;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import org.eclipse.jetty.http.BadMessageException;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
+
+@SuppressWarnings("ALL")
+@RunWith(Enclosed.class)
+public class ZipExceptionHandlingInputStreamTest {
+
+    public static class DelegateTest {
+
+        private final InputStream delegate = Mockito.mock(InputStream.class);
+        private final ZipExceptionHandlingInputStream in = new ZipExceptionHandlingInputStream(delegate, "gzip");
+
+        @Test
+        public void testReadBytes() throws Exception {
+            byte[] buffer = new byte[64];
+
+            doReturn(buffer.length)
+                .when(delegate).read(Mockito.any(byte[].class), anyInt(), anyInt());
+
+            assertEquals(buffer.length, in.read(buffer, 0, buffer.length));
+            verify(delegate).read(buffer, 0, buffer.length);
+            verifyNoMoreInteractions(delegate);
+        }
+
+        @Test
+        public void testReadByte() throws Exception {
+            doReturn(42).when(delegate).read();
+            assertEquals(42, in.read());
+            verify(delegate).read();
+            verifyNoMoreInteractions(delegate);
+        }
+
+        @Test
+        public void testSkip() throws Exception {
+            doReturn(42L).when(delegate).skip(42L);
+            assertEquals(42L, in.skip(42L));
+            verify(delegate).skip(42L);
+            verifyNoMoreInteractions(delegate);
+        }
+
+        @Test
+        public void testAvailable() throws Exception {
+            doReturn(42).when(delegate).available();
+            assertEquals(42, in.available());
+            verify(delegate).available();
+            verifyNoMoreInteractions(delegate);
+        }
+
+        @Test
+        public void testClose() throws Exception {
+            in.close();
+            verify(delegate).close();
+            verifyNoMoreInteractions(delegate);
+        }
+
+        @Test
+        public void testReset() throws Exception {
+            doNothing().when(delegate).reset();
+            in.reset();
+            verify(delegate).reset();
+            verifyNoMoreInteractions(delegate);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class ExceptionTest {
+        @Parameterized.Parameters(name = "{0}")
+        public static Collection<Object[]> parameters() {
+            return Arrays.asList(new Object[][] {
+                {new EOFException()}, {new ZipException()}
+            });
+        }
+
+        private final InputStream delegate = Mockito.mock(InputStream.class);
+        private final ZipExceptionHandlingInputStream in = new ZipExceptionHandlingInputStream(delegate, "gzip");
+
+        private final Exception t;
+
+        public ExceptionTest(Exception t) {
+            this.t = t;
+        }
+
+        @Test(expected = BadMessageException.class)
+        public void testReadBytes() throws Exception {
+            doThrow(t).when(delegate).read(Mockito.any(byte[].class), anyInt(), anyInt());
+            in.read(new byte[32], 0, 32);
+        }
+
+        @Test(expected = BadMessageException.class)
+        public void testReadByte() throws Exception {
+            doThrow(t).when(delegate).read();
+            in.read();
+        }
+
+        @Test(expected = BadMessageException.class)
+        public void testSkip() throws Exception {
+            doThrow(t).when(delegate).skip(42L);
+            in.skip(42L);
+        }
+
+        @Test(expected = BadMessageException.class)
+        public void testAvailable() throws Exception {
+            doThrow(t).when(delegate).available();
+            in.available();
+        }
+
+        @Test(expected = BadMessageException.class)
+        public void testClose() throws Exception {
+            doThrow(t).when(delegate).close();
+            in.close();
+        }
+
+        @Test(expected = BadMessageException.class)
+        public void testReset() throws Exception {
+            doThrow(t).when(delegate).reset();
+            in.reset();
+        }
+    }
+}


### PR DESCRIPTION
###### Problem:
Currently, making a request with `content-encoding` set to `gzip` (or `deflate`) with content that's either not gziped, corrupt, or truncated results in a 500 because the exception from `GZipInputStream` is never handled.

###### Solution:
Gzip request decompression is handled by `BiDiGzipHandler`. This change decorates the GZipInputStream it creates so that `ZipException` and `EORException` are handled, and the exception is propagated as a Jersey BadMessageException. Similar changes were made to handle
deflate.

###### Result:
Making a request like

```
echo plaintext | curl -X POST -d @- http://localhost:8080/endpoint
```
will return a 400 rather than a 500. Additionally, `ZipExceptions` won't be logged as unhandled exceptions.