### PR TITLE
Inject validator feature

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/validation/GetLocatorFeature.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/validation/GetLocatorFeature.java
@@ -1,0 +1,26 @@
+package io.dropwizard.validation;
+
+import org.glassfish.hk2.api.ServiceLocator;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+import java.util.function.Consumer;
+
+public class GetLocatorFeature implements Feature {
+
+    private final Consumer<ServiceLocator> action;
+
+    @Inject
+    private ServiceLocator serviceLocator;
+
+    public GetLocatorFeature(Consumer<ServiceLocator> action) {
+        this.action = action;
+    }
+
+    @Override
+    public boolean configure(FeatureContext context) {
+        action.accept(serviceLocator);
+        return true;
+    }
+}

--- a/dropwizard-core/src/main/java/io/dropwizard/validation/GetResourceContextFeature.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/validation/GetResourceContextFeature.java
@@ -1,26 +1,25 @@
 package io.dropwizard.validation;
 
-import org.glassfish.hk2.api.ServiceLocator;
-
 import javax.inject.Inject;
+import javax.ws.rs.container.ResourceContext;
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
 import java.util.function.Consumer;
 
-public class GetLocatorFeature implements Feature {
+public class GetResourceContextFeature implements Feature {
 
-    private final Consumer<ServiceLocator> action;
+    private final Consumer<ResourceContext> action;
 
     @Inject
-    private ServiceLocator serviceLocator;
+    private ResourceContext resourceContext;
 
-    public GetLocatorFeature(Consumer<ServiceLocator> action) {
+    public GetResourceContextFeature(Consumer<ResourceContext> action) {
         this.action = action;
     }
 
     @Override
     public boolean configure(FeatureContext context) {
-        action.accept(serviceLocator);
+        action.accept(resourceContext);
         return true;
     }
 }

--- a/dropwizard-core/src/main/java/io/dropwizard/validation/InjectValidatorBundle.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/validation/InjectValidatorBundle.java
@@ -4,12 +4,10 @@ import io.dropwizard.Bundle;
 import io.dropwizard.jersey.validation.MutableValidatorFactory;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
-import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.jersey.server.validation.internal.InjectingConstraintValidatorFactory;
 
 import javax.annotation.Nullable;
 import javax.validation.ConstraintValidatorFactory;
-import javax.validation.ValidatorFactory;
 import javax.ws.rs.container.ResourceContext;
 
 public class InjectValidatorBundle implements Bundle {
@@ -30,17 +28,17 @@ public class InjectValidatorBundle implements Bundle {
 
     @Override
     public void run(Environment environment) {
-        GetLocatorFeature getLocatorFeature = new GetLocatorFeature(this::setValidatorFactory);
-        environment.jersey().register(getLocatorFeature);
+        GetResourceContextFeature getResourceContext = new GetResourceContextFeature(this::setValidatorFactory);
+        environment.jersey().register(getResourceContext);
     }
 
-    private void setValidatorFactory(ServiceLocator serviceLocator) {
+    private void setValidatorFactory(ResourceContext resourceContext) {
         if (mutableValidatorFactory == null) {
             return;
         }
 
-        ConstraintValidatorFactory validatorFactory = serviceLocator
-            .getService(ResourceContext.class)
+        // Get original Jersey's ConstraintValidatorFactory
+        ConstraintValidatorFactory validatorFactory = resourceContext
             .getResource(InjectingConstraintValidatorFactory.class);
 
         mutableValidatorFactory.setValidatorFactory(validatorFactory);

--- a/dropwizard-core/src/main/java/io/dropwizard/validation/InjectValidatorBundle.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/validation/InjectValidatorBundle.java
@@ -1,0 +1,49 @@
+package io.dropwizard.validation;
+
+import io.dropwizard.Bundle;
+import io.dropwizard.jersey.validation.MutableValidatorFactory;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.jersey.server.validation.internal.InjectingConstraintValidatorFactory;
+
+import javax.annotation.Nullable;
+import javax.validation.ConstraintValidatorFactory;
+import javax.validation.ValidatorFactory;
+import javax.ws.rs.container.ResourceContext;
+
+public class InjectValidatorBundle implements Bundle {
+
+    @Nullable
+    private MutableValidatorFactory mutableValidatorFactory;
+
+    @Override
+    public void initialize(Bootstrap<?> bootstrap) {
+        ConstraintValidatorFactory factory = bootstrap
+            .getValidatorFactory()
+            .getConstraintValidatorFactory();
+
+        if (factory instanceof MutableValidatorFactory) {
+            this.mutableValidatorFactory = (MutableValidatorFactory) factory;
+        }
+    }
+
+    @Override
+    public void run(Environment environment) {
+        GetLocatorFeature getLocatorFeature = new GetLocatorFeature(this::setValidatorFactory);
+        environment.jersey().register(getLocatorFeature);
+    }
+
+    private void setValidatorFactory(ServiceLocator serviceLocator) {
+        if (mutableValidatorFactory == null) {
+            return;
+        }
+
+        ConstraintValidatorFactory validatorFactory = serviceLocator
+            .getService(ResourceContext.class)
+            .getResource(InjectingConstraintValidatorFactory.class);
+
+        mutableValidatorFactory.setValidatorFactory(validatorFactory);
+    }
+
+}

--- a/dropwizard-core/src/main/java/io/dropwizard/validation/InjectValidatorBundle.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/validation/InjectValidatorBundle.java
@@ -10,6 +10,9 @@ import javax.annotation.Nullable;
 import javax.validation.ConstraintValidatorFactory;
 import javax.ws.rs.container.ResourceContext;
 
+/**
+ * Dropwizard Bundle that enables injecting into constraint validators
+ */
 public class InjectValidatorBundle implements Bundle {
 
     @Nullable
@@ -43,5 +46,4 @@ public class InjectValidatorBundle implements Bundle {
 
         mutableValidatorFactory.setValidatorFactory(validatorFactory);
     }
-
 }

--- a/dropwizard-core/src/test/java/io/dropwizard/validation/InjectValidatorBundleTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/validation/InjectValidatorBundleTest.java
@@ -1,0 +1,102 @@
+package io.dropwizard.validation;
+
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.jersey.validation.MutableValidatorFactory;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import org.hibernate.validator.internal.constraintvalidators.bv.MinValidatorForNumber;
+import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorFactoryImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.validation.ConstraintValidatorFactory;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import javax.validation.constraints.Min;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class InjectValidatorBundleTest {
+
+    private final Application<Configuration> application = new Application<Configuration>() {
+        @Override
+        public void initialize(Bootstrap<Configuration> bootstrap) {
+            bootstrap.addBundle(new InjectValidatorBundle());
+        }
+
+        @Override
+        public void run(Configuration configuration, Environment environment) { }
+    };
+
+    private ValidatorFactory validatorFactory;
+
+    @Before
+    public void setUp() throws Exception {
+        Bootstrap<Configuration> bootstrap = new Bootstrap<>(application);
+        application.initialize(bootstrap);
+
+        validatorFactory = bootstrap.getValidatorFactory();
+    }
+
+    @Test
+    public void shouldReplaceValidatorFactory() {
+        ConstraintValidatorFactory factory = validatorFactory.getConstraintValidatorFactory();
+
+        assertThat(factory).isInstanceOf(MutableValidatorFactory.class);
+    }
+
+    @Test
+    public void shouldValidateNormally() {
+        Validator validator = validatorFactory.getValidator();
+
+        // Run validation manually
+        Set<ConstraintViolation<Bean>> constraintViolations = validator.validate(new Bean(1));
+
+
+        assertThat(constraintViolations.size()).isEqualTo(1);
+
+        Optional<String> message = constraintViolations.stream()
+            .findFirst()
+            .map(ConstraintViolation::getMessage);
+
+        assertThat(message).hasValue("must be greater than or equal to 10");
+    }
+
+    @Test
+    public void shouldInvokeUpdatedFactory() {
+        MutableValidatorFactory mutableFactory = (MutableValidatorFactory) validatorFactory
+            .getConstraintValidatorFactory();
+
+        ConstraintValidatorFactory mockedFactory = mock(
+            ConstraintValidatorFactory.class,
+            delegatesTo(new ConstraintValidatorFactoryImpl())
+        );
+
+        // Swap validator factory at runtime
+        mutableFactory.setValidatorFactory(mockedFactory);
+
+        // Run validation manually
+        Validator validator = validatorFactory.getValidator();
+        validator.validate(new Bean(1));
+
+        verify(mockedFactory).getInstance(eq(MinValidatorForNumber.class));
+    }
+
+    static class Bean {
+
+        @Min(10)
+        final int value;
+
+        Bean(int value) {
+            this.value = value;
+        }
+    }
+}

--- a/dropwizard-e2e/src/main/java/com/example/validation/DefaultValidatorApp.java
+++ b/dropwizard-e2e/src/main/java/com/example/validation/DefaultValidatorApp.java
@@ -1,0 +1,13 @@
+package com.example.validation;
+
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Environment;
+
+public class DefaultValidatorApp extends Application<Configuration> {
+
+    @Override
+    public void run(Configuration configuration, Environment environment) throws Exception {
+        environment.jersey().register(ValidatedResource.class);
+    }
+}

--- a/dropwizard-e2e/src/main/java/com/example/validation/InjectValidatorApp.java
+++ b/dropwizard-e2e/src/main/java/com/example/validation/InjectValidatorApp.java
@@ -1,0 +1,20 @@
+package com.example.validation;
+
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.validation.InjectValidatorBundle;
+
+public class InjectValidatorApp extends Application<Configuration> {
+
+    @Override
+    public void initialize(Bootstrap<Configuration> bootstrap) {
+        bootstrap.addBundle(new InjectValidatorBundle());
+    }
+
+    @Override
+    public void run(Configuration configuration, Environment environment) throws Exception {
+        environment.jersey().register(ValidatedResource.class);
+    }
+}

--- a/dropwizard-e2e/src/main/java/com/example/validation/ValidatedResource.java
+++ b/dropwizard-e2e/src/main/java/com/example/validation/ValidatedResource.java
@@ -1,0 +1,26 @@
+package com.example.validation;
+
+import io.dropwizard.validation.OneOf;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+public class ValidatedResource {
+
+    @GET
+    @Path("/injectable")
+    public void injectableValidation(@QueryParam("value") @OneOf("right") @WasInjected String value) {
+        //Do nothing
+    }
+
+    @GET
+    @Path("/default")
+    public void defaultValidation(@QueryParam("value") @OneOf("right") String value) {
+        //Do nothing
+    }
+}

--- a/dropwizard-e2e/src/main/java/com/example/validation/WasInjected.java
+++ b/dropwizard-e2e/src/main/java/com/example/validation/WasInjected.java
@@ -1,0 +1,23 @@
+package com.example.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER})
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = WasInjectedConstraintValidator.class)
+public @interface WasInjected {
+
+    String message() default "validator was not injected";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/dropwizard-e2e/src/main/java/com/example/validation/WasInjectedConstraintValidator.java
+++ b/dropwizard-e2e/src/main/java/com/example/validation/WasInjectedConstraintValidator.java
@@ -1,0 +1,22 @@
+package com.example.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
+
+public class WasInjectedConstraintValidator implements ConstraintValidator<WasInjected, String> {
+
+    @Context
+    private UriInfo uriInfo;
+
+    @Override
+    public void initialize(WasInjected constraintAnnotation) {
+
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return uriInfo != null;
+    }
+}

--- a/dropwizard-e2e/src/test/java/com/example/validation/DefaultValidatorTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/validation/DefaultValidatorTest.java
@@ -1,0 +1,58 @@
+package com.example.validation;
+
+import io.dropwizard.Configuration;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DefaultValidatorTest {
+
+    @ClassRule
+    public static final DropwizardAppRule<Configuration> RULE = new DropwizardAppRule<>(
+        DefaultValidatorApp.class,
+        resourceFilePath("app1/config.yml")
+    );
+
+    @Test
+    public void shouldValidateNormally() {
+        final Client client = RULE.client();
+        final String url = String.format("http://localhost:%d/default", RULE.getLocalPort());
+        final WebTarget target = client.target(url);
+
+        Response validRequest = target
+            .queryParam("value", "right")
+            .request().get();
+
+        Response invalidRequest = target
+            .queryParam("value", "wrong")
+            .request().get();
+
+        assertThat(validRequest.getStatus()).isEqualTo(204);
+
+        assertThat(invalidRequest.getStatus()).isEqualTo(400);
+        assertThat(invalidRequest.readEntity(String.class))
+            .isEqualTo("{\"errors\":[\"query param value must be one of [right]\"]}");
+    }
+
+    @Test
+    public void shouldNotInjectValidator() {
+        final Client client = RULE.client();
+        final String url = String.format("http://localhost:%d/injectable", RULE.getLocalPort());
+
+        final Response response = client.target(url)
+            .queryParam("value", "right")
+            .request()
+            .get();
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.readEntity(String.class))
+            .isEqualTo("{\"errors\":[\"query param value validator was not injected\"]}");
+    }
+}

--- a/dropwizard-e2e/src/test/java/com/example/validation/InjectValidatorBundleTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/validation/InjectValidatorBundleTest.java
@@ -1,0 +1,56 @@
+package com.example.validation;
+
+import io.dropwizard.Configuration;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InjectValidatorBundleTest {
+
+    @ClassRule
+    public static final DropwizardAppRule<Configuration> RULE = new DropwizardAppRule<>(
+        InjectValidatorApp.class,
+        resourceFilePath("app1/config.yml")
+    );
+
+    @Test
+    public void shouldValidateNormally() {
+        final Client client = RULE.client();
+        final String url = String.format("http://localhost:%d/default", RULE.getLocalPort());
+        final WebTarget target = client.target(url);
+
+        Response validRequest = target
+            .queryParam("value", "right")
+            .request().get();
+
+        Response invalidRequest = target
+            .queryParam("value", "wrong")
+            .request().get();
+
+        assertThat(validRequest.getStatus()).isEqualTo(204);
+
+        assertThat(invalidRequest.getStatus()).isEqualTo(400);
+        assertThat(invalidRequest.readEntity(String.class))
+            .isEqualTo("{\"errors\":[\"query param value must be one of [right]\"]}");
+    }
+
+    @Test
+    public void shouldInjectValidator() {
+        final Client client = RULE.client();
+        final String url = String.format("http://localhost:%d/injectable", RULE.getLocalPort());
+
+        final Response response = client.target(url)
+            .queryParam("value", "right")
+            .request()
+            .get();
+
+        assertThat(response.getStatus()).isEqualTo(204);
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/MutableValidatorFactory.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/MutableValidatorFactory.java
@@ -1,0 +1,23 @@
+package io.dropwizard.jersey.validation;
+
+import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorFactoryImpl;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorFactory;
+
+public class MutableValidatorFactory implements ConstraintValidatorFactory {
+
+    private ConstraintValidatorFactory validatorFactory = new ConstraintValidatorFactoryImpl();
+
+    @Override
+    public final <T extends ConstraintValidator<?, ?>> T getInstance(Class<T> key) {
+        return validatorFactory.getInstance(key);
+    }
+
+    @Override
+    public void releaseInstance(ConstraintValidator<?, ?> instance) { }
+
+    public void setValidatorFactory(ConstraintValidatorFactory validatorFactory) {
+        this.validatorFactory = validatorFactory;
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/Validators.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/Validators.java
@@ -32,6 +32,7 @@ public class Validators {
      */
     public static HibernateValidatorConfiguration newConfiguration() {
         return BaseValidator.newConfiguration()
+                .constraintValidatorFactory(new MutableValidatorFactory())
                 .parameterNameProvider(new JerseyParameterNameProvider())
                 .addValidatedValueHandler(new NonEmptyStringParamUnwrapper())
                 .addValidatedValueHandler(new ParamValidatorUnwrapper());


### PR DESCRIPTION
Following discussion at https://github.com/dropwizard/dropwizard/pull/2427

###### Problem:
Somewhere during update to `1.0.0` we lost ability to inject into custom `ConstraintValidator`s because validator factory was moved into Dropwizard.

###### Solution:
PR Introduces `InjectValidatorBundle` to enable validator injections inside jersey resources. Note that validators for dropwizard configuration are not affected because `ConstraintValidatorFactory` is updated after jersey initialisation.

Under the hood: There is new `MutableValidatorFactory` registered by default in validator configuration that allows to swap factory at runtime. So after jersey initialisation is possible to change `ConstraintValidatorFactoryImpl` with `InjectingConstraintValidatorFactory`

###### Result:
Closes #2234, making injections available in ConstraintValidators