### PR TITLE
Add documentation for `@Priority` for polymorphic auth

### DIFF
--- a/docs/source/manual/auth.rst
+++ b/docs/source/manual/auth.rst
@@ -377,6 +377,9 @@ Note that with the above example, only *authentication* is configured. If you al
 
 * Make sure you add ``Authorizers`` when you build your ``AuthFilters``.
 
+* Make sure any custom ``AuthFilter`` you add has the ``@Priority(Priorities.AUTHENTICATION)`` annotation set
+(otherwise authorization will be tested before the request's security context is properly set and will fail).
+
 * Annotate the resource *method* with the authorization annotation. Unlike the note earlier in
   this document that says authorization annotations are allowed on classes, with this
   poly feature, currently that is not supported. The annotation MUST go on the resource *method*


### PR DESCRIPTION
###### Problem:
Any custom `AuthFilter` needs to have the `@Priority` annotation set
otherwise authorization will run before the auth filters and will
use the default security context set by Jersey.

I was having issues with authorization always allowing my `@RolesAllowed` annotated methods to be called and my auth filter not running (was basing my code on #1632, which has a test case that worked perfectly fine).

Not sure if this is specific to polymorphic auth as I've never used `@RolesAllowed` with custom `AuthFilter`s before. Should we also add documentation about adding the annotation to all custom `AuthFilter`s (there doesn't seem to be anything about this at the moment)?

###### Solution:
Added documentation.

###### Result:
Clearer documentation.
