### PR TITLE
Replace remaining use of Hamcrest with AssertJ

### DIFF
--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/CachingAuthenticatorTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/CachingAuthenticatorTest.java
@@ -2,7 +2,6 @@ package io.dropwizard.auth;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.benmanes.caffeine.cache.CaffeineSpec;
-import com.google.common.cache.CacheBuilderSpec;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -595,11 +595,6 @@
                 <version>4.12</version>
             </dependency>
             <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-core</artifactId>
-                <version>1.3</version>
-            </dependency>
-            <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>

--- a/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
@@ -46,7 +46,7 @@ import java.net.URI;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.any;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -98,12 +98,9 @@ public class DropwizardApacheConnectorTest {
 
     @Test
     public void when_no_read_timeout_override_then_client_request_times_out() {
-        thrown.expect(ProcessingException.class);
-        thrown.expectCause(any(SocketTimeoutException.class));
-
-        client.target(testUri + "/long_running")
-                .request()
-                .get();
+        assertThatThrownBy(() ->client.target(testUri + "/long_running").request().get())
+                .isInstanceOf(ProcessingException.class)
+                .hasCauseInstanceOf(SocketTimeoutException.class);
     }
 
     @Test
@@ -233,11 +230,11 @@ public class DropwizardApacheConnectorTest {
         }
 
         @Override
-        public void run(Configuration configuration, Environment environment) throws Exception {
+        public void run(Configuration configuration, Environment environment) {
             environment.jersey().register(TestResource.class);
             environment.healthChecks().register("dummy", new HealthCheck() {
                 @Override
-                protected Result check() throws Exception {
+                protected Result check() {
                     return Result.healthy();
                 }
             });

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationValidationExceptionTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationValidationExceptionTest.java
@@ -12,8 +12,7 @@ import java.util.Locale;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assume.assumeThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 public class ConfigurationValidationExceptionTest {
     private static class Example {
@@ -26,7 +25,7 @@ public class ConfigurationValidationExceptionTest {
 
     @Before
     public void setUp() throws Exception {
-        assumeThat(Locale.getDefault().getLanguage(), is("en"));
+        assumeThat(Locale.getDefault().getLanguage()).isEqualTo("en");
 
         final Validator validator = BaseValidator.newValidator();
         final Set<ConstraintViolation<Example>> violations = validator.validate(new Example());
@@ -34,7 +33,7 @@ public class ConfigurationValidationExceptionTest {
     }
 
     @Test
-    public void formatsTheViolationsIntoAHumanReadableMessage() throws Exception {
+    public void formatsTheViolationsIntoAHumanReadableMessage() {
         assertThat(e.getMessage())
                 .isEqualTo(String.format(
                         "config.yml has an error:%n" +
@@ -43,7 +42,7 @@ public class ConfigurationValidationExceptionTest {
     }
 
     @Test
-    public void retainsTheSetOfExceptions() throws Exception {
+    public void retainsTheSetOfExceptions() {
         assertThat(e.getConstraintViolations())
                 .isNotEmpty();
     }

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/EnvironmentVariableLookupTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/EnvironmentVariableLookupTest.java
@@ -4,13 +4,12 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assume.assumeThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 public class EnvironmentVariableLookupTest {
     @Test
     public void defaultConstructorEnablesStrict() {
-        assumeThat(System.getenv("nope"), nullValue());
+        assumeThat(System.getenv("nope")).isNull();
 
         assertThatExceptionOfType(UndefinedEnvironmentVariableException.class).isThrownBy(()->
             new EnvironmentVariableLookup().lookup("nope"));
@@ -27,7 +26,7 @@ public class EnvironmentVariableLookupTest {
 
     @Test
     public void lookupThrowsExceptionInStrictMode() {
-        assumeThat(System.getenv("nope"), nullValue());
+        assumeThat(System.getenv("nope")).isNull();
 
         assertThatExceptionOfType(UndefinedEnvironmentVariableException.class).isThrownBy(() ->
             new EnvironmentVariableLookup(true).lookup("nope"));

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/EnvironmentVariableSubstitutorTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/EnvironmentVariableSubstitutorTest.java
@@ -4,8 +4,7 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assume.assumeThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 public class EnvironmentVariableSubstitutorTest {
     @Test
@@ -16,7 +15,7 @@ public class EnvironmentVariableSubstitutorTest {
 
     @Test
     public void defaultConstructorEnablesStrict() {
-        assumeThat(System.getenv("DOES_NOT_EXIST"), nullValue());
+        assumeThat(System.getenv("DOES_NOT_EXIST")).isNull();
 
         assertThatExceptionOfType(UndefinedEnvironmentVariableException.class).isThrownBy(() ->
             new EnvironmentVariableSubstitutor().replace("${DOES_NOT_EXIST}"));
@@ -46,7 +45,7 @@ public class EnvironmentVariableSubstitutorTest {
 
     @Test
     public void substitutorThrowsExceptionInStrictMode() {
-        assumeThat(System.getenv("DOES_NOT_EXIST"), nullValue());
+        assumeThat(System.getenv("DOES_NOT_EXIST")).isNull();
 
         assertThatExceptionOfType(UndefinedEnvironmentVariableException.class).isThrownBy(() ->
             new EnvironmentVariableSubstitutor(true).replace("${DOES_NOT_EXIST}"));

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/DBIHealthCheckTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/DBIHealthCheckTest.java
@@ -11,8 +11,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -39,6 +38,6 @@ public class DBIHealthCheckTest {
                 validationQuery);
         HealthCheck.Result result = dbiHealthCheck.check();
         executorService.shutdown();
-        assertThat("is unhealthy", false, is(result.isHealthy()));
+        assertThat(result.isHealthy()).isFalse();
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/gzip/ConfiguredGZipEncoderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/gzip/ConfiguredGZipEncoderTest.java
@@ -17,13 +17,9 @@ import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.zip.GZIPOutputStream;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
 
 public class ConfiguredGZipEncoderTest {
     @Test
@@ -36,7 +32,7 @@ public class ConfiguredGZipEncoderTest {
 
         new ConfiguredGZipEncoder(true).filter(context);
 
-        assertThat(headers.getFirst(HttpHeaders.CONTENT_ENCODING).toString(), is("gzip"));
+        assertThat(headers.getFirst(HttpHeaders.CONTENT_ENCODING).toString()).isEqualTo("gzip");
     }
 
     @Test
@@ -45,8 +41,8 @@ public class ConfiguredGZipEncoderTest {
         headers.add(HttpHeaders.CONTENT_ENCODING, "gzip");
         WriterInterceptorContextMock context = new WriterInterceptorContextMock(headers);
         new ConfiguredGZipEncoder(true).aroundWriteTo(context);
-        assertThat(context.getOutputStream(), is(instanceOf(GZIPOutputStream.class)));
-        assertThat(context.isProceedCalled(), is(true));
+        assertThat(context.getOutputStream()).isInstanceOf(GZIPOutputStream.class);
+        assertThat(context.isProceedCalled()).isTrue();
     }
     @Test
     public void aroundWriteToSpecX_GZip() throws IOException, WebApplicationException {
@@ -54,8 +50,8 @@ public class ConfiguredGZipEncoderTest {
         headers.add(HttpHeaders.CONTENT_ENCODING, "x-gzip");
         WriterInterceptorContextMock context = new WriterInterceptorContextMock(headers);
         new ConfiguredGZipEncoder(true).aroundWriteTo(context);
-        assertThat(context.getOutputStream(), is(instanceOf(GZIPOutputStream.class)));
-        assertThat(context.isProceedCalled(), is(true));
+        assertThat(context.getOutputStream()).isInstanceOf(GZIPOutputStream.class);
+        assertThat(context.isProceedCalled()).isTrue();
     }
     @Test
     public void otherEncodingWillNotAroundWrite() throws IOException, WebApplicationException {
@@ -63,8 +59,8 @@ public class ConfiguredGZipEncoderTest {
         headers.add(HttpHeaders.CONTENT_ENCODING, "someOtherEnc");
         WriterInterceptorContextMock context = new WriterInterceptorContextMock(headers);
         new ConfiguredGZipEncoder(true).aroundWriteTo(context);
-        assertThat(context.getOutputStream(), is(not(instanceOf(GZIPOutputStream.class))));
-        assertThat(context.isProceedCalled(), is(true));
+        assertThat(context.getOutputStream()).isNotInstanceOf(GZIPOutputStream.class);
+        assertThat(context.isProceedCalled()).isTrue();
     }
     @Test
     public void noEncodingwillNotAroundWrite() throws IOException, WebApplicationException {
@@ -72,8 +68,8 @@ public class ConfiguredGZipEncoderTest {
         headers.add(HttpHeaders.CONTENT_ENCODING, null);
         WriterInterceptorContextMock context = new WriterInterceptorContextMock(headers);
         new ConfiguredGZipEncoder(true).aroundWriteTo(context);
-        assertThat(context.getOutputStream(), is(not(instanceOf(GZIPOutputStream.class))));
-        assertThat(context.isProceedCalled(), is(true));
+        assertThat(context.getOutputStream()).isNotInstanceOf(GZIPOutputStream.class);
+        assertThat(context.isProceedCalled()).isTrue();
     }
 
     private static class WriterInterceptorContextMock implements WriterInterceptorContext {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProviderTest.java
@@ -35,8 +35,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assume.assumeThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -109,7 +108,7 @@ public class JacksonMessageBodyProviderTest {
 
     @Before
     public void setUp() throws Exception {
-        assumeThat(Locale.getDefault().getLanguage(), is("en"));
+        assumeThat(Locale.getDefault().getLanguage()).isEqualTo("en");
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
@@ -49,8 +49,9 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Before
-    public void setUp() {
+    public void setUp() throws Exception {
         assumeThat(Locale.getDefault().getLanguage()).isEqualTo("en");
+        super.setUp();
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
@@ -7,6 +7,7 @@ import io.dropwizard.jersey.jackson.JacksonMessageBodyProviderTest.Example;
 import io.dropwizard.jersey.jackson.JacksonMessageBodyProviderTest.ListExample;
 import io.dropwizard.jersey.jackson.JacksonMessageBodyProviderTest.PartialExample;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -23,12 +24,9 @@ import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assume.assumeThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
-
-
     private static final Locale DEFAULT_LOCALE = Locale.getDefault();
 
     @Override
@@ -50,10 +48,13 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
         Locale.setDefault(DEFAULT_LOCALE);
     }
 
-    @Test
-    public void postInvalidEntityIs422() throws Exception {
-        assumeThat(Locale.getDefault().getLanguage(), is("en"));
+    @Before
+    public void setUp() {
+        assumeThat(Locale.getDefault().getLanguage()).isEqualTo("en");
+    }
 
+    @Test
+    public void postInvalidEntityIs422() {
         final Response response = target("/valid/foo").request(MediaType.APPLICATION_JSON)
                 .post(Entity.entity("{}", MediaType.APPLICATION_JSON));
         assertThat(response.getStatus()).isEqualTo(422);
@@ -61,7 +62,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void postNullEntityIs422() throws Exception {
+    public void postNullEntityIs422() {
         final Response response = target("/valid/foo").request(MediaType.APPLICATION_JSON)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
         assertThat(response.getStatus()).isEqualTo(422);
@@ -71,9 +72,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void postInvalidatedEntityIs422() throws Exception {
-        assumeThat(Locale.getDefault().getLanguage(), is("en"));
-
+    public void postInvalidatedEntityIs422() {
         final Response response = target("/valid/fooValidated").request(MediaType.APPLICATION_JSON)
                 .post(Entity.entity("{}", MediaType.APPLICATION_JSON));
         assertThat(response.getStatus()).isEqualTo(422);
@@ -81,7 +80,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void postInvalidInterfaceEntityIs422() throws Exception {
+    public void postInvalidInterfaceEntityIs422() {
         final Response response = target("/valid2/repr").request(MediaType.APPLICATION_JSON)
             .post(Entity.entity("{\"name\": \"a\"}", MediaType.APPLICATION_JSON));
         assertThat(response.getStatus()).isEqualTo(400);
@@ -90,9 +89,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void returnInvalidEntityIs500() throws Exception {
-        assumeThat(Locale.getDefault().getLanguage(), is("en"));
-
+    public void returnInvalidEntityIs500() {
         final Response response = target("/valid/foo").request(MediaType.APPLICATION_JSON)
                 .post(Entity.entity("{ \"name\": \"Coda\" }", MediaType.APPLICATION_JSON));
         assertThat(response.getStatus()).isEqualTo(500);
@@ -101,9 +98,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void returnInvalidatedEntityIs500() throws Exception {
-        assumeThat(Locale.getDefault().getLanguage(), is("en"));
-
+    public void returnInvalidatedEntityIs500() {
         final Response response = target("/valid/fooValidated").request(MediaType.APPLICATION_JSON)
                 .post(Entity.entity("{ \"name\": \"Coda\" }", MediaType.APPLICATION_JSON));
         assertThat(response.getStatus()).isEqualTo(500);
@@ -112,7 +107,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidReturnIs500() throws Exception {
+    public void getInvalidReturnIs500() {
         // return value is too long and so will fail validation
         final Response response = target("/valid/bar")
                 .queryParam("name", "dropwizard").request().get();
@@ -123,7 +118,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidQueryParamsIs400() throws Exception {
+    public void getInvalidQueryParamsIs400() {
         // query parameter is too short and so will fail validation
         final Response response = target("/valid/bar")
                 .queryParam("name", "hi").request().get();
@@ -141,7 +136,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void cacheIsForParamNamesOnly() throws Exception {
+    public void cacheIsForParamNamesOnly() {
         // query parameter must not be null, and must be at least 3
         final Response response = target("/valid/fhqwhgads")
                 .queryParam("num", 2).request().get();
@@ -160,7 +155,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void postInvalidPrimitiveIs422() throws Exception {
+    public void postInvalidPrimitiveIs422() {
         // query parameter is too short and so will fail validation
         final Response response = target("/valid/simpleEntity")
                 .request().post(Entity.json("hi"));
@@ -172,7 +167,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidCustomTypeIs400() throws Exception {
+    public void getInvalidCustomTypeIs400() {
         // query parameter is too short and so will fail validation
         final Response response = target("/valid/barter")
                 .queryParam("name", "hi").request().get();
@@ -184,7 +179,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidBeanParamsIs400() throws Exception {
+    public void getInvalidBeanParamsIs400() {
         // bean parameter is too short and so will fail validation
         Response response = target("/valid/zoo")
                 .request().get();
@@ -197,7 +192,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidSubBeanParamsIs400() throws Exception {
+    public void getInvalidSubBeanParamsIs400() {
         final Response response = target("/valid/sub-zoo")
                 .queryParam("address", "42 Wallaby Way")
                 .request().get();
@@ -209,7 +204,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getGroupSubBeanParamsIs400() throws Exception {
+    public void getGroupSubBeanParamsIs400() {
         final Response response = target("/valid/sub-group-zoo")
             .queryParam("address", "42 WALLABY WAY")
             .queryParam("name", "Coda")
@@ -221,7 +216,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void postValidGroupsIs400() throws Exception {
+    public void postValidGroupsIs400() {
         final Response response = target("/valid/sub-valid-group-zoo")
             .queryParam("address", "42 WALLABY WAY")
             .queryParam("name", "Coda")
@@ -234,7 +229,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidatedBeanParamsIs400() throws Exception {
+    public void getInvalidatedBeanParamsIs400() {
         // bean parameter is too short and so will fail validation
         final Response response = target("/valid/zoo2")
                 .request().get();
@@ -246,7 +241,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidHeaderParamsIs400() throws Exception {
+    public void getInvalidHeaderParamsIs400() {
         final Response response = target("/valid/head")
                 .request().get();
         assertThat(response.getStatus()).isEqualTo(400);
@@ -256,7 +251,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidCookieParamsIs400() throws Exception {
+    public void getInvalidCookieParamsIs400() {
         final Response response = target("/valid/cooks")
                 .request().get();
         assertThat(response.getStatus()).isEqualTo(400);
@@ -266,7 +261,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidPathParamsIs400() throws Exception {
+    public void getInvalidPathParamsIs400() {
         final Response response = target("/valid/goods/11")
                 .request().get();
         assertThat(response.getStatus()).isEqualTo(400);
@@ -276,7 +271,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidFormParamsIs400() throws Exception {
+    public void getInvalidFormParamsIs400() {
         final Response response = target("/valid/form")
                 .request().post(Entity.form(new Form()));
         assertThat(response.getStatus()).isEqualTo(400);
@@ -286,7 +281,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void postInvalidMethodClassIs422() throws Exception {
+    public void postInvalidMethodClassIs422() {
         final Response response = target("/valid/nothing")
                 .request().post(Entity.entity("{}", MediaType.APPLICATION_JSON_TYPE));
         assertThat(response.getStatus()).isEqualTo(422);
@@ -296,7 +291,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidNestedReturnIs500() throws Exception {
+    public void getInvalidNestedReturnIs500() {
         final Response response = target("/valid/nested").request().get();
         assertThat(response.getStatus()).isEqualTo(500);
 
@@ -305,7 +300,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidNested2ReturnIs500() throws Exception {
+    public void getInvalidNested2ReturnIs500() {
         final Response response = target("/valid/nested2").request().get();
         assertThat(response.getStatus()).isEqualTo(500);
 
@@ -314,7 +309,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidContextIs400() throws Exception {
+    public void getInvalidContextIs400() {
         final Response response = target("/valid/context").request().get();
         assertThat(response.getStatus()).isEqualTo(400);
 
@@ -323,7 +318,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidMatrixParamIs400() throws Exception {
+    public void getInvalidMatrixParamIs400() {
         final Response response = target("/valid/matrix")
                 .matrixParam("bob", "").request().get();
         assertThat(response.getStatus()).isEqualTo(400);
@@ -333,7 +328,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void functionWithSameNameReturnDifferentErrors() throws Exception {
+    public void functionWithSameNameReturnDifferentErrors() {
         // This test is to make sure that functions with the same name and
         // number of parameters (but different parameter types), don't return
         // the same validation error due to any caching effects

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NetUtilTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NetUtilTest.java
@@ -1,17 +1,15 @@
 package io.dropwizard.jetty;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
+
 import java.io.File;
 import java.net.InetAddress;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Collection;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assume.assumeThat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 public class NetUtilTest {
 
@@ -22,9 +20,9 @@ public class NetUtilTest {
      */
     @Test
     public void testDefaultTcpBacklogForWindows() {
-        assumeThat(System.getProperty(OS_NAME_PROPERTY), containsString("win"));
-        assumeThat(isTcpBacklogSettingReadable(), is(false));
-        assertEquals(NetUtil.DEFAULT_TCP_BACKLOG_WINDOWS, NetUtil.getTcpBacklog());
+        assumeThat(System.getProperty(OS_NAME_PROPERTY)).contains("win");
+        assumeThat(isTcpBacklogSettingReadable()).isFalse();
+        assertThat(NetUtil.getTcpBacklog()).isEqualTo(NetUtil.DEFAULT_TCP_BACKLOG_WINDOWS);
     }
 
     /**
@@ -32,9 +30,9 @@ public class NetUtilTest {
      */
     @Test
     public void testNonWindowsDefaultTcpBacklog() {
-        assumeThat(System.getProperty(OS_NAME_PROPERTY), containsString("Mac OS X"));
-        assumeThat(isTcpBacklogSettingReadable(), is(false));
-        assertEquals(NetUtil.DEFAULT_TCP_BACKLOG_LINUX, NetUtil.getTcpBacklog());
+        assumeThat(System.getProperty(OS_NAME_PROPERTY)).contains("Mac OS X");
+        assumeThat(isTcpBacklogSettingReadable()).isFalse();
+        assertThat(NetUtil.getTcpBacklog()).isEqualTo(NetUtil.DEFAULT_TCP_BACKLOG_LINUX);
     }
 
     /**
@@ -42,9 +40,9 @@ public class NetUtilTest {
      */
     @Test
     public void testNonWindowsSpecifiedTcpBacklog() {
-        assumeThat(System.getProperty(OS_NAME_PROPERTY), containsString("Mac OS X"));
-        assumeThat(isTcpBacklogSettingReadable(), is(false));
-        assertEquals(100, NetUtil.getTcpBacklog(100));
+        assumeThat(System.getProperty(OS_NAME_PROPERTY)).contains("Mac OS X");
+        assumeThat(isTcpBacklogSettingReadable()).isFalse();
+        assertThat(NetUtil.getTcpBacklog(100)).isEqualTo(100);
     }
 
     /**
@@ -52,9 +50,9 @@ public class NetUtilTest {
      */
     @Test
     public void testOsSetting() {
-        assumeThat(System.getProperty(OS_NAME_PROPERTY), containsString("Linux"));
-        assumeThat(isTcpBacklogSettingReadable(), is(true));
-        assertNotEquals(-1, NetUtil.getTcpBacklog(-1));
+        assumeThat(System.getProperty(OS_NAME_PROPERTY)).contains("Linux");
+        assumeThat(isTcpBacklogSettingReadable()).isTrue();
+        assertThat(NetUtil.getTcpBacklog(-1)).isNotEqualTo(-1);
         assertThat(NetUtil.getTcpBacklog())
             .as("NetUtil should read more than the first character of somaxconn")
             .isGreaterThan(2);
@@ -77,7 +75,7 @@ public class NetUtilTest {
         assertThat(addresses).contains(InetAddress.getLoopbackAddress());
     }
 
-    public boolean isTcpBacklogSettingReadable() {
+    private boolean isTcpBacklogSettingReadable() {
         return AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
             try {
                 File f = new File(NetUtil.TCP_BACKLOG_SETTING_LOCATION);

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportTest.java
@@ -22,9 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DropwizardTestSupportTest {
 
@@ -46,25 +44,25 @@ public class DropwizardTestSupportTest {
         final String content = ClientBuilder.newClient().target(
             "http://localhost:" + TEST_SUPPORT.getLocalPort() + "/test").request().get(String.class);
 
-        assertThat(content, is("Yes, it's here"));
+        assertThat(content).isEqualTo("Yes, it's here");
     }
 
     @Test
     public void returnsConfiguration() {
         final TestConfiguration config = TEST_SUPPORT.getConfiguration();
-        assertThat(config.getMessage(), is("Yes, it's here"));
+        assertThat(config.getMessage()).isEqualTo("Yes, it's here");
     }
 
     @Test
     public void returnsApplication() {
         final TestApplication application = TEST_SUPPORT.getApplication();
-        assertNotNull(application);
+        assertThat(application).isNotNull();
     }
 
     @Test
     public void returnsEnvironment() {
         final Environment environment = TEST_SUPPORT.getEnvironment();
-        assertThat(environment.getName(), is("TestApplication"));
+        assertThat(environment.getName()).isEqualTo("TestApplication");
     }
 
     @Test
@@ -75,7 +73,7 @@ public class DropwizardTestSupportTest {
                 .request()
                 .post(Entity.entity("", MediaType.TEXT_PLAIN), String.class);
 
-        assertThat(response, is("Hello has been said to test_user"));
+        assertThat(response).isEqualTo("Hello has been said to test_user");
     }
 
     @Test
@@ -86,12 +84,12 @@ public class DropwizardTestSupportTest {
             .request()
             .post(Entity.entity("Custom message", MediaType.TEXT_PLAIN), String.class);
 
-        assertThat(response, is("Custom message"));
+        assertThat(response).isEqualTo("Custom message");
     }
 
     public static class TestApplication extends Application<TestConfiguration> {
         @Override
-        public void run(TestConfiguration configuration, Environment environment) throws Exception {
+        public void run(TestConfiguration configuration, Environment environment) {
             environment.jersey().register(new TestResource(configuration.getMessage()));
             environment.admin().addTask(new HelloTask());
             environment.admin().addTask(new EchoTask());

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleConfigOverrideTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleConfigOverrideTest.java
@@ -9,8 +9,7 @@ import java.util.Optional;
 
 import static io.dropwizard.testing.ConfigOverride.config;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DropwizardAppRuleConfigOverrideTest {
 
@@ -27,12 +26,12 @@ public class DropwizardAppRuleConfigOverrideTest {
         final String content = RULE.client().target("http://localhost:" + RULE.getLocalPort() + "/test")
             .request().get(String.class);
 
-        assertThat(content, is("A new way to say Hooray!"));
+        assertThat(content).isEqualTo("A new way to say Hooray!");
     }
 
     @Test
     public void supportsSuppliedConfigAttributeOverrides() throws Exception {
-        assertThat(System.getProperty("app-rule.extra"), is("supplied"));
-        assertThat(System.getProperty("dw.extra"), is("supplied again"));
+        assertThat(System.getProperty("app-rule.extra")).isEqualTo("supplied");
+        assertThat(System.getProperty("dw.extra")).isEqualTo("supplied again");
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleTest.java
@@ -3,7 +3,6 @@ package io.dropwizard.testing.junit;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.app.DropwizardTestApplication;
 import io.dropwizard.testing.app.TestConfiguration;
-import org.assertj.core.api.Assertions;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -12,9 +11,7 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DropwizardAppRuleTest {
 
@@ -27,25 +24,25 @@ public class DropwizardAppRuleTest {
         final String content = ClientBuilder.newClient().target(
             "http://localhost:" + RULE.getLocalPort() + "/test").request().get(String.class);
 
-        assertThat(content, is("Yes, it's here"));
+        assertThat(content).isEqualTo("Yes, it's here");
     }
 
     @Test
     public void returnsConfiguration() {
         final TestConfiguration config = RULE.getConfiguration();
-        assertThat(config.getMessage(), is("Yes, it's here"));
+        assertThat(config.getMessage()).isEqualTo("Yes, it's here");
     }
 
     @Test
     public void returnsApplication() {
         final DropwizardTestApplication application = RULE.getApplication();
-        assertNotNull(application);
+        assertThat(application).isNotNull();
     }
 
     @Test
     public void returnsEnvironment() {
         final Environment environment = RULE.getEnvironment();
-        assertThat(environment.getName(), is("DropwizardTestApplication"));
+        assertThat(environment.getName()).isEqualTo("DropwizardTestApplication");
     }
 
     @Test
@@ -56,7 +53,7 @@ public class DropwizardAppRuleTest {
             .request()
             .post(Entity.entity("", MediaType.TEXT_PLAIN), String.class);
 
-        assertThat(response, is("Hello has been said to test_user"));
+        assertThat(response).isEqualTo("Hello has been said to test_user");
     }
 
     @Test
@@ -67,12 +64,12 @@ public class DropwizardAppRuleTest {
             .request()
             .post(Entity.entity("Custom message", MediaType.TEXT_PLAIN), String.class);
 
-        assertThat(response, is("Custom message"));
+        assertThat(response).isEqualTo("Custom message");
     }
 
     @Test
     public void clientUsesJacksonMapperFromEnvironment() {
-        Assertions.assertThat(RULE.client().target("http://localhost:" + RULE.getLocalPort() + "/message")
+        assertThat(RULE.client().target("http://localhost:" + RULE.getLocalPort() + "/message")
             .request()
             .get(DropwizardTestApplication.MessageView.class).getMessage())
             .contains("Yes, it's here");
@@ -80,7 +77,7 @@ public class DropwizardAppRuleTest {
 
     @Test
     public void clientSupportsPatchMethod() {
-        Assertions.assertThat(RULE.client().target("http://localhost:" + RULE.getLocalPort() + "/echoPatch")
+        assertThat(RULE.client().target("http://localhost:" + RULE.getLocalPort() + "/echoPatch")
             .request()
             .method("PATCH", Entity.text("Patch is working"), String.class))
             .contains("Patch is working");

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionTest.java
@@ -10,30 +10,28 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
-
 import java.util.Optional;
 
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 public class DropwizardAppExtensionTest {
     public static final DropwizardAppExtension<TestConfiguration> EXTENSION =
-        new DropwizardAppExtension<>(DropwizardTestApplication.class, resourceFilePath("test-config.yaml"));
+            new DropwizardAppExtension<>(DropwizardTestApplication.class, resourceFilePath("test-config.yaml"));
 
     @Test
     public void canGetExpectedResourceOverHttp() {
         final String content = ClientBuilder.newClient().target(
-            "http://localhost:" + EXTENSION.getLocalPort() + "/test").request().get(String.class);
+                "http://localhost:" + EXTENSION.getLocalPort() + "/test").request().get(String.class);
 
-        assertThat(content, is("Yes, it's here"));
+        assertThat(content).isEqualTo("Yes, it's here");
     }
 
     @Test
     public void returnsConfiguration() {
         final TestConfiguration config = EXTENSION.getConfiguration();
-        assertThat(config.getMessage(), is("Yes, it's here"));
+        assertThat(config.getMessage()).isEqualTo("Yes, it's here");
     }
 
     @Test
@@ -45,43 +43,47 @@ public class DropwizardAppExtensionTest {
     @Test
     public void returnsEnvironment() {
         final Environment environment = EXTENSION.getEnvironment();
-        assertThat(environment.getName(), is("DropwizardTestApplication"));
+        assertThat(environment.getName()).isEqualTo("DropwizardTestApplication");
     }
 
     @Test
     public void canPerformAdminTask() {
         final String response
-            = EXTENSION.client().target("http://localhost:"
-            + EXTENSION.getAdminPort() + "/tasks/hello?name=test_user")
-            .request()
-            .post(Entity.entity("", MediaType.TEXT_PLAIN), String.class);
+                = EXTENSION.client().target("http://localhost:"
+                + EXTENSION.getAdminPort() + "/tasks/hello?name=test_user")
+                .request()
+                .post(Entity.entity("", MediaType.TEXT_PLAIN), String.class);
 
-        assertThat(response, is("Hello has been said to test_user"));
+        assertThat(response).isEqualTo("Hello has been said to test_user");
     }
 
     @Test
     public void canPerformAdminTaskWithPostBody() {
-        final String response
-            = EXTENSION.client().target("http://localhost:"
-            + EXTENSION.getAdminPort() + "/tasks/echo")
-            .request()
-            .post(Entity.entity("Custom message", MediaType.TEXT_PLAIN), String.class);
+        final String response = EXTENSION.client()
+                .target("http://localhost:" + EXTENSION.getAdminPort() + "/tasks/echo")
+                .request()
+                .post(Entity.entity("Custom message", MediaType.TEXT_PLAIN), String.class);
 
-        assertThat(response, is("Custom message"));
+        assertThat(response).isEqualTo("Custom message");
     }
 
     @Test
     public void clientUsesJacksonMapperFromEnvironment() {
-        assertThat(EXTENSION.client().target("http://localhost:" + EXTENSION.getLocalPort() + "/message")
-            .request()
-            .get(DropwizardTestApplication.MessageView.class).getMessage(), is(Optional.of("Yes, it's here")));
+        final Optional<String> message = EXTENSION.client()
+                .target("http://localhost:" + EXTENSION.getLocalPort() + "/message")
+                .request()
+                .get(DropwizardTestApplication.MessageView.class)
+                .getMessage();
+        assertThat(message)
+                .hasValue("Yes, it's here");
     }
 
     @Test
     public void clientSupportsPatchMethod() {
-        assertThat(EXTENSION.client().target("http://localhost:" + EXTENSION.getLocalPort() + "/echoPatch")
-            .request()
-            .method("PATCH", Entity.text("Patch is working"), String.class), is("Patch is working"));
+        final String method = EXTENSION.client()
+                .target("http://localhost:" + EXTENSION.getLocalPort() + "/echoPatch")
+                .request()
+                .method("PATCH", Entity.text("Patch is working"), String.class);
+        assertThat(method).isEqualTo("Patch is working");
     }
-
 }

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/PortRangeValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/PortRangeValidatorTest.java
@@ -10,8 +10,7 @@ import java.util.List;
 import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assume.assumeThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 public class PortRangeValidatorTest {
     @SuppressWarnings("PublicField")
@@ -32,7 +31,7 @@ public class PortRangeValidatorTest {
 
     @Before
     public void setUp() throws Exception {
-        assumeThat(Locale.getDefault().getLanguage(), is("en"));
+        assumeThat(Locale.getDefault().getLanguage()).isEqualTo("en");
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -453,12 +453,6 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.hamcrest</groupId>
-                    <artifactId>hamcrest-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>


### PR DESCRIPTION
This change set replaces the remaining use of Hamcrest matchers with the equivalent functionality of AssertJ, which is used in all other tests in Dropwizard, and therefore removes the dependency on Hamcrest completely.

Closes #2437
Closes #2443