### PR TITLE
Add owasp dependency check.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,8 @@
 
     <properties>
         <dropwizard.url>http://www.dropwizard.io/${project.version}</dropwizard.url>
+        <dropwizard.check.fail-owasp>true</dropwizard.check.fail-owasp>
+        <dropwizard.check.skip-owasp>false</dropwizard.check.skip-owasp>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.site.deploy.skip>true</maven.site.deploy.skip>
@@ -662,6 +664,27 @@
                         <configuration>
                             <failOnViolation>true</failOnViolation>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>3.1.2</version>
+                <configuration>
+                    <failBuildOnAnyVulnerability>${dropwizard.check.fail-owasp}</failBuildOnAnyVulnerability>
+                    <skip>${dropwizard.check.skip-owasp}</skip>
+                    <showSummary>true</showSummary>
+                    <format>ALL</format>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>security-check</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,6 @@
 
     <properties>
         <dropwizard.url>http://www.dropwizard.io/${project.version}</dropwizard.url>
-        <dropwizard.check.fail-owasp>true</dropwizard.check.fail-owasp>
-        <dropwizard.check.skip-owasp>false</dropwizard.check.skip-owasp>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.site.deploy.skip>true</maven.site.deploy.skip>
@@ -673,10 +671,9 @@
                 <artifactId>dependency-check-maven</artifactId>
                 <version>3.1.2</version>
                 <configuration>
-                    <failBuildOnAnyVulnerability>${dropwizard.check.fail-owasp}</failBuildOnAnyVulnerability>
-                    <skip>${dropwizard.check.skip-owasp}</skip>
+                    <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
                     <showSummary>true</showSummary>
-                    <format>ALL</format>
+                    <suppressionFiles>suppressed-cves.xml</suppressionFiles>
                 </configuration>
                 <executions>
                     <execution>

--- a/suppressed-cves.xml
+++ b/suppressed-cves.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+    <suppress>
+        <notes><![CDATA[file name: dropwizard-views-1.4.0-SNAPSHOT.jar]]></notes>
+        <gav regex="true">^io\.dropwizard:dropwizard-views(-.*)?:.*$</gav>
+        <cve>CVE-2015-3378</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[file name: dropwizard-views-1.4.0-SNAPSHOT.jar]]></notes>
+        <gav regex="true">^io\.dropwizard:dropwizard-views(-.*)?:.*$</gav>
+        <cve>CVE-2015-3379</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[file name: compiler-0.9.5.jar]]></notes>
+        <gav regex="true">^com\.github\.spullara\.mustache\.java:compiler:.*$</gav>
+        <cve>CVE-2015-8862</cve>
+    </suppress>
+</suppressions>

--- a/suppressed-cves.xml
+++ b/suppressed-cves.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
     <suppress>
-        <notes><![CDATA[false positive, dropwizard does not use Drupal]]></notes>
+        <notes><![CDATA[false positive, Dropwizard does not use Drupal]]></notes>
         <cve>CVE-2015-3378</cve>
     </suppress>
     <suppress>
-        <notes><![CDATA[false positive, dropwizard does not use Drupal]]></notes>
+        <notes><![CDATA[false positive, Dropwizard does not use Drupal]]></notes>
         <cve>CVE-2015-3379</cve>
     </suppress>
     <suppress>

--- a/suppressed-cves.xml
+++ b/suppressed-cves.xml
@@ -1,18 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
     <suppress>
-        <notes><![CDATA[file name: dropwizard-views-1.4.0-SNAPSHOT.jar]]></notes>
-        <gav regex="true">^io\.dropwizard:dropwizard-views(-.*)?:.*$</gav>
+        <notes><![CDATA[false positive, dropwizard does not use Drupal]]></notes>
         <cve>CVE-2015-3378</cve>
     </suppress>
     <suppress>
-        <notes><![CDATA[file name: dropwizard-views-1.4.0-SNAPSHOT.jar]]></notes>
-        <gav regex="true">^io\.dropwizard:dropwizard-views(-.*)?:.*$</gav>
+        <notes><![CDATA[false positive, dropwiard does not use Drupal]]></notes>
         <cve>CVE-2015-3379</cve>
     </suppress>
     <suppress>
-        <notes><![CDATA[file name: compiler-0.9.5.jar]]></notes>
-        <gav regex="true">^com\.github\.spullara\.mustache\.java:compiler:.*$</gav>
+        <notes><![CDATA[false positive]]></notes>
         <cve>CVE-2015-8862</cve>
     </suppress>
 </suppressions>

--- a/suppressed-cves.xml
+++ b/suppressed-cves.xml
@@ -5,7 +5,7 @@
         <cve>CVE-2015-3378</cve>
     </suppress>
     <suppress>
-        <notes><![CDATA[false positive, dropwiard does not use Drupal]]></notes>
+        <notes><![CDATA[false positive, dropwizard does not use Drupal]]></notes>
         <cve>CVE-2015-3379</cve>
     </suppress>
     <suppress>


### PR DESCRIPTION
###### Problem:
Currently, the dropwizard project does not run a check for security vulnerabilities during its build process. This results in dependencies being included that contain security risks (e.g. Jackson versions below 2.9.5)

###### Solution:
I have added the dependency-check plugin to the maven build process (https://jeremylong.github.io/DependencyCheck/) so CVEs can be identified.

###### Result:

