### PR TITLE
Fix bug when using @SelfValidating with @BeanParam (#2334)

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ConstraintMessage.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ConstraintMessage.java
@@ -6,6 +6,7 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Iterables;
 import io.dropwizard.validation.ValidationMethod;
+import io.dropwizard.validation.selfvalidating.SelfValidating;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -55,9 +56,9 @@ public class ConstraintMessage {
             return name + " ";
         }
 
-        // Take the message specified in a ValidationMethod annotation if it
-        // is what caused the violation
-        if (isValidationMethod(v)) {
+        // Take the message specified in a ValidationMethod or SelfValidation
+        // annotation if it is what caused the violation.
+        if (isValidationMethod(v) || isSelfValidating(v)) {
             return "";
         }
 
@@ -149,6 +150,10 @@ public class ConstraintMessage {
 
     private static boolean isValidationMethod(ConstraintViolation<?> v) {
         return v.getConstraintDescriptor().getAnnotation() instanceof ValidationMethod;
+    }
+
+    private static boolean isSelfValidating(ConstraintViolation<?> v) {
+        return v.getConstraintDescriptor().getAnnotation() instanceof SelfValidating;
     }
 
     /**

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
@@ -678,4 +678,51 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
             .containsOnlyOnce("query param choice must be one of [OptionA, OptionB, OptionC]");
     }
 
+    @Test
+    public void selfValidatingBeanParamInvalid() {
+        final Response response = target("/valid/selfValidatingBeanParam")
+            .queryParam("answer", 100)
+            .request()
+            .get();
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.readEntity(String.class))
+            .isEqualTo("{\"errors\":[\"The answer is 42\"]}");
+    }
+
+    @Test
+    public void selfValidatingBeanParamSuccess() {
+        final Response response = target("/valid/selfValidatingBeanParam")
+            .queryParam("answer", 42)
+            .request()
+            .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.readEntity(String.class))
+            .isEqualTo("{\"answer\":42}");
+    }
+
+    @Test
+    public void selfValidatingPayloadInvalid() {
+        final Response response = target("/valid/selfValidatingPayload")
+            .request()
+            .post(Entity.json("{\"answer\":100}"));
+
+        assertThat(response.getStatus()).isEqualTo(422);
+        assertThat(response.readEntity(String.class))
+            .isEqualTo("{\"errors\":[\"The answer is 42\"]}");
+    }
+
+    @Test
+    public void selfValidatingPayloadSuccess() {
+        final String payload = "{\"answer\":42}";
+
+        final Response response = target("/valid/selfValidatingPayload")
+            .request()
+            .post(Entity.json(payload));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.readEntity(String.class))
+            .isEqualTo(payload);
+    }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/SelfValidatingClass.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/SelfValidatingClass.java
@@ -1,0 +1,31 @@
+package io.dropwizard.jersey.validation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.validation.selfvalidating.SelfValidating;
+import io.dropwizard.validation.selfvalidating.SelfValidation;
+import io.dropwizard.validation.selfvalidating.ViolationCollector;
+
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.QueryParam;
+
+@SelfValidating
+public class SelfValidatingClass {
+
+    @JsonProperty
+    private Integer answer;
+
+    public SelfValidatingClass() { }
+
+    public SelfValidatingClass(@NotNull @QueryParam("answer") Integer answer) {
+        this.answer = answer;
+    }
+
+
+    @SelfValidation
+    public void validate(ViolationCollector collector) {
+        if (!answer.equals(42)) {
+            collector.addViolation("The answer is 42");
+        }
+    }
+
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/SelfValidatingClass.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/SelfValidatingClass.java
@@ -5,12 +5,14 @@ import io.dropwizard.validation.selfvalidating.SelfValidating;
 import io.dropwizard.validation.selfvalidating.SelfValidation;
 import io.dropwizard.validation.selfvalidating.ViolationCollector;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.QueryParam;
 
 @SelfValidating
 public class SelfValidatingClass {
 
+    @Nullable
     @JsonProperty
     private Integer answer;
 
@@ -23,7 +25,7 @@ public class SelfValidatingClass {
 
     @SelfValidation
     public void validate(ViolationCollector collector) {
-        if (!answer.equals(42)) {
+        if (answer == null || !answer.equals(42)) {
             collector.addViolation("The answer is 42");
         }
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
@@ -281,4 +281,16 @@ public class ValidatingResource {
         return choice.toString();
     }
 
+    @GET
+    @Path("selfValidatingBeanParam")
+    public SelfValidatingClass selfValidating(@Valid @BeanParam SelfValidatingClass beanParameter) {
+        return beanParameter;
+    }
+
+    @POST
+    @Path("selfValidatingPayload")
+    public SelfValidatingClass selfValidatingPayload(@Valid SelfValidatingClass payload) {
+        return payload;
+    }
+
 }


### PR DESCRIPTION
###### Problem:
When using the new [@SelfValidating](https://github.com/dropwizard/dropwizard/blob/v1.3.1/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/SelfValidating.java) annotation on a class that is used as a `@BeanParam`, a 500 error is raised instead of 400/422.

This is described in more detail in #2334. 

###### Solution:
Handle [@SelfValidating](https://github.com/dropwizard/dropwizard/blob/v1.3.1/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/SelfValidating.java) violations like [@ValidationMethod](https://github.com/dropwizard/dropwizard/blob/v1.3.1/dropwizard-validation/src/main/java/io/dropwizard/validation/ValidationMethod.java).