### PR TITLE
Add support for JSON logs in Dropwizard

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -698,8 +698,8 @@ neverBlock                   false                                      Prevent 
                                                                         Set to true to disable blocking.
 bufferSize                   8KB                                        The buffer size of the underlying FileAppender (setting added in logback 1.1.10). Increasing this
                                                                         from the default of 8KB to 256KB is reported to significantly reduce thread contention.
-immediateFlush               true         If set to true, log events will be immediately flushed to disk. Immediate flushing is safer, but
-                                          it degrades logging throughput.
+immediateFlush               true                                       If set to true, log events will be immediately flushed to disk. Immediate flushing is safer, but
+                                                                        it degrades logging throughput.
 ============================ =========================================  ==================================================================================================
 
 
@@ -766,6 +766,114 @@ Name                   Default      Description
 ====================== ===========  ================
 type                   REQUIRED     The filter type.
 ====================== ===========  ================
+
+.. _man-configuration-json-layout:
+
+JSON layout
+-----------
+
+.. code-block:: yaml
+
+    layout:
+      type: json
+      timestampFormat: "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+      prettyPrint: false
+      appendLineSeparator: true
+      includes: [timestamp, threadName, level, loggerName, message, mdc, exception]
+      customFieldNames:
+        timestamp: "@timestamp"
+      additionalFields:
+        service-name: "user-service"
+      includesMdcKeys: [userId]
+
+
+=======================  =====================  ================
+Name                     Default                Description
+=======================  =====================  ================
+timestampFormat          (none)                 By default, the timestamp is not formatted. To customize how timestamps are formatted,
+                                                set the property to the corresponding DateTimeFormatter_ string or one of the
+                                                predefined formats (e.g. ``ISO_LOCAL_TIME``, ``ISO_ZONED_DATE_TIME``, ``RFC_1123_DATE_TIME``).
+prettyPrint              false                  Whether the JSON output should be formatted for human readability.
+appendLineSeparator      true                   Whether to append a line separator at the end of the message formatted as JSON.
+includes                 (timestamp, level,
+                         threadName,  mdc,
+                         loggerName, message,
+                         exception)             Set of logging event attributes to include in the JSON map:
+
+                                                - ``timestamp``   *true*   Whether to include the timestamp as the ``timestamp`` field.
+                                                - ``level``       *true*   Whether to include the logging level as the ``level`` field.
+                                                - ``threadName``  *true*   Whether to include the thread name as the ``thread`` field.
+                                                - ``mdc``         *true*   Whether to include the MDC properties as the ``mdc`` field.
+                                                - ``loggerName``  *true*   Whether to include the logger name as the ``logger`` field.
+                                                - ``message``     *true*   Whether to include the formatted message as the ``message`` field.
+                                                - ``exception``   *true*   Whether to log exceptions. If the property enabled and there is an exception, it will be formatted to a string as the ``exception`` field.
+                                                - ``contextName`` *false*  Whether to include the logging context name as the ``context`` field .
+customFieldNames         (empty)                Map of field name replacements . For example ``(requestTime:request_time, userAgent:user_agent)``.
+additionalFields         (empty)                Map of fields to add in the JSON map.
+includesMdcKeys          (empty)                Set of MDC keys which should be included in the JSON map. By default includes everything.
+=======================  =====================  ================
+
+.. _DateTimeFormatter:  https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html
+
+.. _man-configuration-json-access-layout:
+
+JSON access log layout
+----------------------
+
+.. code-block:: yaml
+
+    layout:
+      type: access-json
+      timestampFormat: "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+      prettyPrint: false
+      appendLineSeparator: true
+      includes: [timestamp, remoteAddress, remoteUser, protocol, method, requestUri, statusCode, requestTime, contentLength, userAgent]
+      requestHeaders:
+        - X-Request-Id
+      responseHeaders:
+        - X-Request-Id
+      customFieldNames:
+        timestamp: "@timestamp"
+      additionalFields:
+        service-name: "user-service"
+
+=======================  =========================== ================
+Name                     Default                     Description
+=======================  =========================== ================
+timestampFormat          (none)                      By default, the timestamp is not formatted. To customize how timestamps are formatted,
+                                                     set the property to the corresponding DateTimeFormatter_ string or one of the predefined formats
+                                                     (e.g. ``ISO_LOCAL_TIME``, ``ISO_ZONED_DATE_TIME``,``RFC_1123_DATE_TIME``).
+prettyPrint              false                       Whether the JSON output should be formatted for human readability.
+appendLineSeparator      true                        Whether to append a line separator at the end of the message formatted as JSON.
+includes                 (timestamp, remoteAddress,
+                         protocol, method,
+                         requestUri, statusCode,
+                         requestTime, contentLength,
+                         userAgent)                  Set of logging event attributes to include in the JSON map:
+
+                                                     - ``contentLength``     *true*     Whether to include the response content length, if it's known as the ``contentLength`` field.
+                                                     - ``method``            *true*     Whether to include the request HTTP method as the ``method`` field.
+                                                     - ``remoteAddress``     *true*     Whether to include the IP address of the client or last proxy that sent the request as the ``remoteAddress`` field.
+                                                     - ``remoteUser``        *true*     Whether to include information about the remote user as the ``remoteUser`` field.
+                                                     - ``requestTime``       *true*     Whether to include the time elapsed between receiving the request and logging it as the ``requestTime`` field. Time is in *ms*.
+                                                     - ``requestUri``        *true*     Whether to include the URI of the request as the ``uri`` field.
+                                                     - ``statusCode``        *true*     Whether to include the status code of the response as the ``status`` field.
+                                                     - ``protocol``          *true*     Whether to include the request HTTP protocol as the ``protocol`` field.
+                                                     - ``timestamp``         *true*     Whether to include the timestamp of the event the ``timestamp`` field.
+                                                     - ``userAgent``         *true*     Whether to include the user agent of the request as the ``userAgent`` field.
+                                                     - ``requestParameters`` *false*    Whether to include the request parameters as the ``params`` field.
+                                                     - ``requestContent``    *false*    Whether to include the body of the request as the ``requestContent`` field.
+                                                     - ``requestUrl``        *false*    Whether to include the request URL (method, URI, query parameters, protocol) as the ``contentLength`` field.
+                                                     - ``remoteHost``        *false*    Whether to include the fully qualified name of the client or the last proxy that sent the request as the ``remoteHost`` field.
+                                                     - ``responseContent``   *false*    Whether to include the response body as the ``responseContent`` field.
+                                                     - ``serverName``        *false*    Whether to include the name of the server to which the request was sent as the ``serverName`` field.
+requestHeaders           (empty)                     Set of request headers included in the JSON map as the ``headers`` field.
+responseHeaders          (empty)                     Set of response headers included in the JSON map as the ``responseHeaders`` field.
+customFieldNames         (empty)                     Map of field name replacements in the JSON map. For example ``requestTime:request_time, userAgent:user_agent)``.
+additionalFields         (empty)                     Map of fields to add in the JSON map.
+=======================  ===========================  ================
+
+.. _DateTimeFormatter:  https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html
 
 .. _man-configuration-metrics:
 

--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -1025,6 +1025,55 @@ appender with different configurations:
 
 .. _man-core-logging-http-config:
 
+JSON Log Format
+---------------
+
+You may prefer to produce logs in a structured format such as JSON, so it can be processed by analytics or BI software.
+For that, add a module to the project for supporting JSON layouts:
+
+.. code-block:: xml
+
+    <dependency>
+        <groupId>io.dropwizard</groupId>
+        <artifactId>dropwizard-json-logging</artifactId>
+        <version>${dropwizard.version}</version>
+    </dependency>
+
+Setup the JSON layout in the configuration file.
+
+For general logging:
+
+.. code-block:: yaml
+
+    logging:
+      appenders:
+        - type: console
+          layout:
+            type: json
+
+The ``json`` layout will produces the following log message:
+
+.. code-block:: json
+
+    {"timestamp":1515002688000, "level":"INFO","logger":"org.eclipse.jetty.server.Server","thread":"main","message":"Started @6505ms"}
+
+For request logging:
+
+.. code-block:: yaml
+
+    server:
+      requestLog:
+        appenders:
+          - type: console
+            layout:
+              type: access-json
+
+The ``access-json`` layout will produces the following log message:
+
+.. code-block:: json
+
+    {"timestamp":1515002688000, "method":"GET","uri":"/hello-world", "status":200, "protocol":"HTTP/1.1","contentLength":37,"remoteAddress":"127.0.0.1","requestTime":5, "userAgent":"Mozilla/5.0"}
+
 Logging Configuration via HTTP
 ------------------------------
 

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -685,6 +685,11 @@
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
+                <artifactId>dropwizard-json-logging</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-servlets</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/dropwizard-example/example.yml
+++ b/dropwizard-example/example.yml
@@ -25,6 +25,15 @@ database:
 #    port: 8080
 
 server:
+  requestLog:
+    appenders:
+      - type: console
+        layout:
+          type: access-json
+          timestampFormat: "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+          requestHeaders:
+              - User-Agent
+              - X-Request-Id
 #  softNofileLimit: 1000
 #  hardNofileLimit: 1000
   applicationConnectors:
@@ -69,6 +78,9 @@ logging:
 
   appenders:
     - type: console
+      layout:
+        type: json
+        timestampFormat: "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
     - type: file
       threshold: INFO
       logFormat: "%-6level [%d{HH:mm:ss.SSS}] [%t] %logger{5} - %X{code} %msg %n"
@@ -78,7 +90,8 @@ logging:
       timeZone: UTC
       maxFileSize: 10MB
 
-# the key needs to match the configuration key of the renderer (ViewRenderer::getConfigurationKey)
+
+# the key needs to match the suffix of the renderer
 viewRendererConfiguration:
     freemarker:
         strict_syntax: yes

--- a/dropwizard-example/pom.xml
+++ b/dropwizard-example/pom.xml
@@ -83,6 +83,10 @@
             <artifactId>dropwizard-metrics-graphite</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-json-logging</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>

--- a/dropwizard-json-logging/pom.xml
+++ b/dropwizard-json-logging/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>dropwizard-parent</artifactId>
+        <groupId>io.dropwizard</groupId>
+        <version>1.3.0-rc2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>dropwizard-json-logging</artifactId>
+    <name>Dropwizard JSON logging</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.dropwizard</groupId>
+                <artifactId>dropwizard-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-logging</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-request-logging</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-configuration</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/AbstractJsonLayoutBaseFactory.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/AbstractJsonLayoutBaseFactory.java
@@ -1,0 +1,125 @@
+package io.dropwizard.logging.json;
+
+import ch.qos.logback.core.spi.DeferredProcessingAware;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.logging.json.layout.JsonFormatter;
+import io.dropwizard.logging.json.layout.TimestampFormatter;
+import io.dropwizard.logging.layout.DiscoverableLayoutFactory;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+import java.util.Map;
+import java.util.TimeZone;
+
+/**
+ * <table>
+ * <tr>
+ * <th>Name</th>
+ * <th>Default</th>
+ * <th>Description</th>
+ * </tr>
+ * <tr>
+ * <td>{@code timestampFormat}</td>
+ * <td>(none)</td>
+ * <td>By default, the timestamp is not formatted; To format the timestamp using set the property with the
+ * corresponding {@link java.time.format.DateTimeFormatter} string, for example, {@code yyyy-MM-ddTHH:mm:ss.SSSZ}</td>
+ * </tr>
+ * <tr>
+ * <td>{@code prettyPrint}</td>
+ * <td>{@code false}</td>
+ * <td>Whether the JSON output should be formatted for human readability.</td>
+ * </tr>
+ * <tr>
+ * <td>{@code appendLineSeparator}</td>
+ * <td>{@code true}</td>
+ * <td>Whether to append a line separator at the end of the message formatted as JSON.</td>
+ * </tr>
+ * <tr>
+ * <td>{@code customFieldNames}</td>
+ * <td>empty</td>
+ * <td>A map of field name replacements. For example:
+ * <i>(requestTime:request_time, userAgent:user_agent)</i></td>
+ * </tr>
+ * <tr>
+ * <td>{@code additionalFields}</td>
+ * <td>empty</td>
+ * <td>A map of fields to add.</td>
+ * </tr>
+ * </table>
+ */
+public abstract class AbstractJsonLayoutBaseFactory<E extends DeferredProcessingAware>
+    implements DiscoverableLayoutFactory<E> {
+
+    @Nullable
+    private String timestampFormat;
+
+    private boolean prettyPrint;
+    private boolean appendLineSeparator = true;
+
+    @NotNull
+    private Map<String, String> customFieldNames = ImmutableMap.of();
+
+    @NotNull
+    private Map<String, Object> additionalFields = ImmutableMap.of();
+
+    @JsonProperty
+    @Nullable
+    public String getTimestampFormat() {
+        return timestampFormat;
+    }
+
+    @JsonProperty
+    public void setTimestampFormat(String timestampFormat) {
+        this.timestampFormat = timestampFormat;
+    }
+
+    @JsonProperty
+    public boolean isPrettyPrint() {
+        return prettyPrint;
+    }
+
+    @JsonProperty
+    public void setPrettyPrint(boolean prettyPrint) {
+        this.prettyPrint = prettyPrint;
+    }
+
+    @JsonProperty
+    public boolean isAppendLineSeparator() {
+        return appendLineSeparator;
+    }
+
+    @JsonProperty
+    public void setAppendLineSeparator(boolean appendLineSeparator) {
+        this.appendLineSeparator = appendLineSeparator;
+    }
+
+    @JsonProperty
+    public Map<String, String> getCustomFieldNames() {
+        return customFieldNames;
+    }
+
+    @JsonProperty
+    public void setCustomFieldNames(Map<String, String> customFieldNames) {
+        this.customFieldNames = customFieldNames;
+    }
+
+    @JsonProperty
+    public Map<String, Object> getAdditionalFields() {
+        return additionalFields;
+    }
+
+    @JsonProperty
+    public void setAdditionalFields(Map<String, Object> additionalFields) {
+        this.additionalFields = additionalFields;
+    }
+
+    protected JsonFormatter createDropwizardJsonFormatter() {
+        return new JsonFormatter(Jackson.newObjectMapper(), isPrettyPrint(), isAppendLineSeparator());
+    }
+
+    protected TimestampFormatter createTimestampFormatter(TimeZone timeZone) {
+        return new TimestampFormatter(getTimestampFormat(), timeZone.toZoneId());
+    }
+}

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/AccessAttribute.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/AccessAttribute.java
@@ -1,0 +1,27 @@
+package io.dropwizard.logging.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents access logging attributes.
+ */
+public enum AccessAttribute {
+
+    @JsonProperty("contentLength") CONTENT_LENGTH,
+    @JsonProperty("method") METHOD,
+    @JsonProperty("remoteAddress") REMOTE_ADDRESS,
+    @JsonProperty("remoteUser") REMOTE_USER,
+    @JsonProperty("requestTime") REQUEST_TIME,
+    @JsonProperty("requestUri") REQUEST_URI,
+    @JsonProperty("requestUrl") REQUEST_URL,
+    @JsonProperty("statusCode") STATUS_CODE,
+    @JsonProperty("protocol") PROTOCOL,
+    @JsonProperty("remoteHost") REMOTE_HOST,
+    @JsonProperty("serverName") SERVER_NAME,
+    @JsonProperty("requestParameters") REQUEST_PARAMETERS,
+    @JsonProperty("userAgent") USER_AGENT,
+    @JsonProperty("localPort") LOCAL_PORT,
+    @JsonProperty("requestContent") REQUEST_CONTENT,
+    @JsonProperty("responseContent") RESPONSE_CONTENT,
+    @JsonProperty("timestamp") TIMESTAMP;
+}

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/AccessJsonLayoutBaseFactory.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/AccessJsonLayoutBaseFactory.java
@@ -1,0 +1,89 @@
+package io.dropwizard.logging.json;
+
+import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.core.LayoutBase;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.collect.ImmutableSet;
+import io.dropwizard.logging.json.layout.AccessJsonLayout;
+
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.TimeZone;
+
+/**
+ * <table>
+ * <tr>
+ * <th>Name</th>
+ * <th>Default</th>
+ * <th>Description</th>
+ * </tr>
+ * <tr>
+ * <td >{@code includes}</td>
+ * <td>(timestamp, remoteAddress,requestTime, requestUri, statusCode, method, protocol, contentLength, userAgent))</td>
+ * <td>Set of logging event attributes to include in the JSON map.</td>
+ * </tr>
+ * <tr>
+ * <td>{@code requestHeaders}</td>
+ * <td >(empty)</td>
+ * <td>Set of request headers included in the JSON map as the ``headers`` field.</td>
+ * </tr>
+ * <tr>
+ * <td>{@code responseHeaders}</td>
+ * <td>(empty)</td>
+ * <td>Set of response headers included in the JSON map as the ``responseHeaders`` field.</td>
+ * </tr>
+ * </table>
+ */
+@JsonTypeName("access-json")
+public class AccessJsonLayoutBaseFactory extends AbstractJsonLayoutBaseFactory<IAccessEvent> {
+
+    private EnumSet<AccessAttribute> includes = EnumSet.of(AccessAttribute.REMOTE_ADDRESS,
+        AccessAttribute.REMOTE_USER, AccessAttribute.REQUEST_TIME, AccessAttribute.REQUEST_URI,
+        AccessAttribute.STATUS_CODE, AccessAttribute.METHOD, AccessAttribute.PROTOCOL, AccessAttribute.CONTENT_LENGTH,
+        AccessAttribute.USER_AGENT, AccessAttribute.TIMESTAMP);
+
+    private Set<String> responseHeaders = ImmutableSet.of();
+    private Set<String> requestHeaders = ImmutableSet.of();
+
+    @JsonProperty
+    public Set<String> getResponseHeaders() {
+        return responseHeaders;
+    }
+
+    @JsonProperty
+    public void setResponseHeaders(Set<String> responseHeaders) {
+        this.responseHeaders = responseHeaders;
+    }
+
+    @JsonProperty
+    public Set<String> getRequestHeaders() {
+        return requestHeaders;
+    }
+
+    @JsonProperty
+    public void setRequestHeaders(Set<String> requestHeaders) {
+        this.requestHeaders = requestHeaders;
+    }
+
+    @JsonProperty
+    public EnumSet<AccessAttribute> getIncludes() {
+        return includes;
+    }
+
+    @JsonProperty
+    public void setIncludes(EnumSet<AccessAttribute> includes) {
+        this.includes = includes;
+    }
+
+    @Override
+    public LayoutBase<IAccessEvent> build(LoggerContext context, TimeZone timeZone) {
+        final AccessJsonLayout jsonLayout = new AccessJsonLayout(createDropwizardJsonFormatter(),
+            createTimestampFormatter(timeZone), includes, getCustomFieldNames(), getAdditionalFields());
+        jsonLayout.setContext(context);
+        jsonLayout.setRequestHeaders(requestHeaders);
+        jsonLayout.setResponseHeaders(responseHeaders);
+        return jsonLayout;
+    }
+}

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/EventAttribute.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/EventAttribute.java
@@ -1,0 +1,18 @@
+package io.dropwizard.logging.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents event logging attributes.
+ */
+public enum EventAttribute {
+
+    @JsonProperty("level") LEVEL,
+    @JsonProperty("threadName") THREAD_NAME,
+    @JsonProperty("mdc") MDC,
+    @JsonProperty("loggerName") LOGGER_NAME,
+    @JsonProperty("message") MESSAGE,
+    @JsonProperty("exception") EXCEPTION,
+    @JsonProperty("contextName") CONTEXT_NAME,
+    @JsonProperty("timestamp") TIMESTAMP;
+}

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/EventJsonLayoutBaseFactory.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/EventJsonLayoutBaseFactory.java
@@ -1,0 +1,79 @@
+package io.dropwizard.logging.json;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.pattern.RootCauseFirstThrowableProxyConverter;
+import ch.qos.logback.classic.pattern.ThrowableHandlingConverter;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.LayoutBase;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.collect.ImmutableSet;
+import io.dropwizard.logging.json.layout.EventJsonLayout;
+
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.TimeZone;
+
+/**
+ * <table>
+ * <tr>
+ * <th>Name</th>
+ * <th>Default</th>
+ * <th>Description</th>
+ * </tr>
+ * <tr>
+ * <td>{@code includes}</td>
+ * <td>(level, threadName, mdc, loggerName, message, exception, timestamp)</td>
+ * <td>Set of logging event attributes to include in the JSON map.</td>
+ * </tr>
+ * <tr>
+ * <td>{@code includesMdcKeys}</td>
+ * <td>(empty)</td>
+ * <td>Set of MDC keys which should be included in the JSON map. By default includes everything.</td>
+ * </tr>
+ * </table>
+ */
+@JsonTypeName("json")
+public class EventJsonLayoutBaseFactory extends AbstractJsonLayoutBaseFactory<ILoggingEvent> {
+
+    private EnumSet<EventAttribute> includes = EnumSet.of(EventAttribute.LEVEL,
+        EventAttribute.THREAD_NAME, EventAttribute.MDC, EventAttribute.LOGGER_NAME, EventAttribute.MESSAGE,
+        EventAttribute.EXCEPTION, EventAttribute.TIMESTAMP);
+
+    private Set<String> includesMdcKeys = ImmutableSet.of();
+
+    @JsonProperty
+    public EnumSet<EventAttribute> getIncludes() {
+        return includes;
+    }
+
+    @JsonProperty
+    public void setIncludes(EnumSet<EventAttribute> includes) {
+        this.includes = includes;
+    }
+
+    @JsonProperty
+    public Set<String> getIncludesMdcKeys() {
+        return includesMdcKeys;
+    }
+
+    @JsonProperty
+    public void setIncludesMdcKeys(Set<String> includesMdcKeys) {
+        this.includesMdcKeys = includesMdcKeys;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public LayoutBase<ILoggingEvent> build(LoggerContext context, TimeZone timeZone) {
+        final EventJsonLayout jsonLayout = new EventJsonLayout(createDropwizardJsonFormatter(),
+            createTimestampFormatter(timeZone), createThrowableProxyConverter(), includes, getCustomFieldNames(),
+            getAdditionalFields(), includesMdcKeys);
+        jsonLayout.setContext(context);
+        return jsonLayout;
+    }
+
+    protected ThrowableHandlingConverter createThrowableProxyConverter() {
+        return new RootCauseFirstThrowableProxyConverter();
+    }
+
+}

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/AbstractJsonLayout.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/AbstractJsonLayout.java
@@ -1,0 +1,33 @@
+package io.dropwizard.logging.json.layout;
+
+import ch.qos.logback.core.LayoutBase;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+/**
+ * Provides the common functionality for building JSON representations
+ * of {@link ch.qos.logback.access.spi.IAccessEvent} and {@link ch.qos.logback.classic.spi.ILoggingEvent}
+ * events.
+ *
+ * @param <E> represents the type of the event
+ */
+public abstract class AbstractJsonLayout<E> extends LayoutBase<E> {
+
+    private final JsonFormatter jsonFormatter;
+
+    protected AbstractJsonLayout(JsonFormatter jsonFormatter) {
+        this.jsonFormatter = jsonFormatter;
+    }
+
+    @Override
+    @Nullable
+    public String doLayout(E event) {
+        return jsonFormatter.toJson(toJsonMap(event));
+    }
+
+    /**
+     * Converts the provided logging event to a generic {@link Map}
+     */
+    protected abstract Map<String, Object> toJsonMap(E event);
+}

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/AccessJsonLayout.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/AccessJsonLayout.java
@@ -1,0 +1,116 @@
+package io.dropwizard.logging.json.layout;
+
+import ch.qos.logback.access.spi.IAccessEvent;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Sets;
+import com.google.common.net.HttpHeaders;
+import io.dropwizard.logging.json.AccessAttribute;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Builds JSON messages from access log events as {@link IAccessEvent}.
+ */
+public class AccessJsonLayout extends AbstractJsonLayout<IAccessEvent> {
+
+    private ImmutableSet<AccessAttribute> includes;
+
+    private ImmutableSet<String> requestHeaders = ImmutableSortedSet.of();
+    private ImmutableSet<String> responseHeaders = ImmutableSortedSet.of();
+
+    @Nullable
+    private String jsonProtocolVersion;
+
+    private final TimestampFormatter timestampFormatter;
+    private final Map<String, Object> additionalFields;
+    private final Map<String, String> customFieldNames;
+
+    public AccessJsonLayout(JsonFormatter jsonFormatter, TimestampFormatter timestampFormatter,
+                            Set<AccessAttribute> includes, Map<String, String> customFieldNames,
+                            Map<String, Object> additionalFields) {
+        super(jsonFormatter);
+        this.timestampFormatter = timestampFormatter;
+        this.additionalFields = ImmutableMap.copyOf(additionalFields);
+        this.customFieldNames = ImmutableMap.copyOf(customFieldNames);
+        this.includes = Sets.immutableEnumSet(includes);
+    }
+
+    @Override
+    protected Map<String, Object> toJsonMap(IAccessEvent event) {
+        return new MapBuilder(timestampFormatter, customFieldNames, additionalFields, 20)
+            .add("port", isIncluded(AccessAttribute.LOCAL_PORT), event.getLocalPort())
+            .add("contentLength", isIncluded(AccessAttribute.CONTENT_LENGTH), event.getContentLength())
+            .addTimestamp("timestamp", isIncluded(AccessAttribute.TIMESTAMP), event.getTimeStamp())
+            .add("method", isIncluded(AccessAttribute.METHOD), event.getMethod())
+            .add("protocol", isIncluded(AccessAttribute.PROTOCOL), event.getProtocol())
+            .add("requestContent", isIncluded(AccessAttribute.REQUEST_CONTENT), event.getRequestContent())
+            .add("remoteAddress", isIncluded(AccessAttribute.REMOTE_ADDRESS), event.getRemoteAddr())
+            .add("remoteUser", isIncluded(AccessAttribute.REMOTE_USER), event.getRemoteUser())
+            .add("headers", !requestHeaders.isEmpty(),
+                filterHeaders(event.getRequestHeaderMap(), requestHeaders))
+            .add("params", isIncluded(AccessAttribute.REQUEST_PARAMETERS), event.getRequestParameterMap())
+            .add("requestTime", isIncluded(AccessAttribute.REQUEST_TIME), event.getElapsedTime())
+            .add("uri", isIncluded(AccessAttribute.REQUEST_URI), event.getRequestURI())
+            .add("url", isIncluded(AccessAttribute.REQUEST_URL), event.getRequestURL())
+            .add("remoteHost", isIncluded(AccessAttribute.REMOTE_HOST), event.getRemoteHost())
+            .add("responseContent", isIncluded(AccessAttribute.RESPONSE_CONTENT), event.getResponseContent())
+            .add("responseHeaders", !responseHeaders.isEmpty(),
+                filterHeaders(event.getResponseHeaderMap(), responseHeaders))
+            .add("serverName", isIncluded(AccessAttribute.SERVER_NAME), event.getServerName())
+            .add("status", isIncluded(AccessAttribute.STATUS_CODE), event.getStatusCode())
+            .add("userAgent", isIncluded(AccessAttribute.USER_AGENT), event.getRequestHeader(HttpHeaders.USER_AGENT))
+            .add("version", jsonProtocolVersion != null, jsonProtocolVersion)
+            .build();
+    }
+
+    private boolean isIncluded(AccessAttribute userAgent) {
+        return includes.contains(userAgent);
+    }
+
+    private Map<String, String> filterHeaders(Map<String, String> headers, Set<String> filteredHeaderNames) {
+        if (filteredHeaderNames.isEmpty()) {
+            return ImmutableMap.of();
+        }
+        return headers.entrySet().stream()
+            .filter(e -> filteredHeaderNames.contains(e.getKey()))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    public ImmutableSet<AccessAttribute> getIncludes() {
+        return includes;
+    }
+
+    public void setIncludes(Set<AccessAttribute> includes) {
+        this.includes = Sets.immutableEnumSet(includes);
+    }
+
+    @Nullable
+    public String getJsonProtocolVersion() {
+        return jsonProtocolVersion;
+    }
+
+    public void setJsonProtocolVersion(@Nullable String jsonProtocolVersion) {
+        this.jsonProtocolVersion = jsonProtocolVersion;
+    }
+
+    public ImmutableSet<String> getRequestHeaders() {
+        return requestHeaders;
+    }
+
+    public void setRequestHeaders(Set<String> requestHeaders) {
+        this.requestHeaders = ImmutableSortedSet.copyOf(String::compareToIgnoreCase, requestHeaders);
+    }
+
+    public ImmutableSet<String> getResponseHeaders() {
+        return responseHeaders;
+    }
+
+    public void setResponseHeaders(Set<String> responseHeaders) {
+        this.responseHeaders = ImmutableSortedSet.copyOf(String::compareToIgnoreCase, responseHeaders);
+    }
+}

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/EventJsonLayout.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/EventJsonLayout.java
@@ -1,0 +1,111 @@
+package io.dropwizard.logging.json.layout;
+
+import ch.qos.logback.classic.pattern.ThrowableHandlingConverter;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import io.dropwizard.logging.json.EventAttribute;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Builds JSON messages from logging events of the type {@link ILoggingEvent}.
+ */
+public class EventJsonLayout extends AbstractJsonLayout<ILoggingEvent> {
+
+    private ImmutableSet<EventAttribute> includes;
+
+    @Nullable
+    private String jsonProtocolVersion;
+
+    private final ThrowableHandlingConverter throwableProxyConverter;
+    private final TimestampFormatter timestampFormatter;
+    private final Map<String, Object> additionalFields;
+    private final Map<String, String> customFieldNames;
+
+    private ImmutableSet<String> includesMdcKeys;
+
+    public EventJsonLayout(JsonFormatter jsonFormatter, TimestampFormatter timestampFormatter,
+                           ThrowableHandlingConverter throwableProxyConverter, Set<EventAttribute> includes,
+                           Map<String, String> customFieldNames, Map<String, Object> additionalFields,
+                           Set<String> includesMdcKeys) {
+        super(jsonFormatter);
+        this.timestampFormatter = timestampFormatter;
+        this.additionalFields = ImmutableMap.copyOf(additionalFields);
+        this.customFieldNames = ImmutableMap.copyOf(customFieldNames);
+        this.throwableProxyConverter = throwableProxyConverter;
+        this.includes = ImmutableSet.copyOf(includes);
+        this.includesMdcKeys = ImmutableSet.copyOf(includesMdcKeys);
+    }
+
+    @Override
+    public void start() {
+        throwableProxyConverter.start();
+        super.start();
+    }
+
+    @Override
+    public void stop() {
+        super.stop();
+        throwableProxyConverter.stop();
+    }
+
+    @Override
+    protected Map<String, Object> toJsonMap(ILoggingEvent event) {
+        return new MapBuilder(timestampFormatter, customFieldNames, additionalFields, 16)
+            .addTimestamp("timestamp", isIncluded(EventAttribute.TIMESTAMP), event.getTimeStamp())
+            .add("level", isIncluded(EventAttribute.LEVEL), String.valueOf(event.getLevel()))
+            .add("thread", isIncluded(EventAttribute.THREAD_NAME), event.getThreadName())
+            .add("mdc", isIncluded(EventAttribute.MDC), filterMdc(event.getMDCPropertyMap()))
+            .add("logger", isIncluded(EventAttribute.LOGGER_NAME), event.getLoggerName())
+            .add("message", isIncluded(EventAttribute.MESSAGE), event.getFormattedMessage())
+            .add("context", isIncluded(EventAttribute.CONTEXT_NAME), event.getLoggerContextVO().getName())
+            .add("version", jsonProtocolVersion != null, jsonProtocolVersion)
+            .add("exception", isIncluded(EventAttribute.EXCEPTION) && event.getThrowableProxy() != null,
+                throwableProxyConverter.convert(event))
+            .build();
+    }
+
+    private Map<String, String> filterMdc(Map<String, String> mdcPropertyMap) {
+        if (includesMdcKeys.isEmpty()) {
+            return mdcPropertyMap;
+        }
+        return mdcPropertyMap.entrySet()
+            .stream()
+            .filter(e -> includesMdcKeys.contains(e.getKey()))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private boolean isIncluded(EventAttribute exception) {
+        return includes.contains(exception);
+    }
+
+    public ImmutableSet<EventAttribute> getIncludes() {
+        return includes;
+    }
+
+    public void setIncludes(Set<EventAttribute> includes) {
+        this.includes = Sets.immutableEnumSet(includes);
+    }
+
+    @Nullable
+    public String getJsonProtocolVersion() {
+        return jsonProtocolVersion;
+    }
+
+    public void setJsonProtocolVersion(@Nullable String jsonProtocolVersion) {
+        this.jsonProtocolVersion = jsonProtocolVersion;
+    }
+
+    public ImmutableSet<String> getIncludesMdcKeys() {
+        return includesMdcKeys;
+    }
+
+    public void setIncludesMdcKeys(Set<String> includesMdcKeys) {
+        this.includesMdcKeys = ImmutableSet.copyOf(includesMdcKeys);
+    }
+}

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/JsonFormatter.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/JsonFormatter.java
@@ -1,0 +1,57 @@
+package io.dropwizard.logging.json.layout;
+
+import ch.qos.logback.core.CoreConstants;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Map;
+
+/**
+ * Formats objects to JSON strings according to the configured {@link ObjectMapper} and output parameters.
+ */
+public class JsonFormatter {
+
+    private static final int DEFAULT_BUFFER_SIZE = 512;
+
+    private final ObjectMapper objectMapper;
+    private final boolean doesAppendLineSeparator;
+    private final int bufferSize;
+
+    public JsonFormatter(ObjectMapper objectMapper, boolean prettyPrint, boolean doesAppendLineSeparator,
+                         int bufferSize) {
+        this.objectMapper = prettyPrint ? objectMapper.enable(SerializationFeature.INDENT_OUTPUT) : objectMapper;
+        this.doesAppendLineSeparator = doesAppendLineSeparator;
+        this.bufferSize = bufferSize;
+    }
+
+    public JsonFormatter(ObjectMapper objectMapper, boolean prettyPrint, boolean doesAppendLineSeparator) {
+        this(objectMapper, prettyPrint, doesAppendLineSeparator, DEFAULT_BUFFER_SIZE);
+    }
+
+    /**
+     * Converts the provided map as a JSON object according to the configured JSON mapper.
+     *
+     * @param map the provided map
+     * @return the JSON as a string
+     */
+    @Nullable
+    public String toJson(Map<String, Object> map) {
+        if (map == null || map.isEmpty()) {
+            return null;
+        }
+
+        final StringWriter writer = new StringWriter(bufferSize);
+        try {
+            objectMapper.writeValue(writer, map);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Unable to format map as a JSON", e);
+        }
+        if (doesAppendLineSeparator) {
+            writer.append(CoreConstants.LINE_SEPARATOR);
+        }
+        return writer.toString();
+    }
+}

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/MapBuilder.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/MapBuilder.java
@@ -1,0 +1,88 @@
+package io.dropwizard.logging.json.layout;
+
+import com.google.common.collect.Maps;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Builds a Java map based on the provided configuration and customization.
+ */
+public class MapBuilder {
+
+    private final TimestampFormatter timestampFormatter;
+
+    /**
+     * Custom field name replacements in the format (oldName:newName).
+     */
+    private final Map<String, String> customFieldNames;
+
+    /**
+     * Additional fields which should be included in the message.
+     */
+    private final Map<String, Object> additionalFields;
+
+    private final Map<String, Object> map;
+
+    public MapBuilder(TimestampFormatter timestampFormatter, Map<String, String> customFieldNames,
+                      Map<String, Object> additionalFields, int expectedSize) {
+        this.timestampFormatter = timestampFormatter;
+        this.customFieldNames = checkNotNull(customFieldNames);
+        this.additionalFields = checkNotNull(additionalFields);
+        this.map = Maps.newHashMapWithExpectedSize(expectedSize);
+    }
+
+    /**
+     * Adds the string value to the provided map under the provided field name,
+     * if it's should be included.
+     */
+    public MapBuilder add(String fieldName, boolean include, @Nullable String value) {
+        if (include && value != null) {
+            map.put(getFieldName(fieldName), value);
+        }
+        return this;
+    }
+
+    /**
+     * Adds the number to the provided map under the provided field name if it's should be included.
+     */
+    public MapBuilder add(String fieldName, boolean include, @Nullable Number number) {
+        if (include && number != null) {
+            map.put(getFieldName(fieldName), number);
+        }
+        return this;
+    }
+
+    /**
+     * Adds the map to the provided map under the provided field name if it's should be included.
+     */
+    public MapBuilder add(String fieldName, boolean include, @Nullable Map<String, ?> mapValue) {
+        if (include && mapValue != null && !mapValue.isEmpty()) {
+            map.put(getFieldName(fieldName), mapValue);
+        }
+        return this;
+    }
+
+    /**
+     * Adds and optionally formats the timestamp to the provided map under the provided field name,
+     * if it's should be included.
+     */
+    public MapBuilder addTimestamp(String fieldName, boolean include, long timestamp) {
+        if (include && timestamp > 0) {
+            map.put(getFieldName(fieldName), timestampFormatter.format(timestamp));
+        }
+        return this;
+    }
+
+    private String getFieldName(String fieldName) {
+        return customFieldNames.getOrDefault(fieldName, fieldName);
+    }
+
+    public Map<String, Object> build() {
+        map.putAll(additionalFields);
+        return map;
+    }
+
+}

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/TimestampFormatter.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/TimestampFormatter.java
@@ -1,0 +1,52 @@
+package io.dropwizard.logging.json.layout;
+
+import com.google.common.collect.ImmutableMap;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A faster timestamp formatter than the default one in Logback.
+ * Also produces timestamps as numbers if the timestamp formatting is disabled.
+ */
+public class TimestampFormatter {
+
+    private static final Map<String, DateTimeFormatter> FORMATTERS = ImmutableMap.<String, DateTimeFormatter>builder()
+        .put("ISO_LOCAL_DATE", DateTimeFormatter.ISO_LOCAL_DATE)
+        .put("ISO_OFFSET_DATE", DateTimeFormatter.ISO_OFFSET_DATE)
+        .put("ISO_DATE", DateTimeFormatter.ISO_DATE)
+        .put("ISO_LOCAL_TIME", DateTimeFormatter.ISO_LOCAL_TIME)
+        .put("ISO_OFFSET_TIME", DateTimeFormatter.ISO_OFFSET_TIME)
+        .put("ISO_TIME", DateTimeFormatter.ISO_TIME)
+        .put("ISO_LOCAL_DATE_TIME", DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        .put("ISO_OFFSET_DATE_TIME", DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+        .put("ISO_ZONED_DATE_TIME", DateTimeFormatter.ISO_ZONED_DATE_TIME)
+        .put("ISO_DATE_TIME", DateTimeFormatter.ISO_DATE_TIME)
+        .put("ISO_ORDINAL_DATE", DateTimeFormatter.ISO_ORDINAL_DATE)
+        .put("ISO_WEEK_DATE", DateTimeFormatter.ISO_WEEK_DATE)
+        .put("ISO_INSTANT", DateTimeFormatter.ISO_INSTANT)
+        .put("BASIC_ISO_DATE", DateTimeFormatter.BASIC_ISO_DATE)
+        .put("RFC_1123_DATE_TIME", DateTimeFormatter.RFC_1123_DATE_TIME)
+        .build();
+
+    @Nullable
+    private final DateTimeFormatter dateTimeFormatter;
+
+    public TimestampFormatter(@Nullable String timestampFormat, ZoneId zoneId) {
+        if (timestampFormat != null) {
+            dateTimeFormatter = Optional.ofNullable(FORMATTERS.get(timestampFormat))
+                .orElseGet(() -> DateTimeFormatter.ofPattern(timestampFormat))
+                .withZone(zoneId);
+        } else {
+            dateTimeFormatter = null;
+        }
+    }
+
+    public Object format(long timestamp) {
+        return dateTimeFormatter == null ? timestamp : dateTimeFormatter.format(Instant.ofEpochMilli(timestamp));
+    }
+}

--- a/dropwizard-json-logging/src/main/resources/META-INF/services/io.dropwizard.logging.layout.DiscoverableLayoutFactory
+++ b/dropwizard-json-logging/src/main/resources/META-INF/services/io.dropwizard.logging.layout.DiscoverableLayoutFactory
@@ -1,0 +1,2 @@
+io.dropwizard.logging.json.AccessJsonLayoutBaseFactory
+io.dropwizard.logging.json.EventJsonLayoutBaseFactory

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
@@ -1,0 +1,194 @@
+package io.dropwizard.logging.json;
+
+import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.spi.DeferredProcessingAware;
+import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Resources;
+import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.logging.BootstrapLogging;
+import io.dropwizard.logging.ConsoleAppenderFactory;
+import io.dropwizard.logging.DefaultLoggingFactory;
+import io.dropwizard.logging.layout.DiscoverableLayoutFactory;
+import io.dropwizard.request.logging.LogbackAccessRequestLogFactory;
+import io.dropwizard.validation.BaseValidator;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.RequestLog;
+import org.eclipse.jetty.server.Response;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LayoutIntegrationTests {
+
+    static {
+        BootstrapLogging.bootstrap(Level.INFO);
+    }
+
+    private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+    private final YamlConfigurationFactory<ConsoleAppenderFactory> yamlFactory = new YamlConfigurationFactory<>(
+        ConsoleAppenderFactory.class, BaseValidator.newValidator(), objectMapper, "dw-json-log");
+
+    @Before
+    public void setUp() {
+        objectMapper.getSubtypeResolver().registerSubtypes(AccessJsonLayoutBaseFactory.class, EventJsonLayoutBaseFactory.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends DeferredProcessingAware> ConsoleAppenderFactory<T> getAppenderFactory(String s) throws Exception {
+        return yamlFactory.build(new File(Resources.getResource(s).toURI()));
+    }
+
+    @Test
+    public void testDeserializeJson() throws Exception {
+        ConsoleAppenderFactory<ILoggingEvent> appenderFactory = getAppenderFactory("yaml/json-log.yml");
+        DiscoverableLayoutFactory layout = requireNonNull(appenderFactory.getLayout());
+        assertThat(layout).isInstanceOf(EventJsonLayoutBaseFactory.class);
+        EventJsonLayoutBaseFactory factory = (EventJsonLayoutBaseFactory) layout;
+        assertThat(factory).isNotNull();
+        assertThat(factory.getTimestampFormat()).isEqualTo("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+        assertThat(factory.isPrettyPrint()).isFalse();
+        assertThat(factory.isAppendLineSeparator()).isTrue();
+        assertThat(factory.getIncludes()).contains(
+            EventAttribute.LEVEL,
+            EventAttribute.MDC,
+            EventAttribute.MESSAGE,
+            EventAttribute.LOGGER_NAME,
+            EventAttribute.EXCEPTION,
+            EventAttribute.TIMESTAMP);
+        assertThat(factory.getCustomFieldNames()).containsOnly(entry("timestamp", "@timestamp"));
+        assertThat(factory.getAdditionalFields()).containsOnly(entry("service-name", "user-service"),
+            entry("service-build", 218));
+        assertThat(factory.getIncludesMdcKeys()).containsOnly("userId");
+    }
+
+    @Test
+    public void testDeserializeAccessJson() throws Exception {
+        ConsoleAppenderFactory<IAccessEvent> appenderFactory = getAppenderFactory("yaml/json-access-log.yml");
+        DiscoverableLayoutFactory layout = requireNonNull(appenderFactory.getLayout());
+        assertThat(layout).isInstanceOf(AccessJsonLayoutBaseFactory.class);
+        AccessJsonLayoutBaseFactory factory = (AccessJsonLayoutBaseFactory) layout;
+        assertThat(factory.getTimestampFormat()).isEqualTo("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        assertThat(factory.isPrettyPrint()).isFalse();
+        assertThat(factory.isAppendLineSeparator()).isTrue();
+        assertThat(factory.getIncludes()).contains(AccessAttribute.TIMESTAMP,
+            AccessAttribute.REMOTE_USER,
+            AccessAttribute.STATUS_CODE,
+            AccessAttribute.METHOD,
+            AccessAttribute.REQUEST_URL,
+            AccessAttribute.REMOTE_HOST,
+            AccessAttribute.REQUEST_PARAMETERS,
+            AccessAttribute.REQUEST_CONTENT,
+            AccessAttribute.TIMESTAMP,
+            AccessAttribute.USER_AGENT);
+        assertThat(factory.getResponseHeaders()).containsOnly("X-Request-Id");
+        assertThat(factory.getRequestHeaders()).containsOnly("User-Agent", "X-Request-Id");
+        assertThat(factory.getCustomFieldNames()).containsOnly(entry("statusCode", "status_code"),
+            entry("userAgent", "user_agent"));
+        assertThat(factory.getAdditionalFields()).containsOnly(entry("service-name", "shipping-service"),
+            entry("service-version", "1.2.3"));
+    }
+
+    @Test
+    public void testLogJsonToConsole() throws Exception {
+        ConsoleAppenderFactory<ILoggingEvent> consoleAppenderFactory = getAppenderFactory("yaml/json-log-default.yml");
+        DefaultLoggingFactory defaultLoggingFactory = new DefaultLoggingFactory();
+        defaultLoggingFactory.setAppenders(ImmutableList.of(consoleAppenderFactory));
+
+        PrintStream old = System.out;
+        ByteArrayOutputStream redirectedStream = new ByteArrayOutputStream();
+        try {
+            System.setOut(new PrintStream(redirectedStream));
+            defaultLoggingFactory.configure(new MetricRegistry(), "json-log-test");
+            LoggerFactory.getLogger("com.example.app").info("Application log");
+            Thread.sleep(100); // Need to wait, because the logger is async
+
+            JsonNode jsonNode = objectMapper.readTree(redirectedStream.toString());
+            assertThat(jsonNode).isNotNull();
+            assertThat(jsonNode.get("timestamp").isTextual()).isTrue();
+            assertThat(jsonNode.get("level").asText()).isEqualTo("INFO");
+            assertThat(jsonNode.get("logger").asText()).isEqualTo("com.example.app");
+            assertThat(jsonNode.get("message").asText()).isEqualTo("Application log");
+        } finally {
+            System.setOut(old);
+        }
+    }
+
+    @Test
+    public void testLogAccessJsonToConsole() throws Exception {
+        ConsoleAppenderFactory<IAccessEvent> consoleAppenderFactory = getAppenderFactory("yaml/json-access-log-default.yml");
+        // Use sys.err, because there are some other log configuration messages in std.out
+        consoleAppenderFactory.setTarget(ConsoleAppenderFactory.ConsoleStream.STDERR);
+
+        final LogbackAccessRequestLogFactory requestLogHandler = new LogbackAccessRequestLogFactory();
+        requestLogHandler.setAppenders(ImmutableList.of(consoleAppenderFactory));
+
+        PrintStream old = System.err;
+        ByteArrayOutputStream redirectedStream = new ByteArrayOutputStream();
+        try {
+            System.setErr(new PrintStream(redirectedStream));
+            RequestLog requestLog = requestLogHandler.build("json-access-log-test");
+
+            Request request = mock(Request.class);
+            when(request.getRemoteAddr()).thenReturn("10.0.0.1");
+            when(request.getTimeStamp()).thenReturn(TimeUnit.SECONDS.toMillis(1353042047));
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/test/users?age=22&city=LA");
+            when(request.getProtocol()).thenReturn("HTTP/1.1");
+            when(request.getParameterNames()).thenReturn(Collections.enumeration(ImmutableList.of("age", "city")));
+            when(request.getParameterValues("age")).thenReturn(new String[]{"22"});
+            when(request.getParameterValues("city")).thenReturn(new String[]{"LA"});
+            when(request.getAttributeNames()).thenReturn(Collections.enumeration(ImmutableList.of()));
+            when(request.getHeaderNames()).thenReturn(Collections.enumeration(ImmutableList.of("Connection", "User-Agent")));
+            when(request.getHeader("Connection")).thenReturn("keep-alive");
+            when(request.getHeader("User-Agent")).thenReturn("Mozilla/5.0");
+
+            Response response = mock(Response.class);
+            when(response.getStatus()).thenReturn(200);
+            when(response.getContentCount()).thenReturn(8290L);
+            HttpFields httpFields = new HttpFields();
+            httpFields.add("Date", "Mon, 16 Nov 2012 05:00:48 GMT");
+            httpFields.add("Server", "Apache/2.4.12");
+            when(response.getHttpFields()).thenReturn(httpFields);
+            when(response.getHeaderNames()).thenReturn(ImmutableList.of("Date", "Server"));
+            when(response.getHeader("Date")).thenReturn("Mon, 16 Nov 2012 05:00:48 GMT");
+            when(response.getHeader("Server")).thenReturn("Apache/2.4.12");
+
+            requestLog.log(request, response);
+            Thread.sleep(100); // Need to wait, because the logger is async
+
+            JsonNode jsonNode = objectMapper.readTree(redirectedStream.toString());
+            assertThat(jsonNode).isNotNull();
+            assertThat(jsonNode.get("timestamp").isNumber()).isTrue();
+            assertThat(jsonNode.get("requestTime").isNumber()).isTrue();
+            assertThat(jsonNode.get("remoteAddress").asText()).isEqualTo("10.0.0.1");
+            assertThat(jsonNode.get("status").asInt()).isEqualTo(200);
+            assertThat(jsonNode.get("method").asText()).isEqualTo("GET");
+            assertThat(jsonNode.get("uri").asText()).isEqualTo("/test/users?age=22&city=LA");
+            assertThat(jsonNode.get("protocol").asText()).isEqualTo("HTTP/1.1");
+            assertThat(jsonNode.get("userAgent").asText()).isEqualTo("Mozilla/5.0");
+            assertThat(jsonNode.get("contentLength").asInt()).isEqualTo(8290);
+        } finally {
+            System.setErr(old);
+        }
+
+    }
+}

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/AccessJsonLayoutTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/AccessJsonLayoutTest.java
@@ -1,0 +1,197 @@
+package io.dropwizard.logging.json.layout;
+
+import ch.qos.logback.access.spi.IAccessEvent;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.logging.json.AccessAttribute;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.time.ZoneId;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.Mockito.when;
+
+public class AccessJsonLayoutTest {
+
+    private String remoteHost = "nw-4.us.crawl.io";
+    private String serverName = "sw-2.us.api.example.io";
+    private String timestamp = "2018-01-01T14:35:21.000+0000";
+    private String uri = "/test/users?age=22&city=LA";
+    private String url = "GET /test/users?age=22&city=LA HTTP/1.1";
+    private String userAgent = "Mozilla/5.0";
+    private Map<String, String> requestHeaders = ImmutableMap.of("Host", "api.example.io",
+        "User-Agent", userAgent);
+    private Map<String, String> responseHeaders = ImmutableMap.of("Content-Type", "application/json",
+        "Transfer-Encoding", "chunked");
+    private String responseContent = "{\"message\":\"Hello, Crawler!\"}";
+    private String remoteAddress = "192.168.52.15";
+    private IAccessEvent event = Mockito.mock(IAccessEvent.class);
+
+    private TimestampFormatter timestampFormatter = new TimestampFormatter("yyyy-MM-dd'T'HH:mm:ss.SSSZ", ZoneId.of("UTC"));
+    private ObjectMapper objectMapper = Jackson.newObjectMapper();
+    private JsonFormatter jsonFormatter = new JsonFormatter(objectMapper, false, true);
+    private Set<AccessAttribute> includes = EnumSet.of(AccessAttribute.REMOTE_ADDRESS,
+        AccessAttribute.REMOTE_USER, AccessAttribute.REQUEST_TIME, AccessAttribute.REQUEST_URI,
+        AccessAttribute.STATUS_CODE, AccessAttribute.METHOD, AccessAttribute.PROTOCOL, AccessAttribute.CONTENT_LENGTH,
+        AccessAttribute.USER_AGENT, AccessAttribute.TIMESTAMP);
+    private AccessJsonLayout accessJsonLayout = new AccessJsonLayout(jsonFormatter, timestampFormatter,
+        includes, ImmutableMap.of(), ImmutableMap.of());
+
+    @Before
+    public void setUp() {
+        when(event.getTimeStamp()).thenReturn(1514817321000L);
+        when(event.getContentLength()).thenReturn(78L);
+        when(event.getLocalPort()).thenReturn(8080);
+        when(event.getMethod()).thenReturn("GET");
+        when(event.getProtocol()).thenReturn("HTTP/1.1");
+        when(event.getRequestContent()).thenReturn("");
+        when(event.getRemoteAddr()).thenReturn(remoteAddress);
+        when(event.getRemoteUser()).thenReturn("john");
+        when(event.getRequestHeaderMap()).thenReturn(requestHeaders);
+        when(event.getRequestParameterMap()).thenReturn(ImmutableMap.of());
+        when(event.getElapsedTime()).thenReturn(100L);
+        when(event.getRequestURI()).thenReturn(uri);
+        when(event.getRequestURL()).thenReturn(url);
+        when(event.getRemoteHost()).thenReturn(remoteHost);
+        when(event.getResponseContent()).thenReturn(responseContent);
+        when(event.getResponseHeaderMap()).thenReturn(responseHeaders);
+        when(event.getServerName()).thenReturn(serverName);
+        when(event.getStatusCode()).thenReturn(200);
+        when(event.getRequestHeader("User-Agent")).thenReturn(userAgent);
+        accessJsonLayout.setIncludes(includes);
+    }
+
+    @Test
+    public void testProducesDefaultJsonMap() {
+        assertThat(accessJsonLayout.toJsonMap(event)).containsOnly(
+            entry("timestamp", timestamp), entry("remoteUser", "john"),
+            entry("method", "GET"), entry("uri", uri),
+            entry("protocol", "HTTP/1.1"), entry("status", 200),
+            entry("requestTime", 100L), entry("contentLength", 78L),
+            entry("userAgent", userAgent), entry("remoteAddress", remoteAddress));
+    }
+
+    @Test
+    public void testDisableRemoteAddress() {
+        includes.remove(AccessAttribute.REMOTE_ADDRESS);
+        accessJsonLayout.setIncludes(includes);
+
+        assertThat(accessJsonLayout.toJsonMap(event)).containsOnly(
+            entry("timestamp", timestamp), entry("remoteUser", "john"),
+            entry("method", "GET"), entry("uri", uri),
+            entry("protocol", "HTTP/1.1"), entry("status", 200),
+            entry("requestTime", 100L), entry("contentLength", 78L),
+            entry("userAgent", userAgent));
+    }
+
+    @Test
+    public void testDisableTimestamp() {
+        includes.remove(AccessAttribute.TIMESTAMP);
+        accessJsonLayout.setIncludes(includes);
+
+        assertThat(accessJsonLayout.toJsonMap(event)).containsOnly(
+            entry("remoteUser", "john"),
+            entry("method", "GET"), entry("uri", uri),
+            entry("protocol", "HTTP/1.1"), entry("status", 200),
+            entry("requestTime", 100L), entry("contentLength", 78L),
+            entry("userAgent", userAgent), entry("remoteAddress", remoteAddress));
+    }
+
+    @Test
+    public void testEnableSpecificResponseHeader() {
+        accessJsonLayout.setResponseHeaders(ImmutableSet.of("transfer-encoding"));
+
+        assertThat(accessJsonLayout.toJsonMap(event)).containsOnly(
+            entry("timestamp", timestamp), entry("remoteUser", "john"),
+            entry("method", "GET"), entry("uri", uri),
+            entry("protocol", "HTTP/1.1"), entry("status", 200),
+            entry("requestTime", 100L), entry("contentLength", 78L),
+            entry("userAgent", userAgent), entry("remoteAddress", remoteAddress),
+            entry("responseHeaders", ImmutableMap.of("Transfer-Encoding", "chunked")));
+    }
+
+    @Test
+    public void testEnableSpecificRequestHeader() {
+        accessJsonLayout.setRequestHeaders(ImmutableSet.of("user-agent"));
+
+        assertThat(accessJsonLayout.toJsonMap(event)).containsOnly(
+            entry("timestamp", timestamp), entry("remoteUser", "john"),
+            entry("method", "GET"), entry("uri", uri),
+            entry("protocol", "HTTP/1.1"), entry("status", 200),
+            entry("requestTime", 100L), entry("contentLength", 78L),
+            entry("userAgent", userAgent), entry("remoteAddress", remoteAddress),
+            entry("headers", ImmutableMap.of("User-Agent", userAgent)));
+    }
+
+    @Test
+    public void testEnableEverything() {
+        accessJsonLayout.setIncludes(EnumSet.allOf(AccessAttribute.class));
+        accessJsonLayout.setRequestHeaders(ImmutableSet.of("Host", "User-Agent"));
+        accessJsonLayout.setResponseHeaders(ImmutableSet.of("Transfer-Encoding", "Content-Type"));
+
+        assertThat(accessJsonLayout.toJsonMap(event)).containsOnly(
+            entry("timestamp", timestamp), entry("remoteUser", "john"),
+            entry("method", "GET"), entry("uri", uri),
+            entry("protocol", "HTTP/1.1"), entry("status", 200),
+            entry("requestTime", 100L), entry("contentLength", 78L),
+            entry("userAgent", userAgent), entry("remoteAddress", remoteAddress),
+            entry("responseHeaders", responseHeaders),
+            entry("responseContent", responseContent),
+            entry("port", 8080), entry("requestContent", ""),
+            entry("headers", requestHeaders),
+            entry("remoteHost", remoteHost), entry("url", url),
+            entry("serverName", serverName));
+    }
+
+    @Test
+    public void testAddAdditionalFields() {
+        accessJsonLayout = new AccessJsonLayout(jsonFormatter, timestampFormatter, includes, ImmutableMap.of(),
+            ImmutableMap.of("serviceName", "user-service", "serviceVersion", "1.2.3"));
+        assertThat(accessJsonLayout.toJsonMap(event)).containsOnly(
+            entry("timestamp", timestamp), entry("remoteUser", "john"),
+            entry("method", "GET"), entry("uri", uri),
+            entry("protocol", "HTTP/1.1"), entry("status", 200),
+            entry("requestTime", 100L), entry("contentLength", 78L),
+            entry("userAgent", userAgent), entry("remoteAddress", remoteAddress),
+            entry("serviceName", "user-service"), entry("serviceVersion", "1.2.3"));
+    }
+
+    @Test
+    public void testCustomFieldNames() {
+        accessJsonLayout = new AccessJsonLayout(jsonFormatter, timestampFormatter, includes,
+            ImmutableMap.of("remoteUser", "remote_user", "userAgent", "user_agent",
+                "remoteAddress", "remote_address", "contentLength", "content_length",
+                "requestTime", "request_time"), ImmutableMap.of());
+        assertThat(accessJsonLayout.toJsonMap(event)).containsOnly(
+            entry("timestamp", timestamp), entry("remote_user", "john"),
+            entry("method", "GET"), entry("uri", uri),
+            entry("protocol", "HTTP/1.1"), entry("status", 200),
+            entry("request_time", 100L), entry("content_length", 78L),
+            entry("user_agent", userAgent), entry("remote_address", remoteAddress));
+    }
+
+    @Test
+    public void testProducesCorrectJson() throws Exception {
+        JsonNode json = objectMapper.readTree(accessJsonLayout.doLayout(event));
+        assertThat(json).isNotNull();
+        assertThat(json.get("timestamp").asText()).isEqualTo(timestamp);
+        assertThat(json.get("remoteUser").asText()).isEqualTo("john");
+        assertThat(json.get("method").asText()).isEqualTo("GET");
+        assertThat(json.get("uri").asText()).isEqualTo(uri);
+        assertThat(json.get("protocol").asText()).isEqualTo("HTTP/1.1");
+        assertThat(json.get("status").asInt()).isEqualTo(200);
+        assertThat(json.get("requestTime").asInt()).isEqualTo(100);
+        assertThat(json.get("contentLength").asInt()).isEqualTo(78);
+        assertThat(json.get("userAgent").asText()).isEqualTo(userAgent);
+        assertThat(json.get("remoteAddress").asText()).isEqualTo(remoteAddress);
+    }
+}

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/EventJsonLayoutTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/EventJsonLayoutTest.java
@@ -1,0 +1,164 @@
+package io.dropwizard.logging.json.layout;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.pattern.ThrowableProxyConverter;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggerContextVO;
+import ch.qos.logback.classic.spi.ThrowableProxyVO;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.logging.json.EventAttribute;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.time.ZoneId;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class EventJsonLayoutTest {
+
+    private String timestamp = "2018-01-02T15:19:21.000+0000";
+    private String logger = "com.example.user.service";
+    private String message = "User[18] has been registered";
+    private Map<String, String> mdc = ImmutableMap.of("userId", "18", "serviceId", "19", "orderId", "24");
+    private ThrowableProxyConverter throwableProxyConverter = Mockito.mock(ThrowableProxyConverter.class);
+    private TimestampFormatter timestampFormatter = new TimestampFormatter("yyyy-MM-dd'T'HH:mm:ss.SSSZ",
+        ZoneId.of("UTC"));
+    private ObjectMapper objectMapper = Jackson.newObjectMapper();
+    private JsonFormatter jsonFormatter = new JsonFormatter(objectMapper, false, true);
+    private ILoggingEvent event = Mockito.mock(ILoggingEvent.class);
+
+    private Set<EventAttribute> includes = EnumSet.of(EventAttribute.LEVEL,
+        EventAttribute.THREAD_NAME, EventAttribute.MDC, EventAttribute.LOGGER_NAME, EventAttribute.MESSAGE,
+        EventAttribute.EXCEPTION, EventAttribute.TIMESTAMP);
+    private EventJsonLayout eventJsonLayout = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter,
+        includes, ImmutableMap.of(), ImmutableMap.of(), ImmutableSet.of());
+
+    @Before
+    public void setUp() {
+        when(event.getTimeStamp()).thenReturn(1514906361000L);
+        when(event.getLevel()).thenReturn(Level.INFO);
+        when(event.getThreadName()).thenReturn("main");
+        when(event.getMDCPropertyMap()).thenReturn(mdc);
+        when(event.getLoggerName()).thenReturn(logger);
+        when(event.getFormattedMessage()).thenReturn(message);
+        when(event.getLoggerContextVO()).thenReturn(new LoggerContextVO("test", ImmutableMap.of(), 0));
+    }
+
+    @Test
+    public void testProducesDefaultMap() {
+        Map<String, Object> map = eventJsonLayout.toJsonMap(event);
+        assertThat(map).containsOnly(entry("timestamp", timestamp),
+            entry("thread", "main"),
+            entry("level", "INFO"),
+            entry("logger", logger),
+            entry("message", message),
+            entry("mdc", mdc));
+    }
+
+    @Test
+    public void testLogsAnException() {
+        when(event.getThrowableProxy()).thenReturn(new ThrowableProxyVO());
+        when(throwableProxyConverter.convert(event)).thenReturn("Boom!");
+
+        assertThat(eventJsonLayout.toJsonMap(event)).containsOnly(entry("timestamp", timestamp),
+            entry("thread", "main"),
+            entry("level", "INFO"),
+            entry("logger", logger),
+            entry("message", message),
+            entry("mdc", mdc),
+            entry("exception", "Boom!"));
+    }
+
+    @Test
+    public void testDisableTimestamp() {
+        includes.remove(EventAttribute.TIMESTAMP);
+        eventJsonLayout.setIncludes(includes);
+
+        assertThat(eventJsonLayout.toJsonMap(event)).containsOnly(
+            entry("thread", "main"),
+            entry("level", "INFO"),
+            entry("logger", logger),
+            entry("message", message),
+            entry("mdc", mdc));
+    }
+
+    @Test
+    public void testLogVersion() {
+        eventJsonLayout.setJsonProtocolVersion("1.2");
+
+        assertThat(eventJsonLayout.toJsonMap(event)).containsOnly(entry("timestamp", timestamp),
+            entry("thread", "main"),
+            entry("level", "INFO"),
+            entry("logger", logger),
+            entry("message", message),
+            entry("mdc", mdc),
+            entry("version", "1.2"));
+    }
+
+    @Test
+    public void testReplaceFieldName() {
+        Map<String, Object> map = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter, includes,
+            ImmutableMap.of("timestamp", "@timestamp", "message", "@message"), ImmutableMap.of(),
+            ImmutableSet.of())
+            .toJsonMap(event);
+        assertThat(map).containsOnly(entry("@timestamp", timestamp),
+            entry("thread", "main"),
+            entry("level", "INFO"),
+            entry("logger", logger),
+            entry("@message", message),
+            entry("mdc", mdc));
+    }
+
+    @Test
+    public void testAddNewField() {
+        Map<String, Object> map = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter, includes,
+            ImmutableMap.of(), ImmutableMap.of("serviceName", "userService", "serviceBuild", 207),
+            ImmutableSet.of())
+            .toJsonMap(event);
+        assertThat(map).containsOnly(entry("timestamp", timestamp),
+            entry("thread", "main"),
+            entry("level", "INFO"),
+            entry("logger", logger),
+            entry("message", message),
+            entry("mdc", mdc),
+            entry("serviceName", "userService"),
+            entry("serviceBuild", 207));
+    }
+
+    @Test
+    public void testFilterMdc() {
+        Map<String, Object> map = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter, includes,
+            ImmutableMap.of(), ImmutableMap.of(),
+            ImmutableSet.of("userId", "orderId")).toJsonMap(event);
+        assertThat(map).containsOnly(entry("timestamp", timestamp),
+            entry("thread", "main"),
+            entry("level", "INFO"),
+            entry("logger", logger),
+            entry("message", message),
+            entry("mdc", ImmutableMap.of("userId", "18", "orderId", "24")));
+    }
+
+    @Test
+    public void testStartThrowableConverter() {
+        eventJsonLayout.start();
+
+        verify(throwableProxyConverter).start();
+    }
+
+    @Test
+    public void testStopThrowableConverter() {
+        eventJsonLayout.stop();
+
+        verify(throwableProxyConverter).stop();
+    }
+}

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/JsonFormatterTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/JsonFormatterTest.java
@@ -1,0 +1,51 @@
+package io.dropwizard.logging.json.layout;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.dropwizard.jackson.Jackson;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JsonFormatterTest {
+
+    private final Map<String, Object> map = ImmutableMap.of("name", "Jim", "hobbies",
+        ImmutableList.of("Reading", "Biking", "Snorkeling"));
+    private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+
+    @Test
+    public void testNoPrettyPrintNoLineSeparator() {
+        JsonFormatter formatter = new JsonFormatter(objectMapper, false, false);
+        assertThat(formatter.toJson(map)).isEqualTo(
+            "{\"name\":\"Jim\",\"hobbies\":[\"Reading\",\"Biking\",\"Snorkeling\"]}");
+    }
+
+
+    @Test
+    public void testNoPrettyPrintWithLineSeparator() {
+        JsonFormatter formatter = new JsonFormatter(objectMapper, false, true);
+        assertThat(formatter.toJson(map)).isEqualTo(
+            "{\"name\":\"Jim\",\"hobbies\":[\"Reading\",\"Biking\",\"Snorkeling\"]}" + System.lineSeparator());
+    }
+
+    @Test
+    public void testPrettyPrintWithLineSeparator() {
+        JsonFormatter formatter = new JsonFormatter(objectMapper, true, true);
+        assertThat(formatter.toJson(map)).isEqualTo(String.format("{%n" +
+                "  \"name\" : \"Jim\",%n" +
+                "  \"hobbies\" : [ \"Reading\", \"Biking\", \"Snorkeling\" ]%n" +
+                "}%n"));
+    }
+
+    @Test
+    public void testPrettyPrintNoLineSeparator() {
+        JsonFormatter formatter = new JsonFormatter(objectMapper, true, false);
+        assertThat(formatter.toJson(map)).isEqualTo(String.format("{%n" +
+                "  \"name\" : \"Jim\",%n" +
+                "  \"hobbies\" : [ \"Reading\", \"Biking\", \"Snorkeling\" ]%n" +
+                "}"));
+    }
+}

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/MapBuilderTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/MapBuilderTest.java
@@ -1,0 +1,92 @@
+package io.dropwizard.logging.json.layout;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+public class MapBuilderTest {
+
+    private int size = 4;
+    private TimestampFormatter timestampFormatter = new TimestampFormatter("yyyy-MM-dd'T'HH:mm:ss.SSSZ", ZoneId.of("UTC"));
+    private MapBuilder mapBuilder = new MapBuilder(timestampFormatter, ImmutableMap.of(), ImmutableMap.of(), size);
+    private String message = "Since the dawn of time...";
+
+    @Test
+    public void testIncludeStringValue() {
+        assertThat(mapBuilder.add("message", true, message).build())
+            .containsOnly(entry("message", message));
+    }
+
+    @Test
+    public void testDoNotIncludeStringValue() {
+        assertThat(mapBuilder.add("message", false, message).build()).isEmpty();
+    }
+
+    @Test
+    public void testDoNotIncludeNullStringValue() {
+        String value = null;
+        assertThat(mapBuilder.add("message", true, value).build()).isEmpty();
+    }
+
+    @Test
+    public void testIncludeNumberValue() {
+        assertThat(mapBuilder.add("status", true, 200)
+            .build()).containsOnly(entry("status", 200));
+    }
+
+    @Test
+    public void testIncludeMapValue() {
+        assertThat(mapBuilder.add("headers", true, ImmutableMap.of("userAgent", "Lynx/2.8.7"))
+            .build()).containsOnly(entry("headers", ImmutableMap.of("userAgent", "Lynx/2.8.7")));
+    }
+
+    @Test
+    public void testDoNotIncludeEmptyMapValue() {
+        assertThat(mapBuilder.add("headers", true, ImmutableMap.of()).build()).isEmpty();
+    }
+
+    @Test
+    public void testDoNotIncludeNullNumberValue() {
+        Double value = null;
+        assertThat(mapBuilder.add("status", true, value).build()).isEmpty();
+    }
+
+    @Test
+    public void testIncludeFormattedTimestamp() {
+        assertThat(mapBuilder.addTimestamp("timestamp", true, 1514906361000L).build())
+            .containsOnly(entry("timestamp", "2018-01-02T15:19:21.000+0000"));
+    }
+
+    @Test
+    public void testIncludeNotFormattedTimestamp() {
+        assertThat(new MapBuilder(new TimestampFormatter(null, ZoneId.of("UTC")), ImmutableMap.of(),
+            ImmutableMap.of(), size)
+            .addTimestamp("timestamp", true, 1514906361000L)
+            .build()).containsOnly(entry("timestamp", 1514906361000L));
+    }
+
+    @Test
+    public void testReplaceStringFieldName() {
+        assertThat(new MapBuilder(timestampFormatter, ImmutableMap.of("message", "@message"), ImmutableMap.of(), size)
+            .add("message", true, message)
+            .build()).containsOnly(entry("@message", message));
+    }
+
+    @Test
+    public void testReplaceNumberFieldName() {
+        assertThat(new MapBuilder(timestampFormatter, ImmutableMap.of("status", "@status"), ImmutableMap.of(), size)
+            .add("status", true, 200)
+            .build()).containsOnly(entry("@status", 200));
+    }
+
+    @Test
+    public void testAddAdditionalField() {
+        assertThat(new MapBuilder(timestampFormatter, ImmutableMap.of(), ImmutableMap.of("version", "1.8.3"), size)
+            .add("message", true, message).build())
+            .containsOnly(entry("message", message), entry("version", "1.8.3"));
+    }
+}

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/TimestampFormatterTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/TimestampFormatterTest.java
@@ -1,0 +1,33 @@
+package io.dropwizard.logging.json.layout;
+
+import org.junit.Test;
+
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TimestampFormatterTest {
+
+    private final long timestamp = 1513956631000L;
+
+    @Test
+    public void testFormatTimestampAsString() {
+        TimestampFormatter timestampFormatter = new TimestampFormatter("yyyy-MM-dd'T'HH:mm:ss.SSSZ",
+            ZoneId.of("GMT+01:00"));
+        assertThat(timestampFormatter.format(timestamp)).isEqualTo("2017-12-22T16:30:31.000+0100");
+    }
+
+    @Test
+    public void testFormatTimestampFromPredefinedFormat() {
+        TimestampFormatter timestampFormatter = new TimestampFormatter("RFC_1123_DATE_TIME",
+            ZoneId.of("GMT+01:00"));
+        assertThat(timestampFormatter.format(timestamp)).isEqualTo("Fri, 22 Dec 2017 16:30:31 +0100");
+    }
+
+    @Test
+    public void testDoNotFormatTimestamp() {
+        TimestampFormatter timestampFormatter = new TimestampFormatter(null,
+            ZoneId.of("GMT+01:00"));
+        assertThat(timestampFormatter.format(timestamp)).isEqualTo(timestamp);
+    }
+}

--- a/dropwizard-json-logging/src/test/resources/yaml/json-access-log-default.yml
+++ b/dropwizard-json-logging/src/test/resources/yaml/json-access-log-default.yml
@@ -1,0 +1,4 @@
+type: console
+layout:
+  type: access-json
+

--- a/dropwizard-json-logging/src/test/resources/yaml/json-access-log.yml
+++ b/dropwizard-json-logging/src/test/resources/yaml/json-access-log.yml
@@ -1,0 +1,29 @@
+type: console
+layout:
+  type: access-json
+  timestampFormat: "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+  prettyPrint: false
+  appendLineSeparator: true
+  includes:
+    - remoteUser
+    - statusCode
+    - method
+    - protocol
+    - requestUrl
+    - remoteHost
+    - requestParameters
+    - requestContent
+    - userAgent
+    - timestamp
+  responseHeaders:
+    - X-Request-Id
+  requestHeaders:
+    - User-Agent
+    - X-Request-Id
+  customFieldNames:
+    statusCode: status_code
+    userAgent: user_agent
+  additionalFields:
+    service-name: shipping-service
+    service-version: 1.2.3
+

--- a/dropwizard-json-logging/src/test/resources/yaml/json-log-default.yml
+++ b/dropwizard-json-logging/src/test/resources/yaml/json-log-default.yml
@@ -1,0 +1,6 @@
+type: console
+layout:
+  type: json
+  prettyPrint: true
+  timestampFormat: "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+

--- a/dropwizard-json-logging/src/test/resources/yaml/json-log.yml
+++ b/dropwizard-json-logging/src/test/resources/yaml/json-log.yml
@@ -1,0 +1,21 @@
+type: console
+layout:
+  type: json
+  prettyPrint: true
+  timestampFormat: "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+  prettyPrint: false
+  appendLineSeparator: true
+  includes:
+    - level
+    - mdc
+    - loggerName
+    - message
+    - exception
+    - timestamp
+  customFieldNames:
+    timestamp: "@timestamp"
+  additionalFields:
+    service-name: "user-service"
+    service-build: 218
+  includesMdcKeys: [userId]
+

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/AbstractAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/AbstractAppenderFactory.java
@@ -6,13 +6,20 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.AsyncAppenderBase;
 import ch.qos.logback.core.Context;
+import ch.qos.logback.core.LayoutBase;
 import ch.qos.logback.core.pattern.PatternLayoutBase;
 import ch.qos.logback.core.spi.DeferredProcessingAware;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import io.dropwizard.jackson.Jackson;
 import io.dropwizard.logging.async.AsyncAppenderFactory;
 import io.dropwizard.logging.filter.FilterFactory;
+import io.dropwizard.logging.layout.DiscoverableLayoutFactory;
 import io.dropwizard.logging.layout.LayoutFactory;
 
 import javax.annotation.Nullable;
@@ -91,6 +98,9 @@ public abstract class AbstractAppenderFactory<E extends DeferredProcessingAware>
 
     @Nullable
     protected String logFormat;
+
+    @Nullable
+    protected DiscoverableLayoutFactory layout;
 
     @NotNull
     protected TimeZone timeZone = TimeZone.getTimeZone("UTC");
@@ -189,6 +199,15 @@ public abstract class AbstractAppenderFactory<E extends DeferredProcessingAware>
         this.neverBlock = neverBlock;
     }
 
+    @Nullable
+    public DiscoverableLayoutFactory getLayout() {
+        return layout;
+    }
+
+    public void setLayout(@Nullable DiscoverableLayoutFactory layout) {
+        this.layout = layout;
+    }
+
     protected Appender<E> wrapAsync(Appender<E> appender, AsyncAppenderFactory<E> asyncAppenderFactory) {
         return wrapAsync(appender, asyncAppenderFactory, appender.getContext());
     }
@@ -208,12 +227,20 @@ public abstract class AbstractAppenderFactory<E extends DeferredProcessingAware>
         return asyncAppender;
     }
 
-    protected PatternLayoutBase<E> buildLayout(LoggerContext context, LayoutFactory<E> layoutFactory) {
-        final PatternLayoutBase<E> formatter = layoutFactory.build(context, timeZone);
-        if (!Strings.isNullOrEmpty(logFormat)) {
-            formatter.setPattern(logFormat);
+    @SuppressWarnings("unchecked")
+    protected LayoutBase<E> buildLayout(LoggerContext context, LayoutFactory<E> defaultLayoutFactory) {
+        final LayoutBase<E> layoutBase;
+        if (layout == null) {
+            final PatternLayoutBase<E> patternLayoutBase = defaultLayoutFactory.build(context, timeZone);
+            if (!Strings.isNullOrEmpty(logFormat)) {
+                patternLayoutBase.setPattern(logFormat);
+            }
+            layoutBase = patternLayoutBase;
+        } else {
+            layoutBase = layout.build(context, timeZone);
         }
-        formatter.start();
-        return formatter;
+
+        layoutBase.start();
+        return layoutBase;
     }
 }

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/layout/DiscoverableLayoutFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/layout/DiscoverableLayoutFactory.java
@@ -1,0 +1,29 @@
+package io.dropwizard.logging.layout;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.core.LayoutBase;
+import ch.qos.logback.core.pattern.PatternLayoutBase;
+import ch.qos.logback.core.spi.DeferredProcessingAware;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.dropwizard.jackson.Discoverable;
+
+import java.util.TimeZone;
+
+/**
+ * An interface for building Logback {@link LayoutBase} layouts, which could be discovered by Jackson
+ * and specified in the logging configuration.
+ *
+ * @param <E> The type of log event
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+public interface DiscoverableLayoutFactory<E extends DeferredProcessingAware> extends Discoverable {
+
+    /**
+     * Creates a {@link LayoutBase} of type E
+     *
+     * @param context  the Logback context
+     * @param timeZone the TimeZone
+     * @return a new {@link LayoutBase}
+     */
+    LayoutBase<E> build(LoggerContext context, TimeZone timeZone);
+}

--- a/dropwizard-logging/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
+++ b/dropwizard-logging/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
@@ -1,3 +1,4 @@
 io.dropwizard.logging.AppenderFactory
 io.dropwizard.logging.LoggingFactory
 io.dropwizard.logging.filter.FilterFactory
+io.dropwizard.logging.layout.DiscoverableLayoutFactory

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/AppenderFactoryCustomLayoutTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/AppenderFactoryCustomLayoutTest.java
@@ -1,0 +1,62 @@
+package io.dropwizard.logging;
+
+import ch.qos.logback.classic.AsyncAppender;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.ConsoleAppender;
+import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.Resources;
+import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.logging.async.AsyncLoggingEventAppenderFactory;
+import io.dropwizard.logging.filter.NullLevelFilterFactory;
+import io.dropwizard.logging.layout.DropwizardLayoutFactory;
+import io.dropwizard.validation.BaseValidator;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.net.URISyntaxException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("unchecked")
+public class AppenderFactoryCustomLayoutTest {
+
+    static {
+        BootstrapLogging.bootstrap();
+    }
+
+    private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+    private final YamlConfigurationFactory<ConsoleAppenderFactory> factory = new YamlConfigurationFactory<>(
+        ConsoleAppenderFactory.class, BaseValidator.newValidator(), objectMapper, "dw-layout");
+
+    private static File loadResource() throws URISyntaxException {
+        return new File(Resources.getResource("yaml/appender_with_custom_layout.yml").toURI());
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        objectMapper.registerSubtypes(TestLayoutFactory.class);
+    }
+
+    @Test
+    public void testLoadAppenderWithCustomLayout() throws Exception {
+        final ConsoleAppenderFactory<ILoggingEvent> appender = factory.build(loadResource());
+        assertThat(appender.getLayout()).isNotNull().isInstanceOf(TestLayoutFactory.class);
+        TestLayoutFactory layoutFactory = (TestLayoutFactory) appender.getLayout();
+        assertThat(layoutFactory).isNotNull().extracting(TestLayoutFactory::isIncludeSeparator).contains(true);
+    }
+
+    @Test
+    public void testBuildAppenderWithCustomLayout() throws Exception {
+        AsyncAppender appender = (AsyncAppender) factory.build(loadResource())
+            .build(new LoggerContext(), "test-custom-layout", new DropwizardLayoutFactory(),
+                new NullLevelFilterFactory<>(), new AsyncLoggingEventAppenderFactory());
+
+        ConsoleAppender consoleAppender = (ConsoleAppender) appender.getAppender("console-appender");
+        LayoutWrappingEncoder encoder = (LayoutWrappingEncoder) consoleAppender.getEncoder();
+        assertThat(encoder.getLayout()).isInstanceOf(TestLayoutFactory.TestLayout.class);
+    }
+}

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/TestLayoutFactory.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/TestLayoutFactory.java
@@ -1,0 +1,38 @@
+package io.dropwizard.logging;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.LayoutBase;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.dropwizard.logging.layout.DiscoverableLayoutFactory;
+
+import java.util.TimeZone;
+
+@JsonTypeName("test")
+public class TestLayoutFactory implements DiscoverableLayoutFactory<ILoggingEvent> {
+
+    private boolean includeSeparator;
+
+    @Override
+    public LayoutBase<ILoggingEvent> build(LoggerContext context, TimeZone timeZone) {
+        return new TestLayout();
+    }
+
+    @JsonProperty
+    public boolean isIncludeSeparator() {
+        return includeSeparator;
+    }
+
+    @JsonProperty
+    public void setIncludeSeparator(boolean includeSeparator) {
+        this.includeSeparator = includeSeparator;
+    }
+
+    public static class TestLayout extends LayoutBase<ILoggingEvent> {
+        @Override
+        public String doLayout(ILoggingEvent event) {
+            return "TEST!\n";
+        }
+    }
+}

--- a/dropwizard-logging/src/test/resources/yaml/appender_with_custom_layout.yml
+++ b/dropwizard-logging/src/test/resources/yaml/appender_with_custom_layout.yml
@@ -1,0 +1,4 @@
+type: console
+layout:
+  type: test
+  includeSeparator: true

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <module>dropwizard-http2</module>
         <module>dropwizard-request-logging</module>
         <module>dropwizard-e2e</module>
+        <module>dropwizard-json-logging</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
The new `dropwizard-json-log` module allows users to configure a specific layout to convert logging message to JSON. The module supports event logs and access logs like that:

For general logging:
```yaml
    logging:
      appenders:
        - type: console
          layout:
            type: json
```

For request logging:

```yaml
    server:
      requestLog:
        appenders:
          - type: console
            layout:
              type: access-json
```

The default format produces logs like:
```
 {"level":"INFO","logger":"org.eclipse.jetty.server.Server","thread":"main","message":"Started @6505ms","timestamp":"2018-01-03T19:01:37.674Z"}
```

and access logs like
 ```
    {"method":"GET","userAgent":"Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:57.0) Gecko/20100101 Firefox/57.0","uri":"/hello-world","requestTime":5,"protocol":"HTTP/1.1","contentLength":37,"remoteAddress":"127.0.0.1","timestamp":"2018-01-03T19:04:48.448Z","status":200}
```


Solves #1388, #1451 as an alternative to #2180 
  