### PR TITLE
Remove expected exceptions from tests

### DIFF
--- a/dropwizard-client/src/test/java/io/dropwizard/client/proxy/HttpClientConfigurationTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/proxy/HttpClientConfigurationTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 
 public class HttpClientConfigurationTest {
@@ -112,38 +113,43 @@ public class HttpClientConfigurationTest {
         assertThat(proxy.getNonProxyHosts()).isNull();
     }
 
-    @Test(expected = ConfigurationValidationException.class)
-    public void testNoHost() throws Exception {
-        load("yaml/bad_host.yml");
+    @Test
+    public void testNoHost() {
+        assertConfigurationValidationException("yaml/bad_host.yml");
     }
 
-    @Test(expected = ConfigurationValidationException.class)
-    public void testBadPort() throws Exception {
-        load("./yaml/bad_port.yml");
+    @Test
+    public void testBadPort() {
+        assertConfigurationValidationException("./yaml/bad_port.yml");
     }
 
-    @Test(expected = ConfigurationParsingException.class)
-    public void testBadScheme() throws Exception {
-        load("./yaml/bad_scheme.yml");
+    @Test
+    public void testBadScheme() {
+        assertThatExceptionOfType(ConfigurationParsingException.class).isThrownBy(() ->
+            load("./yaml/bad_scheme.yml"));
     }
 
-    @Test(expected = ConfigurationValidationException.class)
-    public void testBadAuthUsername() throws Exception {
-        load("./yaml/bad_auth_username.yml");
+    @Test
+    public void testBadAuthUsername() {
+        assertConfigurationValidationException("./yaml/bad_auth_username.yml");
     }
 
-    @Test(expected = ConfigurationValidationException.class)
-    public void testBadPassword() throws Exception {
-        load("./yaml/bad_auth_password.yml");
+    @Test
+    public void testBadPassword() {
+        assertConfigurationValidationException("./yaml/bad_auth_password.yml");
     }
 
-    @Test(expected = ConfigurationValidationException.class)
-    public void testBadAuthScheme() throws Exception {
-        load("./yaml/bad_auth_scheme.yml");
+    @Test
+    public void testBadAuthScheme() {
+        assertConfigurationValidationException("./yaml/bad_auth_scheme.yml");
     }
 
-    @Test(expected = ConfigurationValidationException.class)
-    public void testBadCredentialType() throws Exception {
-        load("./yaml/bad_auth_credential_type.yml");
+    @Test
+    public void testBadCredentialType() {
+        assertConfigurationValidationException("./yaml/bad_auth_credential_type.yml");
+    }
+
+    private void assertConfigurationValidationException(String configLocation){
+        assertThatExceptionOfType(ConfigurationValidationException.class).isThrownBy(()->load(configLocation));
     }
 }

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/BaseConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/BaseConfigurationFactoryTest.java
@@ -27,6 +27,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
@@ -318,12 +319,11 @@ public abstract class BaseConfigurationFactoryTest {
         }
     }
 
-    @Test(expected = ConfigurationParsingException.class)
+    @Test
     public void throwsAnExceptionOnArrayOverrideWithInvalidType() throws Exception {
         System.setProperty("dw.servers", "one,two");
 
-        factory.build(validFile);
-        failBecauseExceptionWasNotThrown(ConfigurationParsingException.class);
+        assertThatExceptionOfType(ConfigurationParsingException.class).isThrownBy(() -> factory.build(validFile));
     }
 
     @Test

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryFactoryTest.java
@@ -7,20 +7,16 @@ import io.dropwizard.configuration.BaseConfigurationFactoryTest.Example;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.validation.BaseValidator;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import javax.validation.Validator;
 import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 
 public class ConfigurationFactoryFactoryTest {
-
-    @Rule
-    public final ExpectedException expectedException = ExpectedException.none();
 
     private final ConfigurationFactoryFactory<Example> factoryFactory = new DefaultConfigurationFactoryFactory<>();
     private final Validator validator = BaseValidator.newValidator();
@@ -41,9 +37,10 @@ public class ConfigurationFactoryFactoryTest {
             Resources.getResource("factory-test-unknown-property.yml").toURI());
         ConfigurationFactory<Example> factory =
             factoryFactory.create(Example.class, validator, Jackson.newObjectMapper(), "dw");
-        expectedException.expect(ConfigurationException.class);
-        expectedException.expectMessage("Unrecognized field at: trait");
-        factory.build(validFileWithUnknownProp);
+
+        assertThatExceptionOfType(ConfigurationException.class)
+            .isThrownBy(() -> factory.build(validFileWithUnknownProp))
+            .withMessageContaining("Unrecognized field at: trait");
     }
 
     @Test

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/EnvironmentVariableLookupTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/EnvironmentVariableLookupTest.java
@@ -3,16 +3,17 @@ package io.dropwizard.configuration;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assume.assumeThat;
 
 public class EnvironmentVariableLookupTest {
-    @Test(expected = UndefinedEnvironmentVariableException.class)
+    @Test
     public void defaultConstructorEnablesStrict() {
         assumeThat(System.getenv("nope"), nullValue());
 
-        EnvironmentVariableLookup lookup = new EnvironmentVariableLookup();
-        lookup.lookup("nope");
+        assertThatExceptionOfType(UndefinedEnvironmentVariableException.class).isThrownBy(()->
+            new EnvironmentVariableLookup().lookup("nope"));
     }
 
     @Test
@@ -24,11 +25,11 @@ public class EnvironmentVariableLookupTest {
         assertThat(lookup.lookup("nope")).isNull();
     }
 
-    @Test(expected = UndefinedEnvironmentVariableException.class)
+    @Test
     public void lookupThrowsExceptionInStrictMode() {
         assumeThat(System.getenv("nope"), nullValue());
 
-        EnvironmentVariableLookup lookup = new EnvironmentVariableLookup(true);
-        lookup.lookup("nope");
+        assertThatExceptionOfType(UndefinedEnvironmentVariableException.class).isThrownBy(() ->
+            new EnvironmentVariableLookup(true).lookup("nope"));
     }
 }

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/EnvironmentVariableSubstitutorTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/EnvironmentVariableSubstitutorTest.java
@@ -3,6 +3,7 @@ package io.dropwizard.configuration;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assume.assumeThat;
 
@@ -13,12 +14,12 @@ public class EnvironmentVariableSubstitutorTest {
         assertThat(substitutor.isEnableSubstitutionInVariables()).isFalse();
     }
 
-    @Test(expected = UndefinedEnvironmentVariableException.class)
+    @Test
     public void defaultConstructorEnablesStrict() {
         assumeThat(System.getenv("DOES_NOT_EXIST"), nullValue());
 
-        EnvironmentVariableSubstitutor substitutor = new EnvironmentVariableSubstitutor();
-        substitutor.replace("${DOES_NOT_EXIST}");
+        assertThatExceptionOfType(UndefinedEnvironmentVariableException.class).isThrownBy(() ->
+            new EnvironmentVariableSubstitutor().replace("${DOES_NOT_EXIST}"));
     }
 
     @Test
@@ -43,12 +44,12 @@ public class EnvironmentVariableSubstitutorTest {
         assertThat(substitutor.replace("${DOES_NOT_EXIST:-default}")).isEqualTo("default");
     }
 
-    @Test(expected = UndefinedEnvironmentVariableException.class)
+    @Test
     public void substitutorThrowsExceptionInStrictMode() {
         assumeThat(System.getenv("DOES_NOT_EXIST"), nullValue());
 
-        EnvironmentVariableSubstitutor substitutor = new EnvironmentVariableSubstitutor(true);
-        substitutor.replace("${DOES_NOT_EXIST}");
+        assertThatExceptionOfType(UndefinedEnvironmentVariableException.class).isThrownBy(() ->
+            new EnvironmentVariableSubstitutor(true).replace("${DOES_NOT_EXIST}"));
     }
 
     @Test

--- a/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceFactoryTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceFactoryTest.java
@@ -20,6 +20,7 @@ import java.sql.SQLException;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class DataSourceFactoryTest {
     private final MetricRegistry metricRegistry = new MetricRegistry();
@@ -91,12 +92,13 @@ public class DataSourceFactoryTest {
         }
     }
 
-    @Test(expected = SQLException.class)
-    public void invalidJDBCDriverClassThrowsSQLException() throws SQLException {
+    @Test
+    public void invalidJDBCDriverClassThrowsSQLException() {
         final DataSourceFactory factory = new DataSourceFactory();
         factory.setDriverClass("org.example.no.driver.here");
 
-        factory.build(metricRegistry, "test").getConnection();
+        assertThatExceptionOfType(SQLException.class).isThrownBy(() ->
+            factory.build(metricRegistry, "test").getConnection());
     }
 
     @Test

--- a/dropwizard-example/src/test/java/com/example/helloworld/db/PersonDAOTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/db/PersonDAOTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class PersonDAOTest {
 
@@ -48,8 +49,9 @@ public class PersonDAOTest {
         assertThat(persons).extracting("jobTitle").containsOnly("The plumber", "The cook", "The watchman");
     }
 
-    @Test(expected = ConstraintViolationException.class)
+    @Test
     public void handlesNullFullName() {
-        daoTestRule.inTransaction(() -> personDAO.create(new Person(null, "The null")));
+        assertThatExceptionOfType(ConstraintViolationException.class).isThrownBy(()->
+            daoTestRule.inTransaction(() -> personDAO.create(new Person(null, "The null"))));
     }
 }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/AbstractDAOTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/AbstractDAOTest.java
@@ -20,6 +20,7 @@ import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
@@ -171,12 +172,13 @@ public class AbstractDAOTest {
             .isEqualTo("woo");
     }
 
-    @Test(expected = NonUniqueResultException.class)
+    @Test
     public void throwsOnNonUniqueResultsFromJpaCriteriaQueries() throws Exception {
         when(session.createQuery(criteriaQuery)).thenReturn(query);
         when(query.getResultList()).thenReturn(ImmutableList.of("woo", "boo"));
 
-        dao.uniqueResult(criteriaQuery);
+        assertThatExceptionOfType(NonUniqueResultException.class).isThrownBy(() ->
+            dao.uniqueResult(criteriaQuery));
     }
 
     @Test

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
@@ -11,14 +11,13 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -29,9 +28,6 @@ public class UnitOfWorkAwareProxyFactoryTest {
     }
 
     private SessionFactory sessionFactory;
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Before
     public void setUp() throws Exception {
@@ -83,12 +79,11 @@ public class UnitOfWorkAwareProxyFactoryTest {
 
     @Test
     public void testProxyHandlesErrors() {
-        thrown.expect(IllegalStateException.class);
-        thrown.expectMessage("Session cluster is down");
-
-        new UnitOfWorkAwareProxyFactory("default", sessionFactory)
+        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(()->
+            new UnitOfWorkAwareProxyFactory("default", sessionFactory)
                 .create(BrokenAuthenticator.class)
-                .authenticate("b812ae4");
+                .authenticate("b812ae4"))
+            .withMessage("Session cluster is down");
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalCookieParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalCookieParamResourceTest.java
@@ -16,6 +16,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.core.Application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class OptionalCookieParamResourceTest extends AbstractJerseyTest {
 
@@ -60,10 +61,11 @@ public class OptionalCookieParamResourceTest extends AbstractJerseyTest {
         assertThat(response).isEqualTo(myMessage);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test
     public void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() {
         String invalidUUID = "invalid-uuid";
-        target("/optional/uuid").request().cookie("uuid", invalidUUID).get(String.class);
+        assertThatExceptionOfType(BadRequestException.class).isThrownBy(() ->
+            target("/optional/uuid").request().cookie("uuid", invalidUUID).get(String.class));
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalHeaderParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalHeaderParamResourceTest.java
@@ -16,6 +16,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.core.Application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class OptionalHeaderParamResourceTest extends AbstractJerseyTest {
 
@@ -60,10 +61,11 @@ public class OptionalHeaderParamResourceTest extends AbstractJerseyTest {
         assertThat(response).isEqualTo(myMessage);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test
     public void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() {
         String invalidUUID = "invalid-uuid";
-        target("/optional/uuid").request().header("uuid", invalidUUID).get(String.class);
+        assertThatExceptionOfType(BadRequestException.class).isThrownBy(() ->
+            target("/optional/uuid").request().header("uuid", invalidUUID).get(String.class));
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalQueryParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalQueryParamResourceTest.java
@@ -16,6 +16,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class OptionalQueryParamResourceTest extends AbstractJerseyTest {
 
@@ -68,10 +69,11 @@ public class OptionalQueryParamResourceTest extends AbstractJerseyTest {
         assertThat(response).isEqualTo(myMessage);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test
     public void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() {
         String invalidUUID = "invalid-uuid";
-        target("/optional/uuid").queryParam("uuid", invalidUUID).request().get(String.class);
+        assertThatExceptionOfType(BadRequestException.class).isThrownBy(() ->
+            target("/optional/uuid").queryParam("uuid", invalidUUID).request().get(String.class));
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalCookieParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalCookieParamResourceTest.java
@@ -16,6 +16,7 @@ import javax.ws.rs.core.Application;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class OptionalCookieParamResourceTest extends AbstractJerseyTest {
 
@@ -60,10 +61,11 @@ public class OptionalCookieParamResourceTest extends AbstractJerseyTest {
         assertThat(response).isEqualTo(myMessage);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test
     public void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() {
         String invalidUUID = "invalid-uuid";
-        target("/optional/uuid").request().cookie("uuid", invalidUUID).get(String.class);
+        assertThatExceptionOfType(BadRequestException.class).isThrownBy(() ->
+            target("/optional/uuid").request().cookie("uuid", invalidUUID).get(String.class));
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalHeaderParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalHeaderParamResourceTest.java
@@ -16,6 +16,7 @@ import javax.ws.rs.core.Application;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class OptionalHeaderParamResourceTest extends AbstractJerseyTest {
 
@@ -60,10 +61,11 @@ public class OptionalHeaderParamResourceTest extends AbstractJerseyTest {
         assertThat(response).isEqualTo(myMessage);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test
     public void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() {
         String invalidUUID = "invalid-uuid";
-        target("/optional/uuid").request().header("uuid", invalidUUID).get(String.class);
+        assertThatExceptionOfType(BadRequestException.class).isThrownBy(() ->
+            target("/optional/uuid").request().header("uuid", invalidUUID).get(String.class));
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalQueryParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalQueryParamResourceTest.java
@@ -16,6 +16,7 @@ import javax.ws.rs.core.Application;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class OptionalQueryParamResourceTest extends AbstractJerseyTest {
 
@@ -68,10 +69,11 @@ public class OptionalQueryParamResourceTest extends AbstractJerseyTest {
         assertThat(response).isEqualTo(myMessage);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test
     public void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() {
         String invalidUUID = "invalid-uuid";
-        target("/optional/uuid").queryParam("uuid", invalidUUID).request().get(String.class);
+        assertThatExceptionOfType(BadRequestException.class).isThrownBy(() ->
+            target("/optional/uuid").queryParam("uuid", invalidUUID).request().get(String.class));
     }
 
     @Test

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
@@ -36,6 +36,7 @@ import java.util.Set;
 
 import static org.apache.commons.lang3.reflect.FieldUtils.getField;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
@@ -137,13 +138,14 @@ public class HttpsConnectorFactoryTest {
         assertNotNull(factory.configureSslContextFactory(new SslContextFactory()));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void windowsKeyStoreUnavailableThrowsException() throws Exception {
         assumeFalse(canAccessWindowsKeyStore());
 
         final HttpsConnectorFactory factory = new HttpsConnectorFactory();
         factory.setKeyStoreType(WINDOWS_MY_KEYSTORE_NAME);
-        factory.configureSslContextFactory(new SslContextFactory());
+        assertThatIllegalStateException().isThrownBy(() ->
+            factory.configureSslContextFactory(new SslContextFactory()));
     }
 
     @Test

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/PostBodyTaskTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/PostBodyTaskTest.java
@@ -5,6 +5,8 @@ import org.junit.Test;
 
 import java.io.PrintWriter;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 public class PostBodyTaskTest {
     private final PostBodyTask task = new PostBodyTask("test") {
         @Override
@@ -14,8 +16,9 @@ public class PostBodyTaskTest {
     };
 
     @SuppressWarnings("deprecation")
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void throwsExceptionWhenCallingExecuteWithoutThePostBody() throws Exception {
-        task.execute(new ImmutableMultimap.Builder<String, String>().build(), new PrintWriter(System.out));
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() ->
+            task.execute(new ImmutableMultimap.Builder<String, String>().build(), new PrintWriter(System.out)));
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/FixtureHelpersTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/FixtureHelpersTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 public class FixtureHelpersTest {
     @Test
@@ -11,8 +12,8 @@ public class FixtureHelpersTest {
         assertThat(fixture("fixtures/fixture.txt")).isEqualTo("YAY FOR ME");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void throwsIllegalStateExceptionWhenFileDoesNotExist() {
-        fixture("this-does-not-exist.foo");
+        assertThatIllegalArgumentException().isThrownBy(() -> fixture("this-does-not-exist.foo"));
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DAOTestRuleTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DAOTestRuleTest.java
@@ -10,6 +10,7 @@ import javax.validation.ConstraintViolationException;
 import java.io.Serializable;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 public class DAOTestRuleTest {
@@ -41,9 +42,10 @@ public class DAOTestRuleTest {
         assertThat(testEntity.getDescription()).isEqualTo("description");
     }
 
-    @Test(expected = ConstraintViolationException.class)
+    @Test
     public void transactionThrowsExceptionAsExpected() {
-        daoTestRule.inTransaction(() -> persist(new TestEntity(null)));
+        assertThatExceptionOfType(ConstraintViolationException.class).isThrownBy(()->
+            daoTestRule.inTransaction(() -> persist(new TestEntity(null))));
     }
 
     @Test

--- a/dropwizard-util/src/test/java/io/dropwizard/util/DurationTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/DurationTest.java
@@ -7,80 +7,81 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 public class DurationTest {
     @Test
     public void convertsDays() throws Exception {
         assertThat(Duration.days(2).toDays())
-                .isEqualTo(2);
+            .isEqualTo(2);
         assertThat(Duration.days(2).toHours())
-                .isEqualTo(48);
+            .isEqualTo(48);
     }
 
     @Test
     public void convertsHours() throws Exception {
         assertThat(Duration.hours(2).toMinutes())
-                .isEqualTo(120);
+            .isEqualTo(120);
     }
 
     @Test
     public void convertsMinutes() throws Exception {
         assertThat(Duration.minutes(3).toSeconds())
-                .isEqualTo(180);
+            .isEqualTo(180);
     }
 
     @Test
     public void convertsSeconds() throws Exception {
         assertThat(Duration.seconds(2).toMilliseconds())
-                .isEqualTo(2000);
+            .isEqualTo(2000);
     }
 
     @Test
     public void convertsMilliseconds() throws Exception {
         assertThat(Duration.milliseconds(2).toMicroseconds())
-                .isEqualTo(2000);
+            .isEqualTo(2000);
     }
 
     @Test
     public void convertsMicroseconds() throws Exception {
         assertThat(Duration.microseconds(2).toNanoseconds())
-                .isEqualTo(2000);
+            .isEqualTo(2000);
     }
 
     @Test
     public void convertsNanoseconds() throws Exception {
         assertThat(Duration.nanoseconds(2).toNanoseconds())
-                .isEqualTo(2);
+            .isEqualTo(2);
     }
 
     @Test
     public void parsesDays() throws Exception {
         assertThat(Duration.parse("1d"))
-                .isEqualTo(Duration.days(1));
+            .isEqualTo(Duration.days(1));
 
         assertThat(Duration.parse("1 day"))
-                .isEqualTo(Duration.days(1));
+            .isEqualTo(Duration.days(1));
 
         assertThat(Duration.parse("2 days"))
-                .isEqualTo(Duration.days(2));
+            .isEqualTo(Duration.days(2));
     }
 
     @Test
     public void parsesHours() throws Exception {
         assertThat(Duration.parse("1h"))
-                .isEqualTo(Duration.hours(1));
+            .isEqualTo(Duration.hours(1));
 
         assertThat(Duration.parse("1 hour"))
-                .isEqualTo(Duration.hours(1));
+            .isEqualTo(Duration.hours(1));
 
         assertThat(Duration.parse("2 hours"))
-                .isEqualTo(Duration.hours(2));
+            .isEqualTo(Duration.hours(2));
     }
 
     @Test
     public void parsesMinutes() throws Exception {
         assertThat(Duration.parse("1m"))
-                .isEqualTo(Duration.minutes(1));
+            .isEqualTo(Duration.minutes(1));
 
         assertThat(Duration.parse("1min"))
             .isEqualTo(Duration.minutes(1));
@@ -89,100 +90,100 @@ public class DurationTest {
             .isEqualTo(Duration.minutes(2));
 
         assertThat(Duration.parse("1 minute"))
-                .isEqualTo(Duration.minutes(1));
+            .isEqualTo(Duration.minutes(1));
 
         assertThat(Duration.parse("2 minutes"))
-                .isEqualTo(Duration.minutes(2));
+            .isEqualTo(Duration.minutes(2));
     }
 
     @Test
     public void parsesSeconds() throws Exception {
         assertThat(Duration.parse("1s"))
-                .isEqualTo(Duration.seconds(1));
+            .isEqualTo(Duration.seconds(1));
 
         assertThat(Duration.parse("1 second"))
-                .isEqualTo(Duration.seconds(1));
+            .isEqualTo(Duration.seconds(1));
 
         assertThat(Duration.parse("2 seconds"))
-                .isEqualTo(Duration.seconds(2));
+            .isEqualTo(Duration.seconds(2));
     }
 
     @Test
     public void parsesMilliseconds() throws Exception {
         assertThat(Duration.parse("1ms"))
-                .isEqualTo(Duration.milliseconds(1));
+            .isEqualTo(Duration.milliseconds(1));
 
         assertThat(Duration.parse("1 millisecond"))
-                .isEqualTo(Duration.milliseconds(1));
+            .isEqualTo(Duration.milliseconds(1));
 
         assertThat(Duration.parse("2 milliseconds"))
-                .isEqualTo(Duration.milliseconds(2));
+            .isEqualTo(Duration.milliseconds(2));
     }
 
     @Test
     public void parsesMicroseconds() throws Exception {
         assertThat(Duration.parse("1us"))
-                .isEqualTo(Duration.microseconds(1));
+            .isEqualTo(Duration.microseconds(1));
 
         assertThat(Duration.parse("1 microsecond"))
-                .isEqualTo(Duration.microseconds(1));
+            .isEqualTo(Duration.microseconds(1));
 
         assertThat(Duration.parse("2 microseconds"))
-                .isEqualTo(Duration.microseconds(2));
+            .isEqualTo(Duration.microseconds(2));
     }
 
     @Test
     public void parsesNanoseconds() throws Exception {
         assertThat(Duration.parse("1ns"))
-                .isEqualTo(Duration.nanoseconds(1));
+            .isEqualTo(Duration.nanoseconds(1));
 
         assertThat(Duration.parse("1 nanosecond"))
-                .isEqualTo(Duration.nanoseconds(1));
+            .isEqualTo(Duration.nanoseconds(1));
 
         assertThat(Duration.parse("2 nanoseconds"))
-                .isEqualTo(Duration.nanoseconds(2));
+            .isEqualTo(Duration.nanoseconds(2));
     }
 
     @Test
     public void parseDurationWithWhiteSpaces() {
         assertThat(Duration.parse("5   seconds"))
-                .isEqualTo(Duration.seconds(5));
+            .isEqualTo(Duration.seconds(5));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void unableParseWrongDurationCount() {
-        Duration.parse("five seconds");
+        assertThatIllegalArgumentException().isThrownBy(() -> Duration.parse("five seconds"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void unableParseWrongDurationTimeUnit() {
-        Duration.parse("1gs");
+        assertThatIllegalArgumentException().isThrownBy(() -> Duration.parse("1gs"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void unableParseWrongDurationFormat() {
-        Duration.parse("1 milli second");
+        assertThatIllegalArgumentException().isThrownBy(() -> Duration.parse("1 milli second"));
     }
 
     @Test
     public void isHumanReadable() throws Exception {
         assertThat(Duration.microseconds(1).toString())
-                .isEqualTo("1 microsecond");
+            .isEqualTo("1 microsecond");
 
         assertThat(Duration.microseconds(3).toString())
-                .isEqualTo("3 microseconds");
+            .isEqualTo("3 microseconds");
     }
 
     @Test
     public void hasAQuantity() throws Exception {
         assertThat(Duration.microseconds(12).getQuantity())
-                .isEqualTo(12);
+            .isEqualTo(12);
     }
 
     @Test
     public void hasAUnit() throws Exception {
         assertThat(Duration.microseconds(1).getUnit())
-                .isEqualTo(TimeUnit.MICROSECONDS);
+            .isEqualTo(TimeUnit.MICROSECONDS);
     }
 
     @Test

--- a/dropwizard-util/src/test/java/io/dropwizard/util/GenericsTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/GenericsTest.java
@@ -7,9 +7,9 @@ import java.util.HashMap;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import org.junit.Rule;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -35,30 +35,37 @@ public class GenericsTest<T> {
     private Class<?> typeParameter;
     private Class<? super T> bound;
     private Class<?> boundTypeParameter;
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
+    private Class<? extends Exception> expectedException;
+    private String expectedMessage;
 
-    public GenericsTest(Class<?> klass, Class<?> typeParameter, Class<? super T> bound, Class<?> boundTypeParameter, Class<? extends Exception> expectedException, String expectedMessage) {
+    public GenericsTest(Class<?> klass, Class<?> typeParameter, Class<? super T> bound, Class<?> boundTypeParameter,
+                        Class<? extends Exception> expectedException, String expectedMessage) {
         this.klass = klass;
         this.typeParameter = typeParameter;
         this.bound = bound;
         this.boundTypeParameter = boundTypeParameter;
-
-        if (expectedException != null) {
-            thrown.expect(expectedException);
-            if (expectedMessage != null)
-                thrown.expectMessage(expectedMessage);
-        }
+        this.expectedException = expectedException;
+        this.expectedMessage = expectedMessage;
     }
 
     @Test
     public void testTypeParameter() {
-        assertThat(Generics.getTypeParameter(klass)).isEqualTo(typeParameter);
+        if (expectedException == null) {
+            assertThat(Generics.getTypeParameter(klass)).isEqualTo(typeParameter);
+        } else {
+            assertThatExceptionOfType(expectedException).isThrownBy(() -> Generics.getTypeParameter(klass))
+                .withMessage(expectedMessage);
+        }
     }
 
     @Test
     public void testBoundTypeParameter() {
-        assertThat(Generics.getTypeParameter(klass, bound)).isEqualTo(boundTypeParameter);
+        if (expectedException == null) {
+            assertThat(Generics.getTypeParameter(klass, bound)).isEqualTo(boundTypeParameter);
+        } else {
+            assertThatExceptionOfType(expectedException).isThrownBy(() -> Generics.getTypeParameter(klass, bound))
+                .withMessage(expectedMessage);
+        }
     }
 
     public static class IntegerList extends ArrayList<Integer> { }

--- a/dropwizard-util/src/test/java/io/dropwizard/util/SizeTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/SizeTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 public class SizeTest {
     @Test
@@ -130,19 +131,19 @@ public class SizeTest {
         assertThat(Size.parse("1T")).isEqualTo(Size.terabytes(1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void unableParseWrongSizeCount() {
-        Size.parse("three bytes");
+        assertThatIllegalArgumentException().isThrownBy(() -> Size.parse("three bytes"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void unableParseWrongSizeUnit() {
-        Size.parse("1EB");
+        assertThatIllegalArgumentException().isThrownBy(() -> Size.parse("1EB"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void unableParseWrongSizeFormat() {
-        Size.parse("1 mega byte");
+        assertThatIllegalArgumentException().isThrownBy(() -> Size.parse("1 mega byte"));
     }
 
     @Test
@@ -546,7 +547,7 @@ public class SizeTest {
         assertThat(mapper.readValue("\"1 terabytes\"", Size.class)).isEqualTo(Size.terabytes(1L));
         assertThat(mapper.readValue("\"2 terabytes\"", Size.class)).isEqualTo(Size.terabytes(2L));
     }
-    
+
     @Test
     public void verifyComparableContract() {
         final Size kb = Size.kilobytes(1024L);


### PR DESCRIPTION
###### Problem:
Modern testing libraries seems to favour an approach with explicit testing for errors where tested code is wrapped in a lambda expression, because it provides flexibility in verifying the cause of the error. For example, JUnit5 doesn't support it anymore the `expected` attribute in the `Test` annotation and the `ExpectedException` rule.

###### Solution:
Replace them with AssertJ's `assertThrown`. 

###### Result:
 If we ever switch to JUnit5 for testing, migration would be easier.