### PR TITLE
Upgrade Jackson to 2.9.4 in 1.2.* to address a CVE

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -24,7 +24,7 @@
         <dropwizard.version>${project.version}</dropwizard.version>
         <guava.version>23.5-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
-        <jackson.version>2.9.3</jackson.version>
+        <jackson.version>2.9.4</jackson.version>
         <jetty.version>9.4.8.v20171121</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics3.version>3.2.5</metrics3.version>


### PR DESCRIPTION
###### Problem:
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-17485

According to the CVE, maliciously crafted JSON input can allow a remote code execution, if it's passed directly to the `readValue` method of `ÒbjectMapper`. The blacklist of deserialized types is
ignored if the Spring libraries are available in the classpath.

###### Solution:
Upgrade Jackson to 2.9.4 with a fix to the CVE.

###### Result:
Dropwizard doesn't use Spring, but some end users use Spring along with Dropwizard, so we should give them a simple way to protect their applications.