### PR TITLE
Run code coverage only if needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: java
 before_install:
   - ulimit -c unlimited -S
 script:
-  - ./mvnw test -B
+  - ./mvnw test -B -P code-coverage
   - ./mvnw site -pl docs -B
 after_success:
   - bash .travis_after_success.sh

--- a/pom.xml
+++ b/pom.xml
@@ -395,6 +395,39 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>code-coverage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>0.8.0</version>
+                        <executions>
+                            <execution>
+                                <id>prepare-agent</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <excludes>
+                                <exclude>io/dropwizard/benchmarks/**/*.class</exclude>
+                                <exclude>org/openjdk/jmh/**/*.class</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>${argLine} -Duser.language=en -Duser.region=US</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <dependencyManagement>
@@ -537,7 +570,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>${argLine} -Duser.language=en -Duser.region=US</argLine>
+                    <argLine>-Duser.language=en -Duser.region=US</argLine>
                 </configuration>
             </plugin>
             <plugin>
@@ -616,25 +649,6 @@
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                         </manifest>
                     </archive>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.0</version>
-                <executions>
-                    <execution>
-                        <id>prepare-agent</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <excludes>
-                        <exclude>io/dropwizard/benchmarks/**/*.class</exclude>
-                        <exclude>org/openjdk/jmh/**/*.class</exclude>
-                    </excludes>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
###### Problem:
The jacoco agent runs by default alongs with the tests which creates additional overhead. We need only on Travis CI, where we measure code coverage, we don't in another CI or during local development.

###### Solution:
Move the jacoco agent to a separate profile which is invoked by the build script at Travis.

###### Result:
More fast tests during development.