### PR TITLE
Fix errorpone warnings

### DIFF
--- a/dropwizard-e2e/src/test/java/com/example/request_log/CustomRequestLogPatternIntegrationTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/request_log/CustomRequestLogPatternIntegrationTest.java
@@ -5,11 +5,12 @@ import io.dropwizard.testing.ConfigOverride;
 import org.junit.Test;
 
 import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CustomRequestLogPatternIntegrationTest extends AbstractRequestLogPatternIntegrationTest {
@@ -34,7 +35,7 @@ public class CustomRequestLogPatternIntegrationTest extends AbstractRequestLogPa
         Thread.sleep(100); // To let async logs to finish
 
         List<String> logs;
-        try (BufferedReader reader = new BufferedReader(new FileReader(new File(tempFile)))) {
+        try (BufferedReader reader = Files.newBufferedReader(Paths.get(tempFile), UTF_8)) {
             logs = reader.lines().collect(Collectors.toList());
         }
 

--- a/dropwizard-e2e/src/test/java/com/example/request_log/RequestLogPatternIntegrationTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/request_log/RequestLogPatternIntegrationTest.java
@@ -3,12 +3,13 @@ package com.example.request_log;
 import org.junit.Test;
 
 import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class RequestLogPatternIntegrationTest extends AbstractRequestLogPatternIntegrationTest {
@@ -27,7 +28,7 @@ public class RequestLogPatternIntegrationTest extends AbstractRequestLogPatternI
         Thread.sleep(100); // To let async logs to finish
 
         List<String> logs;
-        try (BufferedReader reader = new BufferedReader(new FileReader(new File(tempFile)))) {
+        try (BufferedReader reader = Files.newBufferedReader(Paths.get(tempFile), UTF_8)) {
             logs = reader.lines().collect(Collectors.toList());
         }
         assertThat(logs).hasSize(100).allMatch(s -> REQUEST_LOG_PATTERN.matcher(s).matches());

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2CIntegrationTest.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2CIntegrationTest.java
@@ -21,15 +21,12 @@ import javax.ws.rs.core.Response;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class Http2CIntegrationTest  extends AbstractHttp2Test {
-
-
     @Rule
     public DropwizardAppRule<Configuration> appRule = new DropwizardAppRule<>(
             FakeApplication.class, ResourceHelpers.resourceFilePath("test-http2c.yml"));
 
-    private HttpClient client;
-
     @Before
+    @Override
     public void setUp() throws Exception {
         final HTTP2Client http2Client = new HTTP2Client();
         http2Client.setClientConnectionFactory(new HTTP2ClientConnectionFactory()); // No need for ALPN
@@ -38,6 +35,7 @@ public class Http2CIntegrationTest  extends AbstractHttp2Test {
     }
 
     @After
+    @Override
     public void tearDown() throws Exception {
         client.stop();
     }

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/DBIFactoryTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/DBIFactoryTest.java
@@ -6,8 +6,8 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.LinkedList;
 
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -59,9 +59,9 @@ public class DBIFactoryTest {
         final PooledDataSourceFactory configuration = mock(PooledDataSourceFactory.class);
 
         // Capture what is configured
-        final Deque<Class<?>> af = new LinkedList<>();
-        final Deque<Class<?>> cm = new LinkedList<>();
-        final Deque<Class<?>> cf = new LinkedList<>();
+        final Deque<Class<?>> af = new ArrayDeque<>();
+        final Deque<Class<?>> cm = new ArrayDeque<>();
+        final Deque<Class<?>> cf = new ArrayDeque<>();
 
         Mockito.doAnswer(invocation -> {
             final ArgumentFactory<?> x = invocation.getArgument(0);

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/setup/JerseyEnvironment.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/setup/JerseyEnvironment.java
@@ -93,7 +93,7 @@ public class JerseyEnvironment {
      * @param name the name of the Jersey property
      * @see org.glassfish.jersey.server.ResourceConfig
      */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})
     @Nullable
     public <T> T getProperty(String name) {
         return (T) config.getProperties().get(name);

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/TimestampFormatter.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/TimestampFormatter.java
@@ -6,7 +6,6 @@ import javax.annotation.Nullable;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -15,7 +14,7 @@ import java.util.Optional;
  */
 public class TimestampFormatter {
 
-    private static final Map<String, DateTimeFormatter> FORMATTERS = ImmutableMap.<String, DateTimeFormatter>builder()
+    private static final ImmutableMap<String, DateTimeFormatter> FORMATTERS = ImmutableMap.<String, DateTimeFormatter>builder()
         .put("ISO_LOCAL_DATE", DateTimeFormatter.ISO_LOCAL_DATE)
         .put("ISO_OFFSET_DATE", DateTimeFormatter.ISO_OFFSET_DATE)
         .put("ISO_DATE", DateTimeFormatter.ISO_DATE)

--- a/dropwizard-metrics/src/main/java/io/dropwizard/metrics/ConsoleReporterFactory.java
+++ b/dropwizard-metrics/src/main/java/io/dropwizard/metrics/ConsoleReporterFactory.java
@@ -41,17 +41,15 @@ import java.util.TimeZone;
 @JsonTypeName("console")
 public class ConsoleReporterFactory extends BaseFormattedReporterFactory {
     public enum ConsoleStream {
-        STDOUT(System.out),
-        STDERR(System.err);
-
-        private final PrintStream printStream;
-
-        ConsoleStream(PrintStream printStream) {
-            this.printStream = printStream;
-        }
+        STDOUT,
+        STDERR;
 
         public PrintStream get() {
-            return printStream;
+            if (this == STDERR) {
+                return System.err;
+            } else {
+                return System.out;
+            }
         }
     }
 

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/AbstractMigrationTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/AbstractMigrationTest.java
@@ -11,14 +11,15 @@ import java.util.UUID;
 public class AbstractMigrationTest {
 
     static {
-        ArgumentParsers.setTerminalWidthDetection(false);
         SqlGeneratorFactory.getInstance().unregister(AddColumnGeneratorSQLite.class);
     }
 
     protected static final String UTF_8 = "UTF-8";
 
     protected static Subparser createSubparser(AbstractLiquibaseCommand<?> command) {
-        final Subparser subparser = ArgumentParsers.newArgumentParser("db")
+        final Subparser subparser = ArgumentParsers.newFor("db")
+            .terminalWidthDetection(false)
+            .build()
             .addSubparsers()
             .addParser(command.getName())
             .description(command.getDescription());

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDumpCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDumpCommandTest.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @NotThreadSafe
 public class DbDumpCommandTest extends AbstractMigrationTest {
 
-    private static final List<String> ATTRIBUTE_NAMES = ImmutableList.of("columns", "foreign-keys", "indexes",
+    private static final ImmutableList<String> ATTRIBUTE_NAMES = ImmutableList.of("columns", "foreign-keys", "indexes",
         "primary-keys", "sequences", "tables", "unique-constraints", "views");
     private static DocumentBuilder xmlParser;
 

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCommandTest.java
@@ -65,7 +65,9 @@ public class DbMigrateCommandTest extends AbstractMigrationTest {
 
     @Test
     public void testPrintHelp() throws Exception {
-        final Subparser subparser = ArgumentParsers.newArgumentParser("db")
+        final Subparser subparser = ArgumentParsers.newFor("db")
+                .terminalWidthDetection(false)
+                .build()
                 .addSubparsers()
                 .addParser(migrateCommand.getName())
                 .description(migrateCommand.getDescription());

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/layout/SafeRequestParameterConverterTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/layout/SafeRequestParameterConverterTest.java
@@ -3,6 +3,7 @@ package io.dropwizard.request.logging.layout;
 import ch.qos.logback.access.spi.AccessEvent;
 import ch.qos.logback.access.spi.ServerAdapter;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -10,7 +11,7 @@ import org.mockito.Mockito;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.Vector;
+import java.util.ArrayList;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -37,9 +38,10 @@ public class SafeRequestParameterConverterTest {
     @Test
     public void testConvertOneParameter() throws Exception {
         Mockito.when(httpServletRequest.getParameterValues("name")).thenReturn(new String[]{"Alice"});
-        final Vector<String> parameterNames = new Vector<>();
+        final ArrayList<String> parameterNames = new ArrayList<>();
         parameterNames.add("name");
-        Mockito.when(httpServletRequest.getParameterNames()).thenReturn(parameterNames.elements());
+        Mockito.when(httpServletRequest.getParameterNames())
+            .thenReturn(Iterators.asEnumeration(parameterNames.iterator()));
 
         // Invoked by AccessEvent#prepareForDeferredProcessing
         accessEvent.buildRequestParameterMap();
@@ -53,9 +55,10 @@ public class SafeRequestParameterConverterTest {
     @Test
     public void testConvertSeveralParameters() throws Exception {
         Mockito.when(httpServletRequest.getParameterValues("name")).thenReturn(new String[]{"Alice", "Bob"});
-        final Vector<String> parameterNames = new Vector<>();
+        final ArrayList<String> parameterNames = new ArrayList<>();
         parameterNames.add("name");
-        Mockito.when(httpServletRequest.getParameterNames()).thenReturn(parameterNames.elements());
+        Mockito.when(httpServletRequest.getParameterNames())
+            .thenReturn(Iterators.asEnumeration(parameterNames.iterator()));
 
         // Invoked by AccessEvent#prepareForDeferredProcessing
         accessEvent.buildRequestParameterMap();

--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/assets/AssetServlet.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/assets/AssetServlet.java
@@ -251,9 +251,9 @@ public class AssetServlet extends HttpServlet {
             final int resourceLength) {
         final ImmutableList.Builder<ByteRange> builder = ImmutableList.builder();
         if (rangeHeader.contains("=")) {
-            final String[] parts = rangeHeader.split("=");
-            if (parts.length > 1) {
-                final List<String> ranges = Splitter.on(",").trimResults().splitToList(parts[1]);
+            final List<String> parts = Splitter.on("=").splitToList(rangeHeader);
+            if (parts.size() > 1) {
+                final List<String> ranges = Splitter.on(",").trimResults().splitToList(parts.get(1));
                 for (final String range : ranges) {
                     builder.add(ByteRange.parse(range, resourceLength));
                 }

--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/assets/ByteRange.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/assets/ByteRange.java
@@ -1,6 +1,9 @@
 package io.dropwizard.servlets.assets;
 
+import com.google.common.base.Splitter;
+
 import javax.annotation.concurrent.Immutable;
+import java.util.List;
 import java.util.Objects;
 
 @Immutable
@@ -34,16 +37,16 @@ public final class ByteRange {
             final int start = Integer.parseInt(byteRange);
             return new ByteRange(resourceLength + start, resourceLength - 1);
         }
-        final String[] parts = byteRange.split("-");
-        if (parts.length == 2) {
-            final int start = Integer.parseInt(parts[0]);
-            int end = Integer.parseInt(parts[1]);
+        final List<String> parts = Splitter.on("-").omitEmptyStrings().splitToList(byteRange);
+        if (parts.size() == 2) {
+            final int start = Integer.parseInt(parts.get(0));
+            int end = Integer.parseInt(parts.get(1));
             if (end > resourceLength) {
                 end = resourceLength - 1;
             }
             return new ByteRange(start, end);
         } else {
-            final int start = Integer.parseInt(parts[0]);
+            final int start = Integer.parseInt(parts.get(0));
             return new ByteRange(start, resourceLength - 1);
         }
     }

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/PostBodyTaskTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/PostBodyTaskTest.java
@@ -3,8 +3,10 @@ package io.dropwizard.servlets.tasks;
 import com.google.common.collect.ImmutableMultimap;
 import org.junit.Test;
 
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class PostBodyTaskTest {
@@ -19,6 +21,7 @@ public class PostBodyTaskTest {
     @Test
     public void throwsExceptionWhenCallingExecuteWithoutThePostBody() throws Exception {
         assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() ->
-            task.execute(new ImmutableMultimap.Builder<String, String>().build(), new PrintWriter(System.out)));
+            task.execute(new ImmutableMultimap.Builder<String, String>().build(),
+                new PrintWriter(new OutputStreamWriter(System.out, UTF_8))));
     }
 }

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/TaskServletTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/TaskServletTest.java
@@ -6,7 +6,6 @@ import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -24,6 +23,7 @@ import java.util.Collections;
 
 import static com.codahale.metrics.MetricRegistry.name;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -132,20 +132,14 @@ public class TaskServletTest {
      */
     @Test
     public void verifyTaskExecuteMethod() {
-        try {
-            Task.class.getMethod("execute", ImmutableMultimap.class, PrintWriter.class);
-        } catch (NoSuchMethodException e) {
-            Assert.fail("Execute method for " + Task.class.getName() + " not found");
-        }
+        assertThatCode(() -> Task.class.getMethod("execute", ImmutableMultimap.class, PrintWriter.class))
+            .doesNotThrowAnyException();
     }
 
     @Test
     public void verifyPostBodyTaskExecuteMethod() {
-        try {
-            PostBodyTask.class.getMethod("execute", ImmutableMultimap.class, String.class, PrintWriter.class);
-        } catch (NoSuchMethodException e) {
-            Assert.fail("Execute method for " + PostBodyTask.class.getName() + " not found");
-        }
+        assertThatCode(() -> PostBodyTask.class.getMethod("execute", ImmutableMultimap.class, String.class, PrintWriter.class))
+            .doesNotThrowAnyException();
     }
 
     @Test
@@ -242,6 +236,7 @@ public class TaskServletTest {
             "vacuum-cleaning-exceptions"));
     }
 
+    @SuppressWarnings("InputStreamSlowMultibyteRead")
     private static class TestServletInputStream extends ServletInputStream {
         private InputStream delegate;
 

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
@@ -266,7 +266,7 @@ public class DropwizardTestSupport<C extends Configuration> {
         }
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})
     public <A extends Application<C>> A getApplication() {
         return (A) requireNonNull(application);
     }

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
@@ -192,7 +192,7 @@ public class DropwizardAppRule<C extends Configuration> extends ExternalResource
         return testSupport.newApplication();
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})
     public <A extends Application<C>> A getApplication() {
         return testSupport.getApplication();
     }

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardAppExtension.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardAppExtension.java
@@ -190,7 +190,7 @@ public class DropwizardAppExtension<C extends Configuration> implements Dropwiza
         return testSupport.newApplication();
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})
     public <A extends Application<C>> A getApplication() {
         return testSupport.getApplication();
     }

--- a/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/MultipleContentTypeTest.java
+++ b/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/MultipleContentTypeTest.java
@@ -129,7 +129,7 @@ public class MultipleContentTypeTest extends JerseyTest {
 
     @Provider
     @Produces(MediaType.APPLICATION_JSON)
-    public class InfoMessageBodyWriter implements MessageBodyWriter<Info> {
+    public static class InfoMessageBodyWriter implements MessageBodyWriter<Info> {
         @Override
         public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
             return Info.class.isAssignableFrom(type);


### PR DESCRIPTION
###### Problem:
Errorprone warnings during builds are irksome.

###### Solution:
Fix the errors:

- Most of them in tests
- The ones involving generic return types are suppressed (`TypeParameterUnusedInFormals`) as they are part of our public API and I don't think we're changing that now
- Switched ConsoleReporterFactory.ConsoleStream enum from containing a non-immutable type (`PrintStream`) to a function returning that printstream (stdout or stderr)
- [Use Guava's `Splitter` instead of `String.split`](https://github.com/google/error-prone/blob/fc16cc53b8a05cc410f1cea1fcdd98a3fcb9e614/docs/bugpattern/StringSplit.md) in the `ByteRange` and `AssetServlet` classes
- errorpone detected that the futures were unused in the `JerseyClientIntegrationTest.java` test, so I collected them as `CompletableFutures` using jersey rx client (which is backwards incompatible in 2.27, but I can take care of that 👌 ) -- and thus queried for successful completion.

###### Result:
No more errorprone warnings! No behavior should be changed.
