### PR TITLE
deps: Upgrade jetty to 9.4.8.v20171121

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -25,7 +25,7 @@
         <guava.version>23.5-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
         <jackson.version>2.9.3</jackson.version>
-        <jetty.version>9.4.7.v20170914</jetty.version>
+        <jetty.version>9.4.8.v20171121</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics3.version>3.2.5</metrics3.version>
         <slf4j.version>1.7.25</slf4j.version>
@@ -254,7 +254,7 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-alpn-server</artifactId>
+                <artifactId>jetty-alpn-openjdk8-server</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>
@@ -275,6 +275,11 @@
             <dependency>
                 <groupId>org.eclipse.jetty.http2</groupId>
                 <artifactId>http2-http-client-transport</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-alpn-openjdk8-client</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>

--- a/dropwizard-http2/pom.xml
+++ b/dropwizard-http2/pom.xml
@@ -71,6 +71,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-alpn-openjdk8-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>
             <scope>test</scope>
@@ -78,7 +84,7 @@
 
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-alpn-server</artifactId>
+            <artifactId>jetty-alpn-openjdk8-server</artifactId>
         </dependency>
 
         <!-- This needs to be on your JVM's bootpath for HTTP2 to work with ALPN protocol

--- a/dropwizard-http2/src/test/resources/test-http2-with-custom-cipher.yml
+++ b/dropwizard-http2/src/test/resources/test-http2-with-custom-cipher.yml
@@ -4,6 +4,7 @@ server:
     type: h2
     port: 0
     keyStorePassword: http2_server
+    trustStorePassword: http2_client
     validateCerts: false
     supportedCipherSuites:
       - 'TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384'

--- a/dropwizard-http2/src/test/resources/test-http2.yml
+++ b/dropwizard-http2/src/test/resources/test-http2.yml
@@ -4,6 +4,7 @@ server:
     type: h2
     port: 0
     keyStorePassword: http2_server
+    trustStorePassword: http2_client
     validateCerts: false
   applicationContextPath: /api
   adminContextPath: /admin


### PR DESCRIPTION
###### Problem:
The jetty version is outdated

###### Solution:
Upgrade to the latest one.

###### Result:
Dropwizard use can take advantage of new features like support of native SSL via [Conscrypt](https://github.com/google/conscrypt/): 
https://webtide.com/conscrypting-native-ssl-for-jetty/
