### PR TITLE
Http2 ALPN and bootclasspath update

### DIFF
--- a/dropwizard-http2/pom.xml
+++ b/dropwizard-http2/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <!-- Default alpn-boot version. See <profiles> for specific profiles. -->
         <alpn-boot.version>8.1.12.v20180117</alpn-boot.version>
-        <argLine>-Xbootclasspath/p:/"${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar" -Duser.language=en -Duser.region=US</argLine>
+        <argLine>"-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar" -Duser.language=en -Duser.region=US</argLine>
     </properties>
 
     <dependencyManagement>

--- a/dropwizard-http2/pom.xml
+++ b/dropwizard-http2/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <!-- Default alpn-boot version. See <profiles> for specific profiles. -->
         <alpn-boot.version>8.1.12.v20180117</alpn-boot.version>
-        <argLine>-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar -Duser.language=en -Duser.region=US</argLine>
+        <argLine>-Xbootclasspath/p:/"${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar" -Duser.language=en -Duser.region=US</argLine>
     </properties>
 
     <dependencyManagement>
@@ -481,6 +481,30 @@
                 <property>
                     <name>java.version</name>
                     <value>1.8.0_162</value>
+                </property>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.12.v20180117</alpn-boot.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_171</id>
+            <activation>
+                <property>
+                    <name>java.version</name>
+                    <value>1.8.0_171</value>
+                </property>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.12.v20180117</alpn-boot.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_172</id>
+            <activation>
+                <property>
+                    <name>java.version</name>
+                    <value>1.8.0_172</value>
                 </property>
             </activation>
             <properties>


### PR DESCRIPTION
###### Problem:
- JDK 171 & 172 have missing alpn values, so add them to the pom
- I have a machine that contains special characters in `${user.home}`, so quotes are necessary to reference the ALPN jar correctly. @arteam I see that you reverted this behavior in 3b8c255d929e and I just want to make sure I'm not missing something.

###### Result:
I can run http2 tests on this machine again 😄 
