### PR TITLE
Disable protocols less secure than tls v1.2 by default

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -417,52 +417,52 @@ Extends the attributes that are available to the :ref:`HTTP connector <man-confi
           allowRenegotiation: true
           endpointIdentificationAlgorithm: (none)
 
-================================ ==================  ======================================================================================
-Name                             Default             Description
-================================ ==================  ======================================================================================
-keyStorePath                     REQUIRED            The path to the Java key store which contains the host certificate and private key.
-keyStorePassword                 REQUIRED            The password used to access the key store.
-keyStoreType                     JKS                 The type of key store (usually ``JKS``, ``PKCS12``, ``JCEKS``,
-                                                     ``Windows-MY``}, or ``Windows-ROOT``).
-keyStoreProvider                 (none)              The JCE provider to use to access the key store.
-trustStorePath                   (none)              The path to the Java key store which contains the CA certificates used to establish
-                                                     trust.
-trustStorePassword               (none)              The password used to access the trust store.
-trustStoreType                   JKS                 The type of trust store (usually ``JKS``, ``PKCS12``, ``JCEKS``,
-                                                     ``Windows-MY``, or ``Windows-ROOT``).
-trustStoreProvider               (none)              The JCE provider to use to access the trust store.
-keyManagerPassword               (none)              The password, if any, for the key manager.
-needClientAuth                   (none)              Whether or not client authentication is required.
-wantClientAuth                   (none)              Whether or not client authentication is requested.
-certAlias                        (none)              The alias of the certificate to use.
-crlPath                          (none)              The path to the file which contains the Certificate Revocation List.
-enableCRLDP                      false               Whether or not CRL Distribution Points (CRLDP) support is enabled.
-enableOCSP                       false               Whether or not On-Line Certificate Status Protocol (OCSP) support is enabled.
-maxCertPathLength                (unlimited)         The maximum certification path length.
-ocspResponderUrl                 (none)              The location of the OCSP responder.
-jceProvider                      (none)              The name of the JCE provider to use for cryptographic support. See `Oracle documentation <https://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html>`_ for more information.
-validateCerts                    false               Whether or not to validate TLS certificates before starting. If enabled, Dropwizard
-                                                     will refuse to start with expired or otherwise invalid certificates. This option will
-                                                     cause unconditional failure in Dropwizard 1.x until a new validation mechanism can be
-                                                     implemented.
-validatePeers                    false               Whether or not to validate TLS peer certificates. This option will
-                                                     cause unconditional failure in Dropwizard 1.x until a new validation mechanism can be
-                                                     implemented.
-supportedProtocols               (none)              A list of protocols (e.g., ``SSLv3``, ``TLSv1``) which are supported. All
-                                                     other protocols will be refused.
-excludedProtocols                (none)              A list of protocols (e.g., ``SSLv3``, ``TLSv1``) which are excluded. These
-                                                     protocols will be refused.
-supportedCipherSuites            (none)              A list of cipher suites (e.g., ``TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256``) which
-                                                     are supported. All other cipher suites will be refused
-excludedCipherSuites             (none)              A list of cipher suites (e.g., ``TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256``) which
-                                                     are excluded. These cipher suites will be refused and exclusion takes higher
-                                                     precedence than inclusion, such that if a cipher suite is listed in
-                                                     ``supportedCipherSuites`` and ``excludedCipherSuites``, the cipher suite will be
-                                                     excluded. To verify that the proper cipher suites are being whitelisted and
-                                                     blacklisted, it is recommended to use the tool `sslyze`_.
-allowRenegotiation               true                Whether or not TLS renegotiation is allowed.
-endpointIdentificationAlgorithm  (none)              Which endpoint identification algorithm, if any, to use during the TLS handshake.
-================================ ==================  ======================================================================================
+================================ ================================ ======================================================================================
+Name                             Default                          Description
+================================ ================================ ======================================================================================
+keyStorePath                     REQUIRED                         The path to the Java key store which contains the host certificate and private key.
+keyStorePassword                 REQUIRED                         The password used to access the key store.
+keyStoreType                     JKS                              The type of key store (usually ``JKS``, ``PKCS12``, ``JCEKS``,
+                                                                  ``Windows-MY``}, or ``Windows-ROOT``).
+keyStoreProvider                 (none)                           The JCE provider to use to access the key store.
+trustStorePath                   (none)                           The path to the Java key store which contains the CA certificates used to establish
+                                                                  trust.
+trustStorePassword               (none)                           The password used to access the trust store.
+trustStoreType                   JKS                              The type of trust store (usually ``JKS``, ``PKCS12``, ``JCEKS``,
+                                                                  ``Windows-MY``, or ``Windows-ROOT``).
+trustStoreProvider               (none)                           The JCE provider to use to access the trust store.
+keyManagerPassword               (none)                           The password, if any, for the key manager.
+needClientAuth                   (none)                           Whether or not client authentication is required.
+wantClientAuth                   (none)                           Whether or not client authentication is requested.
+certAlias                        (none)                           The alias of the certificate to use.
+crlPath                          (none)                           The path to the file which contains the Certificate Revocation List.
+enableCRLDP                      false                            Whether or not CRL Distribution Points (CRLDP) support is enabled.
+enableOCSP                       false                            Whether or not On-Line Certificate Status Protocol (OCSP) support is enabled.
+maxCertPathLength                (unlimited)                      The maximum certification path length.
+ocspResponderUrl                 (none)                           The location of the OCSP responder.
+jceProvider                      (none)                           The name of the JCE provider to use for cryptographic support. See `Oracle documentation <https://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html>`_ for more information.
+validateCerts                    false                            Whether or not to validate TLS certificates before starting. If enabled, Dropwizard
+                                                                  will refuse to start with expired or otherwise invalid certificates. This option will
+                                                                  cause unconditional failure in Dropwizard 1.x until a new validation mechanism can be
+                                                                  implemented.
+validatePeers                    false                            Whether or not to validate TLS peer certificates. This option will
+                                                                  cause unconditional failure in Dropwizard 1.x until a new validation mechanism can be
+                                                                  implemented.
+supportedProtocols               (none)                           A list of protocols (e.g., ``SSLv3``, ``TLSv1``) which are supported. All
+                                                                  other protocols will be refused.
+excludedProtocols                ["SSL.*", "TLSv1", "TLSv1\\.1"]  A list of protocols (e.g., ``SSLv3``, ``TLSv1``) which are excluded. These
+                                                                  protocols will be refused.
+supportedCipherSuites            (none)                           A list of cipher suites (e.g., ``TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256``) which
+                                                                  are supported. All other cipher suites will be refused
+excludedCipherSuites             (none)                           A list of cipher suites (e.g., ``TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256``) which
+                                                                  are excluded. These cipher suites will be refused and exclusion takes higher
+                                                                  precedence than inclusion, such that if a cipher suite is listed in
+                                                                  ``supportedCipherSuites`` and ``excludedCipherSuites``, the cipher suite will be
+                                                                  excluded. To verify that the proper cipher suites are being whitelisted and
+                                                                  blacklisted, it is recommended to use the tool `sslyze`_.
+allowRenegotiation               true                             Whether or not TLS renegotiation is allowed.
+endpointIdentificationAlgorithm  (none)                           Which endpoint identification algorithm, if any, to use during the TLS handshake.
+================================ ================================ ======================================================================================
 
 .. _sslyze: https://github.com/nabla-c0d3/sslyze
 

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
@@ -182,7 +182,7 @@ import java.util.stream.Collectors;
  *     </tr>
  *     <tr>
  *         <td>{@code excludedProtocols}</td>
- *         <td>Jetty's default</td>
+ *         <td>["SSL.*", "TLSv1", "TLSv1\.1"]</td>
  *         <td>
  *             A list of protocols (e.g., {@code SSLv3}, {@code TLSv1}) which are excluded. These
  *             protocols will be refused.
@@ -287,7 +287,7 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
     private List<String> supportedProtocols;
 
     @Nullable
-    private List<String> excludedProtocols;
+    private List<String> excludedProtocols = Arrays.asList("SSL.*", "TLSv1", "TLSv1\\.1");
 
     @Nullable
     private List<String> supportedCipherSuites;


### PR DESCRIPTION
I'm feeling this out -- feel free to discuss 😄 

###### Problem:
Thanks to https://github.com/dropwizard/dropwizard/pull/2405 we'll see the following on startup for an HTTPS connector:

```
Enabled protocols: [TLSv1, TLSv1.1, TLSv1.2]
Disabled protocols: [SSLv2Hello, SSLv3]
```

You may recall that nearly two years ago I tripped up upgrading to Dropwizard 1.0 as [only TLSv1.2 seemed supported](https://github.com/dropwizard/dropwizard/issues/1700), so why is Dropwizard logging that TLSv1 and TLSv1.1 is enabled? Jetty would serve TLSv1.1 requests when the server runtime and client could agree on a cipher suite (nothing surprising here).  But by default, openssl could not communicate via TLSv1.1 with a Dropwizard server running on the latest oracle / openjdk versions. This can be verified with [sslyze](https://github.com/nabla-c0d3/sslyze), where it only lists TLS v1.2 cipher suites as possible. While one can use an alternate provider on the server (bouncycastle) -- if by default Dropwizard doesn't expose a non-TLSv1.2 cipher suite, what's the point of enabling TLSv1 and TLSv1.1? 

###### Solution:
Double down on the statement that [that only TLSv1.2 is enabled by default](https://github.com/dropwizard/dropwizard/issues/1700), by disabling everything that is less secure.

###### Result:
Secure by default! If someone has allowed TLSv1.1 cipher suites they'll now need to reset the `excludeProtocols` to the defaults

```yaml
server:
    applicationConnectors:
        - type: https
          port: 0
          keyStorePath: keystore.jks
          excludedProtocols:
```

On startup we'll see:

```
Enabled protocols: [TLSv1.2]
Disabled protocols: [SSLv2Hello, SSLv3, TLSv1, TLSv1.1]
```

When TLS v1.3 becomes supported, it will automatically be picked up and enabled.