### PR TITLE
Add `dropwizard-jdbi3` to bom

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -678,6 +678,11 @@
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
+                <artifactId>dropwizard-jdbi3</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-jersey</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
Oops >_>

###### Problem:
I dun goofed and forgot to add `dropwizard-jdbi3` to the project's bom

###### Solution:
Added it to the bom

###### Result:
It's now in the bom
