### PR TITLE
Remove the type target from the `@CacheControl` annotation

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/caching/CacheControl.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/caching/CacheControl.java
@@ -12,7 +12,7 @@ import java.util.concurrent.TimeUnit;
  * the annotated method.
  */
 @Documented
-@Target({ElementType.TYPE, ElementType.METHOD})
+@Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CacheControl {
     /**


### PR DESCRIPTION
###### Problem:
`@CacheControl` can be applied at the resource level, but actually handled only at the method level,

###### Solution:
Remove the type target from the `@CacheControl` annotation.  It doesn't seem useful to specify it at the resource level, because resources typically contain methods with different caching behavior.

###### Result:
Less confusion for Dropwizard users who use `@CacheControl`
Fixes #2226