### PR TITLE
Upgrade handling an unknown value in FuzzyEnumModule

### DIFF
--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/FuzzyEnumModule.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/FuzzyEnumModule.java
@@ -56,7 +56,7 @@ public class FuzzyEnumModule extends Module {
             if (constant != null) {
                 return constant;
             }
-            throw ctxt.mappingException(jp.getText() + " was not one of " + acceptedValues);
+            throw ctxt.weirdStringException(jp.getText(), handledType(), jp.getText() + " was not one of " + acceptedValues);
         }
     }
 

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/FuzzyEnumModuleTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/FuzzyEnumModuleTest.java
@@ -122,7 +122,8 @@ public class FuzzyEnumModuleTest {
             failBecauseExceptionWasNotThrown(JsonMappingException.class);
         } catch (JsonMappingException e) {
             assertThat(e.getOriginalMessage())
-                    .isEqualTo("wrong was not one of [NANOSECONDS, MICROSECONDS, MILLISECONDS, SECONDS, MINUTES, HOURS, DAYS]");
+                    .isEqualTo("Cannot deserialize value of type `java.util.concurrent.TimeUnit` from String \"wrong\": " +
+                        "wrong was not one of [NANOSECONDS, MICROSECONDS, MILLISECONDS, SECONDS, MINUTES, HOURS, DAYS]");
         }
     }
 


### PR DESCRIPTION
###### Problem:
Since Jackson 2.9, the `mappingException` method has been deprecated in favour of more specific methods

###### Solution:
Use the `weirdStringException` method for our case when we can't map a string value to a an enum value.

###### Result:
No compilation warnings and easier migration to newer Jackson versions.