### PR TITLE
Skip an OWASP dependency check in the dev profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -301,6 +301,13 @@
                             <perCoreThreadCount>true</perCoreThreadCount>
                         </configuration>
                     </plugin>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
###### Problem:
In the dev profile we want to build and install artifacts as fast as possible, and an OWASP check is quite slow.

###### Solution:
Disable the dependency-check plugin in the dev profile.

###### Result:
Faster builds during development
