### PR TITLE
Provide class that returns a 204 for Optional.empty()

### DIFF
--- a/dropwizard-e2e/src/main/java/com/example/app1/App1.java
+++ b/dropwizard-e2e/src/main/java/com/example/app1/App1.java
@@ -5,6 +5,7 @@ import com.google.common.base.Throwables;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.jersey.optional.EmptyOptionalException;
+import io.dropwizard.jersey.optional.EmptyOptionalNoContentExceptionMapper;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
@@ -26,14 +27,8 @@ public class App1 extends Application<Configuration> {
     @Override
     public void run(Configuration config, Environment env) throws Exception {
         // Ensure that we can override the default 404 response on an
-        // empty optional and return a 204 instead. Anonymous class can't
-        // be converted to a lambda as Mappers need to be concrete classes.
-        env.jersey().register(new ExceptionMapper<EmptyOptionalException>() {
-            @Override
-            public Response toResponse(EmptyOptionalException exception) {
-                return Response.noContent().build();
-            }
-        });
+        // empty optional and return a 204 instead.
+        env.jersey().register(new EmptyOptionalNoContentExceptionMapper());
 
         // This exception mapper ensures that we handle Jetty's EofException
         // the way we want to (we override the default simply to add instrumentation)

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/EmptyOptionalNoContentExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/EmptyOptionalNoContentExceptionMapper.java
@@ -1,0 +1,15 @@
+package io.dropwizard.jersey.optional;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+/**
+ * Returns a 204 for Optional.empty()
+ * {@link EmptyOptionalExceptionMapper} returns a 404 for Optional.empty()
+ */
+public class EmptyOptionalNoContentExceptionMapper implements ExceptionMapper<EmptyOptionalException> {
+    @Override
+    public Response toResponse(EmptyOptionalException exception) {
+        return Response.noContent().build();
+    }
+}


### PR DESCRIPTION
###### Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->
https://github.com/dropwizard/dropwizard/issues/1727 points out that returning a 204 for Optional.empty() is usually a more reasonable server response, but a dangerous change to default behavior. https://github.com/dropwizard/dropwizard/pull/1784 addressed the issue by showing how to override the default behavior. However, overriding the default behavior requires implementing a new class (i.e. EmptyOptionalNoContentExceptionMapper). It would be nice if users didn't have to implement this class every time they want to override the default behavior. Although, the implementation is really small, so I understand if this is rejected.

###### Solution:
<!-- Describe the modifications you've done. -->
Uses the same solution presented in https://github.com/dropwizard/dropwizard/pull/1784, but includes the implementation in dropwizard-jersey

###### Result:
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->
An additional class in the public API
