### PR TITLE
Update liquibase to 3.6.1

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -152,7 +152,7 @@
             <dependency>
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-core</artifactId>
-                <version>3.6.0</version>
+                <version>3.6.1</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.yaml</groupId>


### PR DESCRIPTION
Fixes #2385

By the way it might be nice to have a message about the change to checksums in Liquibase 3.6 somewhere in Dropwizard's release notes, I nearly had a heart attack when I ran a `db status` this morning ;)