### PR TITLE
Clean up tests in jersey.params

### DIFF
--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/BooleanParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/BooleanParamTest.java
@@ -3,15 +3,25 @@ package io.dropwizard.jersey.params;
 import io.dropwizard.jersey.errors.ErrorMessage;
 import org.junit.Test;
 
+import javax.annotation.Nullable;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class BooleanParamTest {
+    private void booleanParamNegativeTest(@Nullable String input) {
+        assertThatThrownBy(() -> new BooleanParam(input))
+            .isInstanceOfSatisfying(WebApplicationException.class, e -> {
+                assertThat(e.getResponse().getStatus()).isEqualTo(400);
+                assertThat(e.getResponse().getEntity()).isEqualTo(
+                    new ErrorMessage(400, "Parameter must be \"true\" or \"false\".")
+                );
+            });
+    }
+
     @Test
-    public void trueReturnsTrue() throws Exception {
+    public void trueReturnsTrue() {
         final BooleanParam param = new BooleanParam("true");
 
         assertThat(param.get())
@@ -19,7 +29,7 @@ public class BooleanParamTest {
     }
 
     @Test
-    public void uppercaseTrueReturnsTrue() throws Exception {
+    public void uppercaseTrueReturnsTrue() {
         final BooleanParam param = new BooleanParam("TRUE");
 
         assertThat(param.get())
@@ -27,7 +37,7 @@ public class BooleanParamTest {
     }
 
     @Test
-    public void falseReturnsFalse() throws Exception {
+    public void falseReturnsFalse() {
         final BooleanParam param = new BooleanParam("false");
 
         assertThat(param.get())
@@ -35,7 +45,7 @@ public class BooleanParamTest {
     }
 
     @Test
-    public void uppercaseFalseReturnsFalse() throws Exception {
+    public void uppercaseFalseReturnsFalse() {
         final BooleanParam param = new BooleanParam("FALSE");
 
         assertThat(param.get())
@@ -43,40 +53,12 @@ public class BooleanParamTest {
     }
 
     @Test
-    @SuppressWarnings("ResultOfObjectAllocationIgnored")
-    public void nullThrowsAnException() throws Exception {
-        try {
-            new BooleanParam(null);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            final Response response = e.getResponse();
-
-            assertThat(response.getStatus())
-                    .isEqualTo(400);
-
-            ErrorMessage entity = (ErrorMessage) response.getEntity();
-            assertThat(entity.getCode()).isEqualTo(400);
-            assertThat(entity.getMessage())
-                    .isEqualTo("Parameter must be \"true\" or \"false\".");
-        }
+    public void nullThrowsAnException() {
+        booleanParamNegativeTest(null);
     }
 
     @Test
-    @SuppressWarnings("ResultOfObjectAllocationIgnored")
-    public void nonBooleanValuesThrowAnException() throws Exception {
-        try {
-            new BooleanParam("foo");
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            final Response response = e.getResponse();
-
-            assertThat(response.getStatus())
-                    .isEqualTo(400);
-
-            ErrorMessage entity = (ErrorMessage) response.getEntity();
-            assertThat(entity.getCode()).isEqualTo(400);
-            assertThat(entity.getMessage())
-                    .isEqualTo("Parameter must be \"true\" or \"false\".");
-        }
+    public void nonBooleanValuesThrowAnException() {
+        booleanParamNegativeTest("foo");
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/DateTimeParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/DateTimeParamTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class DateTimeParamTest {
     @Test
-    public void parsesDateTimes() throws Exception {
+    public void parsesDateTimes() {
         final DateTimeParam param = new DateTimeParam("2012-11-19");
 
         assertThat(param.get())

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/DurationParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/DurationParamTest.java
@@ -5,36 +5,27 @@ import io.dropwizard.util.Duration;
 import org.junit.Test;
 
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class DurationParamTest {
 
     @Test
-    public void parseDurationSeconds() throws Exception {
+    public void parseDurationSeconds() {
         final DurationParam param = new DurationParam("10 seconds");
         assertThat(param.get())
             .isEqualTo(Duration.seconds(10));
     }
 
     @Test
-    public void badValueThrowsException() throws Exception {
-        try {
-            new DurationParam("invalid", "param_name");
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            final Response response = e.getResponse();
-
-            assertThat(response.getStatus())
-                .isEqualTo(400);
-
-            ErrorMessage entity = (ErrorMessage) response.getEntity();
-            assertThat(entity.getCode()).isEqualTo(400);
-            assertThat(entity.getMessage())
-                .isEqualTo("param_name is not a valid duration.");
-        }
+    public void badValueThrowsException() {
+        assertThatThrownBy(() -> new DurationParam("invalid", "param_name"))
+            .isInstanceOfSatisfying(WebApplicationException.class, e -> {
+                assertThat(e.getResponse().getStatus()).isEqualTo(400);
+                assertThat(e.getResponse().getEntity()).isEqualTo(
+                    new ErrorMessage(400, "param_name is not a valid duration.")
+                );
+            });
     }
-
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/InstantParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/InstantParamTest.java
@@ -1,7 +1,7 @@
 package io.dropwizard.jersey.params;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.dropwizard.jersey.errors.ErrorMessage;
 import org.junit.Test;
@@ -10,11 +10,10 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.LocalDateTime;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
 
 public class InstantParamTest {
     @Test
-    public void parsesDateTimes() throws Exception {
+    public void parsesDateTimes() {
         final InstantParam param = new InstantParam("2012-11-19T00:00:00Z");
         Instant instant = LocalDateTime.of(2012, 11, 19, 0, 0)
             .toInstant(ZoneOffset.UTC);
@@ -24,20 +23,13 @@ public class InstantParamTest {
     }
 
     @Test
-    public void nullThrowsAnException() throws Exception {
-        try {
-            new InstantParam(null, "myDate");
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            final Response response = e.getResponse();
-
-            assertThat(response.getStatus())
-                .isEqualTo(400);
-
-            ErrorMessage entity = (ErrorMessage) response.getEntity();
-            assertThat(entity.getCode()).isEqualTo(400);
-            assertThat(entity.getMessage())
-                .isEqualTo("myDate must be in a ISO-8601 format.");
-        }
+    public void nullThrowsAnException() {
+        assertThatThrownBy(() -> new InstantParam(null, "myDate"))
+            .isInstanceOfSatisfying(WebApplicationException.class, e -> {
+                assertThat(e.getResponse().getStatus()).isEqualTo(400);
+                assertThat(e.getResponse().getEntity()).isEqualTo(
+                    new ErrorMessage(400, "myDate must be in a ISO-8601 format.")
+                );
+            });
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/IntParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/IntParamTest.java
@@ -4,14 +4,13 @@ import io.dropwizard.jersey.errors.ErrorMessage;
 import org.junit.Test;
 
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class IntParamTest {
     @Test
-    public void anIntegerReturnsAnInteger() throws Exception {
+    public void anIntegerReturnsAnInteger() {
         final IntParam param = new IntParam("200");
 
         assertThat(param.get())
@@ -19,21 +18,13 @@ public class IntParamTest {
     }
 
     @Test
-    @SuppressWarnings("ResultOfObjectAllocationIgnored")
-    public void aNonIntegerThrowsAnException() throws Exception {
-        try {
-            new IntParam("foo");
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            final Response response = e.getResponse();
-
-            assertThat(response.getStatus())
-                    .isEqualTo(400);
-
-            ErrorMessage entity = (ErrorMessage) response.getEntity();
-            assertThat(entity.getCode()).isEqualTo(400);
-            assertThat(entity.getMessage())
-                    .isEqualTo("Parameter is not a number.");
-        }
+    public void aNonIntegerThrowsAnException() {
+        assertThatThrownBy(() -> new IntParam("foo"))
+            .isInstanceOfSatisfying(WebApplicationException.class, e -> {
+                assertThat(e.getResponse().getStatus()).isEqualTo(400);
+                assertThat(e.getResponse().getEntity()).isEqualTo(
+                    new ErrorMessage(400, "Parameter is not a number.")
+                );
+            });
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/LocalDateParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/LocalDateParamTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class LocalDateParamTest {
     @Test
-    public void parsesLocalDates() throws Exception {
+    public void parsesLocalDates() {
         final LocalDateParam param = new LocalDateParam("2012-11-20");
 
         assertThat(param.get())

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/LongParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/LongParamTest.java
@@ -4,14 +4,13 @@ import io.dropwizard.jersey.errors.ErrorMessage;
 import org.junit.Test;
 
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class LongParamTest {
     @Test
-    public void aLongReturnsALong() throws Exception {
+    public void aLongReturnsALong() {
         final LongParam param = new LongParam("200");
 
         assertThat(param.get())
@@ -19,21 +18,13 @@ public class LongParamTest {
     }
 
     @Test
-    @SuppressWarnings("ResultOfObjectAllocationIgnored")
-    public void aNonIntegerThrowsAnException() throws Exception {
-        try {
-            new LongParam("foo");
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            final Response response = e.getResponse();
-
-            assertThat(response.getStatus())
-                    .isEqualTo(400);
-
-            ErrorMessage entity = (ErrorMessage) response.getEntity();
-            assertThat(entity.getCode()).isEqualTo(400);
-            assertThat(entity.getMessage())
-                    .isEqualTo("Parameter is not a number.");
-        }
+    public void aNonIntegerThrowsAnException() {
+        assertThatThrownBy(() -> new LongParam("foo"))
+            .isInstanceOfSatisfying(WebApplicationException.class, e -> {
+                assertThat(e.getResponse().getStatus()).isEqualTo(400);
+                assertThat(e.getResponse().getEntity()).isEqualTo(
+                    new ErrorMessage(400, "Parameter is not a number.")
+                );
+            });
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/NonEmptyStringParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/NonEmptyStringParamTest.java
@@ -8,19 +8,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class NonEmptyStringParamTest {
     @Test
-    public void aBlankStringIsAnAbsentString() throws Exception {
+    public void aBlankStringIsAnAbsentString() {
         final NonEmptyStringParam param = new NonEmptyStringParam("");
         assertThat(param.get()).isEqualTo(Optional.empty());
     }
 
     @Test
-    public void aNullStringIsAnAbsentString() throws Exception {
+    public void aNullStringIsAnAbsentString() {
         final NonEmptyStringParam param = new NonEmptyStringParam(null);
         assertThat(param.get()).isEqualTo(Optional.empty());
     }
 
     @Test
-    public void aStringWithContentIsItself() throws Exception {
+    public void aStringWithContentIsItself() {
         final NonEmptyStringParam param = new NonEmptyStringParam("hello");
         assertThat(param.get()).isEqualTo(Optional.of("hello"));
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/SizeParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/SizeParamTest.java
@@ -5,27 +5,27 @@ import io.dropwizard.util.Size;
 import org.junit.Test;
 
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class SizeParamTest {
 
     @Test
-    public void parseSizeKilobytes() throws Exception {
+    public void parseSizeKilobytes() {
         final SizeParam param = new SizeParam("10kb");
         assertThat(param.get())
             .isEqualTo(Size.kilobytes(10));
     }
 
     @Test
-    public void badValueThrowsException() throws Exception {
-        final Throwable exn = catchThrowable(() -> new SizeParam("10 kelvins", "degrees"));
-        assertThat(exn).isInstanceOf(WebApplicationException.class);
-        final Response response = ((WebApplicationException) exn).getResponse();
-        assertThat(response.getStatus()).isEqualTo(400);
-        assertThat((ErrorMessage) response.getEntity())
-            .isEqualTo(new ErrorMessage(400, "degrees is not a valid size."));
+    public void badValueThrowsException() {
+        assertThatThrownBy(() -> new SizeParam("10 kelvins", "degrees"))
+            .isInstanceOfSatisfying(WebApplicationException.class, e -> {
+                assertThat(e.getResponse().getStatus()).isEqualTo(400);
+                assertThat(e.getResponse().getEntity()).isEqualTo(
+                    new ErrorMessage(400, "degrees is not a valid size.")
+                );
+            });
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/UUIDParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/UUIDParamTest.java
@@ -4,23 +4,20 @@ import io.dropwizard.jersey.errors.ErrorMessage;
 import org.junit.Test;
 
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class UUIDParamTest {
-    private void badUUID(WebApplicationException e) {
-        final Response response = e.getResponse();
-
-        assertThat(response.getStatus())
-            .isEqualTo(400);
-
-        ErrorMessage entity = (ErrorMessage) response.getEntity();
-        assertThat(entity.getCode()).isEqualTo(400);
-        assertThat(entity.getMessage())
-            .isEqualTo("Parameter is not a UUID.");
+    private void UuidParamNegativeTest(String input) {
+        assertThatThrownBy(() -> new UUIDParam(input))
+            .isInstanceOfSatisfying(WebApplicationException.class, e -> {
+                assertThat(e.getResponse().getStatus()).isEqualTo(400);
+                assertThat(e.getResponse().getEntity()).isEqualTo(
+                    new ErrorMessage(400, "Parameter is not a UUID.")
+                );
+            });
     }
 
     @Test
@@ -35,19 +32,16 @@ public class UUIDParamTest {
 
     @Test
     public void noSpaceUUID() {
-        assertThatThrownBy(() -> new UUIDParam("067e61623b6f4ae2a1712470b63dff00"))
-            .isInstanceOfSatisfying(WebApplicationException.class, this::badUUID);
+        UuidParamNegativeTest("067e61623b6f4ae2a1712470b63dff00");
     }
 
     @Test
     public void tooLongUUID() {
-        assertThatThrownBy(() -> new UUIDParam("067e6162-3b6f-4ae2-a171-2470b63dff000"))
-            .isInstanceOfSatisfying(WebApplicationException.class, this::badUUID);
+        UuidParamNegativeTest("067e6162-3b6f-4ae2-a171-2470b63dff000");
     }
 
     @Test
     public void aNonUUIDThrowsAnException() {
-        assertThatThrownBy(() -> new UUIDParam("foo"))
-            .isInstanceOfSatisfying(WebApplicationException.class, this::badUUID);
+        UuidParamNegativeTest("foo");
     }
 }


### PR DESCRIPTION
###### Problem:
Tests in the jersey.params class are a bit verbose, contain duplicate code, and unnecessary exception modifiers

###### Solution:
- Remove unused exception modifier
- Prefer `assertThatThrownBy` to `failBecauseExceptionWasNotThrown`

###### Result:
jersey.params tests are now more concise and written in a consistent style
