### PR TITLE
Add configuration option to EventJsonLayoutBaseFactory to flatten MDC

### DIFF
--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/EventJsonLayoutBaseFactory.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/EventJsonLayoutBaseFactory.java
@@ -31,6 +31,11 @@ import java.util.TimeZone;
  * <td>(empty)</td>
  * <td>Set of MDC keys which should be included in the JSON map. By default includes everything.</td>
  * </tr>
+ * <tr>
+ * <td>{@code flattenMdc}</td>
+ * <td>{@code false}</td>
+ * <td>Whether the MDC should be included under the key "mdc" or flattened into the map.</td>
+ * </tr>
  * </table>
  */
 @JsonTypeName("json")
@@ -41,6 +46,7 @@ public class EventJsonLayoutBaseFactory extends AbstractJsonLayoutBaseFactory<IL
         EventAttribute.EXCEPTION, EventAttribute.TIMESTAMP);
 
     private Set<String> includesMdcKeys = ImmutableSet.of();
+    private boolean flattenMdc = false;
 
     @JsonProperty
     public EnumSet<EventAttribute> getIncludes() {
@@ -62,12 +68,22 @@ public class EventJsonLayoutBaseFactory extends AbstractJsonLayoutBaseFactory<IL
         this.includesMdcKeys = includesMdcKeys;
     }
 
+    @JsonProperty
+    public boolean isFlattenMdc() {
+        return flattenMdc;
+    }
+
+    @JsonProperty
+    public void setFlattenMdc(boolean flattenMdc) {
+        this.flattenMdc = flattenMdc;
+    }
+
     @Override
     @SuppressWarnings("unchecked")
     public LayoutBase<ILoggingEvent> build(LoggerContext context, TimeZone timeZone) {
         final EventJsonLayout jsonLayout = new EventJsonLayout(createDropwizardJsonFormatter(),
             createTimestampFormatter(timeZone), createThrowableProxyConverter(), includes, getCustomFieldNames(),
-            getAdditionalFields(), includesMdcKeys);
+            getAdditionalFields(), includesMdcKeys, flattenMdc);
         jsonLayout.setContext(context);
         return jsonLayout;
     }

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
@@ -74,6 +74,7 @@ public class LayoutIntegrationTests {
             EventAttribute.LOGGER_NAME,
             EventAttribute.EXCEPTION,
             EventAttribute.TIMESTAMP);
+        assertThat(factory.isFlattenMdc()).isTrue();
         assertThat(factory.getCustomFieldNames()).containsOnly(entry("timestamp", "@timestamp"));
         assertThat(factory.getAdditionalFields()).containsOnly(entry("service-name", "user-service"),
             entry("service-build", 218));

--- a/dropwizard-json-logging/src/test/resources/yaml/json-log.yml
+++ b/dropwizard-json-logging/src/test/resources/yaml/json-log.yml
@@ -18,4 +18,5 @@ layout:
     service-name: "user-service"
     service-build: 218
   includesMdcKeys: [userId]
+  flattenMdc: true
 


### PR DESCRIPTION
###### Problem:
My logging needs are to have the MDC in the root JSON object, not nested under the key `mdc`. 

###### Solution:
A configuration option (defaulting to false) that allows the user the flatten MDC into the root object.
