### PR TITLE
Fix javadoc for ViewBundle

### DIFF
--- a/dropwizard-views/src/main/java/io/dropwizard/views/ViewBundle.java
+++ b/dropwizard-views/src/main/java/io/dropwizard/views/ViewBundle.java
@@ -51,8 +51,8 @@ import static com.google.common.base.MoreObjects.firstNonNull;
  * <p>A resource method with a view would looks something like this:</p>
  *
  * <pre><code>
- * \@GET
- * public PersonView getPerson(\@PathParam("id") String id) {
+ * @GET
+ * public PersonView getPerson(@PathParam("id") String id) {
  *     return new PersonView(dao.find(id));
  * }
  * </code></pre>
@@ -60,7 +60,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
  * <p>Freemarker templates look something like this:</p>
  *
  * <pre>{@code
- * &lt;#-- @ftlvariable name="" type="com.example.application.PersonView" --&gt;
+ * <#-- @ftlvariable name="" type="com.example.application.PersonView" -->
  * <html>
  *     <body>
  *         <h1>Hello, ${person.name?html}!</h1>
@@ -73,7 +73,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
  * at the top indicate to Freemarker (and your IDE) that the root object is a {@code Person},
  * allowing for better type-safety in your templates.</p>
  *
- * @see <a href="http://freemarker.sourceforge.net/docs/index.html">FreeMarker Manual</a>
+ * See Also: <a href="http://freemarker.sourceforge.net/docs/index.html">FreeMarker Manual</a>
  *
  * <p>Mustache templates look something like this:</p>
  *
@@ -87,7 +87,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
  *
  * <p>In this template, {@code {{person.name}}} calls {@code getPerson().getName()}.</p>
  *
- * @see <a href="http://mustache.github.io/mustache.5.html">Mustache Manual</a>
+ * See Also: <a href="http://mustache.github.io/mustache.5.html">Mustache Manual</a>
  */
 public class ViewBundle<T extends Configuration> implements ConfiguredBundle<T>, ViewConfigurable<T> {
     private final Iterable<ViewRenderer> viewRenderers;


### PR DESCRIPTION
###### Problem:
The formatting of [ViewBundle's JavaDoc](http://www.dropwizard.io/1.3.1/dropwizard-views/apidocs/index.html) is broken.

The formatting breaks after the @see Link to the FreeMarker reference. The rest of the javadoc relating to Mustache is totally broken.

###### Solution:
@see may not be used for inline links, but will always start a new section at the end of the javadoc ([reference](https://docs.oracle.com/javase/6/docs/technotes/tools/windows/javadoc.html#@see)). @link in turn is used to link to other classes and thus is also no good substitute ([reference](https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#link)). 

Inline links should thus be created with plain HTML ([stackoverflow](https://stackoverflow.com/questions/1082050/linking-to-an-external-url-in-javadoc)).

###### Result:
Javadoc is properly formatted.
