### PR TITLE
Switch the build to run on JDK 10 from JDK 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 language: java
 before_install:
   - ulimit -c unlimited -S
+  - 'wget https://raw.githubusercontent.com/sormuras/bach/master/install-jdk.sh'
 script:
   - ./mvnw test -B -P code-coverage
   - ./mvnw site -pl docs -B
@@ -21,11 +22,8 @@ matrix:
           packages:
             - oracle-java8-installer
     - os: linux
-      jdk: oraclejdk9
-      addons:
-        apt:
-          packages:
-            - oracle-java9-installer
+      env: JDK='OpenJDK 10'
+      install: . ./install-jdk.sh -F 10
 deploy:
   provider: script
   script: bash .travis_deploy.sh

--- a/dropwizard-example/pom.xml
+++ b/dropwizard-example/pom.xml
@@ -280,7 +280,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.0</version>
+                <version>0.8.1</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>
@@ -311,13 +311,13 @@
             </build>
         </profile>
         <profile>
-            <id>jdk9</id>
+            <id>jdk10</id>
             <activation>
-                <jdk>9</jdk>
+                <jdk>10</jdk>
             </activation>
             <properties>
-                <maven.compiler.source>1.9</maven.compiler.source>
-                <maven.compiler.target>1.9</maven.compiler.target>
+                <maven.compiler.source>1.10</maven.compiler.source>
+                <maven.compiler.target>1.10</maven.compiler.target>
             </properties>
             <build>
                 <plugins>

--- a/dropwizard-example/pom.xml
+++ b/dropwizard-example/pom.xml
@@ -141,7 +141,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.20.1</version>
+                    <version>2.21.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/dropwizard-http2/pom.xml
+++ b/dropwizard-http2/pom.xml
@@ -97,9 +97,9 @@
          see http://www.eclipse.org/jetty/documentation/current/alpn-chapter.html for reference. -->
     <profiles>
         <profile>
-            <id>jdk9</id>
+            <id>jdk10</id>
             <activation>
-                <jdk>9</jdk>
+                <jdk>10</jdk>
             </activation>
             <properties>
                 <argLine>-Duser.language=en -Duser.region=US --add-modules java.xml.bind</argLine>

--- a/dropwizard-testing/pom.xml
+++ b/dropwizard-testing/pom.xml
@@ -84,7 +84,7 @@
                     <dependency>
                         <groupId>org.junit.platform</groupId>
                         <artifactId>junit-platform-surefire-provider</artifactId>
-                        <version>1.0.1</version>
+                        <version>1.1.0</version>
                     </dependency>
                     <dependency>
                         <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -486,7 +486,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.19.1</version>
+                    <version>2.21.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -373,9 +373,9 @@
             </build>
         </profile>
         <profile>
-            <id>jdk9</id>
+            <id>jdk10</id>
             <activation>
-                <jdk>9</jdk>
+                <jdk>10</jdk>
             </activation>
             <properties>
                 <argLine>-Duser.language=en -Duser.region=US --add-modules java.xml.bind</argLine>
@@ -395,14 +395,14 @@
         <profile>
             <id>code-coverage</id>
             <activation>
-                <jdk>9</jdk>
+                <jdk>10</jdk>
             </activation>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.8.0</version>
+                        <version>0.8.1</version>
                         <executions>
                             <execution>
                                 <id>prepare-agent</id>


### PR DESCRIPTION
###### Problem:
JDK 9 has been deprecated in favour of JDK 10.

###### Solution:
Switch the build to run on JDK 10. Unfortunately, Travis doesn't support Oracle JDK 10 yet, but we can download OpenJDK 10.

###### Result:
Test Dropwizard on the latest JDK release.