### PR TITLE
Strip the Content-Length header after decompressing HTTP requests

### DIFF
--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/BiDiGzipHandlerTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/BiDiGzipHandlerTest.java
@@ -162,6 +162,9 @@ public class BiDiGzipHandlerTest {
         protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
             assertThat(req.getHeader(HttpHeaders.CONTENT_TYPE)).isEqualToIgnoringCase(PLAIN_TEXT_UTF_8);
             assertThat(req.getHeader(HttpHeaders.CONTENT_ENCODING)).isNull();
+            assertThat(req.getHeader(HttpHeaders.CONTENT_LENGTH)).isNull();
+            assertThat(req.getContentLength()).isEqualTo(-1);
+            assertThat(req.getContentLengthLong()).isEqualTo(-1L);
             assertThat(CharStreams.toString(req.getReader())).isEqualTo(
                 Resources.toString(Resources.getResource("assets/new-banner.txt"), StandardCharsets.UTF_8));
 


### PR DESCRIPTION
###### Problem:
`BiDiGzipHandler` decompresses HTTP requests with compressed data, so for the handlers down the stack the content looks like plain-text data and they don't need to bother with decompressing in the application level logic. Unfortunately, the handler doesn't strip the original `Content-Length` header from requests, and requests return the content length of compressed content instead of uncompressed. This can create confusing situations for applications that check the length of requests for future processing. A classic example is a reverse proxy handler which parses a request, enriches it, and sends it to an origin server for processing. In this case, the proxy handler will send plain data to the origin server, but with a misleading `Content-Length` header and the origin will reject the request as malformed.

###### Solution:
A solution is to strip the `Content-Length` header from the request and override the `getContentLength` method of `HttpServletRequest` to specify it as an unknown. In this case the proxy handler will pass the request as chunked to the origin server (albeit without the `Transfer-Encoding` header), and it will be correctly handled. This seems to be a correct behaviour, because we don't know the length of
decoded content beforehand.

###### Result:
Transparent handling of compressed HTTP requests in Dropwizard applications.
Resolves #2268 