### PR TITLE
Upgrade to Guava 24.0-jre

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -22,7 +22,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <dropwizard.version>${project.version}</dropwizard.version>
-        <guava.version>23.5-jre</guava.version>
+        <guava.version>24.0-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
         <jackson.version>2.9.3</jackson.version>
         <jetty.version>9.4.8.v20171121</jetty.version>


### PR DESCRIPTION
###### Problem:
Guava 24.0-jre was recently released, and Dropwizard's 1.3.0 release candidates are using 23.5-jre still. There is no specific issue driving this, just a general keeping up to date sort of thing.

###### Solution:
I updated the Guava version in the dropwizard-bom

###### Result:
Guava will be up to date in the next minor version release of Dropwizard
