### PR TITLE
Checkout all freemarker templates with lf line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,5 @@
 *.md text=auto
 *.mustache text eol=lf
 *.ftl text eol=lf
+*.ftlh text eol=lf
+*.ftlx text eol=lf


### PR DESCRIPTION
###### Problem:
On Windows machines with git crlf auto convert turned on, `rendersViewsWithAbsoluteTemplatePaths` will fail as `example.ftlh` is committed with lf line endings but will be checked out with crlf endings. Our Windows CI (appveyor) doesn't suffer from this issue as this git feature is turned off.

###### Solution:
Set all extensions that we use for freemarker templates to explicitly keep the line ending as lf.

###### Result:
Can run this test on Windows.
