### PR TITLE
Upgrade Jetty to 9.4.10.v20180503

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -22,7 +22,7 @@
         <guava.version>24.0-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
         <jackson.version>2.9.5</jackson.version>
-        <jetty.version>9.4.8.v20171121</jetty.version>
+        <jetty.version>9.4.10.v20180503</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.0.2</metrics4.version>
         <slf4j.version>1.7.25</slf4j.version>


### PR DESCRIPTION
###### Problem:
We use not the latest version of Jetty in the upstream

###### Solution:
Bump the version

###### Result:
We take advantage of many small bugfixes in Jetty, especially in the HTTP/2 module. See

https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.9.v20180320
https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.10.v20180503