### PR TITLE
Allow constraint validators access to context types

### DIFF
--- a/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
@@ -78,7 +78,7 @@ public class DropwizardApacheConnectorTest {
         clientConfiguration.setTimeout(Duration.milliseconds(DEFAULT_CONNECT_TIMEOUT_IN_MILLIS));
 
         environment = new Environment("test-dropwizard-apache-connector", Jackson.newObjectMapper(),
-                Validators.newValidator(), new MetricRegistry(),
+                Validators.newValidatorFactory(), new MetricRegistry(),
                 getClass().getClassLoader());
         client = (JerseyClient) new JerseyClientBuilder(environment)
                 .using(clientConfiguration)

--- a/dropwizard-core/src/main/java/io/dropwizard/cli/EnvironmentCommand.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/EnvironmentCommand.java
@@ -31,7 +31,7 @@ public abstract class EnvironmentCommand<T extends Configuration> extends Config
     protected void run(Bootstrap<T> bootstrap, Namespace namespace, T configuration) throws Exception {
         final Environment environment = new Environment(bootstrap.getApplication().getName(),
                                                         bootstrap.getObjectMapper(),
-                                                        bootstrap.getValidatorFactory().getValidator(),
+                                                        bootstrap.getValidatorFactory(),
                                                         bootstrap.getMetricRegistry(),
                                                         bootstrap.getClassLoader(),
                                                         bootstrap.getHealthCheckRegistry());

--- a/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
@@ -42,7 +42,7 @@ import javax.annotation.Nullable;
 import javax.servlet.DispatcherType;
 import javax.servlet.Servlet;
 import javax.validation.Valid;
-import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import java.io.BufferedReader;
@@ -529,7 +529,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
     protected Handler createAppServlet(Server server,
                                        JerseyEnvironment jersey,
                                        ObjectMapper objectMapper,
-                                       Validator validator,
+                                       ValidatorFactory validatorFactory,
                                        MutableServletContextHandler handler,
                                        @Nullable Servlet jerseyContainer,
                                        MetricRegistry metricRegistry) {
@@ -545,7 +545,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
         if (jerseyContainer != null) {
             jerseyRootPath.ifPresent(jersey::setUrlPattern);
             jersey.register(new JacksonFeature(objectMapper));
-            jersey.register(new HibernateValidationBinder(validator));
+            jersey.register(new HibernateValidationBinder(validatorFactory));
             if (registerDefaultExceptionMappers == null || registerDefaultExceptionMappers) {
                 jersey.register(new ExceptionMapperBinder(detailedJsonProcessingExceptionMapper));
             }

--- a/dropwizard-core/src/main/java/io/dropwizard/server/DefaultServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/DefaultServerFactory.java
@@ -158,7 +158,7 @@ public class DefaultServerFactory extends AbstractServerFactory {
         final Handler applicationHandler = createAppServlet(server,
                                                             environment.jersey(),
                                                             environment.getObjectMapper(),
-                                                            environment.getValidator(),
+                                                            environment.getValidatorFactory(),
                                                             environment.getApplicationContext(),
                                                             environment.getJerseyServletContainer(),
                                                             environment.metrics());

--- a/dropwizard-core/src/main/java/io/dropwizard/server/SimpleServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/SimpleServerFactory.java
@@ -110,7 +110,7 @@ public class SimpleServerFactory extends AbstractServerFactory {
         final Handler applicationHandler = createAppServlet(server,
                                                             environment.jersey(),
                                                             environment.getObjectMapper(),
-                                                            environment.getValidator(),
+                                                            environment.getValidatorFactory(),
                                                             environment.getApplicationContext(),
                                                             environment.getJerseyServletContainer(),
                                                             environment.metrics());

--- a/dropwizard-core/src/main/java/io/dropwizard/setup/Environment.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/Environment.java
@@ -16,6 +16,7 @@ import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import javax.annotation.Nullable;
 import javax.servlet.Servlet;
 import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -32,6 +33,7 @@ public class Environment {
     private final HealthCheckRegistry healthCheckRegistry;
 
     private final ObjectMapper objectMapper;
+    private ValidatorFactory validatorFactory;
     private Validator validator;
 
     private final JerseyContainerHolder jerseyServletContainer;
@@ -55,7 +57,7 @@ public class Environment {
      */
     public Environment(String name,
                        ObjectMapper objectMapper,
-                       Validator validator,
+                       ValidatorFactory validatorFactory,
                        MetricRegistry metricRegistry,
                        @Nullable ClassLoader classLoader,
                        HealthCheckRegistry healthCheckRegistry) {
@@ -63,7 +65,8 @@ public class Environment {
         this.objectMapper = objectMapper;
         this.metricRegistry = metricRegistry;
         this.healthCheckRegistry = healthCheckRegistry;
-        this.validator = validator;
+        this.validatorFactory = validatorFactory;
+        this.validator = validatorFactory.getValidator();
 
         this.servletContext = new MutableServletContextHandler();
         servletContext.setClassLoader(classLoader);
@@ -114,10 +117,10 @@ public class Environment {
      */
     public Environment(String name,
                        ObjectMapper objectMapper,
-                       Validator validator,
+                       ValidatorFactory validatorFactory,
                        MetricRegistry metricRegistry,
                        @Nullable ClassLoader classLoader) {
-        this(name, objectMapper, validator, metricRegistry, classLoader, new HealthCheckRegistry());
+        this(name, objectMapper, validatorFactory, metricRegistry, classLoader, new HealthCheckRegistry());
     }
 
     /**
@@ -177,10 +180,18 @@ public class Environment {
     }
 
     /**
+     * Returns the {@link ValidatorFactory} that will create the {@link Validator}
+     */
+    public ValidatorFactory getValidatorFactory() {
+        return validatorFactory;
+    }
+
+    /**
      * Sets the application's {@link Validator}.
      */
-    public void setValidator(Validator validator) {
-        this.validator = requireNonNull(validator);
+    public void setValidatorFactory(ValidatorFactory validatorFactory) {
+        this.validatorFactory = requireNonNull(validatorFactory);
+        this.validator = validatorFactory.getValidator();
     }
 
     /**

--- a/dropwizard-core/src/test/java/io/dropwizard/server/AbstractServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/AbstractServerFactoryTest.java
@@ -81,7 +81,7 @@ public class AbstractServerFactoryTest {
             createAppServlet(server,
                                   environment.jersey(),
                                   environment.getObjectMapper(),
-                                  environment.getValidator(),
+                                  environment.getValidatorFactory(),
                                   environment.getApplicationContext(),
                                   environment.getJerseyServletContainer(),
                                   environment.metrics());

--- a/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
@@ -43,7 +43,7 @@ import static org.junit.Assert.assertEquals;
 
 public class DefaultServerFactoryTest {
     private Environment environment = new Environment("test", Jackson.newObjectMapper(),
-            Validators.newValidator(), new MetricRegistry(),
+            Validators.newValidatorFactory(), new MetricRegistry(),
             ClassLoader.getSystemClassLoader());
     private DefaultServerFactory http;
 
@@ -118,7 +118,7 @@ public class DefaultServerFactoryTest {
         http.setRegisterDefaultExceptionMappers(false);
         assertThat(http.getRegisterDefaultExceptionMappers()).isFalse();
         Environment environment = new Environment("test", Jackson.newObjectMapper(),
-                Validators.newValidator(), new MetricRegistry(),
+                Validators.newValidatorFactory(), new MetricRegistry(),
                 ClassLoader.getSystemClassLoader());
         http.build(environment);
         assertThat(environment.jersey().getResourceConfig().getSingletons())

--- a/dropwizard-core/src/test/java/io/dropwizard/server/SimpleServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/SimpleServerFactoryTest.java
@@ -20,6 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -42,15 +43,15 @@ public class SimpleServerFactoryTest {
 
     private SimpleServerFactory http;
     private final ObjectMapper objectMapper = Jackson.newObjectMapper();
-    private Validator validator = BaseValidator.newValidator();
-    private Environment environment = new Environment("testEnvironment", objectMapper, validator, new MetricRegistry(),
+    private ValidatorFactory validatorFactory = BaseValidator.newConfiguration().buildValidatorFactory();
+    private Environment environment = new Environment("testEnvironment", objectMapper, validatorFactory, new MetricRegistry(),
             ClassLoader.getSystemClassLoader());
 
     @Before
     public void setUp() throws Exception {
         objectMapper.getSubtypeResolver().registerSubtypes(ConsoleAppenderFactory.class,
                 FileAppenderFactory.class, SyslogAppenderFactory.class, HttpConnectorFactory.class);
-        http = (SimpleServerFactory) new YamlConfigurationFactory<>(ServerFactory.class, validator, objectMapper, "dw")
+        http = (SimpleServerFactory) new YamlConfigurationFactory<>(ServerFactory.class, validatorFactory.getValidator(), objectMapper, "dw")
                 .build(new File(Resources.getResource("yaml/simple_server.yml").toURI()));
     }
 

--- a/dropwizard-core/src/test/java/io/dropwizard/setup/ExceptionMapperBinderTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/setup/ExceptionMapperBinderTest.java
@@ -20,6 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -34,15 +35,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ExceptionMapperBinderTest {
     private SimpleServerFactory http;
     private final ObjectMapper objectMapper = Jackson.newObjectMapper();
-    private Validator validator = BaseValidator.newValidator();
-    private Environment environment = new Environment("testEnvironment", objectMapper, validator, new MetricRegistry(),
+    private ValidatorFactory validatorFactory = BaseValidator.newConfiguration().buildValidatorFactory();
+    private Environment environment = new Environment("testEnvironment", objectMapper, validatorFactory, new MetricRegistry(),
         ClassLoader.getSystemClassLoader());
 
     @Before
     public void setUp() throws Exception {
         objectMapper.getSubtypeResolver().registerSubtypes(ConsoleAppenderFactory.class,
             FileAppenderFactory.class, SyslogAppenderFactory.class, HttpConnectorFactory.class);
-        http = (SimpleServerFactory) new YamlConfigurationFactory<>(ServerFactory.class, validator, objectMapper, "dw")
+        http = (SimpleServerFactory) new YamlConfigurationFactory<>(ServerFactory.class, validatorFactory.getValidator(), objectMapper, "dw")
             .build(new File(Resources.getResource("yaml/simple_server.yml").toURI()));
     }
 

--- a/dropwizard-forms/src/test/java/io/dropwizard/forms/MultiPartBundleTest.java
+++ b/dropwizard-forms/src/test/java/io/dropwizard/forms/MultiPartBundleTest.java
@@ -20,7 +20,7 @@ public class MultiPartBundleTest {
         final Environment environment = new Environment(
                 "multipart-test",
                 Jackson.newObjectMapper(),
-                BaseValidator.newValidator(),
+                BaseValidator.newConfiguration().buildValidatorFactory(),
                 new MetricRegistry(),
                 getClass().getClassLoader()
         );

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OptionalDoubleTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OptionalDoubleTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class OptionalDoubleTest {
     private final Environment env = new Environment("test-optional-double", Jackson.newObjectMapper(),
-        Validators.newValidator(), new MetricRegistry(), null);
+        Validators.newValidatorFactory(), new MetricRegistry(), null);
 
     private TestDao dao;
 

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OptionalIntTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OptionalIntTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class OptionalIntTest {
     private final Environment env = new Environment("test-optional-int", Jackson.newObjectMapper(),
-        Validators.newValidator(), new MetricRegistry(), null);
+        Validators.newValidatorFactory(), new MetricRegistry(), null);
 
     private TestDao dao;
 

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OptionalLongTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/args/OptionalLongTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class OptionalLongTest {
     private final Environment env = new Environment("test-optional-long", Jackson.newObjectMapper(),
-        Validators.newValidator(), new MetricRegistry(), null);
+        Validators.newValidatorFactory(), new MetricRegistry(), null);
 
     private TestDao dao;
 

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/DBIClient.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/DBIClient.java
@@ -40,7 +40,7 @@ public class DBIClient extends ExternalResource {
     @Override
     protected void before() throws Throwable {
         final Environment environment = new Environment("test", Jackson.newObjectMapper(),
-                Validators.newValidator(), new MetricRegistry(),
+                Validators.newValidatorFactory(), new MetricRegistry(),
                 getClass().getClassLoader());
 
         final DataSourceFactory dataSourceFactory = new DataSourceFactory();

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalDateTimeTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalDateTimeTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class GuavaOptionalDateTimeTest {
 
     private final Environment env = new Environment("test-guava-date-time", Jackson.newObjectMapper(),
-            Validators.newValidator(), new MetricRegistry(), null);
+            Validators.newValidatorFactory(), new MetricRegistry(), null);
 
     private TaskDao dao;
 

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalInstantTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalInstantTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class GuavaOptionalInstantTest {
     private final Environment env = new Environment("test-guava-instant", Jackson.newObjectMapper(),
-            Validators.newValidator(), new MetricRegistry(), null);
+            Validators.newValidatorFactory(), new MetricRegistry(), null);
 
     private TaskDao dao;
 

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalLocalDateTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalLocalDateTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class GuavaOptionalLocalDateTest {
     private final Environment env = new Environment("test-guava-local-date", Jackson.newObjectMapper(),
-            Validators.newValidator(), new MetricRegistry(), null);
+            Validators.newValidatorFactory(), new MetricRegistry(), null);
 
     private TaskDao dao;
 

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalLocalDateTimeTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalLocalDateTimeTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class GuavaOptionalLocalDateTimeTest {
     private final Environment env = new Environment("test-guava-local-date-time", Jackson.newObjectMapper(),
-            Validators.newValidator(), new MetricRegistry(), null);
+            Validators.newValidatorFactory(), new MetricRegistry(), null);
 
     private TaskDao dao;
 

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalOffsetDateTimeTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalOffsetDateTimeTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class GuavaOptionalOffsetDateTimeTest {
 
     private final Environment env = new Environment("test-guava-offset-date-time", Jackson.newObjectMapper(),
-            Validators.newValidator(), new MetricRegistry(), null);
+            Validators.newValidatorFactory(), new MetricRegistry(), null);
 
     private TaskDao dao;
 

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalZonedDateTimeTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/GuavaOptionalZonedDateTimeTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class GuavaOptionalZonedDateTimeTest {
 
     private final Environment env = new Environment("test-guava-zoned-date-time", Jackson.newObjectMapper(),
-            Validators.newValidator(), new MetricRegistry(), null);
+            Validators.newValidatorFactory(), new MetricRegistry(), null);
 
     private TaskDao dao;
 

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalDateTimeTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalDateTimeTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class OptionalDateTimeTest {
 
     private final Environment env = new Environment("test-optional-date-time", Jackson.newObjectMapper(),
-            Validators.newValidator(), new MetricRegistry(), null);
+            Validators.newValidatorFactory(), new MetricRegistry(), null);
 
 
     private TaskDao dao;

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalInstantTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalInstantTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class OptionalInstantTest {
     private final Environment env = new Environment("test-optional-instant", Jackson.newObjectMapper(),
-            Validators.newValidator(), new MetricRegistry(), null);
+            Validators.newValidatorFactory(), new MetricRegistry(), null);
 
     private TaskDao dao;
 

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalLocalDateTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalLocalDateTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class OptionalLocalDateTest {
     private final Environment env = new Environment("test-optional-local-date", Jackson.newObjectMapper(),
-            Validators.newValidator(), new MetricRegistry(), null);
+            Validators.newValidatorFactory(), new MetricRegistry(), null);
 
     private TaskDao dao;
 

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalLocalDateTimeTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalLocalDateTimeTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class OptionalLocalDateTimeTest {
     private final Environment env = new Environment("test-optional-local-date-time", Jackson.newObjectMapper(),
-            Validators.newValidator(), new MetricRegistry(), null);
+            Validators.newValidatorFactory(), new MetricRegistry(), null);
 
     private TaskDao dao;
 

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalOffsetDateTimeTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalOffsetDateTimeTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class OptionalOffsetDateTimeTest {
 
     private final Environment env = new Environment("test-optional-offset-date-time", Jackson.newObjectMapper(),
-            Validators.newValidator(), new MetricRegistry(), null);
+            Validators.newValidatorFactory(), new MetricRegistry(), null);
 
     private TaskDao dao;
 

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalZonedDateTimeTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/timestamps/OptionalZonedDateTimeTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class OptionalZonedDateTimeTest {
 
     private final Environment env = new Environment("test-optional-zoned-date-time", Jackson.newObjectMapper(),
-            Validators.newValidator(), new MetricRegistry(), null);
+            Validators.newValidatorFactory(), new MetricRegistry(), null);
 
     private TaskDao dao;
 

--- a/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/JdbiTest.java
+++ b/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/JdbiTest.java
@@ -35,7 +35,7 @@ public class JdbiTest {
 
     @Before
     public void setUp() throws Exception {
-        environment = new Environment("test", new ObjectMapper(), Validators.newValidator(),
+        environment = new Environment("test", new ObjectMapper(), Validators.newValidatorFactory(),
             metricRegistry, ClassLoader.getSystemClassLoader());
 
         DataSourceFactory dataSourceFactory = new DataSourceFactory();

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/HibernateValidationBinder.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/HibernateValidationBinder.java
@@ -1,19 +1,50 @@
 package io.dropwizard.jersey.validation;
 
+import org.glassfish.hk2.api.Factory;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.server.internal.inject.ConfiguredValidator;
+import org.glassfish.jersey.server.validation.internal.InjectingConstraintValidatorFactory;
 
-import javax.validation.Validator;
+import javax.inject.Inject;
+import javax.validation.ValidatorContext;
+import javax.validation.ValidatorFactory;
+import javax.ws.rs.container.ResourceContext;
+import javax.ws.rs.core.Context;
 
 public class HibernateValidationBinder extends AbstractBinder {
-    private final Validator validator;
+    private final ValidatorFactory factory;
 
-    public HibernateValidationBinder(Validator validator) {
-        this.validator = validator;
+    public HibernateValidationBinder(ValidatorFactory factory) {
+        this.factory = factory;
     }
 
     @Override
     protected void configure() {
-        bind(new DropwizardConfiguredValidator(validator)).to(ConfiguredValidator.class);
+        bind(factory).to(ValidatorFactory.class);
+        bindFactory(ValidatorProvider.class).to(ConfiguredValidator.class);
+    }
+
+    private static class ValidatorProvider implements Factory<ConfiguredValidator> {
+        @Context
+        private ResourceContext resourceContext;
+
+        private final ValidatorFactory factory;
+
+        @Inject
+        @SuppressWarnings("NullAway") // NullAway can't prove that resourceContext is not null
+        private ValidatorProvider(ValidatorFactory factory) {
+            this.factory = factory;
+        }
+
+        @Override
+        public ConfiguredValidator provide() {
+            final ValidatorContext context = factory.usingContext();
+            context.constraintValidatorFactory(resourceContext.getResource(InjectingConstraintValidatorFactory.class));
+            return new DropwizardConfiguredValidator(context.getValidator());
+        }
+
+        @Override
+        public void dispose(ConfiguredValidator instance) {
+        }
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/IsCool.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/IsCool.java
@@ -1,0 +1,45 @@
+package io.dropwizard.jersey.validation;
+
+import javax.annotation.Nullable;
+import javax.validation.Constraint;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.Payload;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({ METHOD, FIELD, PARAMETER })
+@Retention(RUNTIME)
+@Constraint(validatedBy = IsCool.CoolValidator.class)
+public @interface IsCool {
+
+    String message() default "is not yet cool enough (or maybe it's too cool)!";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    class CoolValidator implements ConstraintValidator<IsCool, String> {
+        @Context
+        @Nullable
+        private UriInfo uriInfo;
+
+        @Override
+        public void initialize(IsCool constraintAnnotation) {
+        }
+
+        @Override
+        public boolean isValid(String value, ConstraintValidatorContext context) {
+            return value != null && value.endsWith("iscool")
+                && uriInfo != null && uriInfo.getQueryParameters().containsKey("sneaky-param");
+        }
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
@@ -14,8 +14,9 @@ import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.NotEmpty;
 import org.hibernate.validator.valuehandling.UnwrapValidatedValue;
 
-import javax.servlet.ServletContext;
+import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
+import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -259,7 +260,7 @@ public class ValidatingResource {
 
     @GET
     @Path("context")
-    public String contextual(@Valid @Context @NotNull ServletContext con) {
+    public String contextual(@Valid @Context @NotNull HttpSession con) {
         return "A";
     }
 
@@ -279,6 +280,12 @@ public class ValidatingResource {
     @Path("enumParam")
     public String enumParam(@NotNull @QueryParam("choice") Choice choice) {
         return choice.toString();
+    }
+
+    @GET
+    @Path("customValidation")
+    public String enumParam(@IsCool @QueryParam("coolness") String param) {
+        return param;
     }
 
     @GET

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/common/DropwizardTestResourceConfig.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/common/DropwizardTestResourceConfig.java
@@ -43,7 +43,7 @@ class DropwizardTestResourceConfig extends DropwizardResourceConfig {
             property(property.getKey(), property.getValue());
         }
         register(new JacksonFeature(configuration.mapper));
-        register(new HibernateValidationBinder(configuration.validator));
+        register(new HibernateValidationBinder(configuration.validatorFactory));
         for (Supplier<?> singleton : configuration.singletons) {
             register(singleton.get());
         }

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/common/Resource.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/common/Resource.java
@@ -17,6 +17,7 @@ import org.glassfish.jersey.test.spi.TestContainerFactory;
 
 import javax.annotation.Nullable;
 import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.WebTarget;
 import java.util.HashMap;
@@ -40,7 +41,7 @@ public class Resource {
         private final Set<Class<?>> providers = new HashSet<>();
         private final Map<String, Object> properties = new HashMap<>();
         private ObjectMapper mapper = Jackson.newObjectMapper();
-        private Validator validator = Validators.newValidator();
+        private ValidatorFactory validatorFactory = Validators.newValidatorFactory();
         private Consumer<ClientConfig> clientConfigurator = c -> {
         };
         private TestContainerFactory testContainerFactory = new InMemoryTestContainerFactory();
@@ -52,8 +53,8 @@ public class Resource {
             return (B) this;
         }
 
-        public B setValidator(Validator validator) {
-            this.validator = validator;
+        public B setValidatorFactory(ValidatorFactory validatorFactory) {
+            this.validatorFactory = validatorFactory;
             return (B) this;
         }
 
@@ -119,7 +120,7 @@ public class Resource {
                 config.property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true);
             };
             return new Resource(new ResourceTestJerseyConfiguration(
-                singletons, providers, properties, mapper, validator,
+                singletons, providers, properties, mapper, validatorFactory,
                 extendedConfigurator, testContainerFactory, registerDefaultExceptionMappers));
         }
     }

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/common/ResourceTestJerseyConfiguration.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/common/ResourceTestJerseyConfiguration.java
@@ -6,6 +6,7 @@ import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
 
 import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -22,19 +23,21 @@ class ResourceTestJerseyConfiguration {
     final Set<Class<?>> providers;
     final Map<String, Object> properties;
     final ObjectMapper mapper;
+    final ValidatorFactory validatorFactory;
     final Validator validator;
     final Consumer<ClientConfig> clientConfigurator;
     final TestContainerFactory testContainerFactory;
     final boolean registerDefaultExceptionMappers;
 
     ResourceTestJerseyConfiguration(Set<Supplier<?>> singletons, Set<Class<?>> providers, Map<String, Object> properties,
-                                    ObjectMapper mapper, Validator validator, Consumer<ClientConfig> clientConfigurator,
+                                    ObjectMapper mapper, ValidatorFactory validatorFactory, Consumer<ClientConfig> clientConfigurator,
                                     TestContainerFactory testContainerFactory, boolean registerDefaultExceptionMappers) {
         this.singletons = singletons;
         this.providers = providers;
         this.properties = properties;
         this.mapper = mapper;
-        this.validator = validator;
+        this.validatorFactory = validatorFactory;
+        this.validator = validatorFactory.getValidator();
         this.clientConfigurator = clientConfigurator;
         this.testContainerFactory = testContainerFactory;
         this.registerDefaultExceptionMappers = registerDefaultExceptionMappers;


### PR DESCRIPTION
###### Problem:
Currently one can't use `@Context` injection in constraint validators (and other hooks in hibernate validator). (#2234)

###### Solution:
Everytime Jersey requests a new `ConfiguredValidator` we create a new one with the current context:

```java
final ValidatorContext context = factory.usingContext();
context.constraintValidatorFactory(resourceContext.getResource(InjectingConstraintValidatorFactory.class));
return new DropwizardConfiguredValidator(context.getValidator());
```

And just like that, our constraint validator receive context injections!

Not so fast.

For every request, a validator will need to be newly instantiated with the request context. The issue is that Dropwizard already sends in a fully configured validator that can't be used across multiple requests simultaneously for context injection to work. This required changing the `Environment` and `JerseyClientBuilder` public APIs which I am loathe to do (but had to).

###### Result:
Can use `@Context` inside constraint validators

public APIs that have had their signature changed (breaking changes):

```
JerseyClientBuilder::using(Validator) -> JerseyClientBuilder::using(ValidatorFactory)
Environment::new(..., Validator, ...) -> Environment::new(..., ValidatorFactory, ...)
Environment::setValidator(Validator) -> Environment::setValidatorFactory(ValidatorFactory)
Resource::setValidator(Validator) -> Resource::setValidatorFactory(ValidatorFactory)
```

To help those who may not care about context injection and just want a validator, I have decided to keep `Environment::getValidator`. It returns a single instance of a validator that created by the validator factory in `Environment` constructor or when a new factory is passed to `Environment::setValidatorFactory`

Closes #2234

