### PR TITLE
Fixed template broken after enabling html escaping of strings in Free…

### DIFF
--- a/dropwizard-example/src/main/resources/com/example/helloworld/views/freemarker/person.ftl
+++ b/dropwizard-example/src/main/resources/com/example/helloworld/views/freemarker/person.ftl
@@ -5,7 +5,7 @@
     </head>
     <body>
         <!-- calls getPerson().getFullName() and sanitizes it -->
-        <h1>Hello, ${person.fullName?html}!</h1>
-        You are an awesome ${person.jobTitle?html}.
+        <h1>Hello, ${person.fullName}!</h1>
+        You are an awesome ${person.jobTitle}.
     </body>
 </html>

--- a/dropwizard-example/src/test/java/com/example/helloworld/IntegrationTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/IntegrationTest.java
@@ -5,12 +5,14 @@ import com.example.helloworld.core.Person;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.eclipse.jetty.http.HttpStatus;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -57,13 +59,35 @@ public class IntegrationTest {
     @Test
     public void testPostPerson() throws Exception {
         final Person person = new Person("Dr. IntegrationTest", "Chief Wizard");
-        final Person newPerson = RULE.client().target("http://localhost:" + RULE.getLocalPort() + "/people")
-                .request()
-                .post(Entity.entity(person, MediaType.APPLICATION_JSON_TYPE))
-                .readEntity(Person.class);
+        final Person newPerson = postPerson(person);
         assertThat(newPerson.getId()).isNotNull();
         assertThat(newPerson.getFullName()).isEqualTo(person.getFullName());
         assertThat(newPerson.getJobTitle()).isEqualTo(person.getJobTitle());
+    }
+
+    @Test
+    public void testRenderingPersonFreemarker() throws Exception {
+        testRenderingPerson("view_freemarker");
+    }
+
+    @Test
+    public void testRenderingPersonMustache() throws Exception {
+        testRenderingPerson("view_mustache");
+    }
+
+    private void testRenderingPerson(String viewName) throws Exception {
+        final Person person = new Person("Dr. IntegrationTest", "Chief Wizard");
+        final Person newPerson = postPerson(person);
+        final String url = "http://localhost:" + RULE.getLocalPort() + "/people/" + newPerson.getId() + "/" + viewName;
+        Response response = RULE.client().target(url).request().get();
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK_200);
+    }
+
+    private Person postPerson(Person person) {
+        return RULE.client().target("http://localhost:" + RULE.getLocalPort() + "/people")
+                .request()
+                .post(Entity.entity(person, MediaType.APPLICATION_JSON_TYPE))
+                .readEntity(Person.class);
     }
 
     @Test


### PR DESCRIPTION
…marker templates by default, added integration tests.

See also: https://github.com/dropwizard/dropwizard/pull/2251

Before you could see this in logs trying to render 'view_freemarker' template:

```
Causing: io.dropwizard.views.ViewRenderException: freemarker.core.ParseException: Syntax error in template "com/example/helloworld/views/freemarker/person.ftl" in line 8, column 38:
! Using ?html (legacy escaping) is not allowed when auto-escaping is on with a markup output format (HTML), to avoid double-escaping mistakes.
```

###### Problem:

Seems that auto-escaping for strings in Freemarker templates is enabled by default.
But an example template still contains **?html** , so we've got **ViewRenderException** mentioned in comment to commit, and a http status **500**.

###### Solution:

Fixed template assuming auto-escape enabled.
Added small tests verifying that **/people/{personId}/{view_name}** returns **200 OK**.

###### Result:
