### PR TITLE
Add a TCP and UDP log appenders to Dropwizard

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -33,6 +33,7 @@ v1.3.0: Unreleased
 * Upgrade handling an unknown value in FuzzyEnumModule `#2266 <https://github.com/dropwizard/dropwizard/pull/2266>`_
 * Add support for providing a custom layout during logging bootstrap `#2260 <https://github.com/dropwizard/dropwizard/pull/2260>`_
 * Add context path to logged endpoints `#2254 <https://github.com/dropwizard/dropwizard/pull/2254>`_
+* Add a TCP and UDP log appenders to Dropwizard `#2291 <https://github.com/dropwizard/dropwizard/pull/2291>`_
 * Upgrade to metrics 4.0.2
 * Upgrade to Guava 24.0-jre
 * Upgrade to JUnit 5.0.3

--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -746,6 +746,60 @@ neverBlock                   false                                  Prevent the 
 ============================ =====================================  ==================================================================================================
 
 
+.. _man-configuration-logging-tcp:
+
+TCP
+------
+
+.. code-block:: yaml
+
+    logging:
+      level: INFO
+      appenders:
+        - type: tcp
+          host: localhost
+          port: 4560
+          connectionTimeout: 500ms
+          immediateFlush: true
+          sendBufferSize: 8KB
+
+
+============================ =============  ==================================================================
+Name                         Default        Description
+============================ =============  ==================================================================
+host                         localhost      The hostname of the TCP server.
+port                         4560           The port on which the TCP server is listening.
+connectionTimeout            500ms          The timeout to connect to the TCP server.
+immediateFlush               true           If set to true, log events will be immediately send to the server
+                                            Immediate flushing is safer, but it degrades logging throughput.
+sendBufferSize               8KB            The buffer size of the underlying SocketAppender.
+                                            Takes into effect if immediateFlush is disabled.
+============================ =============  ==================================================================
+
+
+.. _man-configuration-logging-udp:
+
+UDP
+------
+
+.. code-block:: yaml
+
+    logging:
+      level: INFO
+      appenders:
+        - type: udp
+          host: localhost
+          port: 514
+
+
+============================ =============  ==================================================================
+Name                         Default        Description
+============================ =============  ==================================================================
+host                         localhost      The hostname of the UDP server.
+port                         514            The port on which the UDP server is listening.
+============================ =============  ==================================================================
+
+
 .. _man-configuration-logging-filter-factories:
 
 FilterFactories

--- a/dropwizard-logging/src/main/java/ch/qos/logback/core/recovery/ResilentSocketOutputStream.java
+++ b/dropwizard-logging/src/main/java/ch/qos/logback/core/recovery/ResilentSocketOutputStream.java
@@ -1,0 +1,62 @@
+package ch.qos.logback.core.recovery;
+
+import javax.net.SocketFactory;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+/**
+ * Represents a resilent persistent connection via TCP as an {@link OutputStream}.
+ * Automatically tries to reconnect to the server if it encounters errors during writing
+ * data via a TCP connection.
+ */
+public class ResilentSocketOutputStream extends ResilientOutputStreamBase {
+
+    private final String host;
+    private final int port;
+    private final int connectionTimeoutMs;
+    private final int sendBufferSize;
+    private final SocketFactory socketFactory;
+
+    /**
+     * Creates a new stream based on the socket configuration.
+     *
+     * @param host                The host or an IP address of the server.
+     * @param port                The port on the server which accepts TCP connections.
+     * @param connectionTimeoutMs The timeout for establishing a new TCP connection.
+     * @param sendBufferSize      The size of the send buffer of the socket stream in bytes.
+     * @param socketFactory       The factory for customizing the client socket.
+     */
+    public ResilentSocketOutputStream(String host, int port, int connectionTimeoutMs, int sendBufferSize,
+                                      SocketFactory socketFactory) {
+        this.host = host;
+        this.port = port;
+        this.connectionTimeoutMs = connectionTimeoutMs;
+        this.sendBufferSize = sendBufferSize;
+        this.socketFactory = socketFactory;
+        try {
+            this.os = openNewOutputStream();
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to create a TCP connection to " + host + ":" + port, e);
+        }
+        this.presumedClean = true;
+    }
+
+    @Override
+    String getDescription() {
+        return "tcp [" + host + ":" + port + "]";
+    }
+
+    @Override
+    OutputStream openNewOutputStream() throws IOException {
+        final Socket socket = socketFactory.createSocket();
+        // Prevent automatic closing of the connection during periods of inactivity.
+        socket.setKeepAlive(true);
+        // Important not to cache `InetAddress` in case the host moved to a new IP address.
+        socket.connect(new InetSocketAddress(InetAddress.getByName(host), port), connectionTimeoutMs);
+        return new BufferedOutputStream(socket.getOutputStream(), sendBufferSize);
+    }
+}

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/AbstractOutputStreamAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/AbstractOutputStreamAppenderFactory.java
@@ -1,0 +1,33 @@
+package io.dropwizard.logging;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.OutputStreamAppender;
+import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
+import ch.qos.logback.core.spi.DeferredProcessingAware;
+import io.dropwizard.logging.async.AsyncAppenderFactory;
+import io.dropwizard.logging.filter.LevelFilterFactory;
+import io.dropwizard.logging.layout.LayoutFactory;
+
+/**
+ * A base implementation of {@link AppenderFactory} producing an appender based on {@link OutputStreamAppender}.
+ */
+public abstract class AbstractOutputStreamAppenderFactory<E extends DeferredProcessingAware>
+    extends AbstractAppenderFactory<E> {
+
+    protected abstract OutputStreamAppender<E> appender(LoggerContext context);
+
+    @Override
+    public Appender<E> build(LoggerContext context, String applicationName, LayoutFactory<E> layoutFactory,
+                             LevelFilterFactory<E> levelFilterFactory, AsyncAppenderFactory<E> asyncAppenderFactory) {
+        final OutputStreamAppender<E> appender = appender(context);
+        final LayoutWrappingEncoder<E> layoutEncoder = new LayoutWrappingEncoder<>();
+        layoutEncoder.setLayout(buildLayout(context, layoutFactory));
+        appender.setEncoder(layoutEncoder);
+
+        appender.addFilter(levelFilterFactory.build(threshold));
+        getFilterFactories().forEach(f -> appender.addFilter(f.build()));
+        appender.start();
+        return wrapAsync(appender, asyncAppenderFactory);
+    }
+}

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/ConsoleAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/ConsoleAppenderFactory.java
@@ -1,15 +1,11 @@
 package io.dropwizard.logging;
 
 import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.ConsoleAppender;
-import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
+import ch.qos.logback.core.OutputStreamAppender;
 import ch.qos.logback.core.spi.DeferredProcessingAware;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import io.dropwizard.logging.async.AsyncAppenderFactory;
-import io.dropwizard.logging.filter.LevelFilterFactory;
-import io.dropwizard.logging.layout.LayoutFactory;
 
 import javax.validation.constraints.NotNull;
 
@@ -60,7 +56,7 @@ import javax.validation.constraints.NotNull;
  * @see AbstractAppenderFactory
  */
 @JsonTypeName("console")
-public class ConsoleAppenderFactory<E extends DeferredProcessingAware> extends AbstractAppenderFactory<E> {
+public class ConsoleAppenderFactory<E extends DeferredProcessingAware> extends AbstractOutputStreamAppenderFactory<E> {
     @SuppressWarnings("UnusedDeclaration")
     public enum ConsoleStream {
         STDOUT("System.out"),
@@ -91,21 +87,11 @@ public class ConsoleAppenderFactory<E extends DeferredProcessingAware> extends A
     }
 
     @Override
-    public Appender<E> build(LoggerContext context, String applicationName, LayoutFactory<E> layoutFactory,
-                             LevelFilterFactory<E> levelFilterFactory, AsyncAppenderFactory<E> asyncAppenderFactory) {
+    protected OutputStreamAppender<E> appender(LoggerContext context) {
         final ConsoleAppender<E> appender = new ConsoleAppender<>();
         appender.setName("console-appender");
         appender.setContext(context);
         appender.setTarget(target.get());
-
-        final LayoutWrappingEncoder<E> layoutEncoder = new LayoutWrappingEncoder<>();
-        layoutEncoder.setLayout(buildLayout(context, layoutFactory));
-        appender.setEncoder(layoutEncoder);
-
-        appender.addFilter(levelFilterFactory.build(threshold));
-        getFilterFactories().forEach(f -> appender.addFilter(f.build()));
-        appender.start();
-
-        return wrapAsync(appender, asyncAppenderFactory);
+        return appender;
     }
 }

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
@@ -1,9 +1,8 @@
 package io.dropwizard.logging;
 
 import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.FileAppender;
-import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
+import ch.qos.logback.core.OutputStreamAppender;
 import ch.qos.logback.core.rolling.DefaultTimeBasedFileNamingAndTriggeringPolicy;
 import ch.qos.logback.core.rolling.FixedWindowRollingPolicy;
 import ch.qos.logback.core.rolling.RollingFileAppender;
@@ -126,7 +125,7 @@ import static java.util.Objects.requireNonNull;
  * @see AbstractAppenderFactory
  */
 @JsonTypeName("file")
-public class FileAppenderFactory<E extends DeferredProcessingAware> extends AbstractAppenderFactory<E> {
+public class FileAppenderFactory<E extends DeferredProcessingAware> extends AbstractOutputStreamAppenderFactory<E> {
 
     @Nullable
     private String currentLogFilename;
@@ -246,25 +245,14 @@ public class FileAppenderFactory<E extends DeferredProcessingAware> extends Abst
     }
 
     @Override
-    public Appender<E> build(LoggerContext context, String applicationName, LayoutFactory<E> layoutFactory,
-                             LevelFilterFactory<E> levelFilterFactory, AsyncAppenderFactory<E> asyncAppenderFactory) {
+    protected OutputStreamAppender<E> appender(LoggerContext context) {
         final FileAppender<E> appender = buildAppender(context);
         appender.setName("file-appender");
-
         appender.setAppend(true);
         appender.setContext(context);
-
-        final LayoutWrappingEncoder<E> layoutEncoder = new LayoutWrappingEncoder<>();
-        layoutEncoder.setLayout(buildLayout(context, layoutFactory));
-        appender.setEncoder(layoutEncoder);
-
         appender.setImmediateFlush(immediateFlush);
         appender.setPrudent(false);
-        appender.addFilter(levelFilterFactory.build(threshold));
-        getFilterFactories().forEach(f -> appender.addFilter(f.build()));
-        appender.start();
-
-        return wrapAsync(appender, asyncAppenderFactory);
+        return appender;
     }
 
     protected FileAppender<E> buildAppender(LoggerContext context) {

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/TcpSocketAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/TcpSocketAppenderFactory.java
@@ -1,0 +1,151 @@
+package io.dropwizard.logging;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
+import ch.qos.logback.core.spi.DeferredProcessingAware;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.dropwizard.logging.async.AsyncAppenderFactory;
+import io.dropwizard.logging.filter.LevelFilterFactory;
+import io.dropwizard.logging.layout.LayoutFactory;
+import io.dropwizard.logging.socket.DropwizardSocketAppender;
+import io.dropwizard.util.Duration;
+import io.dropwizard.util.Size;
+import io.dropwizard.validation.MinSize;
+import io.dropwizard.validation.PortRange;
+import org.hibernate.validator.constraints.NotEmpty;
+
+import javax.net.SocketFactory;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+/**
+ * An {@link AppenderFactory} implementation which provides an appender that writes events to a TCP socket.
+ * <p/>
+ * <b>Configuration Parameters:</b>
+ * <table>
+ * <tr>
+ * <td>Name</td>
+ * <td>Default</td>
+ * <td>Description</td>
+ * </tr>
+ * <tr>
+ * <td>{@code host}</td>
+ * <td>{@code localhost}</td>
+ * <td>The hostname of the TCP server.</td>
+ * </tr>
+ * <tr>
+ * <td>{@code port}</td>
+ * <td>{@code 4560}</td>
+ * <td>The port on which the TCP server is listening.</td>
+ * </tr>
+ * <tr>
+ * <td>{@code connectionTimeout}</td>
+ * <td>{@code 500 ms}</td>
+ * <td>The timeout to connect to the TCP server.</td>
+ * </tr>
+ * <tr>
+ * <td>{@code immediateFlush}</td>
+ * <td>{@code true}</td>
+ * <td>If set to true, log events will be immediately send to the server. Immediate flushing is safer, but it
+ * degrades logging throughput.</td>
+ * </tr>
+ * <tr>
+ * <td>{@code sendBufferSize}</td>
+ * <td>8KB</td>
+ * <td>The buffer size of the underlying SocketAppender. Takes into effect if immediateFlush is disabled.</td>
+ * </tr>
+ * </table>
+ */
+@JsonTypeName("tcp")
+public class TcpSocketAppenderFactory<E extends DeferredProcessingAware> extends AbstractAppenderFactory<E> {
+
+    @NotEmpty
+    private String host = "localhost";
+
+    @PortRange
+    private int port = 4560;
+
+    @NotNull
+    private Duration connectionTimeout = Duration.milliseconds(500);
+
+    private boolean immediateFlush = true;
+
+    @MinSize(1)
+    private Size sendBufferSize = Size.kilobytes(8);
+
+    @JsonProperty
+    public String getHost() {
+        return host;
+    }
+
+    @JsonProperty
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    @JsonProperty
+    public int getPort() {
+        return port;
+    }
+
+    @JsonProperty
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    @JsonProperty
+    public Duration getConnectionTimeout() {
+        return connectionTimeout;
+    }
+
+    @JsonProperty
+    public void setConnectionTimeout(Duration connectionTimeout) {
+        this.connectionTimeout = connectionTimeout;
+    }
+
+    @JsonProperty
+    public boolean isImmediateFlush() {
+        return immediateFlush;
+    }
+
+    @JsonProperty
+    public void setImmediateFlush(boolean immediateFlush) {
+        this.immediateFlush = immediateFlush;
+    }
+
+    @JsonProperty
+    public Size getSendBufferSize() {
+        return sendBufferSize;
+    }
+
+    @JsonProperty
+    public void setSendBufferSize(Size sendBufferSize) {
+        this.sendBufferSize = sendBufferSize;
+    }
+
+    @Override
+    public Appender<E> build(LoggerContext context, String applicationName, LayoutFactory<E> layoutFactory,
+                             LevelFilterFactory<E> levelFilterFactory, AsyncAppenderFactory<E> asyncAppenderFactory) {
+        final DropwizardSocketAppender<E> appender = new DropwizardSocketAppender<>(host, port,
+            (int) connectionTimeout.toMilliseconds(), (int) sendBufferSize.toBytes(), socketFactory());
+        appender.setContext(context);
+        appender.setName("tcp-socket-appender");
+        appender.setImmediateFlush(immediateFlush);
+
+        final LayoutWrappingEncoder<E> layoutEncoder = new LayoutWrappingEncoder<>();
+        layoutEncoder.setLayout(buildLayout(context, layoutFactory));
+        appender.setEncoder(layoutEncoder);
+
+        appender.addFilter(levelFilterFactory.build(threshold));
+        getFilterFactories().forEach(f -> appender.addFilter(f.build()));
+        appender.start();
+        return wrapAsync(appender, asyncAppenderFactory);
+    }
+
+    protected SocketFactory socketFactory() {
+        return SocketFactory.getDefault();
+    }
+
+}

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/TcpSocketAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/TcpSocketAppenderFactory.java
@@ -1,14 +1,10 @@
 package io.dropwizard.logging;
 
 import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.core.Appender;
-import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
+import ch.qos.logback.core.OutputStreamAppender;
 import ch.qos.logback.core.spi.DeferredProcessingAware;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import io.dropwizard.logging.async.AsyncAppenderFactory;
-import io.dropwizard.logging.filter.LevelFilterFactory;
-import io.dropwizard.logging.layout.LayoutFactory;
 import io.dropwizard.logging.socket.DropwizardSocketAppender;
 import io.dropwizard.util.Duration;
 import io.dropwizard.util.Size;
@@ -17,7 +13,6 @@ import io.dropwizard.validation.PortRange;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.net.SocketFactory;
-import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 /**
@@ -59,7 +54,7 @@ import javax.validation.constraints.NotNull;
  * </table>
  */
 @JsonTypeName("tcp")
-public class TcpSocketAppenderFactory<E extends DeferredProcessingAware> extends AbstractAppenderFactory<E> {
+public class TcpSocketAppenderFactory<E extends DeferredProcessingAware> extends AbstractOutputStreamAppenderFactory<E> {
 
     @NotEmpty
     private String host = "localhost";
@@ -126,22 +121,13 @@ public class TcpSocketAppenderFactory<E extends DeferredProcessingAware> extends
     }
 
     @Override
-    public Appender<E> build(LoggerContext context, String applicationName, LayoutFactory<E> layoutFactory,
-                             LevelFilterFactory<E> levelFilterFactory, AsyncAppenderFactory<E> asyncAppenderFactory) {
-        final DropwizardSocketAppender<E> appender = new DropwizardSocketAppender<>(host, port,
+    protected OutputStreamAppender<E> appender(LoggerContext context) {
+        final OutputStreamAppender<E> appender = new DropwizardSocketAppender<>(host, port,
             (int) connectionTimeout.toMilliseconds(), (int) sendBufferSize.toBytes(), socketFactory());
         appender.setContext(context);
         appender.setName("tcp-socket-appender");
         appender.setImmediateFlush(immediateFlush);
-
-        final LayoutWrappingEncoder<E> layoutEncoder = new LayoutWrappingEncoder<>();
-        layoutEncoder.setLayout(buildLayout(context, layoutFactory));
-        appender.setEncoder(layoutEncoder);
-
-        appender.addFilter(levelFilterFactory.build(threshold));
-        getFilterFactories().forEach(f -> appender.addFilter(f.build()));
-        appender.start();
-        return wrapAsync(appender, asyncAppenderFactory);
+        return appender;
     }
 
     protected SocketFactory socketFactory() {

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/UdpSocketAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/UdpSocketAppenderFactory.java
@@ -1,0 +1,83 @@
+package io.dropwizard.logging;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
+import ch.qos.logback.core.spi.DeferredProcessingAware;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.dropwizard.logging.async.AsyncAppenderFactory;
+import io.dropwizard.logging.filter.LevelFilterFactory;
+import io.dropwizard.logging.layout.LayoutFactory;
+import io.dropwizard.logging.socket.DropwizardUdpSocketAppender;
+import io.dropwizard.validation.PortRange;
+import org.hibernate.validator.constraints.NotEmpty;
+
+/**
+ * An {@link AppenderFactory} implementation which provides an appender that writes events to an UDP socket.
+ * <p/>
+ * <b>Configuration Parameters:</b>
+ * <table>
+ * <tr>
+ * <td>Name</td>
+ * <td>Default</td>
+ * <td>Description</td>
+ * </tr>
+ * <tr>
+ * <td>{@code host}</td>
+ * <td>{@code localhost}</td>
+ * <td>The hostname of the UDP server.</td>
+ * </tr>
+ * <tr>
+ * <td>{@code port}</td>
+ * <td>{@code 514}</td>
+ * <td>The port on which the UDP server is listening.</td>
+ * </tr>
+ * </table>
+ */
+@JsonTypeName("udp")
+public class UdpSocketAppenderFactory<E extends DeferredProcessingAware> extends AbstractAppenderFactory<E> {
+
+    @NotEmpty
+    private String host = "localhost";
+
+    @PortRange
+    private int port = 514;
+
+    @JsonProperty
+    public String getHost() {
+        return host;
+    }
+
+    @JsonProperty
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    @JsonProperty
+    public int getPort() {
+        return port;
+    }
+
+    @JsonProperty
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    @Override
+    public Appender<E> build(LoggerContext context, String applicationName, LayoutFactory<E> layoutFactory,
+                             LevelFilterFactory<E> levelFilterFactory, AsyncAppenderFactory<E> asyncAppenderFactory) {
+        final DropwizardUdpSocketAppender<E> appender = new DropwizardUdpSocketAppender<>(host, port);
+        appender.setContext(context);
+        appender.setName("udp-socket-appender");
+
+        final LayoutWrappingEncoder<E> layoutEncoder = new LayoutWrappingEncoder<>();
+        layoutEncoder.setLayout(buildLayout(context, layoutFactory));
+        appender.setEncoder(layoutEncoder);
+
+        appender.addFilter(levelFilterFactory.build(threshold));
+        getFilterFactories().forEach(f -> appender.addFilter(f.build()));
+        appender.start();
+        return wrapAsync(appender, asyncAppenderFactory);
+    }
+}

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/UdpSocketAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/UdpSocketAppenderFactory.java
@@ -1,14 +1,10 @@
 package io.dropwizard.logging;
 
 import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.core.Appender;
-import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
+import ch.qos.logback.core.OutputStreamAppender;
 import ch.qos.logback.core.spi.DeferredProcessingAware;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import io.dropwizard.logging.async.AsyncAppenderFactory;
-import io.dropwizard.logging.filter.LevelFilterFactory;
-import io.dropwizard.logging.layout.LayoutFactory;
 import io.dropwizard.logging.socket.DropwizardUdpSocketAppender;
 import io.dropwizard.validation.PortRange;
 import org.hibernate.validator.constraints.NotEmpty;
@@ -36,7 +32,7 @@ import org.hibernate.validator.constraints.NotEmpty;
  * </table>
  */
 @JsonTypeName("udp")
-public class UdpSocketAppenderFactory<E extends DeferredProcessingAware> extends AbstractAppenderFactory<E> {
+public class UdpSocketAppenderFactory<E extends DeferredProcessingAware> extends AbstractOutputStreamAppenderFactory<E> {
 
     @NotEmpty
     private String host = "localhost";
@@ -65,19 +61,10 @@ public class UdpSocketAppenderFactory<E extends DeferredProcessingAware> extends
     }
 
     @Override
-    public Appender<E> build(LoggerContext context, String applicationName, LayoutFactory<E> layoutFactory,
-                             LevelFilterFactory<E> levelFilterFactory, AsyncAppenderFactory<E> asyncAppenderFactory) {
+    protected OutputStreamAppender<E> appender(LoggerContext context) {
         final DropwizardUdpSocketAppender<E> appender = new DropwizardUdpSocketAppender<>(host, port);
         appender.setContext(context);
         appender.setName("udp-socket-appender");
-
-        final LayoutWrappingEncoder<E> layoutEncoder = new LayoutWrappingEncoder<>();
-        layoutEncoder.setLayout(buildLayout(context, layoutFactory));
-        appender.setEncoder(layoutEncoder);
-
-        appender.addFilter(levelFilterFactory.build(threshold));
-        getFilterFactories().forEach(f -> appender.addFilter(f.build()));
-        appender.start();
-        return wrapAsync(appender, asyncAppenderFactory);
+        return appender;
     }
 }

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/socket/DropwizardSocketAppender.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/socket/DropwizardSocketAppender.java
@@ -1,0 +1,43 @@
+package io.dropwizard.logging.socket;
+
+import ch.qos.logback.core.OutputStreamAppender;
+import ch.qos.logback.core.recovery.ResilentSocketOutputStream;
+import ch.qos.logback.core.spi.DeferredProcessingAware;
+
+import javax.net.SocketFactory;
+import java.io.OutputStream;
+
+/**
+ * Sends log events to a TCP server, a connection to which is represented as {@link ResilentSocketOutputStream}.
+ */
+public class DropwizardSocketAppender<E extends DeferredProcessingAware> extends OutputStreamAppender<E> {
+
+    private final String host;
+    private final int port;
+    private final int connectionTimeoutMs;
+    private final int sendBufferSize;
+    private final SocketFactory socketFactory;
+
+    public DropwizardSocketAppender(String host, int port, int connectionTimeoutMs, int sendBufferSize,
+                                    SocketFactory socketFactory) {
+        this.host = host;
+        this.port = port;
+        this.connectionTimeoutMs = connectionTimeoutMs;
+        this.sendBufferSize = sendBufferSize;
+        this.socketFactory = socketFactory;
+    }
+
+    @Override
+    public void start() {
+        setOutputStream(socketOutputStream());
+        super.start();
+    }
+
+    protected OutputStream socketOutputStream() {
+        final ResilentSocketOutputStream outputStream = new ResilentSocketOutputStream(host, port,
+            connectionTimeoutMs, sendBufferSize, socketFactory);
+        outputStream.setContext(context);
+        return outputStream;
+    }
+}
+

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/socket/DropwizardUdpSocketAppender.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/socket/DropwizardUdpSocketAppender.java
@@ -1,0 +1,57 @@
+package io.dropwizard.logging.socket;
+
+import ch.qos.logback.core.OutputStreamAppender;
+import ch.qos.logback.core.spi.DeferredProcessingAware;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.SocketException;
+
+/**
+ * Sends log events to a UDP server, a connection to which is represented as a stream.
+ */
+public class DropwizardUdpSocketAppender<E extends DeferredProcessingAware> extends OutputStreamAppender<E> {
+
+    private final String host;
+    private final int port;
+
+    public DropwizardUdpSocketAppender(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    @Override
+    public void start() {
+        setOutputStream(datagramSocketOutputStream(host, port));
+        super.start();
+    }
+
+    protected OutputStream datagramSocketOutputStream(String host, int port) {
+        final DatagramSocket datagramSocket;
+        try {
+            datagramSocket = new DatagramSocket();
+        } catch (SocketException e) {
+            throw new IllegalStateException("Unable to create a datagram socket", e);
+        }
+        return new OutputStream() {
+            @Override
+            public void write(int b) throws IOException {
+                throw new UnsupportedOperationException("Datagram doesn't work at byte level");
+            }
+
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+                // Important not to cache InetAddress and let the JVM/OS to handle DNS caching.
+                datagramSocket.send(new DatagramPacket(b, off, len, InetAddress.getByName(host), port));
+            }
+
+            @Override
+            public void close() throws IOException {
+                datagramSocket.close();
+            }
+        };
+    }
+}

--- a/dropwizard-logging/src/main/resources/META-INF/services/io.dropwizard.logging.AppenderFactory
+++ b/dropwizard-logging/src/main/resources/META-INF/services/io.dropwizard.logging.AppenderFactory
@@ -1,3 +1,5 @@
 io.dropwizard.logging.ConsoleAppenderFactory
 io.dropwizard.logging.FileAppenderFactory
 io.dropwizard.logging.SyslogAppenderFactory
+io.dropwizard.logging.TcpSocketAppenderFactory
+io.dropwizard.logging.UdpSocketAppenderFactory

--- a/dropwizard-logging/src/test/java/ch/qos/logback/core/recovery/ResilentSocketOutputStreamTest.java
+++ b/dropwizard-logging/src/test/java/ch/qos/logback/core/recovery/ResilentSocketOutputStreamTest.java
@@ -1,0 +1,82 @@
+package ch.qos.logback.core.recovery;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.net.SocketFactory;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+public class ResilentSocketOutputStreamTest {
+
+    private ResilentSocketOutputStream resilentSocketOutputStream;
+
+    private Thread thread;
+    private ServerSocket ss;
+    private CountDownLatch latch = new CountDownLatch(1);
+
+    @Before
+    public void setUp() throws Exception {
+        ss = new ServerSocket(0);
+        thread = new Thread(() -> {
+            while (!Thread.currentThread().isInterrupted()) {
+                try (Socket socket = ss.accept()) {
+                    byte[] buffer = new byte[128];
+                    int read = socket.getInputStream().read(buffer);
+                    if (read > 0) {
+                        assertThat(new String(buffer, 0, read, StandardCharsets.UTF_8)).isEqualTo("Test message");
+                        latch.countDown();
+                    }
+                } catch (IOException e) {
+                    break;
+                }
+            }
+        });
+        thread.start();
+        resilentSocketOutputStream = new ResilentSocketOutputStream("localhost", ss.getLocalPort(),
+            1024, 500, SocketFactory.getDefault());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        ss.close();
+        thread.interrupt();
+        resilentSocketOutputStream.close();
+    }
+
+    @Test
+    public void testCreatesCleanOutputStream() throws Exception {
+        assertThat(resilentSocketOutputStream.presumedClean).isTrue();
+        assertThat(resilentSocketOutputStream.os).isNotNull();
+    }
+
+    @Test
+    public void testThrowsExceptionIfCantCreateOutputStream() throws Exception {
+        assertThatIllegalStateException().isThrownBy(() -> new ResilentSocketOutputStream("10.255.255.1", 1024,
+            100, 1024, SocketFactory.getDefault()))
+            .withMessage("Unable to create a TCP connection to 10.255.255.1:1024");
+    }
+
+    @Test
+    public void testWriteMessage() throws Exception {
+        resilentSocketOutputStream.write("Test message".getBytes(StandardCharsets.UTF_8));
+        resilentSocketOutputStream.flush();
+
+        latch.await(5, TimeUnit.SECONDS);
+        assertThat(latch.getCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void testGetDescription() {
+        assertThat(resilentSocketOutputStream.getDescription()).isEqualTo(String.format("tcp [localhost:%d]",
+            ss.getLocalPort()));
+    }
+}

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/TcpSocketAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/TcpSocketAppenderFactoryTest.java
@@ -1,0 +1,137 @@
+package io.dropwizard.logging;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.Resources;
+import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.util.Duration;
+import io.dropwizard.util.Size;
+import io.dropwizard.validation.BaseValidator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketException;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TcpSocketAppenderFactoryTest {
+    private static final int TCP_PORT = 24562;
+
+    private Thread thread;
+    private ServerSocket ss;
+
+    private int messageCount = 100;
+    private CountDownLatch latch = new CountDownLatch(messageCount);
+
+    private ObjectMapper objectMapper = Jackson.newObjectMapper();
+    private YamlConfigurationFactory<DefaultLoggingFactory> yamlConfigurationFactory = new YamlConfigurationFactory<>(
+        DefaultLoggingFactory.class, BaseValidator.newValidator(), objectMapper, "dw-tcp");
+
+    @Before
+    public void setUp() throws Exception {
+        objectMapper.getSubtypeResolver().registerSubtypes(TcpSocketAppenderFactory.class);
+        ss = new ServerSocket(TCP_PORT);
+        thread = new Thread(() -> {
+            while (!Thread.currentThread().isInterrupted()) {
+                Socket socket;
+                try {
+                    socket = ss.accept();
+                } catch (SocketException e) {
+                    break;
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    continue;
+                }
+                new Thread(() -> readAndVerifyData(socket)).start();
+            }
+        });
+        thread.start();
+    }
+
+    private void readAndVerifyData(Socket socket) {
+        try (Socket s = socket; BufferedReader reader = new BufferedReader(new InputStreamReader(
+            s.getInputStream(), StandardCharsets.UTF_8))) {
+            for (int i = 0; i < messageCount; i++) {
+                String line = reader.readLine();
+                if (line == null) {
+                    break;
+                }
+                assertThat(line).startsWith("INFO").contains("com.example.app: Application log " + i);
+                latch.countDown();
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+
+    @After
+    public void tearDown() throws Exception {
+        thread.interrupt();
+        ss.close();
+    }
+
+    private static File resourcePath(String path) throws URISyntaxException {
+        return new File(Resources.getResource(path).toURI());
+    }
+
+    @Test
+    public void testParseConfig() throws Exception {
+        DefaultLoggingFactory loggingFactory = yamlConfigurationFactory.build(resourcePath("yaml/logging-tcp-custom.yml"));
+        assertThat(loggingFactory.getAppenders()).hasSize(1);
+        TcpSocketAppenderFactory<ILoggingEvent> tcpAppenderFactory = (TcpSocketAppenderFactory<ILoggingEvent>)
+            loggingFactory.getAppenders().get(0);
+        assertThat(tcpAppenderFactory.getHost()).isEqualTo("172.16.11.245");
+        assertThat(tcpAppenderFactory.getPort()).isEqualTo(17001);
+        assertThat(tcpAppenderFactory.getConnectionTimeout()).isEqualTo(Duration.milliseconds(100));
+        assertThat(tcpAppenderFactory.getSendBufferSize()).isEqualTo(Size.kilobytes(2));
+        assertThat(tcpAppenderFactory.isImmediateFlush()).isFalse();
+    }
+
+    @Test
+    public void testTestTcpLogging() throws Exception {
+        DefaultLoggingFactory loggingFactory = yamlConfigurationFactory.build(resourcePath("yaml/logging-tcp.yml"));
+        loggingFactory.configure(new MetricRegistry(), "tcp-test");
+
+        Logger logger = LoggerFactory.getLogger("com.example.app");
+        for (int i = 0; i < messageCount; i++) {
+            logger.info("Application log {}", i);
+        }
+
+        latch.await(5, TimeUnit.SECONDS);
+        assertThat(latch.getCount()).isEqualTo(0);
+        loggingFactory.reset();
+    }
+
+    @Test
+    public void testBufferingTcpLogging() throws Exception {
+        DefaultLoggingFactory loggingFactory = yamlConfigurationFactory.build(resourcePath(
+            "yaml/logging-tcp-buffered.yml"));
+        loggingFactory.configure(new MetricRegistry(), "tcp-test");
+
+        Logger logger = LoggerFactory.getLogger("com.example.app");
+        for (int i = 0; i < messageCount; i++) {
+            logger.info("Application log {}", i);
+        }
+        // We have to flush the buffer manually
+        loggingFactory.reset();
+
+        latch.await(5, TimeUnit.SECONDS);
+        assertThat(latch.getCount()).isEqualTo(0);
+    }
+}

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/UdpSocketAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/UdpSocketAppenderFactoryTest.java
@@ -1,0 +1,82 @@
+package io.dropwizard.logging;
+
+import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.Resources;
+import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.validation.BaseValidator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.SocketException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UdpSocketAppenderFactoryTest {
+
+    private static final int UDP_PORT = 32144;
+
+    private Thread thread;
+    private DatagramSocket datagramSocket;
+
+    private int messagesCount = 100;
+    private CountDownLatch countDownLatch = new CountDownLatch(messagesCount);
+
+    @Before
+    public void setUp() throws Exception {
+        datagramSocket = new DatagramSocket(UDP_PORT);
+        thread = new Thread(() -> {
+            byte[] buffer = new byte[256];
+            for (int i = 0; i < messagesCount; i++) {
+                try {
+                    DatagramPacket datagramPacket = new DatagramPacket(buffer, buffer.length);
+                    datagramSocket.receive(datagramPacket);
+                    assertThat(new String(buffer, 0, datagramPacket.getLength()))
+                        .startsWith("INFO").contains("com.example.app: Application log " + i);
+                    countDownLatch.countDown();
+                } catch (SocketException e) {
+                    break;
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        });
+        thread.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        thread.interrupt();
+        datagramSocket.close();
+    }
+
+    @Test
+    public void testSendLogsByTcp() throws Exception {
+        ObjectMapper objectMapper = Jackson.newObjectMapper();
+        objectMapper.getSubtypeResolver().registerSubtypes(UdpSocketAppenderFactory.class);
+
+        DefaultLoggingFactory loggingFactory = new YamlConfigurationFactory<>(DefaultLoggingFactory.class,
+            BaseValidator.newValidator(), objectMapper, "dw-udp")
+            .build(new File(Resources.getResource("yaml/logging-udp.yml").toURI()));
+        loggingFactory.configure(new MetricRegistry(), "udp-test");
+
+        Logger logger = LoggerFactory.getLogger("com.example.app");
+        for (int i = 0; i < 100; i++) {
+            logger.info("Application log {}", i);
+        }
+
+        countDownLatch.await(5, TimeUnit.SECONDS);
+        assertThat(countDownLatch.getCount()).isEqualTo(0);
+        loggingFactory.reset();
+    }
+}

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/socket/DropwizardUdpSocketAppenderTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/socket/DropwizardUdpSocketAppenderTest.java
@@ -1,0 +1,65 @@
+package io.dropwizard.logging.socket;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Context;
+import ch.qos.logback.core.OutputStreamAppender;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DropwizardUdpSocketAppenderTest {
+
+    private OutputStreamAppender<ILoggingEvent> udpStreamAppender;
+
+    private DatagramSocket datagramSocket;
+    private Thread thread;
+    private CountDownLatch countDownLatch = new CountDownLatch(1);
+
+    @Before
+    public void setUp() throws Exception {
+        datagramSocket = new DatagramSocket();
+        thread = new Thread(() -> {
+            byte[] buffer = new byte[128];
+            while (!Thread.currentThread().isInterrupted()) {
+                DatagramPacket datagramPacket = new DatagramPacket(buffer, buffer.length);
+                try {
+                    datagramSocket.receive(datagramPacket);
+                    assertThat(new String(buffer, 0, datagramPacket.getLength(), UTF_8))
+                        .isEqualTo("Test message");
+                    countDownLatch.countDown();
+                } catch (IOException e) {
+                    break;
+                }
+            }
+        });
+        thread.start();
+        udpStreamAppender = new DropwizardUdpSocketAppender<>("localhost", datagramSocket.getLocalPort());
+        udpStreamAppender.setContext(Mockito.mock(Context.class));
+        udpStreamAppender.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        datagramSocket.close();
+        thread.interrupt();
+        udpStreamAppender.stop();
+    }
+
+    @Test
+    public void testSendMessage() throws Exception {
+        udpStreamAppender.getOutputStream().write("Test message".getBytes(UTF_8));
+
+        countDownLatch.await(5, TimeUnit.SECONDS);
+        assertThat(countDownLatch.getCount()).isEqualTo(0);
+    }
+}

--- a/dropwizard-logging/src/test/resources/yaml/logging-tcp-buffered.yml
+++ b/dropwizard-logging/src/test/resources/yaml/logging-tcp-buffered.yml
@@ -1,0 +1,7 @@
+level: INFO
+appenders:
+  - type: tcp
+    host: localhost
+    port: 24562
+    immediateFlush: false
+    sendBufferSize: 1KB

--- a/dropwizard-logging/src/test/resources/yaml/logging-tcp-custom.yml
+++ b/dropwizard-logging/src/test/resources/yaml/logging-tcp-custom.yml
@@ -1,0 +1,8 @@
+level: INFO
+appenders:
+  - type: tcp
+    host: 172.16.11.245
+    port: 17001
+    connectionTimeout: 100ms
+    immediateFlush: false
+    sendBufferSize: 2KB

--- a/dropwizard-logging/src/test/resources/yaml/logging-tcp.yml
+++ b/dropwizard-logging/src/test/resources/yaml/logging-tcp.yml
@@ -1,0 +1,5 @@
+level: INFO
+appenders:
+  - type: tcp
+    host: localhost
+    port: 24562

--- a/dropwizard-logging/src/test/resources/yaml/logging-udp.yml
+++ b/dropwizard-logging/src/test/resources/yaml/logging-udp.yml
@@ -1,0 +1,5 @@
+level: INFO
+appenders:
+  - type: udp
+    host: localhost
+    port: 32144


### PR DESCRIPTION
Add support for sending log events to a log management server via TCP or UDP. This is useful for applications that want ship logs to a remote machine for processing/alerting. We recently have added support for formatting messages as JSON and in combination with TCP/UDP logging it can be an interesting solution for a direct log shipping from Dropwizard without 3rd-party modules. 

From the implementation side `TcpSocketAppenderFactory` and `UdpSocketAppenderFactory` are both discoverable and work with generic logging events. That means they can be configured in a YAML config file for general and request logging.
```yaml
logging:
  level: INFO
  appenders:
    - type: tcp
      host: localhost
      port: 24562
```

```yaml
server:
  requestLog:
    appenders:
      - type: tcp
        host: localhost
        port: 24562
```

From the reliability side, the appenders extend `ResilientOutputStreamBase`. That means in case if the connections drops because of network glitch or a DNS failure, it will back off and try to reopen a new connection automatically.