### PR TITLE
Add support for PATCH request to Jersey test client

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
@@ -11,6 +11,7 @@ import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.DropwizardTestSupport;
 import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.HttpUrlConnectorProvider;
 import org.glassfish.jersey.client.JerseyClientBuilder;
 import org.junit.rules.ExternalResource;
 
@@ -240,6 +241,7 @@ public class DropwizardAppRule<C extends Configuration> extends ExternalResource
         return new JerseyClientBuilder()
             .register(new JacksonBinder(getObjectMapper()))
             .property(ClientProperties.CONNECT_TIMEOUT, DEFAULT_CONNECT_TIMEOUT_MS)
-            .property(ClientProperties.READ_TIMEOUT, DEFAULT_READ_TIMEOUT_MS);
+            .property(ClientProperties.READ_TIMEOUT, DEFAULT_READ_TIMEOUT_MS)
+            .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true);
     }
 }

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardAppExtension.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardAppExtension.java
@@ -11,6 +11,7 @@ import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.DropwizardTestSupport;
 import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.HttpUrlConnectorProvider;
 import org.glassfish.jersey.client.JerseyClientBuilder;
 
 import javax.annotation.Nullable;
@@ -238,6 +239,7 @@ public class DropwizardAppExtension<C extends Configuration> implements Dropwiza
         return new JerseyClientBuilder()
             .register(new JacksonBinder(getObjectMapper()))
             .property(ClientProperties.CONNECT_TIMEOUT, DEFAULT_CONNECT_TIMEOUT_MS)
-            .property(ClientProperties.READ_TIMEOUT, DEFAULT_READ_TIMEOUT_MS);
+            .property(ClientProperties.READ_TIMEOUT, DEFAULT_READ_TIMEOUT_MS)
+            .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true);
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/DropwizardTestApplication.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/DropwizardTestApplication.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMultimap;
 import io.dropwizard.Application;
+import io.dropwizard.jersey.PATCH;
 import io.dropwizard.servlets.tasks.PostBodyTask;
 import io.dropwizard.servlets.tasks.Task;
 import io.dropwizard.setup.Environment;
@@ -44,6 +45,12 @@ public class DropwizardTestApplication extends Application<TestConfiguration> {
         @Produces(MediaType.APPLICATION_JSON)
         public MessageView messageView() {
             return new MessageView(Optional.of(message));
+        }
+
+        @Path("echoPatch")
+        @PATCH
+        public String echoPatch(String patchMessage) {
+            return patchMessage;
         }
     }
 

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleTest.java
@@ -77,4 +77,12 @@ public class DropwizardAppRuleTest {
             .get(DropwizardTestApplication.MessageView.class).getMessage())
             .contains("Yes, it's here");
     }
+
+    @Test
+    public void clientSupportsPatchMethod() {
+        Assertions.assertThat(RULE.client().target("http://localhost:" + RULE.getLocalPort() + "/echoPatch")
+            .request()
+            .method("PATCH", Entity.text("Patch is working"), String.class))
+            .contains("Patch is working");
+    }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionTest.java
@@ -76,4 +76,12 @@ public class DropwizardAppExtensionTest {
             .request()
             .get(DropwizardTestApplication.MessageView.class).getMessage(), is(Optional.of("Yes, it's here")));
     }
+
+    @Test
+    public void clientSupportsPatchMethod() {
+        assertThat(EXTENSION.client().target("http://localhost:" + EXTENSION.getLocalPort() + "/echoPatch")
+            .request()
+            .method("PATCH", Entity.text("Patch is working"), String.class), is("Patch is working"));
+    }
+
 }


### PR DESCRIPTION
###### Problem:
Dropwizard supports PATCH method via a custom annotation io.dropwizard.jersey.PATCH. The io.dropwizard.client.io.dropwizard.client.JerseyClientBuilder also allows to submit patch requests.
However test client from `DropwizardAppRule`, 
uses org.glassfish.jersey.client.JerseyClientBuilder which does not support `PATCH` requests by default. See issue #2287

###### Solution:
A simple workaround however is to set JerseyClientBuilder.property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true)

###### Result:
Jersey test client can now be used to submit patch requests via `client.target(...).request(...).method("PATCH", Entity.text("Patch is working"), String.class)`
