### PR TITLE
Upgraded Hamcrest to 2.0.0.0 release

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -596,8 +596,8 @@
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-core</artifactId>
-                <version>1.3</version>
+                <artifactId>java-hamcrest</artifactId>
+                <version>2.0.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>


### PR DESCRIPTION
###### Problem:
Hamcrest 1.3 is an old release that is not maintained anymore. It makes writing Java 7+ code that generates no warnings (e.g. SonarQube ones) not  easy.



###### Solution:
I propose migrating to Java-Hamcrest 2.0.0.0:

```
<dependency>
    <groupId>org.hamcrest</groupId>
    <artifactId>java-hamcrest</artifactId>
    <version>2.0.0.0</version>
    <scope>test</scope>
</dependency>
```

I have verified that all tests in Dropwizard's code base still pass after the upgrade.

###### Result:
Better support Java 7+ syntax