### PR TITLE
Add support for providing a custom layout during logging bootstrap

### DIFF
--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.when;
 public class LayoutIntegrationTests {
 
     static {
-        BootstrapLogging.bootstrap(Level.INFO);
+        BootstrapLogging.bootstrap(Level.INFO, new EventJsonLayoutBaseFactory());
     }
 
     private final ObjectMapper objectMapper = Jackson.newObjectMapper();

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/BootstrapLogging.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/BootstrapLogging.java
@@ -2,10 +2,13 @@ package io.dropwizard.logging;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.filter.ThresholdFilter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.ConsoleAppender;
+import ch.qos.logback.core.Layout;
 import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
+import io.dropwizard.logging.layout.DiscoverableLayoutFactory;
 
 import javax.annotation.concurrent.GuardedBy;
 import java.util.TimeZone;
@@ -35,6 +38,10 @@ public class BootstrapLogging {
     }
 
     public static void bootstrap(Level level) {
+        bootstrap(level, DropwizardLayout::new);
+    }
+
+    public static void bootstrap(Level level, DiscoverableLayoutFactory<ILoggingEvent> layoutFactory) {
         LoggingUtil.hijackJDKLogging();
 
         BOOTSTRAPPING_LOCK.lock();
@@ -45,8 +52,8 @@ public class BootstrapLogging {
             final Logger root = LoggingUtil.getLoggerContext().getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
             root.detachAndStopAllAppenders();
 
-            final DropwizardLayout formatter = new DropwizardLayout(root.getLoggerContext(), TimeZone.getDefault());
-            formatter.start();
+            final Layout<ILoggingEvent> layout = layoutFactory.build(root.getLoggerContext(), TimeZone.getDefault());
+            layout.start();
 
             final ThresholdFilter filter = new ThresholdFilter();
             filter.setLevel(level.toString());
@@ -57,7 +64,7 @@ public class BootstrapLogging {
             appender.setContext(root.getLoggerContext());
 
             final LayoutWrappingEncoder<ILoggingEvent> layoutEncoder = new LayoutWrappingEncoder<>();
-            layoutEncoder.setLayout(formatter);
+            layoutEncoder.setLayout(layout);
             appender.setEncoder(layoutEncoder);
             appender.start();
 


### PR DESCRIPTION
###### Problem:
Dropwizard users have the ability to configure their application to use JSON as the logging format. Unfortunately, the default logging bootstrap mechanism which kicks off before Dropwizard logging
configuration, uses the default logging layout. As a result, some internal logging messages (Jetty, Hibernate initialization) are produced in a not recognized format.

###### Solution:
This change add possibility to specify a layout factory during the bootstrap process. Users can override the bootstrap method of `Application` and provide an own layout format. For example,

```java
BootstrapLogging.bootstrap(Level.INFO, new EventJsonLayoutBaseFactory());
```

###### Result:
As a result, the all applications logs will produced in the JSON format.
Resolves #2250 