### PR TITLE
Fix incorrect reading of somaxconn for tcp backlog on linux

### DIFF
--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/NetUtil.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/NetUtil.java
@@ -15,13 +15,13 @@
  */
 package io.dropwizard.jetty;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
@@ -73,9 +73,9 @@ public class NetUtil {
             // The known defaults:
             // - Windows NT Server 4.0+: 200
             // - Linux and Mac OS X: 128
-            try {
-                return Integer.parseInt(new String(Files.readAllBytes(Paths.get(TCP_BACKLOG_SETTING_LOCATION)),
-                    StandardCharsets.UTF_8).trim());
+            final File file = new File(TCP_BACKLOG_SETTING_LOCATION);
+            try (BufferedReader in = new BufferedReader(new FileReader(file))) {
+                return Integer.parseInt(in.readLine().trim());
             } catch (SecurityException | IOException | NumberFormatException | NullPointerException e) {
                 return tcpBacklog;
             }

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NetUtilTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NetUtilTest.java
@@ -55,6 +55,9 @@ public class NetUtilTest {
         assumeThat(System.getProperty(OS_NAME_PROPERTY), containsString("Linux"));
         assumeThat(isTcpBacklogSettingReadable(), is(true));
         assertNotEquals(-1, NetUtil.getTcpBacklog(-1));
+        assertThat(NetUtil.getTcpBacklog())
+            .as("NetUtil should read more than the first character of somaxconn")
+            .isGreaterThan(2);
     }
 
     @Test


### PR DESCRIPTION
###### Problem:
Dropwizard drops connections during a burst of short lived connections, as the accept queue is set to (most commonly) 1 or 2 due to `Files.readAllBytes` unable to work with pseudo files like somaxconn

###### Solution:
[Adopt Netty's implementation](https://github.com/netty/netty/blob/77ec8397927e3ceb9b9a447a74e718f625ed9976/common/src/main/java/io/netty/util/NetUtil.java#L261-L269)

###### Result:
Test passed and dropwizard should be more burst resistant. Closes #2429

Dropwizard users currently afflicted by this bug, can override this default behavior by specifying an `acceptQueueSize` in their configuration.