### PR TITLE
Remove prerequisites from archetype pom

### DIFF
--- a/dropwizard-archetypes/java-simple/src/main/resources/archetype-resources/pom.xml
+++ b/dropwizard-archetypes/java-simple/src/main/resources/archetype-resources/pom.xml
@@ -5,9 +5,6 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <prerequisites>
-        <maven>3.0.0</maven>
-    </prerequisites>
 
     <groupId>\${groupId}</groupId>
     <artifactId>\${artifactId}</artifactId>


### PR DESCRIPTION
Since Maven 3.5, maven will warn when using `<prerequisites>..</prerequisites>` for a non maven-plugin project. Since Dropwizard projects are not maven plugins, we remove it from the
archetype pom.

https://maven.apache.org/docs/3.5.0/release-notes.html