### PR TITLE
Improve validation message for min/max duration

### DIFF
--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/ThrottlingAppenderTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/ThrottlingAppenderTest.java
@@ -97,14 +97,14 @@ public class ThrottlingAppenderTest {
     public void appenderWithZeroMessageRate() {
         assertThatThrownBy(() -> factory.build(loadResource("yaml/appender_with_zero_message_rate.yml")))
             .isInstanceOf(ConfigurationValidationException.class)
-            .hasMessageContaining("messageRate must be greater than (or equal to, if in 'inclusive' mode) 0 SECONDS");
+            .hasMessageContaining("messageRate must be greater than 0 SECONDS");
     }
 
     @Test
     public void appenderWithInvalidMessageRate() {
         assertThatThrownBy(() -> factory.build(loadResource("yaml/appender_with_invalid_message_rate.yml")))
             .isInstanceOf(ConfigurationValidationException.class)
-            .hasMessageContaining("messageRate must be less than (or equal to, if in 'inclusive' mode) 1 MINUTES");
+            .hasMessageContaining("messageRate must be less than or equal to 1 MINUTES");
     }
 
     @Test

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/MaxDuration.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/MaxDuration.java
@@ -26,7 +26,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Documented
 @Constraint(validatedBy = MaxDurationValidator.class)
 public @interface MaxDuration {
-    String message() default "must be less than (or equal to, if in 'inclusive' mode) {value} {unit}";
+    String message() default "must be less than ${inclusive == true ? 'or equal to ' : ''}{value} {unit}";
 
     Class<?>[] groups() default { };
 

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/MinDuration.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/MinDuration.java
@@ -26,7 +26,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Documented
 @Constraint(validatedBy = MinDurationValidator.class)
 public @interface MinDuration {
-    String message() default "must be greater than (or equal to, if in 'inclusive' mode) {value} {unit}";
+    String message() default "must be greater than ${inclusive == true ? 'or equal to ' : ''}{value} {unit}";
 
     Class<?>[] groups() default { };
 

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/DurationValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/DurationValidatorTest.java
@@ -79,12 +79,12 @@ public class DurationValidatorTest {
             assertThat(errors)
                     .containsOnly(
                             "outOfRange must be between 10 MINUTES and 30 MINUTES",
-                            "tooBig must be less than (or equal to, if in 'inclusive' mode) 30 SECONDS",
-                            "tooBigExclusive must be less than (or equal to, if in 'inclusive' mode) 30 SECONDS",
-                            "tooSmall must be greater than (or equal to, if in 'inclusive' mode) 30 SECONDS",
-                            "tooSmallExclusive must be greater than (or equal to, if in 'inclusive' mode) 30 SECONDS",
-                            "maxDurs[0].<collection element> must be less than (or equal to, if in 'inclusive' mode) 30 SECONDS",
-                            "minDurs[0].<collection element> must be greater than (or equal to, if in 'inclusive' mode) 30 SECONDS",
+                            "tooBig must be less than or equal to 30 SECONDS",
+                            "tooBigExclusive must be less than 30 SECONDS",
+                            "tooSmall must be greater than or equal to 30 SECONDS",
+                            "tooSmallExclusive must be greater than 30 SECONDS",
+                            "maxDurs[0].<collection element> must be less than or equal to 30 SECONDS",
+                            "minDurs[0].<collection element> must be greater than or equal to 30 SECONDS",
                             "rangeDurs[0].<collection element> must be between 10 MINUTES and 30 MINUTES");
         }
     }


### PR DESCRIPTION
###### Problem:
Currently max/min duration will give errors like:

```
messageRate must be less than (or equal to, if in 'inclusive' mode) 1 MINUTES
```

From the user's point of view, they don't know if inclusive is true or not, so it can be a bit misleading

###### Solution:
Hibernate allows a bit of logic in the error templates!

###### Result:
The new error messages one will see:

if inclusive is true

```
messageRate must be less than or equal to 1 MINUTES
```

if inclusive is false:

```
messageRate must be less than 1 MINUTES
```