### PR TITLE
Link to SSL docs in the HTTP/2 config section

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -482,8 +482,12 @@ For an encrypted connection HTTP/2 uses ALPN protocol. It's a TLS extension, tha
 a protocol to use after the handshake is complete. If either side does not support ALPN, then the protocol will
 be ignored, and an HTTP/1.1 connection over TLS will be used instead.
 
-For this connector to work with ALPN protocol you need to provide alpn-boot library to JVM's bootpath.
-The correct library version depends on a JVM version. Consult Jetty ALPN guide__ for the reference.
+For this connector to work with ALPN protocol you need to either:
+
+* Enable native SSL support via Google's Conscrypt as described in the :ref:`SSL section <man-core-ssl>` of the
+  Core manual; or
+* Provide alpn-boot library to JVM's bootpath. The correct library version depends on the JVM version.
+  Consult Jetty ALPN guide__ for the reference.
 
 .. __: http://www.eclipse.org/jetty/documentation/current/alpn-chapter.html
 


### PR DESCRIPTION
###### Problem:
The HTTP/2 section in the configuration manual only mentions adding `alpn-boot` library to the JVM bootpath for the connector to work with the ALPN protocol. The same can be achieved by using Google's Conscrypt as described in the core manual, which was modified in #2230.

###### Solution:
Interlink the two sections.

Please let me know if things can be worded/organized better.
