### PR TITLE
Add possibility to disable logging bootstrap for ResourceTestRule

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/common/Resource.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/common/Resource.java
@@ -29,10 +29,6 @@ import static java.util.Objects.requireNonNull;
 
 public class Resource {
 
-    static {
-        BootstrapLogging.bootstrap();
-    }
-
     /**
      * A {@link Resource} builder which enables configuration of a Jersey testing environment.
      */
@@ -48,6 +44,7 @@ public class Resource {
         };
         private TestContainerFactory testContainerFactory = new InMemoryTestContainerFactory();
         private boolean registerDefaultExceptionMappers = true;
+        private boolean bootstrapLogging = true;
 
         public B setMapper(ObjectMapper mapper) {
             this.mapper = mapper;
@@ -102,12 +99,20 @@ public class Resource {
             return (B) this;
         }
 
+        public B bootstrapLogging(boolean value){
+            bootstrapLogging = value;
+            return (B) this;
+        }
+
         /**
          * Builds a {@link Resource} with a configured Jersey testing environment.
          *
          * @return a new {@link Resource}
          */
         protected Resource buildResource() {
+            if (bootstrapLogging) {
+                BootstrapLogging.bootstrap();
+            }
             return new Resource(new ResourceTestJerseyConfiguration(
                 singletons, providers, properties, mapper, validator,
                 clientConfigurator, testContainerFactory, registerDefaultExceptionMappers));

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestRuleWithoutLoggingBootstrap.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestRuleWithoutLoggingBootstrap.java
@@ -1,0 +1,22 @@
+package io.dropwizard.testing.app;
+
+import io.dropwizard.testing.junit.ResourceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ResourceTestRuleWithoutLoggingBootstrap {
+    @Rule
+    public final ResourceTestRule resourceTestRule = ResourceTestRule.builder()
+            .addResource(TestResource::new)
+            .bootstrapLogging(false)
+            .build();
+
+    @Test
+    public void testResource() {
+        assertThat(resourceTestRule.target("test").request()
+                .get(String.class))
+                .isEqualTo("Default message");
+    }
+}


### PR DESCRIPTION
###### Problem:
Currently, users who don't have Logback in the classpath can't use `ResourceTestRule`, because it automatically tries to configure logging with Logback. We should provide a configuration parameter
which allows users to disable it.

###### Solution:
Add a configuration parameter `bootstrapLogging` to `Resource.Builder`

###### Result:
Fixes #2333