### PR TITLE
Logging throttle tests now CI friendly

### DIFF
--- a/dropwizard-logging/src/test/resources/yaml/logging-message-rate.yml
+++ b/dropwizard-logging/src/test/resources/yaml/logging-message-rate.yml
@@ -1,12 +1,2 @@
-level: INFO
-loggers:
-  "com.example.app": INFO
-appenders:
-  - type: file
-    currentLogFilename: '${default}.log'
-    queueSize: 10000
-    discardingThreshold: 0
-    messageRate: ${messageRate}
-    archivedLogFilenamePattern: '${default}-%d.log.gz'
-    logFormat: "%-5level %logger: %msg%n"
-    archivedFileCount: 5
+type: console
+messageRate: ${messageRate}


### PR DESCRIPTION
###### Problem:
The logging throttle tests are flaky on CI, due to a combination of sleeps, file logs (file IO can be slow in CI) , and asserting on exact lines that are logged.

###### Solution:
- Log into `System.out` to avoid file IO
- Use a ratelimiter instead of a sleep to simulate an application logging at an average rate
- Don't assert on the contents on the log lines, but assert how approximately how many should have been logged and that there are no duplicates.

###### Result:
No more flakiness!
