### PR TITLE
Update release notes with latest versions

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -4,13 +4,30 @@
 Release Notes
 #############
 
+.. _rel-1.3.3:
+
+v1.3.3: Jun 6, 2018
+==================
+
+* Fix jersey attempting to resolve auth filter fields `#2324 <https://github.com/dropwizard/dropwizard/pull/2324>`_
+* Upgrade to JUnit5 5.2.0 `#2347 <https://github.com/dropwizard/dropwizard/pull/2347>`_
+* Upgrade to Jdbi3 3.2.1 `#2369 <https://github.com/dropwizard/dropwizard/pull/2369>`_
+* Upgrade Liquibase from 3.5.5 to 3.6.0 `#2325 <https://github.com/dropwizard/dropwizard/pull/2325>`_
+
+.. _rel-1.3.2:
+
+v1.3.2 / v1.2.6: May 11, 2018
+==================
+
+* Upgrade Jetty to 9.4.10.v20180503 `#2346 <https://github.com/dropwizard/dropwizard/pull/2346>`_
+* Add possibility to disable logging bootstrap for ResourceTestRule `#2333 <https://github.com/dropwizard/dropwizard/pull/2333>`_
+
 .. _rel-1.3.1:
 
-v1.3.1: Unreleased
+v1.3.1 / v1.2.5: Apr 4, 2018
 ==================
 
 * Upgrade to Jackson 2.9.5 (`CVE-2018-7489 <https://nvd.nist.gov/vuln/detail/CVE-2018-7489>`_)
-
 
 .. _rel-1.3.0:
 


### PR DESCRIPTION
Release notes were a bit out of date. I noticed a couple of our releases (v1.3.1 / v1.2.5) and (v1.3.2 / v1.2.6) had the exact same changelog so I condensed them into a single entry. Is this ok, or should I expand them out.