### PR TITLE
Make ignoreExceptionOnPreLoadon on PoolProperties configurable

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -1487,6 +1487,12 @@ validationInterval              30 seconds               To avoid excess validat
 validatorClassName              none                     Name of a class of a custom validator implementation, which
                                                          will be used for validating connections.
 jdbcInterceptors                none                       A semicolon separated list of JDBC interceptor classnames.
+
+ignoreExceptionOnPreLoad        false                    Flag whether ignore error of connection creation while
+                                                         initializing the pool. Set to true if you want to ignore
+                                                         error of connection creation while initializing the pool.
+                                                         Set to false if you want to fail the initialization of the
+                                                         pool by throwing exception.
 ============================    =====================    ===============================================================
 
 .. _man-configuration-polymorphic:

--- a/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
+++ b/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
@@ -295,6 +295,15 @@ import java.util.concurrent.TimeUnit;
  *             {@link org.apache.tomcat.jdbc.pool.JdbcInterceptor}
  *         </td>
  *     </tr>
+ *     <tr>
+ *         <td>{@code ignoreExceptionOnPreLoad}</td>
+ *         <td>{@code false}</td>
+ *         <td>
+ *             Flag whether ignore error of connection creation while initializing the pool. Set to
+ *             true if you want to ignore error of connection creation while initializing the pool.
+ *             Set to false if you want to fail the initialization of the pool by throwing exception.
+ *         </td>
+ *     </tr>
  * </table>
  */
 public class DataSourceFactory implements PooledDataSourceFactory {
@@ -419,6 +428,8 @@ public class DataSourceFactory implements PooledDataSourceFactory {
     private Duration removeAbandonedTimeout = Duration.seconds(60L);
 
     private Optional<String> jdbcInterceptors = Optional.empty();
+
+    private boolean ignoreExceptionOnPreLoad = false;
 
     @JsonProperty
     @Override
@@ -836,6 +847,16 @@ public class DataSourceFactory implements PooledDataSourceFactory {
         this.jdbcInterceptors = jdbcInterceptors;
     }
 
+    @JsonProperty
+    public boolean isIgnoreExceptionOnPreLoad() {
+        return ignoreExceptionOnPreLoad;
+    }
+
+    @JsonProperty
+    public void setIgnoreExceptionOnPreLoad(boolean ignoreExceptionOnPreLoad) {
+        this.ignoreExceptionOnPreLoad = ignoreExceptionOnPreLoad;
+    }
+
     @Override
     public void asSingleConnectionPool() {
         minSize = 1;
@@ -862,6 +883,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
         poolConfig.setDefaultTransactionIsolation(defaultTransactionIsolation.get());
         poolConfig.setDriverClassName(driverClass);
         poolConfig.setFairQueue(useFairQueue);
+        poolConfig.setIgnoreExceptionOnPreLoad(ignoreExceptionOnPreLoad);
         poolConfig.setInitialSize(initialSize);
         poolConfig.setInitSQL(initializationQuery);
         poolConfig.setLogAbandoned(logAbandonedConnections);

--- a/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceConfigurationTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceConfigurationTest.java
@@ -55,6 +55,7 @@ public class DataSourceConfigurationTest {
         assertThat(ds.getValidationQueryTimeout()).isEqualTo(Optional.of(Duration.seconds(3)));
         assertThat(ds.getValidatorClassName()).isEqualTo(Optional.of("io.dropwizard.db.CustomConnectionValidator"));
         assertThat(ds.getJdbcInterceptors()).isEqualTo(Optional.of("StatementFinalizer;SlowQueryReport"));
+        assertThat(ds.isIgnoreExceptionOnPreLoad()).isTrue();
     }
 
     @Test
@@ -96,6 +97,7 @@ public class DataSourceConfigurationTest {
         assertThat(ds.getCheckConnectionOnConnect()).isEqualTo(true);
         assertThat(ds.getCheckConnectionOnReturn()).isEqualTo(false);
         assertThat(ds.getValidationQueryTimeout()).isEqualTo(Optional.empty());
+        assertThat(ds.isIgnoreExceptionOnPreLoad()).isFalse();
     }
 
     @Test

--- a/dropwizard-db/src/test/resources/yaml/full_db_pool.yml
+++ b/dropwizard-db/src/test/resources/yaml/full_db_pool.yml
@@ -34,6 +34,7 @@ defaultTransactionIsolation: read-committed
 removeAbandoned: true
 removeAbandonedTimeout: 15s
 useFairQueue: false
+ignoreExceptionOnPreLoad: true
 
 logAbandonedConnections: true
 logValidationErrors: true


### PR DESCRIPTION
###### Problem:
If Dropwizard starts when the database is down, the application will shutdown. This is caused by org.apache.tomcat.jdbc.pool.ConnectionPool where there is an explicit check on ignoreExceptionOnPreLoadon property. If this is set to "true" Dropwizard will still be able to start without a database present.

###### Solution:
Make ignoreExceptionOnPreLoadon on PoolProperties configurable