### PR TITLE
Move dependency check to maven verify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
   - ulimit -c unlimited -S
   - 'wget https://raw.githubusercontent.com/sormuras/bach/master/install-jdk.sh'
 script:
-  - ./mvnw test -B -P code-coverage
+  - ./mvnw verify -B -P code-coverage
   - ./mvnw site -pl docs -B
 after_success:
   - bash .travis_after_success.sh

--- a/pom.xml
+++ b/pom.xml
@@ -685,7 +685,6 @@
                 <executions>
                     <execution>
                         <id>security-check</id>
-                        <phase>validate</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>


### PR DESCRIPTION
###### Problem:
 A significant amount of time spent in `mvn test` is in checking the dependency for vulnerabilities. Running `mvn test` takes upwards of 13 mins for me when the vulnerability database needs to be updated. While extremely important to check for vulnerabilities, it is bizarre to have it as part of the `validate` stage in maven, which is the very first stage executed for "validating the project is correct and all necessary information is available". Additionally running mvn test on a submodule fails due to the vuln check (I think because it searches for the suppressed warnings, but I'm not 100% sure)

I know we have the dev profile, which will skip the dependency check, but I'm still working on some test concurrency issues brought on by the dev profile.

###### Solution:
- Move the vulnerability check to the `verify` phase (which is the default)
- Have travis run verify, so we still get the vulnerability check on CI

###### Result:
- `mvn test` drops down to 3mins
- `mvn test` can work on individual submodules.
