### PR TITLE
Add context path to logged endpoints

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/setup/Environment.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/Environment.java
@@ -6,6 +6,7 @@ import com.codahale.metrics.health.HealthCheckRegistry;
 import com.codahale.metrics.health.SharedHealthCheckRegistries;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.setup.JerseyContainerHolder;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
@@ -71,11 +72,13 @@ public class Environment {
 
         this.adminContext = new MutableServletContextHandler();
         adminContext.setClassLoader(classLoader);
+
         this.adminEnvironment = new AdminEnvironment(adminContext, healthCheckRegistry, metricRegistry);
 
         this.lifecycleEnvironment = new LifecycleEnvironment();
 
         final DropwizardResourceConfig jerseyConfig = new DropwizardResourceConfig(metricRegistry);
+        jerseyConfig.setContextPath(servletContext.getContextPath());
 
         this.jerseyServletContainer = new JerseyContainerHolder(new JerseyServletContainer(jerseyConfig));
         this.jerseyEnvironment = new JerseyEnvironment(jerseyServletContainer, jerseyConfig);

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -11,8 +11,6 @@ import io.dropwizard.jersey.caching.CacheControlledResponseFeature;
 import io.dropwizard.jersey.params.AbstractParamConverterProvider;
 import io.dropwizard.jersey.sessions.SessionFactoryProvider;
 import io.dropwizard.jersey.validation.FuzzyEnumParamConverterProvider;
-
-import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.ServerProperties;
 import org.glassfish.jersey.server.model.Resource;
@@ -31,7 +29,6 @@ import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.util.Comparator;
 import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
@@ -123,16 +123,16 @@ public class DropwizardResourceConfigTest {
                 .contains("    GET     /locator/bar (io.dropwizard.jersey.DropwizardResourceConfigTest.ResourcePathOnMethodLevel)")
                 .contains("    UNKNOWN /obj/{it} (java.lang.Object)");
     }
-    
+
     @Test
     public void logsProgrammaticalEndpoints() {
         Resource.Builder resourceBuilder = Resource.builder("/prefix");
         resourceBuilder.addChildResource(Resource.from(DummyResource.class));
         resourceBuilder.addChildResource(Resource.from(TestResource.class));
         resourceBuilder.addChildResource(Resource.from(ImplementingResource.class));
-        
+
         rc.registerResources(resourceBuilder.build());
-        
+
         final String expectedLog = String.format(
                 "The following paths were found for the configured resources:%n"
                 + "%n"
@@ -141,15 +141,15 @@ public class DropwizardResourceConfigTest {
                 + "    GET     /prefix/async (io.dropwizard.jersey.dummy.DummyResource)%n"
                 + "    GET     /prefix/dummy (io.dropwizard.jersey.DropwizardResourceConfigTest.TestResource)%n"
         );
-        
+
         assertThat(rc.getEndpointsInfo()).isEqualTo(expectedLog);
     }
-    
+
     @Test
     public void testEndpointLoggerPathCleaning() {
         String dirtyPath = " /this//is///a/dirty//path/     ";
         String anotherDirtyPath = "a/l//p/h/  /a/b /////  e/t";
-        
+
         assertThat(rc.cleanUpPath(dirtyPath)).isEqualTo("/this/is/a/dirty/path/");
         assertThat(rc.cleanUpPath(anotherDirtyPath)).isEqualTo("a/l/p/h/a/b/e/t");
     }
@@ -163,6 +163,28 @@ public class DropwizardResourceConfigTest {
 
         assertThat(rc.getEndpointsInfo()).contains(expectedLog);
         assertThat(rc.getEndpointsInfo()).containsOnlyOnce("    GET     /callme (io.dropwizard.jersey.DropwizardResourceConfigTest.TestDuplicateResource)");
+    }
+
+    @Test
+    public void logsEndpointsContextPath() {
+        rc.setContextPath("/context");
+        rc.register(TestResource.class);
+        rc.register(ImplementingResource.class);
+
+        assertThat(rc.getEndpointsInfo())
+            .contains("GET     /context/dummy (io.dropwizard.jersey.DropwizardResourceConfigTest.TestResource)")
+            .contains("GET     /context/another (io.dropwizard.jersey.DropwizardResourceConfigTest.ImplementingResource)");
+    }
+
+    @Test
+    public void logsEndpointsNoSlashContextPath() {
+        rc.setContextPath("context");
+        rc.register(TestResource.class);
+        rc.register(ImplementingResource.class);
+
+        assertThat(rc.getEndpointsInfo())
+            .contains("GET     /context/dummy (io.dropwizard.jersey.DropwizardResourceConfigTest.TestResource)")
+            .contains("GET     /context/another (io.dropwizard.jersey.DropwizardResourceConfigTest.ImplementingResource)");
     }
 
     @Path("/dummy")


### PR DESCRIPTION
###### Problem:
Endpoints logged out take into consideration jersey's URL pattern, but not the context path.
```
GET /endpointA
POST /endpointA
```
Copy pasting this URL gives 404s if you have context-path

###### Solution:
Append context path if present to the end points along with jersey URL pattern

###### Result:
```
GET /context-path/endpointA
POST /context-path/endpointA
```
