### PR TITLE
Helpful error logging on JSON mapping

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapper.java
@@ -41,9 +41,9 @@ public class JsonProcessingExceptionMapper extends LoggingExceptionMapper<JsonPr
         /*
          * Otherwise, it's those pesky users.
          */
-        LOGGER.error("Unable to process JSON", exception);
-
         final String message = exception.getOriginalMessage();
+        LOGGER.error("Unable to process JSON", message);
+
         final ErrorMessage errorMessage = new ErrorMessage(Response.Status.BAD_REQUEST.getStatusCode(),
                 "Unable to process JSON", showDetails ? message : null);
         return Response.status(Response.Status.BAD_REQUEST)

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapper.java
@@ -41,7 +41,7 @@ public class JsonProcessingExceptionMapper extends LoggingExceptionMapper<JsonPr
         /*
          * Otherwise, it's those pesky users.
          */
-        LOGGER.debug("Unable to process JSON", exception);
+        LOGGER.error("Unable to process JSON", exception);
 
         final String message = exception.getOriginalMessage();
         final ErrorMessage errorMessage = new ErrorMessage(Response.Status.BAD_REQUEST.getStatusCode(),


### PR DESCRIPTION
When this error is logged as debug level, by default developer will not see root cause of the error, and I struggled several hours because the only response was "Unable to process JSON" and logs for io.dropwizard ERROR level did not show any problems.

Invalid jackson mappings are quite common and should be more visible at least Error level.
