### PR TITLE
Add additional syslog logging facilities

### DIFF
--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/SyslogAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/SyslogAppenderFactory.java
@@ -74,15 +74,19 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 @JsonTypeName("syslog")
 public class SyslogAppenderFactory extends AbstractAppenderFactory<ILoggingEvent> {
     public enum Facility {
+        ALERT,
+        AUDIT,
         AUTH,
         AUTHPRIV,
         DAEMON,
+        CLOCK,
         CRON,
         FTP,
         LPR,
         KERN,
         MAIL,
         NEWS,
+        NTP,
         SYSLOG,
         USER,
         UUCP,

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/SyslogAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/SyslogAppenderFactoryTest.java
@@ -13,7 +13,10 @@ import io.dropwizard.logging.layout.DropwizardLayoutFactory;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
 
+import java.util.Locale;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 public class SyslogAppenderFactoryTest {
 
@@ -75,5 +78,14 @@ public class SyslogAppenderFactoryTest {
             new NullLevelFilterFactory<>(), new AsyncLoggingEventAppenderFactory());
 
         assertThat(appender.getName()).isEqualTo("async-syslog-appender");
+    }
+
+    @Test
+    public void syslogFacilityTest() {
+        for (SyslogAppenderFactory.Facility facility : SyslogAppenderFactory.Facility.values()) {
+            assertThatCode(() ->
+                    SyslogAppender.facilityStringToint(facility.toString().toLowerCase(Locale.ENGLISH)))
+                .doesNotThrowAnyException();
+        }
     }
 }


### PR DESCRIPTION
###### Problem:
Dropwizard's syslog appender doesn't support all facility levels. [See wiki for possible values](https://en.wikipedia.org/wiki/Syslog#Facility). In addition, [Logback supports these additional values](https://github.com/qos-ch/logback/blob/4dd08e68321548cd85251ec389f5a832505e1268/logback-core/src/main/java/ch/qos/logback/core/net/SyslogAppenderBase.java#L125-L177), so there is no reason to not include them. There was some talk of the interaction with slf4j in #2173, but since Dropwizard's syslog appender only deals with logback, slf4j doesn't enter the picture.

###### Solution:
Add the missing facilities to the configuration. These facilities are then tested against logback's string-to-int syslog resolution function to ensure that we don't allow any faulty configuration options.

###### Result:
Closes #2173
