### PR TITLE
Overhaul logging resource endpoints

### DIFF
--- a/dropwizard-benchmarks/pom.xml
+++ b/dropwizard-benchmarks/pom.xml
@@ -55,5 +55,9 @@
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-jersey</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework</groupId>
+            <artifactId>jersey-test-framework-core</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/dropwizard-benchmarks/src/main/java/io/dropwizard/benchmarks/jersey/DropwizardResourceConfigBenchmark.java
+++ b/dropwizard-benchmarks/src/main/java/io/dropwizard/benchmarks/jersey/DropwizardResourceConfigBenchmark.java
@@ -3,6 +3,7 @@ package io.dropwizard.benchmarks.jersey;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.jersey.DropwizardResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -19,6 +20,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Application;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -31,10 +33,20 @@ public class DropwizardResourceConfigBenchmark {
             new DropwizardResourceConfig(true, new MetricRegistry());
 
     @Setup
-    public void setUp() {
+    public void setUp() throws Exception {
         dropwizardResourceConfig.register(DistributionResource.class);
         dropwizardResourceConfig.register(AssetResource.class);
         dropwizardResourceConfig.register(ClustersResource.class);
+
+        final JerseyTest jerseyTest = new JerseyTest() {
+            @Override
+            protected Application configure() {
+                return dropwizardResourceConfig;
+            }
+        };
+
+        jerseyTest.setUp();
+        jerseyTest.tearDown();
     }
 
     @Benchmark

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -5,7 +5,9 @@ import com.codahale.metrics.jersey2.InstrumentedResourceMethodApplicationListene
 import com.fasterxml.classmate.ResolvedType;
 import com.fasterxml.classmate.TypeResolver;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
 import io.dropwizard.jersey.caching.CacheControlledResponseFeature;
 import io.dropwizard.jersey.params.AbstractParamConverterProvider;
@@ -23,15 +25,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import javax.ws.rs.Path;
-import javax.ws.rs.ext.Provider;
 import java.io.Serializable;
-import java.lang.annotation.Annotation;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class DropwizardResourceConfig extends ResourceConfig {
     private static final Logger LOGGER = LoggerFactory.getLogger(DropwizardResourceConfig.class);
@@ -42,6 +45,7 @@ public class DropwizardResourceConfig extends ResourceConfig {
 
     private String urlPattern = "/*";
     private String contextPath = "/";
+    private final ComponentLoggingListener loggingListener = new ComponentLoggingListener(this);
 
     public DropwizardResourceConfig(MetricRegistry metricRegistry) {
         this(false, metricRegistry);
@@ -59,10 +63,7 @@ public class DropwizardResourceConfig extends ResourceConfig {
         }
 
         property(ServerProperties.WADL_FEATURE_DISABLE, Boolean.TRUE);
-        if (!testOnly) {
-            // create a subclass to pin it to Throwable
-            register(new ComponentLoggingListener(this));
-        }
+        register(loggingListener);
 
         register(new InstrumentedResourceMethodApplicationListener(metricRegistry));
         register(CacheControlledResponseFeature.class);
@@ -82,12 +83,6 @@ public class DropwizardResourceConfig extends ResourceConfig {
         return new DropwizardResourceConfig(true, metricRegistry);
     }
 
-    public void logComponents() {
-        LOGGER.debug("resources = {}", canonicalNamesByAnnotation(Path.class));
-        LOGGER.debug("providers = {}", canonicalNamesByAnnotation(Provider.class));
-        LOGGER.info(getEndpointsInfo());
-    }
-
     public String getUrlPattern() {
         return urlPattern;
     }
@@ -96,8 +91,16 @@ public class DropwizardResourceConfig extends ResourceConfig {
         this.urlPattern = urlPattern;
     }
 
+    public String getContextPath() {
+        return contextPath;
+    }
+
     public void setContextPath(String contextPath){
         this.contextPath = contextPath;
+    }
+
+    public String getEndpointsInfo() {
+        return loggingListener.getEndpointsInfo();
     }
 
     /**
@@ -114,132 +117,9 @@ public class DropwizardResourceConfig extends ResourceConfig {
         return allClasses;
     }
 
-    private Set<String> canonicalNamesByAnnotation(final Class<? extends Annotation> annotation) {
-        final Set<String> result = new HashSet<>();
-        for (Class<?> clazz : getClasses()) {
-            if (clazz.isAnnotationPresent(annotation)) {
-                result.add(clazz.getCanonicalName());
-            }
-        }
-        return result;
-    }
-
-    public String getEndpointsInfo() {
-        final StringBuilder msg = new StringBuilder(1024);
-        final Set<EndpointLogLine> endpointLogLines = new TreeSet<>(new EndpointComparator());
-
-        msg.append("The following paths were found for the configured resources:");
-        msg.append(NEWLINE).append(NEWLINE);
-
-        final Set<Class<?>> allResourcesClasses = new HashSet<>();
-        for (Class<?> clazz : allClasses()) {
-            if (!clazz.isInterface() && Resource.from(clazz) != null) {
-                allResourcesClasses.add(clazz);
-            }
-        }
-
-        for (Class<?> klass : allResourcesClasses) {
-            new EndpointLogger(contextPath, urlPattern, klass).populate(endpointLogLines);
-        }
-
-        final Set<Resource> allResources = this.getResources();
-        for (Resource res : allResources) {
-            for (Resource childRes : res.getChildResources()) {
-                // It is not necessary to check if a handler class is already being logged.
-                //
-                // This code will never be reached because of ambiguous (sub-)resource methods
-                // related to the OPTIONS method and @Consumes/@Produces annotations.
-
-                for (Class<?> childResHandlerClass : childRes.getHandlerClasses()) {
-                    EndpointLogger epl = new EndpointLogger(contextPath, urlPattern, childResHandlerClass);
-                    epl.populate(cleanUpPath(res.getPath() + epl.rootPath), epl.klass, false, childRes, endpointLogLines);
-                }
-            }
-        }
-
-        if (!endpointLogLines.isEmpty()) {
-            for (EndpointLogLine line : endpointLogLines) {
-                msg.append(line).append(NEWLINE);
-            }
-        } else {
-            msg.append("    NONE").append(NEWLINE);
-        }
-
-        return msg.toString();
-    }
-
     @VisibleForTesting
-    String cleanUpPath(String path) {
+    static String cleanUpPath(String path) {
         return PATH_DIRTY_SLASHES.matcher(path).replaceAll("/").trim();
-    }
-
-
-    /**
-     * Takes care of recursively creating all registered endpoints and providing them as Collection of lines to log
-     * on application start.
-     */
-    private static class EndpointLogger {
-        private final String rootPath;
-        private final Class<?> klass;
-
-        EndpointLogger(String contextPath, String urlPattern, Class<?> klass) {
-            final String rootPattern = urlPattern.endsWith("/*") ? urlPattern.substring(0, urlPattern.length() - 1) : urlPattern;
-            final String normalizedContextPath = contextPath.isEmpty() || contextPath.equals("/") ? "" :
-                contextPath.startsWith("/") ? contextPath : "/" + contextPath;
-            this.rootPath = normalizedContextPath + rootPattern;
-            this.klass = klass;
-        }
-
-        public void populate(Set<EndpointLogLine> endpointLogLines) {
-            populate(this.rootPath, klass, false, endpointLogLines);
-        }
-
-        private void populate(String basePath, Class<?> klass, boolean isLocator,
-                              Set<EndpointLogLine> endpointLogLines) {
-            populate(basePath, klass, isLocator, Resource.from(klass), endpointLogLines);
-        }
-
-        private void populate(String basePath, Class<?> klass, boolean isLocator, Resource resource,
-                              Set<EndpointLogLine> endpointLogLines) {
-            if (!isLocator) {
-                basePath = normalizePath(basePath, resource.getPath());
-            }
-
-            for (ResourceMethod method : resource.getResourceMethods()) {
-                endpointLogLines.add(new EndpointLogLine(method.getHttpMethod(), basePath, klass));
-            }
-
-            for (Resource childResource : resource.getChildResources()) {
-                for (ResourceMethod method : childResource.getAllMethods()) {
-                    if (method.getType() == ResourceMethod.JaxrsType.RESOURCE_METHOD) {
-                        final String path = normalizePath(basePath, childResource.getPath());
-                        endpointLogLines.add(new EndpointLogLine(method.getHttpMethod(), path, klass));
-                    } else if (method.getType() == ResourceMethod.JaxrsType.SUB_RESOURCE_LOCATOR) {
-                        final String path = normalizePath(basePath, childResource.getPath());
-                        final ResolvedType responseType = TYPE_RESOLVER
-                                .resolve(method.getInvocable().getResponseType());
-                        final Class<?> erasedType = !responseType.getTypeBindings().isEmpty() ?
-                                responseType.getTypeBindings().getBoundType(0).getErasedType() :
-                                responseType.getErasedType();
-                        if (Resource.from(erasedType) == null) {
-                            endpointLogLines.add(new EndpointLogLine(method.getHttpMethod(), path, erasedType));
-                        } else {
-                            populate(path, erasedType, true, endpointLogLines);
-                        }
-                    }
-                }
-            }
-        }
-
-        private static String normalizePath(String basePath, String path) {
-            if (path == null) {
-                return basePath;
-            }
-            if (basePath.endsWith("/")) {
-                return path.startsWith("/") ? basePath + path.substring(1) : basePath + path;
-            }
-            return path.startsWith("/") ? basePath + path : basePath + "/" + path;
-        }
     }
 
     private static class EndpointLogLine {
@@ -274,16 +154,116 @@ public class DropwizardResourceConfig extends ResourceConfig {
 
     private static class ComponentLoggingListener implements ApplicationEventListener {
         private final DropwizardResourceConfig config;
+        private List<Resource> resources = Collections.emptyList();
+        private Set<Class<?>> providers = Collections.emptySet();
 
-        ComponentLoggingListener(DropwizardResourceConfig config) {
+        public ComponentLoggingListener(DropwizardResourceConfig config) {
             this.config = config;
         }
 
         @Override
         public void onEvent(ApplicationEvent event) {
             if (event.getType() == ApplicationEvent.Type.INITIALIZATION_APP_FINISHED) {
-                config.logComponents();
+                resources = event.getResourceModel().getResources();
+                providers = event.getProviders();
+
+                final String resourceClasses = resources.stream()
+                    .map(x -> x.getClass().getCanonicalName())
+                    .collect(Collectors.joining(", "));
+
+                final String providerClasses = providers.stream()
+                    .map(Class::getCanonicalName)
+                    .collect(Collectors.joining(", "));
+
+                LOGGER.debug("resources = {}", resourceClasses);
+                LOGGER.debug("providers = {}", providerClasses);
+                LOGGER.info(getEndpointsInfo());
             }
+        }
+
+        private List<EndpointLogLine> logMethodLines(Resource resource, String contextPath) {
+            final ImmutableList.Builder<EndpointLogLine> builder = ImmutableList.builder();
+            for (ResourceMethod method : resource.getAllMethods()) {
+                if ("OPTIONS".equalsIgnoreCase(method.getHttpMethod())) {
+                    continue;
+                }
+
+                final String path = cleanUpPath(contextPath + Strings.nullToEmpty(resource.getPath()));
+                final Class<?> handler = method.getInvocable().getHandler().getHandlerClass();
+                switch (method.getType()) {
+                    case RESOURCE_METHOD:
+                        builder.add(new EndpointLogLine(method.getHttpMethod(), path, handler));
+                        break;
+                    case SUB_RESOURCE_LOCATOR:
+                        final ResolvedType responseType = TYPE_RESOLVER
+                            .resolve(method.getInvocable().getResponseType());
+                        final Class<?> erasedType = !responseType.getTypeBindings().isEmpty() ?
+                            responseType.getTypeBindings().getBoundType(0).getErasedType() :
+                            responseType.getErasedType();
+
+                        final Resource res = Resource.from(erasedType);
+                        if (res == null) {
+                            builder.add(new EndpointLogLine(method.getHttpMethod(), path, handler));
+                        } else {
+                            builder.addAll(logResourceLines(res, path));
+                        }
+
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            return builder.build();
+        }
+
+        private List<EndpointLogLine> logResourceLines(Resource resource, String contextPath) {
+            final ImmutableList.Builder<EndpointLogLine> builder = ImmutableList.builder();
+            for (Resource child : resource.getChildResources()) {
+                builder.addAll(logResourceLines(child, cleanUpPath(contextPath + Strings.nullToEmpty(resource.getPath()))));
+            }
+
+            builder.addAll(logMethodLines(resource, contextPath));
+
+            return builder.build();
+        }
+
+        String getEndpointsInfo() {
+            final StringBuilder msg = new StringBuilder(1024);
+            final Set<EndpointLogLine> endpointLogLines = new TreeSet<>(new EndpointComparator());
+            final String contextPath = config.getContextPath();
+            final String normalizedContextPath = contextPath.isEmpty() || contextPath.equals("/") ? "" :
+                contextPath.startsWith("/") ? contextPath : "/" + contextPath;
+            final String pattern = config.getUrlPattern().endsWith("/*") ?
+                config.getUrlPattern().substring(0, config.getUrlPattern().length() - 1) :
+                config.getUrlPattern();
+
+            final String path = cleanUpPath(normalizedContextPath + pattern);
+
+            msg.append("The following paths were found for the configured resources:");
+            msg.append(NEWLINE).append(NEWLINE);
+
+            for (Resource resource : resources) {
+                endpointLogLines.addAll(logResourceLines(resource, path));
+            }
+
+            final List<EndpointLogLine> providerLines = providers.stream()
+                .map(Resource::from)
+                .filter(Objects::nonNull)
+                .flatMap(res -> logResourceLines(res, path).stream())
+                .collect(Collectors.toList());
+
+            endpointLogLines.addAll(providerLines);
+
+            if (!endpointLogLines.isEmpty()) {
+                for (EndpointLogLine line : endpointLogLines) {
+                    msg.append(line).append(NEWLINE);
+                }
+            } else {
+                msg.append("    NONE").append(NEWLINE);
+            }
+
+            return msg.toString();
         }
 
         @Override

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
@@ -3,7 +3,9 @@ package io.dropwizard.jersey;
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.dummy.DummyResource;
 import io.dropwizard.logging.BootstrapLogging;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.server.model.Resource;
+import org.glassfish.jersey.test.JerseyTest;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -13,6 +15,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,6 +30,28 @@ public class DropwizardResourceConfigTest {
     @Before
     public void setUp() {
         rc = DropwizardResourceConfig.forTesting(new MetricRegistry());
+    }
+
+    // Start and stop a jersey test instance so that our resource config
+    // successfully hooks into the Jersey start up application event
+    private void runJersey() {
+        final JerseyTest jerseyTest = new JerseyTest() {
+            @Override
+            protected Application configure() {
+                return rc;
+            }
+        };
+
+        try {
+            jerseyTest.setUp();
+        } catch (Exception e) {
+            throw new RuntimeException("Could not start jersey", e);
+        } finally {
+            try {
+                jerseyTest.tearDown();
+            } catch (Exception ignored) {
+            }
+        }
     }
 
     @Test
@@ -68,6 +93,7 @@ public class DropwizardResourceConfigTest {
                 ResourcePathOnMethodLevel.class
         );
 
+        runJersey();
         assertThat(rc.getEndpointsInfo())
                 .contains("GET     /bar (io.dropwizard.jersey.DropwizardResourceConfigTest.ResourcePathOnMethodLevel)")
                 .contains("GET     /dummy (io.dropwizard.jersey.DropwizardResourceConfigTest.TestResource)");
@@ -75,13 +101,15 @@ public class DropwizardResourceConfigTest {
 
     @Test
     public void logsNoInterfaces() {
-        rc.packages(getClass().getPackage().getName());
+        rc.packages(getClass().getName());
 
+        runJersey();
         assertThat(rc.getEndpointsInfo()).doesNotContain("io.dropwizard.jersey.DropwizardResourceConfigTest.ResourceInterface");
     }
 
     @Test
     public void logsNoEndpointsWhenNoResourcesAreRegistered() {
+        runJersey();
         assertThat(rc.getEndpointsInfo()).contains("    NONE");
     }
 
@@ -90,6 +118,7 @@ public class DropwizardResourceConfigTest {
         rc.register(TestResource.class);
         rc.register(ImplementingResource.class);
 
+        runJersey();
         assertThat(rc.getEndpointsInfo())
                 .contains("GET     /dummy (io.dropwizard.jersey.DropwizardResourceConfigTest.TestResource)")
                 .contains("GET     /another (io.dropwizard.jersey.DropwizardResourceConfigTest.ImplementingResource)");
@@ -102,6 +131,7 @@ public class DropwizardResourceConfigTest {
         rc.register(TestResource.class);
         rc.register(ImplementingResource.class);
 
+        runJersey();
         final String expectedLog = String.format(
                 "The following paths were found for the configured resources:%n"
                 + "%n"
@@ -118,10 +148,11 @@ public class DropwizardResourceConfigTest {
     public void logsNestedEndpoints() {
         rc.register(WrapperResource.class);
 
+        runJersey();
         assertThat(rc.getEndpointsInfo())
                 .contains("    GET     /wrapper/bar (io.dropwizard.jersey.DropwizardResourceConfigTest.ResourcePathOnMethodLevel)")
                 .contains("    GET     /locator/bar (io.dropwizard.jersey.DropwizardResourceConfigTest.ResourcePathOnMethodLevel)")
-                .contains("    UNKNOWN /obj/{it} (java.lang.Object)");
+                .contains("    UNKNOWN /obj/{it} (io.dropwizard.jersey.DropwizardResourceConfigTest.WrapperResource)");
     }
 
     @Test
@@ -133,6 +164,7 @@ public class DropwizardResourceConfigTest {
 
         rc.registerResources(resourceBuilder.build());
 
+        runJersey();
         final String expectedLog = String.format(
                 "The following paths were found for the configured resources:%n"
                 + "%n"
@@ -150,13 +182,15 @@ public class DropwizardResourceConfigTest {
         String dirtyPath = " /this//is///a/dirty//path/     ";
         String anotherDirtyPath = "a/l//p/h/  /a/b /////  e/t";
 
-        assertThat(rc.cleanUpPath(dirtyPath)).isEqualTo("/this/is/a/dirty/path/");
-        assertThat(rc.cleanUpPath(anotherDirtyPath)).isEqualTo("a/l/p/h/a/b/e/t");
+        assertThat(DropwizardResourceConfig.cleanUpPath(dirtyPath)).isEqualTo("/this/is/a/dirty/path/");
+        assertThat(DropwizardResourceConfig.cleanUpPath(anotherDirtyPath)).isEqualTo("a/l/p/h/a/b/e/t");
     }
 
     @Test
     public void duplicatePathsTest() {
         rc.register(TestDuplicateResource.class);
+
+        runJersey();
         final String expectedLog = String.format("The following paths were found for the configured resources:%n" + "%n"
                 + "    GET     /anotherMe (io.dropwizard.jersey.DropwizardResourceConfigTest.TestDuplicateResource)%n"
                 + "    GET     /callme (io.dropwizard.jersey.DropwizardResourceConfigTest.TestDuplicateResource)%n");
@@ -166,11 +200,54 @@ public class DropwizardResourceConfigTest {
     }
 
     @Test
+    public void logEndpointWithRootSubresource() {
+        rc.register(new ShoppingStore());
+
+        runJersey();
+        final String expectedLog = String.format("The following paths were found for the configured resources:%n" + "%n"
+            + "    GET     /customers/{id} (io.dropwizard.jersey.DropwizardResourceConfigTest.Customer)%n"
+            + "    UNKNOWN /customers/{id}/address (io.dropwizard.jersey.DropwizardResourceConfigTest.Customer)%n");
+
+        assertThat(rc.getEndpointsInfo()).contains(expectedLog);
+    }
+
+    @Test
+    public void logEndpointBinder() {
+        rc.register(ResourceInterface.class);
+        rc.register(new AbstractBinder() {
+            @Override
+            protected void configure() {
+                bind(ImplementingResource.class).to(ResourceInterface.class);
+            }
+        });
+
+        runJersey();
+        final String expectedLog = String.format("The following paths were found for the configured resources:%n" + "%n"
+            + "    GET     /another (io.dropwizard.jersey.DropwizardResourceConfigTest.ResourceInterface)");
+
+        assertThat(rc.getEndpointsInfo()).contains(expectedLog);
+    }
+
+    @Test
+    public void logsEndpointsContextPathUrlPattern() {
+        rc.setContextPath("/context");
+        rc.setUrlPattern("/pattern");
+        rc.register(TestResource.class);
+        rc.register(ImplementingResource.class);
+
+        runJersey();
+        assertThat(rc.getEndpointsInfo())
+            .contains("GET     /context/pattern/dummy (io.dropwizard.jersey.DropwizardResourceConfigTest.TestResource)")
+            .contains("GET     /context/pattern/another (io.dropwizard.jersey.DropwizardResourceConfigTest.ImplementingResource)");
+    }
+
+    @Test
     public void logsEndpointsContextPath() {
         rc.setContextPath("/context");
         rc.register(TestResource.class);
         rc.register(ImplementingResource.class);
 
+        runJersey();
         assertThat(rc.getEndpointsInfo())
             .contains("GET     /context/dummy (io.dropwizard.jersey.DropwizardResourceConfigTest.TestResource)")
             .contains("GET     /context/another (io.dropwizard.jersey.DropwizardResourceConfigTest.ImplementingResource)");
@@ -182,6 +259,7 @@ public class DropwizardResourceConfigTest {
         rc.register(TestResource.class);
         rc.register(ImplementingResource.class);
 
+        runJersey();
         assertThat(rc.getEndpointsInfo())
             .contains("GET     /context/dummy (io.dropwizard.jersey.DropwizardResourceConfigTest.TestResource)")
             .contains("GET     /context/another (io.dropwizard.jersey.DropwizardResourceConfigTest.ImplementingResource)");
@@ -279,5 +357,22 @@ public class DropwizardResourceConfigTest {
         public String bar() {
             return "";
         }
+    }
+
+    @Path("/")
+    public static class ShoppingStore {
+        @Path("/customers/{id}")
+        public Customer getCustomer(@PathParam("id") int id) {
+            return new Customer();
+        }
+    }
+
+    public static class Customer {
+        @GET
+        public String get() {return "A";}
+
+        @Path("/address")
+        public String getAddress() {return "B";}
+
     }
 }


### PR DESCRIPTION
###### Problem:
Dropwizard logs resource endpoints on startup like so:

```
    GET     / (io.dropwizard.jersey.dummy.DummyResource)
    GET     /another (io.dropwizard.jersey.DropwizardResourceConfigTest.ImplementingResource)
```

It's very nice, but the current implementation only caters to resources registered directly through `DropwizardResourceConfig` and may fail to log endpoints that have been registered through a DI tool or some other mechanism. See #2244

###### Solution:
Use the jersey application event hooks so that after jersey has finished initializing the application we can query jersey's (more accurate) state than our own. The result is an implementation that is more accurate and simple (imo).

This does require us to start a jersey instance so that it has a chance to collect all the information, which did cause some modifications to the tests (but not much!). This is technically a breaking change for those dropwizard users who have unit tests using `DropwizardResourceConfig::getEndpointsInfo`, as they'll now see no endpoints logged until jersey is started. I estimate the number of users impacted to be minimal to nil.

I also added an endpoint logging test that asserts the effects of `urlPattern`, as I noticed that is missing in the current implementation.

As consequence of querying jersey's state, we see more endpoints available. Jersey exposes an `OPTIONS` endpoint for all registered resources, which I have decided to filter out to maintain compatibility. If desired, I can include a parameter to log these as well.

`forTesting` in `DropwizardResourceConfig` is now defunct. There may, at one time, been a use for it. But I'm not sure why logging of endpoints would be disabled for tests. Additionally, the comment "create a subclass to pin it to Throwable" refers to a bygone era.

Lastly, for sub resource locators where the response type is not a resource, the log line has been improve from this

```
    UNKNOWN /obj/{it} (java.lang.Object)
    UNKNOWN /customers/{id}/address (java.lang.String)
```

to

```
    UNKNOWN /obj/{it} (io.dropwizard.jersey.DropwizardResourceConfigTest.WrapperResource)
    UNKNOWN /customers/{id}/address (io.dropwizard.jersey.DropwizardResourceConfigTest.Customer)
```

Instead of printing the response type's class, it prints the handling class type (imo, much better)

###### Result:
Closes #2244