### PR TITLE
Constraint validation caches error prefixes

### DIFF
--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
@@ -629,6 +629,25 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
+    public void minCustomMessage() {
+        final Response response = target("/valid/messageValidation")
+            .queryParam("length", 1)
+            .request()
+            .get();
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.readEntity(String.class))
+            .containsOnlyOnce("query param length The value 1 is less then 2");
+
+        final Response response2 = target("/valid/messageValidation")
+            .queryParam("length", 0)
+            .request()
+            .get();
+        assertThat(response2.getStatus()).isEqualTo(400);
+        assertThat(response2.readEntity(String.class))
+            .containsOnlyOnce("query param length The value 0 is less then 2");
+    }
+
+    @Test
     public void notPresentEnumParameter() {
         final Response response = target("/valid/enumParam")
             .request()

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
@@ -83,6 +83,18 @@ public class ValidatingResource {
     }
 
     @GET
+    @Path("messageValidation")
+    public String messageValidation(
+        @UnwrapValidatedValue
+        @NotNull
+        @Min(value = 2, message = "The value ${validatedValue} is less then {value}")
+        @QueryParam("length")
+            LongParam length
+    ) {
+        return Long.toString(length.get());
+    }
+
+    @GET
     @Path("barter")
     public String isnt(@QueryParam("name") @Length(min = 3) @UnwrapValidatedValue NonEmptyStringParam name) {
         return name.get().orElse(null);


### PR DESCRIPTION
Previously, once a validation constraint was evaluated the entire string
was cached. The impetus for a cache is that reflection is used to
determine if we need to prefix an error message with additional context
(eg. "query parameter x ..."). Repeatedly calculating this prefix is
wasteful -- thus the cache was born.

The biggest issue with this cache is that while it worked with all
Hibernate Validation default message templates, it failed for message
templates that contained the invalid value (eg. "query parameter x
({validatedValue}) is greater than {value}"), as the same error would be
returned regardless of validatedValue. It would also fail for custom
constraint validators that didn't return the same message everytime.

The fix is to switch the cache from caching the entire error message to
just the error prefix (eg. "query parameter x", "return value", no
prefix).

This has no effect on performance and will allow for more
custom validation messages in Dropwizard.

Closes https://github.com/dropwizard/dropwizard/issues/2245
Ref https://github.com/dropwizard/dropwizard/issues/2090
CC'ing users who expressed interest: @imochurad @rtti @peterklijn

