### PR TITLE
Upgrade to JDBI 3.3.0

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -28,7 +28,7 @@
         <slf4j.version>1.7.25</slf4j.version>
         <logback.version>1.2.3</logback.version>
         <h2.version>1.4.197</h2.version>
-        <jdbi3.version>3.2.1</jdbi3.version>
+        <jdbi3.version>3.3.0</jdbi3.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
###### Problem:

JDBI 3.2.1 has an issue when using `@BindMethods` with generic return types.

###### Solution:

JDBI 3.3.0 has a fix for this issue. Hence, my request to upgrade.

###### Result:

DropWizard will depend on a fixed version of JDBI3.
