### PR TITLE
Fix ResourceURL.isDirectory to handle Jar paths that are URL-escaped.

### DIFF
--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/assets/ResourceURL.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/assets/ResourceURL.java
@@ -43,9 +43,7 @@ public class ResourceURL {
                     // This seems to return null for directories (though that behavior is undocumented as far as I
                     // can tell). If you have a better idea, please improve this.
 
-                    final String fileName = resourceURL.getFile();
-                    // leaves just the relative file path inside the jar
-                    final String relativeFilePath = fileName.substring(fileName.lastIndexOf('!') + 2);
+                    final String relativeFilePath = entry.getName();
                     final JarFile jarFile = jarConnection.getJarFile();
                     final ZipEntry zipEntry = jarFile.getEntry(relativeFilePath);
                     final InputStream inputStream = jarFile.getInputStream(zipEntry);


### PR DESCRIPTION
The heuristic inside the "jar" codepath in ResourceURL.isDirectory is
splitting the filename from the URL by String indexing.  This means that
if the file name would be URL-escaped (e.g. if it has a space in it) then
relativeFilePath is still escaped.  This manifests as zipEntry being null,
which then causes NullPointerException -> IOException ->
ResourceNotFoundException.

Fix this by using entry.getName() instead of taking a URL substring.
This works because jarConnection has been formed by correctly parsing the URL.

###### Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->

###### Solution:
<!-- Describe the modifications you've done. -->

###### Result:
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->
