### PR TITLE
Add an example of using Dropwizard with Conscrypt

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -322,6 +322,49 @@ connection similar to pre-Dropwizard 1.0.
 
 .. _man-core-bootstrapping:
 
+Since the version 9.4.8 (Dropwizard 1.2.3) Jetty supports native SSL via Google's `Conscrypt`_ which uses `BoringSSL`_
+(Google's fork of OpenSSL) for handling cryptography. You can enable it in Dropwizard by registering the provider
+in your app:
+
+.. code-block:: xml
+
+    <dependency>
+        <groupId>org.conscrypt</groupId>
+        <artifactId>conscrypt-openjdk-uber</artifactId>
+        <version>${conscrypt.version}</version>
+    </dependency>
+
+.. code-block:: java
+
+    static {
+        Security.addProvider(new OpenSSLProvider());
+    }
+
+and setting the JCE provider in the configuration:
+
+.. code-block:: yaml
+
+    server:
+      type: simple
+      connector:
+        type: https
+        jceProvider: Conscrypt
+
+For HTTP/2 servers you need to add an ALPN Conscrypt provider as a dependency.
+
+.. code-block:: xml
+
+    <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-alpn-conscrypt-server</artifactId>
+        <version>${jetty.version}</version>
+        <scope>test</scope>
+    </dependency>
+
+.. _`Conscrypt`: https://github.com/google/conscrypt
+.. _`BoringSSL`: https://github.com/google/boringssl
+
+
 Bootstrapping
 =============
 

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -283,6 +283,11 @@
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-alpn-conscrypt-server</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.eclipse.jetty.toolchain.setuid</groupId>
                 <artifactId>jetty-setuid-java</artifactId>
                 <version>1.0.3</version>

--- a/dropwizard-http2/pom.xml
+++ b/dropwizard-http2/pom.xml
@@ -84,6 +84,12 @@
 
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-alpn-conscrypt-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-alpn-openjdk8-server</artifactId>
         </dependency>
 

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/AbstractHttp2Test.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/AbstractHttp2Test.java
@@ -2,11 +2,17 @@ package io.dropwizard.http2;
 
 import com.google.common.base.Charsets;
 import io.dropwizard.logging.BootstrapLogging;
+import io.dropwizard.testing.ResourceHelpers;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.client.api.Result;
 import org.eclipse.jetty.client.util.BufferingResponseListener;
 import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.eclipse.jetty.http2.client.http.HttpClientTransportOverHTTP2;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.junit.After;
+import org.junit.Before;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -20,6 +26,24 @@ public class AbstractHttp2Test {
 
     static {
         BootstrapLogging.bootstrap();
+    }
+
+    final SslContextFactory sslContextFactory = new SslContextFactory();
+    HttpClient client;
+
+    @Before
+    public void setUp() throws Exception {
+        sslContextFactory.setTrustStorePath(ResourceHelpers.resourceFilePath("stores/http2_client.jts"));
+        sslContextFactory.setTrustStorePassword("http2_client");
+        sslContextFactory.start();
+
+        client = new HttpClient(new HttpClientTransportOverHTTP2(new HTTP2Client()), sslContextFactory);
+        client.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        client.stop();
     }
 
     protected static void assertResponse(ContentResponse response) {

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2IntegrationTest.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2IntegrationTest.java
@@ -5,14 +5,8 @@ import io.dropwizard.Configuration;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
-import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.http2.client.HTTP2Client;
-import org.eclipse.jetty.http2.client.http.HttpClientTransportOverHTTP2;
-import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.glassfish.jersey.client.JerseyClient;
 import org.glassfish.jersey.client.JerseyClientBuilder;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -33,24 +27,6 @@ public class Http2IntegrationTest extends AbstractHttp2Test {
             ConfigOverride.config("tls_http2", "server.connector.trustStorePath",
                     ResourceHelpers.resourceFilePath("stores/http2_client.jts"))
     );
-
-    private final SslContextFactory sslContextFactory = new SslContextFactory();
-    private HttpClient client;
-
-    @Before
-    public void setUp() throws Exception {
-        sslContextFactory.setTrustStorePath(ResourceHelpers.resourceFilePath("stores/http2_client.jts"));
-        sslContextFactory.setTrustStorePassword("http2_client");
-        sslContextFactory.start();
-
-        client = new HttpClient(new HttpClientTransportOverHTTP2(new HTTP2Client()), sslContextFactory);
-        client.start();
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        client.stop();
-    }
 
     @Test
     public void testHttp11() throws Exception {

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2WithConscrypt.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2WithConscrypt.java
@@ -2,6 +2,7 @@ package io.dropwizard.http2;
 
 import io.dropwizard.Configuration;
 import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.conscrypt.OpenSSLProvider;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.http2.client.HTTP2Client;
 import org.eclipse.jetty.http2.client.http.HttpClientTransportOverHTTP2;
@@ -11,18 +12,23 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.security.Security;
 import java.util.Optional;
 
 import static io.dropwizard.testing.ConfigOverride.config;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 
-public class Http2WithCustomCipherTest extends AbstractHttp2Test {
+public class Http2WithConscrypt extends AbstractHttp2Test {
 
-    private static final String PREFIX = "tls_custom_http2";
+    static {
+        Security.addProvider(new OpenSSLProvider());
+    }
+
+    private static final String PREFIX = "tls_conscrypt";
 
     @Rule
     public final DropwizardAppRule<Configuration> appRule = new DropwizardAppRule<>(
-        FakeApplication.class, resourceFilePath("test-http2-with-custom-cipher.yml"),
+        FakeApplication.class, resourceFilePath("test-http2-with-conscrypt.yml"),
         Optional.of(PREFIX),
         config(PREFIX, "server.connector.keyStorePath", resourceFilePath("stores/http2_server.jks")),
         config(PREFIX, "server.connector.trustStorePath", resourceFilePath("stores/http2_client.jts"))

--- a/dropwizard-http2/src/test/resources/test-http2-with-conscrypt.yml
+++ b/dropwizard-http2/src/test/resources/test-http2-with-conscrypt.yml
@@ -1,0 +1,11 @@
+server:
+  type: simple
+  connector:
+    type: h2
+    port: 0
+    keyStorePassword: http2_server
+    trustStorePassword: http2_client
+    validateCerts: false
+    jceProvider: Conscrypt
+  applicationContextPath: /api
+  adminContextPath: /admin


### PR DESCRIPTION
###### Problem:
Jetty 9.4.8 supports native SSL via [Conscrypt](https://github.com/google/conscrypt), but it's not clear how to use it in Dropwizard.

###### Solution:
Add an integration test and upgrade the SSL documentation.

###### Result:
Dropwizard users can see how they can take advantage of native SSL.
