### PR TITLE
Upgrade Jadira to 7.0.0-rc1

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -105,9 +105,9 @@
                 <version>${h2.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.arteam.jadira</groupId>
+                <groupId>org.jadira.usertype</groupId>
                 <artifactId>usertype.core</artifactId>
-                <version>6.0.1.GA-jdk9</version>
+                <version>7.0.0.CR1</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.slf4j</groupId>

--- a/dropwizard-hibernate/pom.xml
+++ b/dropwizard-hibernate/pom.xml
@@ -39,7 +39,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.github.arteam.jadira</groupId>
+            <groupId>org.jadira.usertype</groupId>
             <artifactId>usertype.core</artifactId>
         </dependency>
         <dependency>

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
@@ -2,6 +2,7 @@ package io.dropwizard.hibernate;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.DropwizardResourceConfig;
@@ -103,6 +104,8 @@ public class JerseyIntegrationTest extends JerseyTest {
         final MetricRegistry metricRegistry = new MetricRegistry();
         final SessionFactoryFactory factory = new SessionFactoryFactory();
         final DataSourceFactory dbConfig = new DataSourceFactory();
+        dbConfig.setProperties(ImmutableMap.of("hibernate.jdbc.time_zone", "UTC"));
+
         final HibernateBundle<?> bundle = mock(HibernateBundle.class);
         final Environment environment = mock(Environment.class);
         final LifecycleEnvironment lifecycleEnvironment = mock(LifecycleEnvironment.class);

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryFactoryTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryFactoryTest.java
@@ -59,7 +59,8 @@ public class SessionFactoryFactoryTest {
 
         final ImmutableMap<String, String> properties = ImmutableMap.of(
             "hibernate.show_sql", "true",
-            "hibernate.dialect", "org.hibernate.dialect.HSQLDialect");
+            "hibernate.dialect", "org.hibernate.dialect.HSQLDialect",
+            "hibernate.jdbc.time_zone", "UTC");
         config.setProperties(properties);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -231,10 +231,6 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
-        <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>
     </repositories>
 
     <distributionManagement>


### PR DESCRIPTION
###### Problem:
We depend on a Jadira fork instead of an official release, because we want to run Dropwizard apps with Hibernate under JDK 9.

###### Solution:
There has been a new release of Jadira which supports running under JDK 9. That means we can remove a dependency on my fork via jitpack.

This new release also now picks up the database timezone from the `hibernate.jdbc.time_zone` property, so we should specify it in our tests, otherwise Hibernates reads timestamps in the host's timezone.  Theoretically, it can break applications which run databases and application servers in different timezones, but one could argue that such systems should explicitly specify the database timezone. See:
* https://github.com/JadiraOrg/jadira/issues/58
* http://in.relation.to/2016/09/12/jdbc-time-zone-configuration-property/

###### Result:
No 3rd party dependencies in Dropwizard.