### PR TITLE
Update jackson version to 2.9.6. Fixes #2392

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -21,7 +21,7 @@
         <dropwizard.version>${project.version}</dropwizard.version>
         <guava.version>25.0-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
-        <jackson.version>2.9.5</jackson.version>
+        <jackson.version>2.9.6</jackson.version>
         <jetty.version>9.4.10.v20180503</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.0.2</metrics4.version>


### PR DESCRIPTION
Jackson patched a [2.9.6](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.6) version with some security fixes.

###### Problem:
Jackson 2.9.5 contains the following CVEs

- CVE-2018-12022
- CVE-2018-12023

###### Solution:
Upgrade to jackson 2.9.6 which contains patches for both of these CVEs

###### Result:
CVEs are patched
