### PR TITLE
Make possible to collect backend exceptions

### DIFF
--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/DropwizardTestApplication.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/DropwizardTestApplication.java
@@ -12,6 +12,7 @@ import javax.annotation.Nullable;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.PUT;
 import javax.ws.rs.core.MediaType;
 import java.io.PrintWriter;
 import java.util.Collections;
@@ -53,6 +54,12 @@ public class DropwizardTestApplication extends Application<TestConfiguration> {
         @PATCH
         public String echoPatch(String patchMessage) {
             return patchMessage;
+        }
+
+        @Path("throwError")
+        @PUT
+        public String throwError(String errorMessage) {
+            throw new RuntimeException(errorMessage);
         }
     }
 

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/ServerSideExceptionsCollectorTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/ServerSideExceptionsCollectorTest.java
@@ -1,8 +1,7 @@
 package io.dropwizard.testing.junit;
 
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
-import static org.junit.Assert.assertThat;
-import static org.hamcrest.CoreMatchers.equalTo;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -78,7 +77,7 @@ public class ServerSideExceptionsCollectorTest
             .request()
             .put(Entity.entity("This is an server side exception", MediaType.TEXT_PLAIN));
 
-        assertThat(response.getStatus(), equalTo(400));
+        assertThat(response.getStatus()).isEqualTo(400);
     }
 
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/ServerSideExceptionsCollectorTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/ServerSideExceptionsCollectorTest.java
@@ -1,0 +1,84 @@
+package io.dropwizard.testing.junit;
+
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runners.model.MultipleFailureException;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.app.DropwizardTestApplication;
+import io.dropwizard.testing.app.TestConfiguration;
+import io.dropwizard.testing.junit.DropwizardAppRule.ServerSideExceptionsCollector;
+
+public class ServerSideExceptionsCollectorTest
+{
+
+    public static class DropwizardTestApplicationWithLogCollector extends DropwizardTestApplication
+    {
+        @Override
+        public void run(TestConfiguration configuration, Environment environment) throws Exception
+        {
+            super.run(configuration, environment);
+
+            // errors will be handled on server side
+            environment.jersey().register(new ExceptionMapper<Throwable>()
+            {
+                @Override
+                public Response toResponse(Throwable exception)
+                {
+                    return Response.status(400).build();
+                }
+            });
+        }
+    }
+
+    @ClassRule
+    public static final DropwizardAppRule<TestConfiguration> APP1_WITHOUT_LOG_COLLECTION = new DropwizardAppRule<>(
+        DropwizardTestApplication.class, resourceFilePath("test-config.yaml"));
+    @Rule
+    public final ServerSideExceptionsCollector app1ErrorCollector = APP1_WITHOUT_LOG_COLLECTION
+        .collectServerSideExceptions();
+
+    @ClassRule
+    public static final DropwizardAppRule<TestConfiguration> APP2_WITH_LOG_COLLECTION = new DropwizardAppRule<>(
+        DropwizardTestApplicationWithLogCollector.class, resourceFilePath("test-config.yaml"));
+    @Rule
+    public final ServerSideExceptionsCollector app2ErrorCollector = APP2_WITH_LOG_COLLECTION
+        .collectServerSideExceptions();
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void canCollectServerSideErrors()
+    {
+        thrown.expect(MultipleFailureException.class);
+        thrown.expectMessage("This is an server side exception");
+
+        APP1_WITHOUT_LOG_COLLECTION.client().target("http://localhost:" + APP1_WITHOUT_LOG_COLLECTION.getLocalPort() + "/throwError")
+            .request()
+            .put(Entity.entity("This is an server side exception", MediaType.TEXT_PLAIN), String.class);
+    }
+
+    @Test
+    public void wontCollectErrorsAlreadyHandled()
+    {
+        final Response response = APP2_WITH_LOG_COLLECTION.client().target("http://localhost:"
+            + APP2_WITH_LOG_COLLECTION.getLocalPort() + "/throwError")
+            .request()
+            .put(Entity.entity("This is an server side exception", MediaType.TEXT_PLAIN));
+
+        assertThat(response.getStatus(), equalTo(400));
+    }
+
+}

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/ServerSideExceptionsCollectorTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/ServerSideExceptionsCollectorTest.java
@@ -1,0 +1,84 @@
+package io.dropwizard.testing.junit5;
+
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.ws.rs.InternalServerErrorException;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.app.DropwizardTestApplication;
+import io.dropwizard.testing.app.TestConfiguration;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+public class ServerSideExceptionsCollectorTest
+{
+
+    public static final DropwizardAppExtension<TestConfiguration> APP1_WITHOUT_LOG_COLLECTION =
+        new DropwizardAppExtension<>(DropwizardTestApplication.class, resourceFilePath("test-config.yaml"));
+
+    @Test
+    public void canCollectServerSideErrors()
+    {
+        Assertions.assertThrows(
+            InternalServerErrorException.class,
+            () -> {
+                APP1_WITHOUT_LOG_COLLECTION.client().target("http://localhost:" + APP1_WITHOUT_LOG_COLLECTION
+                    .getLocalPort() + "/throwError")
+                    .request()
+                    .put(Entity.entity("This is an server side exception", MediaType.TEXT_PLAIN), String.class);
+            },
+            // check if the server exception message was attached to original InternalServerErrorException
+            "This is an server side exception"
+        );
+    }
+
+    public static class DropwizardTestApplicationWithLogCollector extends DropwizardTestApplication
+    {
+        @Override
+        public void run(TestConfiguration configuration, Environment environment) throws Exception
+        {
+            super.run(configuration, environment);
+            // errors will be handled on server side
+            environment.jersey().register(new LogExceptionMapper());
+        }
+
+        @Provider
+        private static class LogExceptionMapper implements ExceptionMapper<Throwable>{
+
+            @Override
+            public Response toResponse(Throwable exception)
+            {
+            return Response.status(400)
+                .entity(exception.getMessage())
+                .build();
+            }
+
+        }
+
+    }
+
+    public static final DropwizardAppExtension<TestConfiguration> APP2_WITH_LOG_COLLECTION =
+        new DropwizardAppExtension<>(DropwizardTestApplicationWithLogCollector.class, resourceFilePath("test-config.yaml"));
+
+    @Test
+    public void wontCollectErrorsAlreadyHandled()
+    {
+        final Response response = APP2_WITH_LOG_COLLECTION.client().target("http://localhost:"
+            + APP2_WITH_LOG_COLLECTION.getLocalPort() + "/throwError")
+            .request()
+            .put(Entity.entity("Server will capture this exception and send http error", MediaType.TEXT_PLAIN));
+
+        assertThat(response.getStatus(), equalTo(400));
+    }
+
+}


### PR DESCRIPTION
This patch enriches the errors with backend exception stack traces when a `@Test` fails.

Without this, error looks like:
```
feign.FeignException: status 500 reading FeatureFlagCRUDClient#store(List); content:
{"code":500,"message":"There was an error processing your request. It has been logged (ID 978e0e322a5eae1f)."}
	at feign.FeignException.errorStatus(FeignException.java:62)
	at feign.codec.ErrorDecoder$Default.decode(ErrorDecoder.java:91)
	at feign.SynchronousMethodHandler.executeAndDecode(SynchronousMethodHandler.java:138)
	at feign.SynchronousMethodHandler.invoke(SynchronousMethodHandler.java:76)
	at feign.ReflectiveFeign$FeignInvocationHandler.invoke(ReflectiveFeign.java:103)
	at $Proxy83.store(Unknown Source)
	at MyTest.throwBackendError(MyTest.java:52)
^--- only shows were it failed on client
...
more on the stack, but I removed
```

With this, more relevant details is available:
```
feign.FeignException: status 500 reading FeatureFlagCRUDClient#store(List); content:
{"code":500,"message":"There was an error processing your request. It has been logged (ID 952586bb1d1433b3)."}
	at feign.FeignException.errorStatus(FeignException.java:62)
	at feign.codec.ErrorDecoder$Default.decode(ErrorDecoder.java:91)
	at feign.SynchronousMethodHandler.executeAndDecode(SynchronousMethodHandler.java:138)
	at feign.SynchronousMethodHandler.invoke(SynchronousMethodHandler.java:76)
	at feign.ReflectiveFeign$FeignInvocationHandler.invoke(ReflectiveFeign.java:103)
        at $Proxy83.store(Unknown Source)
        at MyTest.throwBackendError(MyTest.java:52)
^--- only shows were it failed on client
...     
more on the stack, but I removed    

org.apache.avro.AvroTypeException: Found A, expecting B, missing required field name
	at org.apache.avro.io.ResolvingDecoder.doAction(ResolvingDecoder.java:292)
	at org.apache.avro.io.parsing.Parser.advance(Parser.java:88)
	at org.apache.avro.io.ResolvingDecoder.readFieldOrder(ResolvingDecoder.java:130)
	at org.apache.avro.generic.GenericDatumReader.readRecord(GenericDatumReader.java:223)
	at org.apache.avro.generic.GenericDatumReader.readWithoutConversion(GenericDatumReader.java:174)
	at org.apache.avro.generic.GenericDatumReader.read(GenericDatumReader.java:152)
	at org.apache.avro.generic.GenericDatumReader.read(GenericDatumReader.java:144)
	at org.apache.avro.file.DataFileStream.next(DataFileStream.java:233)
	at org.apache.avro.file.DataFileStream.next(DataFileStream.java:220)
	at com.google.common.collect.ImmutableList.copyOf(ImmutableList.java:266)
	at AvroConsumer.readFrom(AvroConsumer.java:142)
	at AvroConsumer.readFrom(AvroConsumer.java:34)
^--- this is exactly where the error happened
...
more on the stack, but I removed   
```