### PR TITLE
Document that the Timed and Metered can't be used at the same time.

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -1300,6 +1300,11 @@ Dropwizard augments Jersey to automatically record runtime information about you
 * ``@Metered`` measures the rate at which the resource is accessed
 * ``@ExceptionMetered`` measures how often exceptions occur processing the resource
 
+.. important::
+
+    ``@Timed`` and ``@Metered`` cannot be used at the same time. ``@Timed`` includes ``@Metered`` and
+    an ``IllegalArgumentException`` will be thrown if you try to annotate a method with both.
+
 .. _man-core-resources-parameters:
 
 Parameters


### PR DESCRIPTION
###### Problem:

The documentation didn't tell me that I can't annotate a method with `@Timed` and `@Meterd` at the same time.

###### Solution:

I added an Important box that says that `@Timed` includes `@Metered` and that an `IllegalArgumentException` is thrown when both are used at the same time. 

###### Result:

It is easier for a user to understand that `@Timed` and `@Meterd` can't be used at the same time.
