### PR TITLE
Fix shared metrics race with multiple environments

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/setup/Environment.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/Environment.java
@@ -92,15 +92,17 @@ public class Environment {
                 .rejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy())
                 .build();
 
+        // Set the default metric registry to the one in this environment, if
+        // the default isn't already set. If a default is already registered,
+        // ignore the exception.
         try {
-            SharedMetricRegistries.getDefault();
-        } catch (IllegalStateException e) {
             SharedMetricRegistries.setDefault("default", metricRegistry);
+        } catch (IllegalStateException ignored) {
         }
+
         try {
-            SharedHealthCheckRegistries.getDefault();
-        } catch (IllegalStateException e) {
             SharedHealthCheckRegistries.setDefault("default", healthCheckRegistry);
+        } catch (IllegalStateException ignored) {
         }
     }
 


### PR DESCRIPTION
###### Problem:
When creating environments in parallel (like when executing tests in parallel). Two threads may try to get the default metric registry (only to see it does not exist) and both of them try to set the default. One will succeed, the other will fail. This issue was foretold by @arteam in #1938

###### Solution:
Always try and atomically set the default registry and ignore the exception that one already exists. Keeps the same look and feel of the logic.

###### Result:
Behaviorally the same (set the default registry if not already set else ignore). Now race free!
