### PR TITLE
Make sure test Jersey test client uses Dropwizard's ObjectMapper

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
@@ -5,6 +5,7 @@ import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.cli.Command;
 import io.dropwizard.cli.ServerCommand;
+import io.dropwizard.jersey.jackson.JacksonBinder;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.ConfigOverride;
@@ -237,6 +238,7 @@ public class DropwizardAppRule<C extends Configuration> extends ExternalResource
 
     protected JerseyClientBuilder clientBuilder() {
         return new JerseyClientBuilder()
+            .register(new JacksonBinder(getObjectMapper()))
             .property(ClientProperties.CONNECT_TIMEOUT, DEFAULT_CONNECT_TIMEOUT_MS)
             .property(ClientProperties.READ_TIMEOUT, DEFAULT_READ_TIMEOUT_MS);
     }

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardAppExtension.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardAppExtension.java
@@ -5,6 +5,7 @@ import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.cli.Command;
 import io.dropwizard.cli.ServerCommand;
+import io.dropwizard.jersey.jackson.JacksonBinder;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.ConfigOverride;
@@ -235,6 +236,7 @@ public class DropwizardAppExtension<C extends Configuration> implements Dropwiza
 
     protected JerseyClientBuilder clientBuilder() {
         return new JerseyClientBuilder()
+            .register(new JacksonBinder(getObjectMapper()))
             .property(ClientProperties.CONNECT_TIMEOUT, DEFAULT_CONNECT_TIMEOUT_MS)
             .property(ClientProperties.READ_TIMEOUT, DEFAULT_READ_TIMEOUT_MS);
     }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/DropwizardTestApplication.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/DropwizardTestApplication.java
@@ -1,16 +1,20 @@
 package io.dropwizard.testing.app;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMultimap;
 import io.dropwizard.Application;
 import io.dropwizard.servlets.tasks.PostBodyTask;
 import io.dropwizard.servlets.tasks.Task;
 import io.dropwizard.setup.Environment;
-import io.dropwizard.testing.app.TestConfiguration;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 import java.io.PrintWriter;
+import java.util.Optional;
 
 public class DropwizardTestApplication extends Application<TestConfiguration> {
     @Override
@@ -33,6 +37,13 @@ public class DropwizardTestApplication extends Application<TestConfiguration> {
         @GET
         public String test() {
             return message;
+        }
+
+        @Path("message")
+        @GET
+        @Produces(MediaType.APPLICATION_JSON)
+        public MessageView messageView() {
+            return new MessageView(Optional.of(message));
         }
     }
 
@@ -61,6 +72,21 @@ public class DropwizardTestApplication extends Application<TestConfiguration> {
         public void execute(ImmutableMultimap<String, String> parameters, String body, PrintWriter output) throws Exception {
             output.print(body);
             output.flush();
+        }
+    }
+
+    public static class MessageView {
+
+        private Optional<String> message;
+
+        @JsonCreator
+        public MessageView(@JsonProperty("message") Optional<String> message) {
+            this.message = message;
+        }
+
+        @JsonProperty
+        public Optional<String> getMessage() {
+            return message;
         }
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleTest.java
@@ -3,6 +3,7 @@ package io.dropwizard.testing.junit;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.app.DropwizardTestApplication;
 import io.dropwizard.testing.app.TestConfiguration;
+import org.assertj.core.api.Assertions;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -67,5 +68,13 @@ public class DropwizardAppRuleTest {
             .post(Entity.entity("Custom message", MediaType.TEXT_PLAIN), String.class);
 
         assertThat(response, is("Custom message"));
+    }
+
+    @Test
+    public void clientUsesJacksonMapperFromEnvironment() {
+        Assertions.assertThat(RULE.client().target("http://localhost:" + RULE.getLocalPort() + "/message")
+            .request()
+            .get(DropwizardTestApplication.MessageView.class).getMessage())
+            .contains("Yes, it's here");
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionTest.java
@@ -11,6 +11,8 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 
+import java.util.Optional;
+
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -66,5 +68,12 @@ public class DropwizardAppExtensionTest {
             .post(Entity.entity("Custom message", MediaType.TEXT_PLAIN), String.class);
 
         assertThat(response, is("Custom message"));
+    }
+
+    @Test
+    public void clientUsesJacksonMapperFromEnvironment() {
+        assertThat(EXTENSION.client().target("http://localhost:" + EXTENSION.getLocalPort() + "/message")
+            .request()
+            .get(DropwizardTestApplication.MessageView.class).getMessage(), is(Optional.of("Yes, it's here")));
     }
 }


### PR DESCRIPTION
###### Problem:
Currently the Jersey client produced by `DropwizardAppRule` uses a simple Jackson's ObjectMapper. This could be an issue when a serialized/deserialized entity requires additional modules (Java 8
`Optional`, `DateTime`, `ParamaterNames` module etc...), which are
added automatically in Dropwizard's `ÒbjectMapper` and used for the server side.

###### Solution:
Produce a client with a Jackson binder which uses the `ObjectMapper` instance from the test environment.

###### Result:
Less surprises for users and discrepancies between the client and server JSON serialization.