### PR TITLE
Deprecate the native Hibernate criteria API in AbstractDAO

### DIFF
--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/AbstractDAO.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/AbstractDAO.java
@@ -49,7 +49,9 @@ public class AbstractDAO<E> {
      *
      * @return a new {@link Criteria} query
      * @see Session#createCriteria(Class)
+     * @deprecated Use {@link AbstractDAO#criteriaQuery()} instead.
      */
+    @Deprecated
     protected Criteria criteria() {
         return currentSession().createCriteria(entityClass);
     }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/AbstractDAOTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/AbstractDAOTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings("deprecation")
 public class AbstractDAOTest {
     private static class MockDAO extends AbstractDAO<String> {
         MockDAO(SessionFactory factory) {


### PR DESCRIPTION
###### Problem:
Hibernate has deprecated the native Criteria API and since Hibernate 5.2 it's advised to use
the JPA Criteria API. 

###### Solution:
To deprecate the `criteria` method in `AbstractDao` and advice to use `criteriaQuery` implemented in Dropwizard 1.2

###### Result:
Drowizard users are encouraged to use the new API, so have fewer issues when upgrading to newer Dropwizard/Hibernate versions.