### PR TITLE
Switch to JaCoCo for Code coverage

### DIFF
--- a/.travis_after_success.sh
+++ b/.travis_after_success.sh
@@ -5,7 +5,7 @@ if [[ "${TRAVIS_JDK_VERSION}" != "oraclejdk8" ]]; then
     exit
 fi
 
-./mvnw -B cobertura:cobertura coveralls:report
+./mvnw test jacoco:report coveralls:report
 
 if [[ -n ${TRAVIS_TAG} ]]; then
     echo "Skipping deployment for tag \"${TRAVIS_TAG}\""

--- a/dropwizard-example/pom.xml
+++ b/dropwizard-example/pom.xml
@@ -284,6 +284,19 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.0</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -526,11 +526,6 @@
                     <version>3.6</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>cobertura-maven-plugin</artifactId>
-                    <version>2.7</version>
-                </plugin>
-                <plugin>
                     <groupId>org.eluder.coveralls</groupId>
                     <artifactId>coveralls-maven-plugin</artifactId>
                     <version>4.3.0</version>
@@ -553,7 +548,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-Duser.language=en -Duser.region=US</argLine>
+                    <argLine>${argLine} -Duser.language=en -Duser.region=US</argLine>
                 </configuration>
             </plugin>
             <plugin>
@@ -635,27 +630,23 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.0</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
                 <configuration>
-                    <formats>
-                        <format>xml</format>
-                    </formats>
-                    <aggregate>true</aggregate>
-                    <instrumentation>
-                        <excludes>
-                            <exclude>io/dropwizard/benchmarks/**/*.class</exclude>
-                            <exclude>org/openjdk/jmh/**/*.class</exclude>
-                        </excludes>
-                    </instrumentation>
+                    <excludes>
+                        <exclude>io/dropwizard/benchmarks/**/*.class</exclude>
+                        <exclude>org/openjdk/jmh/**/*.class</exclude>
+                    </excludes>
                 </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>net.sourceforge.cobertura</groupId>
-                        <artifactId>cobertura</artifactId>
-                        <version>2.1.1</version>
-                    </dependency>
-                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.eluder.coveralls</groupId>


### PR DESCRIPTION
###### Problem:
We currently use Cobertura for code coverage, which is not actively developed and doesn't support JDK9.

###### Solution:
Switch to JaCoCo which supports JDK9 and is currently actively maintained.

###### Result:
In the future we can our primary build with test coverage on JDK9.
