### PR TITLE
Add support for multiple session factories at the same time

### DIFF
--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWork.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWork.java
@@ -55,5 +55,5 @@ public @interface UnitOfWork {
      * The name of a hibernate bundle (session factory) that specifies
      * a datasource against which a transaction will be opened.
      */
-    String value() default HibernateBundle.DEFAULT_NAME;
+    String[] value() default HibernateBundle.DEFAULT_NAME;
 }

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAspect.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAspect.java
@@ -193,7 +193,7 @@ public class UnitOfWorkAspect {
             return;
         }
 
-        //We need to ensure that the changes in all the sessions have been rollbacked
+        //We need to ensure that the changes in all the sessions have been rolled back
         //and also we need to inform about the exceptions
         List<Optional<RuntimeException>> errors = sessions.values().stream()
             .map(UnitOfWorkAspect::rollbackTransaction)

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
@@ -166,8 +166,8 @@ public class UnitOfWorkAwareProxyFactoryTest {
         }
 
         @Override
-        protected void configureSession() {
-            super.configureSession();
+        protected void configureSessions() {
+            super.configureSessions();
             Transaction transaction = getSession().beginTransaction();
             getSession().createNativeQuery("insert into user_sessions values ('gr6f9y0', 'jeff_29')")
                 .executeUpdate();


### PR DESCRIPTION
###### Problem:
Sometimes we need to use multiple Hibernate bundles on a resource endpoint at the same time. In some projects, this is a requirement and we can't refactor the code to use only one. We found that in the current code we are able to register multiple Hibernate bundles but we can only use one at a time (With the `@UnitOfWork` annotation). This PR is to add the ability to use more than one bundle in the same `@UnitOfWork` context.

###### Solution:
We changed the `@UnitOfWork` annotation to accept multiple values for the bundle name. Also, we changed the `UnitOfWorkAspect` to process all the selected bundles (instead of processing only one) in the same way as before. So when we perform any operation in the aspect we execute it in all the selected bundles. 

This allows us to see all the selected bundles as a group in the way that if an error occurs and the transaction needs to be reverted they are going to be rollbacked in all the selected bundles, the same happens with the commit and clean operations.

###### Result:
The result is that we can select multiple bundles in the same `@UnitOfWork` by passing the values as follow:

`@UnitOfWork(value={'bundle1', 'bundle2'})`
or just
`@UnitOfWork({'bundle1', 'bundle2'})`

The change is totally retro-compatible and we can specify only one bundle by:

`@UnitOfWork('bundle')`
or use the default one (if we only register one bundle) by not passing any value.
`@UnitOfWork`

The rest of the system will remain exactly the same and also the use of Hibernate will not change at all.
