### PR TITLE
Fix jersey attempting to resolve auth filter fields

### DIFF
--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthDynamicFeature.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthDynamicFeature.java
@@ -31,17 +31,20 @@ import java.util.Optional;
  */
 public class AuthDynamicFeature implements DynamicFeature {
 
-    @Nullable
     private final ContainerRequestFilter authFilter;
 
-    @Nullable
     private final Class<? extends ContainerRequestFilter> authFilterClass;
 
+    // We suppress the null away checks, as adding `@Nullable` to the auth
+    // filter fields, causes Jersey to try and resolve the fields to a concrete
+    // type (which subsequently fails).
+    @SuppressWarnings("NullAway")
     public AuthDynamicFeature(ContainerRequestFilter authFilter) {
         this.authFilter = authFilter;
         this.authFilterClass = null;
     }
 
+    @SuppressWarnings("NullAway")
     public AuthDynamicFeature(Class<? extends ContainerRequestFilter> authFilterClass) {
         this.authFilter = null;
         this.authFilterClass = authFilterClass;


### PR DESCRIPTION
By removing `@Nullable` annotation on `AuthDynamicFeature` fields. In
the process we had to supress null away in the constructor, else that
would fail builds.

Fixes the warning that I and some others have seen in #2307

```
WARN  [2018-04-06 18:30:49,644] org.glassfish.jersey.internal.Errors: The following warnings have been detected: WARNING: Parameter authFilterClass of type java.lang.Class<? extends javax.ws.rs.container.ContainerRequestFilter> from private final java.lang.Class<? extends javax.ws.rs.container.ContainerRequestFilter> io.dropwizard.auth.AuthDynamicFeature.authFilterClass is not resolvable to a concrete type.
WARNING: Parameter authFilterClass of type java.lang.Class<? extends javax.ws.rs.container.ContainerRequestFilter> from private final java.lang.Class<? extends javax.ws.rs.container.ContainerRequestFilter> io.dropwizard.auth.AuthDynamicFeature.authFilterClass is not resolvable to a concrete type.
```

Still unresolved:

- Why is this happening now (Dropwizard 1.3)? Seems entirely Jersey related but we haven't bumped Jersey versions in quite some time.
- Doesn't fix the issue seen in OP in #2307 revolving around Kotlin resource class.