### PR TITLE
Fix deprecation usage of argparse4j

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/cli/Cli.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/Cli.java
@@ -106,7 +106,7 @@ public class Cli {
 
     private ArgumentParser buildParser(JarLocation location) {
         final String usage = "java -jar " + location;
-        final ArgumentParser p = ArgumentParsers.newArgumentParser(usage, false);
+        final ArgumentParser p = ArgumentParsers.newFor(usage).addHelp(false).build();
         p.version(location.getVersion().orElse(
                 "No application version detected. Add a Implementation-Version " +
                         "entry to your JAR's manifest to enable this."));


### PR DESCRIPTION
###### Problem:
`ArgumentParsers.newArgumentParser` is deprecated.

###### Solution:
Replace it with the equivalent `ArgumentParsers.newFor`

###### Result:
Behaviorally the same 🙆 
