### PR TITLE
Fix javadoc errors

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/RequestIdFilter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/RequestIdFilter.java
@@ -55,7 +55,7 @@ public class RequestIdFilter implements ContainerResponseFilter {
      * Generate a random UUID v4 that will perform reasonably when used by
      * multiple threads under load.
      *
-     * @see https://github.com/Netflix/netflix-commons/blob/v0.3.0/netflix-commons-util/src/main/java/com/netflix/util/concurrent/ConcurrentUUIDFactory.java
+     * @see <a href="https://github.com/Netflix/netflix-commons/blob/v0.3.0/netflix-commons-util/src/main/java/com/netflix/util/concurrent/ConcurrentUUIDFactory.java">ConcurrentUUIDFactory</a>
      * @return random UUID
      */
     private static UUID generateRandomUuid() {

--- a/dropwizard-views/src/main/java/io/dropwizard/views/ViewBundle.java
+++ b/dropwizard-views/src/main/java/io/dropwizard/views/ViewBundle.java
@@ -50,12 +50,12 @@ import static com.google.common.base.MoreObjects.firstNonNull;
  *
  * <p>A resource method with a view would looks something like this:</p>
  *
- * <pre><code>
- * @GET
+ * <pre>
+ * &#64;GET
  * public PersonView getPerson(@PathParam("id") String id) {
  *     return new PersonView(dao.find(id));
  * }
- * </code></pre>
+ * </pre>
  *
  * <p>Freemarker templates look something like this:</p>
  *


### PR DESCRIPTION
###### Problem:
Intellij found some issues with our javadocs:

- Improper escaping of annotations
- Broken `@see` reference.

###### Solution:
Fix the issues. The javadoc annotation issue was created with #2331, so this should be a once-and-for-all fix for that 😉 

###### Result:
Removed those javadoc warnings and those pages are properly displayed when I generate the api docs with maven site. And intellij no longer gives the warnings.
