### PR TITLE
Support dynamic current session to allow separate read and write connections

### DIFF
--- a/dropwizard-example/src/main/java/com/example/helloworld/HelloWorldApplication.java
+++ b/dropwizard-example/src/main/java/com/example/helloworld/HelloWorldApplication.java
@@ -80,7 +80,7 @@ public class HelloWorldApplication extends Application<HelloWorldConfiguration> 
 
     @Override
     public void run(HelloWorldConfiguration configuration, Environment environment) {
-        final PersonDAO dao = new PersonDAO(hibernateBundle.getSessionFactory());
+        final PersonDAO dao = new PersonDAO();
         final Template template = configuration.buildTemplate();
 
         environment.healthChecks().register("template", new TemplateHealthCheck(template));

--- a/dropwizard-example/src/main/java/com/example/helloworld/db/PersonDAO.java
+++ b/dropwizard-example/src/main/java/com/example/helloworld/db/PersonDAO.java
@@ -2,16 +2,11 @@ package com.example.helloworld.db;
 
 import com.example.helloworld.core.Person;
 import io.dropwizard.hibernate.AbstractDAO;
-import org.hibernate.SessionFactory;
 
 import java.util.List;
 import java.util.Optional;
 
 public class PersonDAO extends AbstractDAO<Person> {
-    public PersonDAO(SessionFactory factory) {
-        super(factory);
-    }
-
     public Optional<Person> findById(Long id) {
         return Optional.ofNullable(get(id));
     }

--- a/dropwizard-example/src/test/java/com/example/helloworld/db/PersonDAOTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/db/PersonDAOTest.java
@@ -1,6 +1,7 @@
 package com.example.helloworld.db;
 
 import com.example.helloworld.core.Person;
+import io.dropwizard.hibernate.UnitOfWorkContext;
 import io.dropwizard.testing.junit.DAOTestRule;
 import org.hibernate.exception.ConstraintViolationException;
 import org.junit.Before;
@@ -23,7 +24,9 @@ public class PersonDAOTest {
 
     @Before
     public void setUp() throws Exception {
-        personDAO = new PersonDAO(daoTestRule.getSessionFactory());
+        UnitOfWorkContext.setSessionFactory(daoTestRule.getSessionFactory());
+
+        personDAO = new PersonDAO();
     }
 
     @Test

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/AbstractDAO.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/AbstractDAO.java
@@ -35,7 +35,7 @@ public class AbstractDAO<E> {
      * @return the current session
      */
     protected Session currentSession() {
-        return UnitOfWorkAspect.getCurrentSession();
+        return UnitOfWorkContext.getCurrentSession();
     }
 
     /**

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/AbstractDAO.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/AbstractDAO.java
@@ -5,14 +5,12 @@ import org.hibernate.Criteria;
 import org.hibernate.Hibernate;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
-import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
 import org.hibernate.query.internal.AbstractProducedQuery;
 
+import javax.persistence.criteria.CriteriaQuery;
 import java.io.Serializable;
 import java.util.List;
-
-import javax.persistence.criteria.CriteriaQuery;
 
 import static java.util.Objects.requireNonNull;
 
@@ -22,26 +20,22 @@ import static java.util.Objects.requireNonNull;
  * @param <E> the class which this DAO manages
  */
 public class AbstractDAO<E> {
-    private final SessionFactory sessionFactory;
     private final Class<?> entityClass;
 
     /**
-     * Creates a new DAO with a given session provider.
-     *
-     * @param sessionFactory    a session provider
+     * Creates a new DAO for {@code <E>}.
      */
-    public AbstractDAO(SessionFactory sessionFactory) {
-        this.sessionFactory = requireNonNull(sessionFactory);
+    public AbstractDAO() {
         this.entityClass = Generics.getTypeParameter(getClass());
     }
 
     /**
-     * Returns the current {@link Session}.
+     * Returns the current {@link Session} according to {@link UnitOfWorkAspect}.
      *
      * @return the current session
      */
     protected Session currentSession() {
-        return sessionFactory.getCurrentSession();
+        return UnitOfWorkAspect.getCurrentSession();
     }
 
     /**

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkContext.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkContext.java
@@ -1,0 +1,24 @@
+package io.dropwizard.hibernate;
+
+import org.hibernate.SessionFactory;
+
+import static java.util.Objects.requireNonNull;
+
+public class UnitOfWorkContext {
+    private final UnitOfWork unitOfWork;
+    private final SessionFactory sessionFactory;
+
+    UnitOfWorkContext(UnitOfWork unitOfWork,
+                      SessionFactory sessionFactory) {
+        this.unitOfWork = requireNonNull(unitOfWork);
+        this.sessionFactory = requireNonNull(sessionFactory);
+    }
+
+    public UnitOfWork getUnitOfWork() {
+        return unitOfWork;
+    }
+
+    public SessionFactory getSessionFactory() {
+        return sessionFactory;
+    }
+}

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkContext.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkContext.java
@@ -1,24 +1,42 @@
 package io.dropwizard.hibernate;
 
+import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 
-import static java.util.Objects.requireNonNull;
+import javax.annotation.Nullable;
 
 public class UnitOfWorkContext {
-    private final UnitOfWork unitOfWork;
-    private final SessionFactory sessionFactory;
+    private static final ThreadLocal<UnitOfWork> UNIT_OF_WORK = new ThreadLocal<>();
+    private static final ThreadLocal<SessionFactory> SESSION_FACTORY = new ThreadLocal<>();
 
-    UnitOfWorkContext(UnitOfWork unitOfWork,
-                      SessionFactory sessionFactory) {
-        this.unitOfWork = requireNonNull(unitOfWork);
-        this.sessionFactory = requireNonNull(sessionFactory);
+    public static void setUnitOfWork(UnitOfWork unitOfWork) {
+        UNIT_OF_WORK.set(unitOfWork);
     }
 
-    public UnitOfWork getUnitOfWork() {
-        return unitOfWork;
+    @Nullable
+    public static UnitOfWork getUnitOfWork() {
+        return UNIT_OF_WORK.get();
     }
 
-    public SessionFactory getSessionFactory() {
-        return sessionFactory;
+    public static void setSessionFactory(SessionFactory sessionFactory) {
+        SESSION_FACTORY.set(sessionFactory);
+    }
+
+    @Nullable
+    public static SessionFactory getSessionFactory() {
+        return SESSION_FACTORY.get();
+    }
+
+    public static Session getCurrentSession() {
+        SessionFactory sessionFactory = getSessionFactory();
+        if (sessionFactory == null) {
+            throw new RuntimeException("No session factory set");
+        }
+        return sessionFactory.getCurrentSession();
+    }
+
+    public static void clear() {
+        UNIT_OF_WORK.remove();
+        SESSION_FACTORY.remove();
     }
 }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/AbstractDAOTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/AbstractDAOTest.java
@@ -94,8 +94,6 @@ public class AbstractDAOTest {
     private final Session session = mock(Session.class);
     private final MockDAO dao = new MockDAO();
 
-    private UnitOfWorkAspect unitOfWorkAspect;
-
     @Before
     public void setup() throws Exception {
         when(criteriaBuilder.createQuery(same(String.class))).thenReturn(criteriaQuery);
@@ -107,16 +105,12 @@ public class AbstractDAOTest {
         when(session.getNamedQuery(anyString())).thenReturn(query);
         when(session.createQuery(anyString(), same(String.class))).thenReturn(query);
 
-        unitOfWorkAspect = new UnitOfWorkAspect(ImmutableMap.of(HibernateBundle.DEFAULT_NAME, factory));
-        UnitOfWork unitOfWork = ClassWithUnitOfWork.class
-                .getDeclaredMethod("defaultUnitOfWork")
-                .getAnnotation(UnitOfWork.class);
-        unitOfWorkAspect.beforeStart(unitOfWork);
+        UnitOfWorkContext.setSessionFactory(factory);
     }
 
     @After
     public void tearDown() throws Exception {
-        unitOfWorkAspect.onFinish();
+        UnitOfWorkContext.clear();
     }
 
     @Test

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/AbstractDAOTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/AbstractDAOTest.java
@@ -1,23 +1,23 @@
 package io.dropwizard.hibernate;
 
 import com.google.common.collect.ImmutableList;
-
+import com.google.common.collect.ImmutableMap;
 import org.hibernate.Criteria;
 import org.hibernate.HibernateException;
 import org.hibernate.NonUniqueResultException;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
-import org.hibernate.query.Query;
 import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.proxy.LazyInitializer;
+import org.hibernate.query.Query;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.Serializable;
-import java.util.List;
-
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
+import java.io.Serializable;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -28,10 +28,6 @@ import static org.mockito.Mockito.when;
 
 public class AbstractDAOTest {
     private static class MockDAO extends AbstractDAO<String> {
-        MockDAO(SessionFactory factory) {
-            super(factory);
-        }
-
         @Override
         public Session currentSession() {
             return super.currentSession();
@@ -96,16 +92,31 @@ public class AbstractDAOTest {
     @SuppressWarnings("unchecked")
     private final Query<String> query = mock(Query.class);
     private final Session session = mock(Session.class);
-    private final MockDAO dao = new MockDAO(factory);
+    private final MockDAO dao = new MockDAO();
+
+    private UnitOfWorkAspect unitOfWorkAspect;
 
     @Before
     public void setup() throws Exception {
         when(criteriaBuilder.createQuery(same(String.class))).thenReturn(criteriaQuery);
+        when(factory.openSession()).thenReturn(session);
         when(factory.getCurrentSession()).thenReturn(session);
+        when(session.getSessionFactory()).thenReturn(factory);
         when(session.createCriteria(String.class)).thenReturn(criteria);
         when(session.getCriteriaBuilder()).thenReturn(criteriaBuilder);
         when(session.getNamedQuery(anyString())).thenReturn(query);
         when(session.createQuery(anyString(), same(String.class))).thenReturn(query);
+
+        unitOfWorkAspect = new UnitOfWorkAspect(ImmutableMap.of(HibernateBundle.DEFAULT_NAME, factory));
+        UnitOfWork unitOfWork = ClassWithUnitOfWork.class
+                .getDeclaredMethod("defaultUnitOfWork")
+                .getAnnotation(UnitOfWork.class);
+        unitOfWorkAspect.beforeStart(unitOfWork);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        unitOfWorkAspect.onFinish();
     }
 
     @Test

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/ClassWithUnitOfWork.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/ClassWithUnitOfWork.java
@@ -1,0 +1,7 @@
+package io.dropwizard.hibernate;
+
+public class ClassWithUnitOfWork {
+    @UnitOfWork
+    public void defaultUnitOfWork() {
+    }
+}

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
@@ -47,10 +47,6 @@ public class JerseyIntegrationTest extends JerseyTest {
     }
 
     public static class PersonDAO extends AbstractDAO<Person> {
-        public PersonDAO(SessionFactory sessionFactory) {
-            super(sessionFactory);
-        }
-
         public Optional<Person> findByName(String name) {
             return Optional.ofNullable(get(name));
         }
@@ -133,7 +129,7 @@ public class JerseyIntegrationTest extends JerseyTest {
 
         final DropwizardResourceConfig config = DropwizardResourceConfig.forTesting(new MetricRegistry());
         config.register(new UnitOfWorkApplicationListener("hr-db", sessionFactory));
-        config.register(new PersonResource(new PersonDAO(sessionFactory)));
+        config.register(new PersonResource(new PersonDAO()));
         config.register(new JacksonMessageBodyProvider(Jackson.newObjectMapper()));
         config.register(new PersistenceExceptionMapper());
         config.register(new DataExceptionMapper());

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/LazyLoadingTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/LazyLoadingTest.java
@@ -71,7 +71,7 @@ public class LazyLoadingTest {
             initDatabase(sessionFactory);
 
             environment.jersey().register(new UnitOfWorkApplicationListener("hr-db", sessionFactory));
-            environment.jersey().register(new DogResource(new DogDAO(sessionFactory)));
+            environment.jersey().register(new DogResource(new DogDAO()));
             environment.jersey().register(new PersistenceExceptionMapper());
             environment.jersey().register(new ConstraintViolationExceptionMapper());
         }
@@ -105,10 +105,6 @@ public class LazyLoadingTest {
     }
 
     public static class DogDAO extends AbstractDAO<Dog> {
-        DogDAO(SessionFactory sessionFactory) {
-            super(sessionFactory);
-        }
-
         Optional<Dog> findByName(String name) {
             return Optional.ofNullable(get(name));
         }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SubResourcesTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SubResourcesTest.java
@@ -60,7 +60,7 @@ public class SubResourcesTest {
             initDatabase(sessionFactory);
 
             environment.jersey().register(new UnitOfWorkApplicationListener("hr-db", sessionFactory));
-            environment.jersey().register(new PersonResource(new PersonDAO(sessionFactory), new DogDAO(sessionFactory)));
+            environment.jersey().register(new PersonResource(new PersonDAO(), new DogDAO()));
         }
 
         private void initDatabase(SessionFactory sessionFactory) {
@@ -147,20 +147,12 @@ public class SubResourcesTest {
     }
 
     public static class PersonDAO extends AbstractDAO<Person> {
-        PersonDAO(SessionFactory sessionFactory) {
-            super(sessionFactory);
-        }
-
         Optional<Person> findByName(String name) {
             return Optional.ofNullable(get(name));
         }
     }
 
     public static class DogDAO extends AbstractDAO<Dog> {
-        DogDAO(SessionFactory sessionFactory) {
-            super(sessionFactory);
-        }
-
         Optional<Dog> findByOwnerAndName(String ownerName, String dogName) {
             return query("SELECT d FROM Dog d WHERE d.owner.name=:owner AND d.name=:name")
                 .setParameter("owner", ownerName)

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkApplicationListenerTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkApplicationListenerTest.java
@@ -52,12 +52,14 @@ public class UnitOfWorkApplicationListenerTest {
         listener.registerSessionFactory("analytics", analyticsSessionFactory);
 
         when(sessionFactory.openSession()).thenReturn(session);
+        when(sessionFactory.getCurrentSession()).thenReturn(session);
         when(session.getSessionFactory()).thenReturn(sessionFactory);
         when(session.beginTransaction()).thenReturn(transaction);
         when(session.getTransaction()).thenReturn(transaction);
         when(transaction.getStatus()).thenReturn(ACTIVE);
 
         when(analyticsSessionFactory.openSession()).thenReturn(analyticsSession);
+        when(analyticsSessionFactory.getCurrentSession()).thenReturn(analyticsSession);
         when(analyticsSession.getSessionFactory()).thenReturn(analyticsSessionFactory);
         when(analyticsSession.beginTransaction()).thenReturn(analyticsTransaction);
         when(analyticsSession.getTransaction()).thenReturn(analyticsTransaction);

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAspectTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAspectTest.java
@@ -100,18 +100,18 @@ public class UnitOfWorkAspectTest {
 
         unitOfWorkAspect.beforeStart(defaultUnitOfWork);
 
-        assertThat(UnitOfWorkAspect.getCurrentSession()).isEqualTo(readOnlySession);
-        assertThat(UnitOfWorkAspect.getSessionFactory()).isEqualTo(readOnlySessionFactory);
-        assertThat(UnitOfWorkAspect.getUnitOfWork()).isEqualTo(defaultUnitOfWork);
+        assertThat(UnitOfWorkContext.getCurrentSession()).isEqualTo(readOnlySession);
+        assertThat(UnitOfWorkContext.getSessionFactory()).isEqualTo(readOnlySessionFactory);
+        assertThat(UnitOfWorkContext.getUnitOfWork()).isEqualTo(defaultUnitOfWork);
     }
 
     @Test
     public void setsContextBeforeStart() {
         unitOfWorkAspect.beforeStart(writeUnitOfWork);
 
-        assertThat(UnitOfWorkAspect.getCurrentSession()).isEqualTo(writeSession);
-        assertThat(UnitOfWorkAspect.getSessionFactory()).isEqualTo(writeSessionFactory);
-        assertThat(UnitOfWorkAspect.getUnitOfWork()).isEqualTo(writeUnitOfWork);
+        assertThat(UnitOfWorkContext.getCurrentSession()).isEqualTo(writeSession);
+        assertThat(UnitOfWorkContext.getSessionFactory()).isEqualTo(writeSessionFactory);
+        assertThat(UnitOfWorkContext.getUnitOfWork()).isEqualTo(writeUnitOfWork);
     }
 
     @Test
@@ -119,8 +119,7 @@ public class UnitOfWorkAspectTest {
         unitOfWorkAspect.beforeStart(writeUnitOfWork);
         unitOfWorkAspect.onFinish();
 
-        assertThat(UnitOfWorkAspect.getCurrentSession()).isNull();
-        assertThat(UnitOfWorkAspect.getSessionFactory()).isNull();
-        assertThat(UnitOfWorkAspect.getUnitOfWork()).isNull();
+        assertThat(UnitOfWorkContext.getSessionFactory()).isNull();
+        assertThat(UnitOfWorkContext.getUnitOfWork()).isNull();
     }
 }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAspectTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAspectTest.java
@@ -1,0 +1,126 @@
+package io.dropwizard.hibernate;
+
+import com.google.common.collect.ImmutableMap;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class UnitOfWorkAspectTest {
+    private static final String READ_ONLY = "readOnly";
+    private static final String WRITE = "write";
+
+    public class ExampleResource {
+        @UnitOfWork
+        void defaultOperation() {
+        }
+
+        @UnitOfWork(READ_ONLY)
+        void readOnlyOperation() {
+        }
+
+        @UnitOfWork(WRITE)
+        void writeOperation() {
+        }
+    }
+
+    private final SessionFactory defaultSessionFactory = mock(SessionFactory.class);
+    private final SessionFactory readOnlySessionFactory = mock(SessionFactory.class);
+    private final SessionFactory writeSessionFactory = mock(SessionFactory.class);
+    private final Session defaultSession = mock(Session.class);
+    private final Session readOnlySession = mock(Session.class);
+    private final Session writeSession = mock(Session.class);
+
+    private UnitOfWorkAspect unitOfWorkAspect;
+    private UnitOfWork readOnlyUnitOfWork;
+    private UnitOfWork writeUnitOfWork;
+    private UnitOfWork defaultUnitOfWork;
+
+    @Before
+    public void setUp() throws Exception {
+        when(defaultSessionFactory.openSession()).thenReturn(defaultSession);
+        when(readOnlySessionFactory.openSession()).thenReturn(readOnlySession);
+        when(writeSessionFactory.openSession()).thenReturn(writeSession);
+
+        when(defaultSessionFactory.getCurrentSession()).thenReturn(defaultSession);
+        when(readOnlySessionFactory.getCurrentSession()).thenReturn(readOnlySession);
+        when(writeSessionFactory.getCurrentSession()).thenReturn(writeSession);
+
+        when(defaultSession.getSessionFactory()).thenReturn(defaultSessionFactory);
+        when(readOnlySession.getSessionFactory()).thenReturn(readOnlySessionFactory);
+        when(writeSession.getSessionFactory()).thenReturn(writeSessionFactory);
+
+        Map<String, SessionFactory> sessionFactories = ImmutableMap.<String, SessionFactory>builder()
+                .put(READ_ONLY, readOnlySessionFactory)
+                .put(WRITE, writeSessionFactory)
+                .build();
+
+        unitOfWorkAspect = new UnitOfWorkAspect(sessionFactories);
+
+        readOnlyUnitOfWork = ExampleResource.class
+                .getDeclaredMethod("readOnlyOperation")
+                .getAnnotation(UnitOfWork.class);
+
+        writeUnitOfWork = ExampleResource.class
+                .getDeclaredMethod("writeOperation")
+                .getAnnotation(UnitOfWork.class);
+
+        defaultUnitOfWork = ExampleResource.class
+                .getDeclaredMethod("defaultOperation")
+                .getAnnotation(UnitOfWork.class);
+    }
+
+    @After
+    public void tearDown() {
+        unitOfWorkAspect.onFinish();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void failsIfUnknownBundleNameIsProvided() {
+        unitOfWorkAspect = new UnitOfWorkAspect(ImmutableMap.of(READ_ONLY, readOnlySessionFactory));
+
+        unitOfWorkAspect.beforeStart(writeUnitOfWork);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void failsIfNoBundleNameIsProvidedButManyExist() {
+        unitOfWorkAspect.beforeStart(defaultUnitOfWork);
+    }
+
+    @Test
+    public void usesTheOnlyBundleIfNoBundleNameIsProvided() {
+        unitOfWorkAspect = new UnitOfWorkAspect(ImmutableMap.of(READ_ONLY, readOnlySessionFactory));
+
+        unitOfWorkAspect.beforeStart(defaultUnitOfWork);
+
+        assertThat(UnitOfWorkAspect.getCurrentSession()).isEqualTo(readOnlySession);
+        assertThat(UnitOfWorkAspect.getSessionFactory()).isEqualTo(readOnlySessionFactory);
+        assertThat(UnitOfWorkAspect.getUnitOfWork()).isEqualTo(defaultUnitOfWork);
+    }
+
+    @Test
+    public void setsContextBeforeStart() {
+        unitOfWorkAspect.beforeStart(writeUnitOfWork);
+
+        assertThat(UnitOfWorkAspect.getCurrentSession()).isEqualTo(writeSession);
+        assertThat(UnitOfWorkAspect.getSessionFactory()).isEqualTo(writeSessionFactory);
+        assertThat(UnitOfWorkAspect.getUnitOfWork()).isEqualTo(writeUnitOfWork);
+    }
+
+    @Test
+    public void clearsContextOnFinish() {
+        unitOfWorkAspect.beforeStart(writeUnitOfWork);
+        unitOfWorkAspect.onFinish();
+
+        assertThat(UnitOfWorkAspect.getCurrentSession()).isNull();
+        assertThat(UnitOfWorkAspect.getSessionFactory()).isNull();
+        assertThat(UnitOfWorkAspect.getUnitOfWork()).isNull();
+    }
+}

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
@@ -173,8 +173,9 @@ public class UnitOfWorkAwareProxyFactoryTest {
         @Override
         protected void configureSession() {
             super.configureSession();
-            Transaction transaction = getCurrentSession().beginTransaction();
-            getCurrentSession().createNativeQuery("insert into user_sessions values ('gr6f9y0', 'jeff_29')")
+            Session currentSession = UnitOfWorkContext.getCurrentSession();
+            Transaction transaction = currentSession.beginTransaction();
+            currentSession.createNativeQuery("insert into user_sessions values ('gr6f9y0', 'jeff_29')")
                 .executeUpdate();
             transaction.commit();
         }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
@@ -173,8 +173,8 @@ public class UnitOfWorkAwareProxyFactoryTest {
         @Override
         protected void configureSession() {
             super.configureSession();
-            Transaction transaction = getSession().beginTransaction();
-            getSession().createNativeQuery("insert into user_sessions values ('gr6f9y0', 'jeff_29')")
+            Transaction transaction = getCurrentSession().beginTransaction();
+            getCurrentSession().createNativeQuery("insert into user_sessions values ('gr6f9y0', 'jeff_29')")
                 .executeUpdate();
             transaction.commit();
         }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkTest.java
@@ -8,19 +8,13 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class UnitOfWorkTest {
-    private static class Example {
-        @UnitOfWork
-        public void example() {
-
-        }
-    }
-
     private UnitOfWork unitOfWork;
 
     @Before
     public void setUp() throws Exception {
-        this.unitOfWork = Example.class.getDeclaredMethod("example")
-                                       .getAnnotation(UnitOfWork.class);
+        this.unitOfWork = ClassWithUnitOfWork.class
+                .getDeclaredMethod("defaultUnitOfWork")
+                .getAnnotation(UnitOfWork.class);
     }
 
     @Test


### PR DESCRIPTION
###### Problem:

I am working on a project which utilizes Dropwizard Hibernate. My current mission is to distribute database operations across two endpoints, one for reads and another for writes. DW Hibernate is great because it provides the UnitOfWork framework which allows for multiple bundles to be configured and for those bundles to be specified on an individual basis by using `UnitOfWork#value`. This accomplishes exactly what I need - I will setup a bundle for reading, a bundle for writing, then on my read-only resources throw a `@UnitOfWork(“read-only”)` and then the resources that require writing `@UnitOfWork(“write”)`.

Currently, UnitOfWorkAspect will determine the appropriate session factory based on the current UnitOfWork (see [UnitOfWork:62](https://github.com/dropwizard/dropwizard/blob/master/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAspect.java#L62)), which is great. The problem is, the session factory and session are then set privately inside of the aspect and made unavailable to other components. This is particularly a problem inside of [AbstractDAO](https://github.com/dropwizard/dropwizard/blob/master/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/AbstractDAO.java), where the session factory is required as an instance parameter. This presents limitations in client code outside of Dropwizard, such as in event listeners that perform database operations.

In summary, I propose two things inside of this PR:
1. The context determined inside of UnitOfWorkAspect be made publicly available to other Dropwizard and non-Dropwizard client components
2. AbstractDAO be modified (a breaking change unfortunately) to not require a SessionFactory for construction, and instead use the UnitOfWork context

###### Solution:

The primary modification includes adding a UnitOfWorkContext class with ThreadLocals to store the context that is determined inside of `UnitOfWorkAspect#beforeStart`. This context is then used to determine the current session AbstractDAO, rather than the injected property that it previously depended on.

###### Result:

The change to UnitOfWorkAspect alone is non-breaking. It simply makes internal context publicly available. The proposed change for AbstractDAO is, unfortunately, breaking. It will be a potentially tedious change but hopefully not complicated. Clients that are only using one bundle currently (I imagine this is the majority case otherwise this issue would have been hit) will have to update their app configuration, or wherever they instantiate their DAOs, to no longer provide a session factory. In my project we have over 100 DAOs and this was a smooth transition that took about 20 minutes.