### PR TITLE
Expose additional GzipHandler properties in GzipHandlerFactory

### DIFF
--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/GzipHandlerFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/GzipHandlerFactory.java
@@ -45,14 +45,33 @@ import static java.util.Objects.requireNonNull;
  *     </tr>
  *     <tr>
  *         <td>{@code excludedUserAgentPatterns}</td>
- *         <td>(none)</td>
- *         <td>The set of user agent patterns to exclude from compression. </td>
+ *         <td>(Jetty's default)</td>
+ *         <td>A list of regex patterns for User-Agent names from which requests should not be compressed. The default
+ *             is {@code [".*MSIE 6.0.*"]}</td>
  *     </tr>
  *     <tr>
  *         <td>{@code compressedMimeTypes}</td>
  *         <td>(Jetty's default)</td>
- *         <td>The list of mime types to compress. The default is all types apart the
+ *         <td>List of MIME types to compress. The default is all types apart the
  *         commonly known image, video, audio and compressed types.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code excludedMimeTypes}</td>
+ *         <td>(Jetty's default)</td>
+ *         <td>List of MIME types not to compress. The default is a list of commonly known image, video, audio and
+ *             compressed types.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code includedPaths}</td>
+ *         <td>(Jetty's default)</td>
+ *         <td>List of paths to consider for compression. The default is all paths.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code excludedPaths}</td>
+ *         <td>(none)</td>
+ *         <td>List of paths to exclude from compression. Performs a {@code String.startsWith(String)} comparison to
+ *             check if the path matches. If it does match then there is no compression. To match subpaths use
+ *             excludePathPatterns instead.</td>
  *     </tr>
  *     <tr>
  *         <td>{@code includedMethods}</td>
@@ -89,7 +108,16 @@ public class GzipHandlerFactory {
     private Set<String> compressedMimeTypes;
 
     @Nullable
+    private Set<String> excludedMimeTypes;
+
+    @Nullable
     private Set<String> includedMethods;
+
+    @Nullable
+    private Set<String> excludedPaths;
+
+    @Nullable
+    private Set<String> includedPaths;
 
     @Min(Deflater.DEFAULT_COMPRESSION)
     @Max(Deflater.BEST_COMPRESSION)
@@ -141,6 +169,17 @@ public class GzipHandlerFactory {
     }
 
     @JsonProperty
+    @Nullable
+    public Set<String> getExcludedMimeTypes() {
+        return excludedMimeTypes;
+    }
+
+    @JsonProperty
+    public void setExcludedMimeTypes(Set<String> mimeTypes) {
+        this.excludedMimeTypes = mimeTypes;
+    }
+
+    @JsonProperty
     public int getDeflateCompressionLevel() {
         return deflateCompressionLevel;
     }
@@ -180,6 +219,28 @@ public class GzipHandlerFactory {
     }
 
     @JsonProperty
+    @Nullable
+    public Set<String> getExcludedPaths() {
+        return excludedPaths;
+    }
+
+    @JsonProperty
+    public void setExcludedPaths(Set<String> paths) {
+        this.excludedPaths = paths;
+    }
+
+    @JsonProperty
+    @Nullable
+    public Set<String> getIncludedPaths() {
+        return includedPaths;
+    }
+
+    @JsonProperty
+    public void setIncludedPaths(Set<String> paths) {
+        this.includedPaths = paths;
+    }
+
+    @JsonProperty
     public boolean isSyncFlush() {
         return syncFlush;
     }
@@ -201,8 +262,20 @@ public class GzipHandlerFactory {
             gzipHandler.setIncludedMimeTypes(Iterables.toArray(compressedMimeTypes, String.class));
         }
 
+        if (excludedMimeTypes != null) {
+            gzipHandler.setExcludedMimeTypes(Iterables.toArray(excludedMimeTypes, String.class));
+        }
+
         if (includedMethods != null) {
             gzipHandler.setIncludedMethods(Iterables.toArray(includedMethods, String.class));
+        }
+
+        if (excludedPaths != null) {
+            gzipHandler.setExcludedPaths(Iterables.toArray(excludedPaths, String.class));
+        }
+
+        if (includedPaths != null) {
+            gzipHandler.setIncludedPaths(Iterables.toArray(includedPaths, String.class));
         }
 
         gzipHandler.setExcludedAgentPatterns(Iterables.toArray(excludedUserAgentPatterns, String.class));

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/GzipHandlerFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/GzipHandlerFactoryTest.java
@@ -6,6 +6,7 @@ import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.util.Size;
 import io.dropwizard.validation.BaseValidator;
+import org.eclipse.jetty.server.Handler;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -13,6 +14,7 @@ import java.io.File;
 import java.util.zip.Deflater;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class GzipHandlerFactoryTest {
     private GzipHandlerFactory gzip;
@@ -80,5 +82,29 @@ public class GzipHandlerFactoryTest {
         assertThat(handler.getIncludedMethods()).containsOnly("GET");
         assertThat(handler.getCompressionLevel()).isEqualTo(Deflater.DEFAULT_COMPRESSION);
         assertThat(handler.isInflateNoWrap()).isTrue();
+    }
+
+    @Test
+    public void testBuilderProperties() {
+        GzipHandlerFactory gzip = new GzipHandlerFactory();
+        gzip.setGzipCompatibleInflation(true); // Also known as "inflate no wrap"
+        gzip.setMinimumEntitySize(Size.bytes(4096));
+        gzip.setIncludedMethods(ImmutableSet.of("GET", "POST"));
+        gzip.setExcludedUserAgentPatterns(ImmutableSet.of("MSIE 6.0"));
+        gzip.setCompressedMimeTypes(ImmutableSet.of("text/html", "application/json"));
+        gzip.setExcludedMimeTypes(ImmutableSet.of("application/thrift"));
+        gzip.setIncludedPaths(ImmutableSet.of("/include/me"));
+        gzip.setExcludedPaths(ImmutableSet.of("/exclude/me"));
+        Handler handler = mock(Handler.class);
+        BiDiGzipHandler biDiGzipHandler = gzip.build(handler);
+
+        assertThat(biDiGzipHandler.isInflateNoWrap());
+        assertThat(biDiGzipHandler.getMinGzipSize()).isEqualTo(4096);
+        assertThat(biDiGzipHandler.getIncludedMethods()).containsExactlyInAnyOrder("GET", "POST");
+        assertThat(biDiGzipHandler.getExcludedAgentPatterns()).containsExactly("MSIE 6.0");
+        assertThat(biDiGzipHandler.getIncludedMimeTypes()).containsExactlyInAnyOrder("text/html", "application/json");
+        assertThat(biDiGzipHandler.getExcludedMimeTypes()).containsExactly("application/thrift");
+        assertThat(biDiGzipHandler.getIncludedPaths()).containsExactly("/include/me");
+        assertThat(biDiGzipHandler.getExcludedPaths()).containsExactly("/exclude/me");
     }
 }


### PR DESCRIPTION
This commit exposes three additional configuration properties from Jetty's GzipHandler in DropWizard's GzipHandlerFactory: excludedMimeTypes, includedPaths, excludedPaths.

###### Problem:
Jetty provides configuration properties for GzipHandler that are not currently exposed in DropWizard. This commit adds these additional properties to GzipHandlerFactory.

###### Solution:
The three additional GzipHandler configuration properties have been exposed in GzipHandlerFactory following the pattern already adhered to by that class.
