### PR TITLE
Allow to use some custom security provider in HTTP client

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -440,7 +440,7 @@ enableCRLDP                      false               Whether or not CRL Distribu
 enableOCSP                       false               Whether or not On-Line Certificate Status Protocol (OCSP) support is enabled.
 maxCertPathLength                (unlimited)         The maximum certification path length.
 ocspResponderUrl                 (none)              The location of the OCSP responder.
-jceProvider                      (none)              The name of the JCE provider to use for cryptographic support.
+jceProvider                      (none)              The name of the JCE provider to use for cryptographic support. See `Oracle documentation <https://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html>`_ for more information.
 validateCerts                    false               Whether or not to validate TLS certificates before starting. If enabled, Dropwizard
                                                      will refuse to start with expired or otherwise invalid certificates. This option will
                                                      cause unconditional failure in Dropwizard 1.x until a new validation mechanism can be
@@ -1315,6 +1315,7 @@ protocol                     TLSv1.2            The default protocol the client 
                                                 See
                                                 `here <http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#SSLContext>`_ for more information.
 provider                     (none)             The name of the JCE provider to use on client side for cryptographic support (for example, SunJCE, Conscrypt, BC, etc).
+                                                See `Oracle documentation <https://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html>`_ for more information.
 verifyHostname               true               Whether to verify the hostname of the server against the hostname presented in the server certificate.
 keyStorePath                 (none)             The path to the Java key store which contains the client certificate and private key.
 keyStorePassword             (none)             The password used to access the key store.

--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -1294,7 +1294,7 @@ TLS
     httpClient:
       tls:
         protocol: TLSv1.2
-        provider: SUN
+        provider: SunJSSE
         verifyHostname: true
         keyStorePath: /path/to/file
         keyStorePassword: changeit

--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -1314,7 +1314,7 @@ Name                         Default            Description
 protocol                     TLSv1.2            The default protocol the client will attempt to use during the SSL Handshake.
                                                 See
                                                 `here <http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#SSLContext>`_ for more information.
-provider                     (none)             The name of the JCE provider to use on client side for cryptographic support.
+provider                     (none)             The name of the JCE provider to use on client side for cryptographic support (for example, SunJCE, Conscrypt, BC, etc).
 verifyHostname               true               Whether to verify the hostname of the server against the hostname presented in the server certificate.
 keyStorePath                 (none)             The path to the Java key store which contains the client certificate and private key.
 keyStorePassword             (none)             The password used to access the key store.

--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -1294,6 +1294,7 @@ TLS
     httpClient:
       tls:
         protocol: TLSv1.2
+        provider: SUN
         verifyHostname: true
         keyStorePath: /path/to/file
         keyStorePassword: changeit
@@ -1313,6 +1314,7 @@ Name                         Default            Description
 protocol                     TLSv1.2            The default protocol the client will attempt to use during the SSL Handshake.
                                                 See
                                                 `here <http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#SSLContext>`_ for more information.
+provider                     (none)             The name of the JCE provider to use on client side for cryptographic support.
 verifyHostname               true               Whether to verify the hostname of the server against the hostname presented in the server certificate.
 keyStorePath                 (none)             The path to the Java key store which contains the client certificate and private key.
 keyStorePassword             (none)             The password used to access the key store.

--- a/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactory.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactory.java
@@ -71,7 +71,8 @@ public class DropwizardSSLConnectionSocketFactory {
         final SSLContext sslContext;
         try {
             final SSLContextBuilder sslContextBuilder = new SSLContextBuilder();
-            sslContextBuilder.useProtocol(configuration.getProtocol());
+            sslContextBuilder.setProtocol(configuration.getProtocol());
+            sslContextBuilder.setProvider(configuration.getProvider());
             loadKeyMaterial(sslContextBuilder);
             loadTrustMaterial(sslContextBuilder);
             sslContext = sslContextBuilder.build();

--- a/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactory.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactory.java
@@ -72,7 +72,10 @@ public class DropwizardSSLConnectionSocketFactory {
         try {
             final SSLContextBuilder sslContextBuilder = new SSLContextBuilder();
             sslContextBuilder.setProtocol(configuration.getProtocol());
-            sslContextBuilder.setProvider(configuration.getProvider());
+            final String configuredProvider = configuration.getProvider();
+            if (configuredProvider != null) {
+                sslContextBuilder.setProvider(configuredProvider);
+            }
             loadKeyMaterial(sslContextBuilder);
             loadTrustMaterial(sslContextBuilder);
             sslContext = sslContextBuilder.build();

--- a/dropwizard-client/src/main/java/io/dropwizard/client/ssl/TlsConfiguration.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/ssl/TlsConfiguration.java
@@ -143,6 +143,7 @@ public class TlsConfiguration {
     }
 
     @JsonProperty
+    @Nullable
     public String getProvider() {
         return provider;
     }

--- a/dropwizard-client/src/main/java/io/dropwizard/client/ssl/TlsConfiguration.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/ssl/TlsConfiguration.java
@@ -16,6 +16,9 @@ public class TlsConfiguration {
     private String protocol = "TLSv1.2";
 
     @Nullable
+    private String provider;
+
+    @Nullable
     private File keyStorePath;
 
     @Nullable
@@ -137,6 +140,16 @@ public class TlsConfiguration {
     @JsonProperty
     public void setProtocol(String protocol) {
         this.protocol = protocol;
+    }
+
+    @JsonProperty
+    public String getProvider() {
+        return provider;
+    }
+
+    @JsonProperty
+    public void setProvider(@Nullable String provider) {
+        this.provider = provider;
     }
 
     @Nullable


### PR DESCRIPTION
###### Problem:
Dropwizard allows to configure JCE provider for server side, passing `jceProvider` property to Jetty. This allows to use some non-standard provider, like Conscrypt. But there is no such setting on client side.

###### Solution:
Add new field `provider` to `TlsConfiguration` and pass it to Apache HTTP client builder.
