### PR TITLE
Upgrade to JUnit5 5.2.0

### DIFF
--- a/dropwizard-testing/pom.xml
+++ b/dropwizard-testing/pom.xml
@@ -84,7 +84,7 @@
                     <dependency>
                         <groupId>org.junit.platform</groupId>
                         <artifactId>junit-platform-surefire-provider</artifactId>
-                        <version>1.1.0</version>
+                        <version>1.2.0</version>
                     </dependency>
                     <dependency>
                         <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <argLine>-Duser.language=en -Duser.region=US</argLine>
 
         <junit.version>4.12.3</junit.version>
-        <junit5.version>5.0.3</junit5.version>
+        <junit5.version>5.2.0</junit5.version>
         <assertj.version>3.9.1</assertj.version>
         <mockito.version>2.15.0</mockito.version>
     </properties>
@@ -435,7 +435,7 @@
             <dependency>
                 <groupId>org.junit.vintage</groupId>
                 <artifactId>junit-vintage-engine</artifactId>
-                <version>${junit.version}</version>
+                <version>${junit5.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <maven.compiler.forceJavacCompilerUse>true</maven.compiler.forceJavacCompilerUse>
         <argLine>-Duser.language=en -Duser.region=US</argLine>
 
-        <junit.version>4.12.3</junit.version>
+        <junit.version>4.12</junit.version>
         <junit5.version>5.2.0</junit5.version>
         <assertj.version>3.9.1</assertj.version>
         <mockito.version>2.15.0</mockito.version>
@@ -433,9 +433,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.junit.vintage</groupId>
-                <artifactId>junit-vintage-engine</artifactId>
-                <version>${junit5.version}</version>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -455,8 +455,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
###### Problem:
We use an outdated version of JUnit 5 dependencies.

###### Solution:
Upgrade the JUnit5 dependencies and `maven-surefire-plugin` to the latest versions.

###### Result:
It adds some new features for parametrized tests and provides better Java 9/10 comparability. Suprisingly enough, we used a very old version of `junit-vintage-engine`
