### PR TITLE
Upgrade dependencies and Maven plugins

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.5.3/apache-maven-3.5.3-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.5.4/apache-maven-3.5.4-bin.zip

--- a/dropwizard-archetypes/pom.xml
+++ b/dropwizard-archetypes/pom.xml
@@ -43,7 +43,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.0.2</version>
+          <version>3.1.0</version>
           <configuration>
             <escapeString>\</escapeString>
           </configuration>
@@ -57,7 +57,7 @@
         <plugin>
           <!-- clean any existing integration tests -->
           <artifactId>maven-clean-plugin</artifactId>
-          <version>2.6.1</version>
+          <version>3.1.0</version>
           <executions>
             <execution>
               <id>prepare-integration-test</id>
@@ -81,7 +81,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-invoker-plugin</artifactId>
-          <version>3.0.1</version>
+          <version>3.1.0</version>
           <configuration>
             <!-- custom settings.xml to have invoker use our local M2 repo for artifacts -->
             <settingsFile>${project.parent.basedir}/src/test/resources/settings.xml</settingsFile>
@@ -140,7 +140,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.0.2</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>package-tools</id>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -19,12 +19,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <dropwizard.version>${project.version}</dropwizard.version>
-        <guava.version>25.0-jre</guava.version>
+        <guava.version>25.1-jre</guava.version>
         <jersey.version>2.27</jersey.version>
         <jackson.version>2.9.6</jackson.version>
         <jetty.version>9.4.11.v20180605</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
-        <metrics4.version>4.0.2</metrics4.version>
+        <metrics4.version>4.0.3</metrics4.version>
         <slf4j.version>1.7.25</slf4j.version>
         <logback.version>1.2.3</logback.version>
         <h2.version>1.4.197</h2.version>
@@ -46,7 +46,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>
-                <version>1.2</version>
+                <version>1.4</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
@@ -71,7 +71,7 @@
             <dependency>
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
-                <version>2.9.9</version>
+                <version>2.10</version>
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>
@@ -86,7 +86,7 @@
             <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>javax.servlet-api</artifactId>
-                <version>4.0.0</version>
+                <version>4.0.1</version>
             </dependency>
             <dependency>
                 <groupId>javax.xml.bind</groupId>
@@ -103,7 +103,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.5.5</version>
+                <version>4.5.6</version>
                 <exclusions>
                     <exclusion>
                         <groupId>commons-logging</groupId>
@@ -114,7 +114,7 @@
             <dependency>
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-jdbc</artifactId>
-                <version>9.0.5</version>
+                <version>9.0.10</version>
             </dependency>
             <dependency>
                 <groupId>com.h2database</groupId>
@@ -143,7 +143,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-core</artifactId>
-                <version>5.2.15.Final</version>
+                <version>5.3.3.Final</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jboss.logging</groupId>
@@ -164,12 +164,12 @@
             <dependency>
                 <groupId>org.hsqldb</groupId>
                 <artifactId>hsqldb</artifactId>
-                <version>2.4.0</version>
+                <version>2.4.1</version>
             </dependency>
             <dependency>
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-core</artifactId>
-                <version>3.6.1</version>
+                <version>3.6.2</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.yaml</groupId>
@@ -211,7 +211,7 @@
             <dependency>
                 <groupId>org.freemarker</groupId>
                 <artifactId>freemarker</artifactId>
-                <version>2.3.27-incubating</version>
+                <version>2.3.28</version>
             </dependency>
             <dependency>
                 <groupId>org.jdbi</groupId>

--- a/dropwizard-client/pom.xml
+++ b/dropwizard-client/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.59</version>
+            <version>1.60</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/dropwizard-client/src/test/java/io/dropwizard/client/ssl/DropwizardSSLConnectionSocketFactoryTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/ssl/DropwizardSSLConnectionSocketFactoryTest.java
@@ -31,6 +31,7 @@ import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.SocketException;
 import java.security.Security;
@@ -256,7 +257,7 @@ public class DropwizardSSLConnectionSocketFactoryTest {
         final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).build("reject_non_supported");
         assertThatThrownBy(() -> client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(4))).request().get())
             .isInstanceOf(ProcessingException.class)
-            .hasRootCauseInstanceOf(SSLException.class);
+            .hasRootCauseInstanceOf(IOException.class);
     }
 
     @Test(expected = SSLInitializationException.class)

--- a/dropwizard-example/pom.xml
+++ b/dropwizard-example/pom.xml
@@ -131,7 +131,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -146,7 +146,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -166,12 +166,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -181,7 +181,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.6</version>
+                    <version>3.7.1</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -260,7 +260,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.17</version>
+                <version>3.0.0</version>
                 <configuration>
                     <configLocation>../checkstyle.xml</configLocation>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,8 @@
 
         <junit.version>4.12</junit.version>
         <junit5.version>5.2.0</junit5.version>
-        <assertj.version>3.9.1</assertj.version>
-        <mockito.version>2.19.0</mockito.version>
+        <assertj.version>3.10.0</assertj.version>
+        <mockito.version>2.20.1</mockito.version>
     </properties>
 
     <developers>
@@ -187,7 +187,7 @@
     </licenses>
 
     <scm>
-        <connection>scm:git:git://github.com/dropwizard/dropwizard.git</connection>
+        <connection>scm:git:https://github.com/dropwizard/dropwizard</connection>
         <developerConnection>scm:git:git@github.com:dropwizard/dropwizard.git</developerConnection>
         <url>https://github.com/dropwizard/dropwizard</url>
         <tag>HEAD</tag>
@@ -353,7 +353,7 @@
                                 <path>
                                     <groupId>com.uber.nullaway</groupId>
                                     <artifactId>nullaway</artifactId>
-                                    <version>0.4.7</version>
+                                    <version>0.5.0</version>
                                 </path>
                             </annotationProcessorPaths>
                             <compilerArgs>
@@ -502,7 +502,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -512,7 +512,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>3.1.0</version>
                     <dependencies>
                         <dependency>
                             <groupId>org.apache.maven.shared</groupId>
@@ -524,12 +524,22 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.7</version>
+                    <version>3.7.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.owasp</groupId>
+                    <artifactId>dependency-check-maven</artifactId>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.eluder.coveralls</groupId>
@@ -539,12 +549,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>2.9</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>kr.motd.maven</groupId>
                     <artifactId>sphinx-maven-plugin</artifactId>
-                    <version>2.0.2</version>
+                    <version>2.2.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -639,7 +649,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.0.0</version>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
                 </configuration>
@@ -660,7 +669,6 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>3.1.2</version>
                 <configuration>
                     <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
                     <showSummary>true</showSummary>
@@ -685,21 +693,21 @@
                 <artifactId>maven-project-info-reports-plugin</artifactId>
                 <configuration>
                     <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
-                    <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
                 </configuration>
                 <reportSets>
                     <reportSet>
                         <reports>
                             <report>index</report>
                             <report>summary</report>
+                            <report>team</report>
                             <report>dependency-info</report>
-                            <report>license</report>
+                            <report>licenses</report>
+                            <report>issue-management</report>
                             <report>scm</report>
-                            <report>issue-tracking</report>
-                            <report>mailing-list</report>
-                            <report>cim</report>
-                            <report>project-team</report>
+                            <report>mailing-lists</report>
+                            <report>ci-management</report>
                             <report>dependencies</report>
+                            <report>dependency-management</report>
                             <report>dependency-convergence</report>
                             <report>modules</report>
                         </reports>


### PR DESCRIPTION
* Guava 25.1: https://github.com/google/guava/releases/tag/v25.1
* Dropwizard Metrics 4.03: https://github.com/dropwizard/metrics/releases/tag/v4.0.3
* Apache Commons Text 1.4: https://commons.apache.org/proper/commons-text/release-notes/RELEASE-NOTES-1.4.txt
* Joda-Time 2.10: http://www.joda.org/joda-time/changes-report.html#a2.10
* Apache HttpClient 4.5.6: http://www.apache.org/dist/httpcomponents/httpclient/RELEASE_NOTES-4.5.x.txt
* Apache Tomcat JDBC 9.0.10
* Hibernate ORM 5.3.3.Final: https://planet.jboss.org/post/hibernate_orm_5_3_3_final_released
* HSQLDB 2.4.1
* Liquibase 3.6.2: https://github.com/liquibase/liquibase/releases/tag/liquibase-parent-3.6.2
* Freemarker 2.3.28: https://freemarker.apache.org/docs/versions_2_3_28.html
* BouncyCastle 1.60: https://bouncycastle.org/releasenotes.html
* AssertJ 3.10.0: https://joel-costigliola.github.io/assertj/assertj-core-news.html#assertj-core-3.10.0
* Mockito 2.20.1: https://github.com/mockito/mockito/blob/v2.20.1/doc/release-notes/official.md
* NullAway: https://github.com/uber/NullAway/blob/v0.5.0/CHANGELOG.md