### PR TITLE
Enable auto escaping of strings in Freemarker templates

### DIFF
--- a/dropwizard-views-freemarker/src/main/java/io/dropwizard/views/freemarker/FreemarkerViewRenderer.java
+++ b/dropwizard-views-freemarker/src/main/java/io/dropwizard/views/freemarker/FreemarkerViewRenderer.java
@@ -4,6 +4,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
+import freemarker.core.HTMLOutputFormat;
 import freemarker.template.Configuration;
 import freemarker.template.DefaultObjectWrapperBuilder;
 import freemarker.template.Template;
@@ -38,6 +39,8 @@ public class FreemarkerViewRenderer implements ViewRenderer {
             configuration.loadBuiltInEncodingMap();
             configuration.setDefaultEncoding(StandardCharsets.UTF_8.name());
             configuration.setClassForTemplateLoading(key, "/");
+            // setting the outputformat implicitly enables auto escaping
+            configuration.setOutputFormat(HTMLOutputFormat.INSTANCE);
             for (Map.Entry<String, String> entry : baseConfig.entrySet()) {
                 configuration.setSetting(entry.getKey(), entry.getValue());
             }

--- a/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/AutoEscapingView.java
+++ b/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/AutoEscapingView.java
@@ -1,0 +1,16 @@
+package io.dropwizard.views.freemarker;
+
+import io.dropwizard.views.View;
+
+public class AutoEscapingView extends View {
+    private final String content;
+
+    protected AutoEscapingView(String content) {
+        super("/auto-escaping.ftl");
+        this.content = content;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}

--- a/dropwizard-views-freemarker/src/test/resources/auto-escaping.ftl
+++ b/dropwizard-views-freemarker/src/test/resources/auto-escaping.ftl
@@ -1,0 +1,10 @@
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>Message from user</title>
+</head>
+<body>
+<h1>Message from user</h1>
+<p>${content}</p>
+</body>
+</html>


### PR DESCRIPTION
## Problem
Output was not being auto escaped by Freemarker

## Solution
Freemarker output format was not set [as HTML] which meant that auto escaping was not enabled. With this change it is enabled by default.  

This might affect users who are using formats other than HTML, but 
there should be enough benefit of making this a default.  The current method for getting the output format setting through to the underlying freemarker library is not very pleasant.

Users relying on the existing behaviour may need to set individual
freemarker values as `?unsafe`

## Question
I couldn't find security contact information - is that something you are planning on adding?