### PR TITLE
Correctly handle the default context path when logging endpoints

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -41,7 +41,7 @@ public class DropwizardResourceConfig extends ResourceConfig {
     private static final Pattern PATH_DIRTY_SLASHES = Pattern.compile("\\s*/\\s*/+\\s*");
 
     private String urlPattern = "/*";
-    private String contextPath = "";
+    private String contextPath = "/";
 
     public DropwizardResourceConfig(MetricRegistry metricRegistry) {
         this(false, metricRegistry);
@@ -184,7 +184,8 @@ public class DropwizardResourceConfig extends ResourceConfig {
 
         EndpointLogger(String contextPath, String urlPattern, Class<?> klass) {
             final String rootPattern = urlPattern.endsWith("/*") ? urlPattern.substring(0, urlPattern.length() - 1) : urlPattern;
-            final String normalizedContextPath = contextPath == null || contextPath.trim().isEmpty() ? "" : contextPath.startsWith("/") ? contextPath : "/" + contextPath;
+            final String normalizedContextPath = contextPath.isEmpty() || contextPath.equals("/") ? "" :
+                contextPath.startsWith("/") ? contextPath : "/" + contextPath;
             this.rootPath = normalizedContextPath + rootPattern;
             this.klass = klass;
         }


### PR DESCRIPTION
###### Problem:
The default context path is not an empty string, but slash. Currently, a slash is considered as a custom context path and printed out along with the endpoint with a slash. So, for a typical endpoint we output two slashes, which is not great.

###### Solution:
A fix is to consider a slash as a default context path and don't print it out.

###### Result:
Logged endpoints without a double slash for applications which uses a root context (i.e. default server configuration).

This is a follow-up for #2254