### PR TITLE
Doc fix: h2 conscrypt pom update

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -357,8 +357,6 @@ For HTTP/2 servers you need to add an ALPN Conscrypt provider as a dependency.
     <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-conscrypt-server</artifactId>
-        <version>${jetty.version}</version>
-        <scope>test</scope>
     </dependency>
 
 .. _`Conscrypt`: https://github.com/google/conscrypt


### PR DESCRIPTION
###### Problem:
Docs needs a little fixin' up when mentioning HTTP2 support and conscrypt.

###### Solution:
Updated docs. Don't need to specify jetty version as it in brought in with our bom. Also one doesn't want it as only a test dependency 😉 
