### PR TITLE
Overhaul https logging of supported protocols and cipher suites

### DIFF
--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
@@ -25,14 +25,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.SSLEngine;
 import java.io.File;
 import java.net.URI;
 import java.security.KeyStore;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Builds HTTPS connectors (HTTP over TLS/SSL).
@@ -632,34 +635,79 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
         return new AbstractLifeCycle.AbstractLifeCycleListener() {
             @Override
             public void lifeCycleStarted(LifeCycle event) {
-                logSupportedParameters(sslContextFactory.getSslContext());
+                logSupportedParameters(sslContextFactory);
             }
         };
     }
 
-    private void logSupportedParameters(SSLContext context) {
+    /**
+     * Given a list of protocols available to the JVM that we can serve up to the client, partition
+     * this list into two groups: a group of protocols we can serve and a group where we can't. This
+     * list takes into account protocols that may have been disabled at the JVM level, and also
+     * protocols that the user explicitly wants to include / exclude. The exclude list (blacklist)
+     * is stronger than include list (whitelist), so a protocol that is in both lists will be
+     * excluded. Other than the initial list of available protocols, the other lists are patterns,
+     * such that one can exclude all SSL protocols with a single exclude entry of "SSL.*". This
+     * function will handle both cipher suites and protocols, but for the sake of conciseness, this
+     * documentation only talks about protocols. This implementation is a slimmed down version from
+     * jetty:
+     * https://github.com/eclipse/jetty.project/blob/93a8afcc6bd1a6e0af7bd9f967c97ae1bc3eb718/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslSelectionDump.java
+     *
+     * @param supportedByJVM protocols available to the JVM.
+     * @param enabledByJVM protocols enabled by lib/security/java.security.
+     * @param excludedByConfig protocols the user doesn't want to expose.
+     * @param includedByConfig the only protocols the user wants to expose.
+     * @return two entry map of protocols that are enabled (true) and those that have been disabled (false).
+     */
+    static Map<Boolean, List<String>> partitionSupport(
+        String[] supportedByJVM,
+        String[] enabledByJVM,
+        String[] excludedByConfig,
+        String[] includedByConfig
+    ) {
+        final List<Pattern> enabled = Arrays.stream(enabledByJVM).map(Pattern::compile).collect(Collectors.toList());
+        final List<Pattern> disabled = Arrays.stream(excludedByConfig).map(Pattern::compile).collect(Collectors.toList());
+        final List<Pattern> included = Arrays.stream(includedByConfig).map(Pattern::compile).collect(Collectors.toList());
+
+        return Arrays.stream(supportedByJVM)
+            .sorted(Comparator.naturalOrder())
+            .collect(Collectors.partitioningBy(x ->
+                disabled.stream().noneMatch(pat -> pat.matcher(x).matches()) &&
+                    enabled.stream().anyMatch(pat -> pat.matcher(x).matches()) &&
+                    (included.isEmpty() || included.stream().anyMatch(pat -> pat.matcher(x).matches()))
+            ));
+
+    }
+
+    private void logSupportedParameters(SslContextFactory contextFactory) {
         if (LOGGED.compareAndSet(false, true)) {
-            final String[] protocols = context.getSupportedSSLParameters().getProtocols();
-            final SSLSocketFactory factory = context.getSocketFactory();
-            final String[] cipherSuites = factory.getSupportedCipherSuites();
-            LOGGER.info("Supported protocols: {}", Arrays.toString(protocols));
-            LOGGER.info("Supported cipher suites: {}", Arrays.toString(cipherSuites));
+            // When Jetty logs out which protocols are enabled / disabled they include tracing
+            // information to detect if the protocol was disabled at the
+            // JRE/lib/security/java.security level. Since we don't log this information we take the
+            // SSLEngine from our context instead of a pristine version.
+            //
+            // For more info from Jetty:
+            // https://github.com/eclipse/jetty.project/blob/93a8afcc6bd1a6e0af7bd9f967c97ae1bc3eb718/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslContextFactory.java#L356-L360
+            final SSLEngine engine = contextFactory.getSslContext().createSSLEngine();
 
-            if (getSupportedProtocols() != null) {
-                LOGGER.info("Configured protocols: {}", getSupportedProtocols());
-            }
+            final Map<Boolean, List<String>> protocols = partitionSupport(
+                engine.getSupportedProtocols(),
+                engine.getEnabledProtocols(),
+                contextFactory.getExcludeProtocols(),
+                contextFactory.getIncludeProtocols()
+            );
 
-            if (getExcludedProtocols() != null) {
-                LOGGER.info("Excluded protocols: {}", getExcludedProtocols());
-            }
+            final Map<Boolean, List<String>> ciphers = partitionSupport(
+                engine.getSupportedCipherSuites(),
+                engine.getEnabledCipherSuites(),
+                contextFactory.getExcludeCipherSuites(),
+                contextFactory.getIncludeCipherSuites()
+            );
 
-            if (getSupportedCipherSuites() != null) {
-                LOGGER.info("Configured cipher suites: {}", getSupportedCipherSuites());
-            }
-
-            if (getExcludedCipherSuites() != null) {
-                LOGGER.info("Excluded cipher suites: {}", getExcludedCipherSuites());
-            }
+            LOGGER.info("Enabled protocols: {}", protocols.get(true));
+            LOGGER.info("Disabled protocols: {}", protocols.get(false));
+            LOGGER.info("Enabled cipher suites: {}", ciphers.get(true));
+            LOGGER.info("Disabled cipher suites: {}", ciphers.get(false));
         }
     }
 

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
@@ -30,13 +30,17 @@ import java.io.File;
 import java.net.URI;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.apache.commons.lang3.reflect.FieldUtils.getField;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.entry;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
@@ -245,6 +249,50 @@ public class HttpsConnectorFactoryTest {
         server.stop();
     }
 
+    @Test
+    public void partitionSupportOnlyEnable() {
+        final String[] supported = {"SSLv2Hello", "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"};
+        final String[] enabled = {"TLSv1", "TLSv1.1", "TLSv1.2"};
+        final Map<Boolean, List<String>> partition =
+            HttpsConnectorFactory.partitionSupport(supported, enabled, new String[]{}, new String[]{});
+
+        assertThat(partition)
+            .containsOnly(
+                entry(true, Arrays.asList("TLSv1", "TLSv1.1", "TLSv1.2")),
+                entry(false, Arrays.asList("SSLv2Hello", "SSLv3"))
+            );
+    }
+
+    @Test
+    public void partitionSupportExclude() {
+        final String[] supported = {"SSLv2Hello", "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"};
+        final String[] enabled = {"SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"};
+        final String[] exclude = {"SSL.*"};
+        final Map<Boolean, List<String>> partition =
+            HttpsConnectorFactory.partitionSupport(supported, enabled, exclude, new String[]{});
+
+        assertThat(partition)
+            .containsOnly(
+                entry(true, Arrays.asList("TLSv1", "TLSv1.1", "TLSv1.2")),
+                entry(false, Arrays.asList("SSLv2Hello", "SSLv3"))
+            );
+    }
+
+    @Test
+    public void partitionSupportInclude() {
+        final String[] supported = {"SSLv2Hello", "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"};
+        final String[] enabled = {"SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"};
+        final String[] exclude = {"SSL*"};
+        final String[] include = {"TLSv1.2|SSLv2Hello"};
+        final Map<Boolean, List<String>> partition =
+            HttpsConnectorFactory.partitionSupport(supported, enabled, exclude, include);
+
+        assertThat(partition)
+            .containsOnly(
+                entry(true, Collections.singletonList("TLSv1.2")),
+                entry(false, Arrays.asList("SSLv2Hello", "SSLv3", "TLSv1", "TLSv1.1"))
+            );
+    }
 
     private boolean canAccessWindowsKeyStore() {
         if (SystemUtils.IS_OS_WINDOWS) {


### PR DESCRIPTION
###### Problem:
On application startup for an https service we'll see something like:

```
INFO  [...] ....HttpsConnectorFactory: Supported protocols: [SSLv2Hello, SSLv3, TLSv1, TLSv1.1, TLSv1.2]
```

While not technically wrong, displaying the protocols that *could* be enabled is misleading as it makes one believe that Dropwizard employs extremely unsafe defaults.

In fact, the logging of configuration values for included / excluded, protocols / cipher suites also doesn't fit with the rest of Dropwizard (ie, we don't log configuration values for other classes)

###### Solution:
Log only the protocols and cipher suites that Jetty will expose. And log the protocols and cipher suites that Jetty will reject (though it could expose them if configured to do so).

This will make a clean break from the previous https configuration logging by adopting Jetty's logic for determining what protocols and cipher suites are included vs excluded (code comments contain link to Jetty's implementation)

###### Result:
Dropwizard https apps will print the following by default:

```
INFO HttpsConnectorFactory: Enabled protocols: [TLSv1, TLSv1.1, TLSv1.2]
INFO HttpsConnectorFactory: Disabled protocols: [SSLv2Hello, SSLv3]
```

And if someone excludes TLSv1 in their config, it will move from enabled to disabled

Side note, even though Jetty will expose TLSv1 and TLSv1.1, the cipher suites compatible with them eliminate 99% of clients so TLSv1.2 is seemingly the only available protocol (a follow-up discussion that I have planned)