### PR TITLE
Add support for PATCH request to ResourceTestRule client when using Grizzly

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/common/Resource.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/common/Resource.java
@@ -7,6 +7,7 @@ import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.logging.BootstrapLogging;
 import io.dropwizard.testing.junit5.ResourceExtension;
 import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.HttpUrlConnectorProvider;
 import org.glassfish.jersey.servlet.ServletProperties;
 import org.glassfish.jersey.test.DeploymentContext;
 import org.glassfish.jersey.test.JerseyTest;
@@ -113,9 +114,13 @@ public class Resource {
             if (bootstrapLogging) {
                 BootstrapLogging.bootstrap();
             }
+            Consumer<ClientConfig> extendedConfigurator = config -> {
+                clientConfigurator.accept(config);
+                config.property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true);
+            };
             return new Resource(new ResourceTestJerseyConfiguration(
                 singletons, providers, properties, mapper, validator,
-                clientConfigurator, testContainerFactory, registerDefaultExceptionMappers));
+                extendedConfigurator, testContainerFactory, registerDefaultExceptionMappers));
         }
     }
 

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ContextInjectionResource.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ContextInjectionResource.java
@@ -1,6 +1,7 @@
 package io.dropwizard.testing.app;
 
 import com.codahale.metrics.annotation.Timed;
+import io.dropwizard.jersey.PATCH;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -23,4 +24,10 @@ public class ContextInjectionResource {
     public String getThis() {
         throw new RuntimeException("Can't touch this");
     }
+
+    @PATCH
+    public String echoPatch(String patchMessage) {
+        return patchMessage;
+    }
+
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestRuleWithGrizzlyTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestRuleWithGrizzlyTest.java
@@ -39,6 +39,14 @@ public class ResourceTestRuleWithGrizzlyTest {
         assertThat(resp.readEntity(String.class)).isEqualTo("Can't touch this");
     }
 
+    @Test
+    public void testClientSupportsPatchMethod() {
+        final String resp = resourceTestRule.target("test")
+            .request()
+            .method("PATCH", Entity.text("Patch is working"), String.class);
+        assertThat(resp).isEqualTo("Patch is working");
+    }
+
     private static class RuntimeExceptionMapper implements ExceptionMapper<RuntimeException> {
         @Override
         public Response toResponse(RuntimeException exception) {

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/ResourceExtensionWithGrizzlyTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/ResourceExtensionWithGrizzlyTest.java
@@ -1,0 +1,43 @@
+package io.dropwizard.testing.junit5;
+
+import io.dropwizard.testing.app.ContextInjectionResource;
+import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+class ResourceExtensionWithGrizzlyTest {
+
+    private ResourceExtension resources = ResourceExtension.builder()
+        .addResource(ContextInjectionResource::new)
+        .setTestContainerFactory(new GrizzlyWebTestContainerFactory())
+        .setClientConfigurator(clientConfig -> clientConfig.register(DummyExceptionMapper.class))
+        .build();
+
+    @Test
+    public void testClientSupportsPatchMethod() {
+        final String resp = resources.target("test")
+            .request()
+            .method("PATCH", Entity.text("Patch is working"), String.class);
+        assertThat(resp).isEqualTo("Patch is working");
+    }
+
+    @Test
+    void testCustomClientConfiguration() {
+        assertThat(resources.client().getConfiguration().isRegistered(DummyExceptionMapper.class)).isTrue();
+    }
+
+    private static class DummyExceptionMapper implements ExceptionMapper<WebApplicationException> {
+        @Override
+        public Response toResponse(WebApplicationException e) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}


### PR DESCRIPTION
###### Problem:
When using the client from ResourceTestRule with the Grizzly container it is not possible to use PATCH via the custom annotation io.dropwizard.jersey.PATCH. (It seems to work with  the in-memory container)
Similar to: #2287 
###### Solution:
Since the builder takes a `Consumer<ClientConfig>`  instead of a property, like in #2287  I choose to set it in the Resource instead of manipulating the builder. This solution is up for discussion. 

```
   protected Resource buildResource() {
   ...
   Consumer<ClientConfig> extendedConfigurator = config -> {
                clientConfigurator.accept(config);
                config.property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true);
            };
```

###### Result:
Now possible to use the client and make a PATCH reuqest
client.target(...).request(...).method("PATCH", Entity.text("Patch is working"), String.class)
