### PR TITLE
UUID param to length check input

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/UUIDParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/UUIDParam.java
@@ -24,6 +24,17 @@ public class UUIDParam extends AbstractParam<UUID> {
 
     @Override
     protected UUID parse(@Nullable String input) throws Exception {
+        // From UUID RFC 4122 spec, a UUID contains 32 hex digits with 4 dashes. fromString will
+        // ensure that only hex exists and that there are 4 dashes, but does no length checking, so
+        // the input could have additional hex digits appended and no error would be raised. Since
+        // the spec clearly defines the length to be 36, we'll ensure the input conforms. Some UUID
+        // implementations are lenient and allow absent dashes (thus making the total length 32),
+        // but since fromString requires dashes we don't need to worry about supporting a range of
+        // lengths.
+        if (input != null && input.length() != 36) {
+            throw new IllegalArgumentException("Expecting a UUID of 36 in length");
+        }
+
         return UUID.fromString(input);
     }
 


### PR DESCRIPTION
###### Problem:
`UUID::fromString` does not length check the input to be 32 in length, which violates UUID RFC 4122 spec. Consequently,  This can be seen in the example where one UUID has a `0` appended

```java
assertThat(UUID.fromString("067e6162-3b6f-4ae2-a171-2470b63dff000")).isEqualTo(
           UUID.fromString("067e6162-3b6f-4ae2-a171-2470b63dff00")
);
```

Fails with:

```
Expected :067e6162-3b6f-4ae2-a171-2470b63dff00
Actual   :067e6162-3b6f-4ae2-a173-470b63dff000
```

While `UUID::fromString` does not care about length when validating, it's clearly an issue as it shifts the internal representation.

###### Solution:
Some UUID implementations are lenient and allow absent dashes (thus making the total length 32), but
since fromString requires dashes we don't need to worry about supporting a range of lengths and may only check against 32.

Backwards compatibility shouldn't be an issue as any other length would either result in an exception from `UUID::fromString` or a corrupted UUID that isn't equivalent with the input anyways.

###### Result:
Previously UUIDs that were too long are now rejected. Closes #2374
