### PR TITLE
Change fuzzy enum deserializer to be cacheable.

### DIFF
--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/FuzzyEnumModule.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/FuzzyEnumModule.java
@@ -58,6 +58,12 @@ public class FuzzyEnumModule extends Module {
             }
             throw ctxt.weirdStringException(jp.getText(), handledType(), jp.getText() + " was not one of " + acceptedValues);
         }
+
+        @Override
+        public boolean isCachable() {
+            // Should cache enum deserializers similar to com.fasterxml.jackson.databind.deser.std.EnumDeserializer
+            return true;
+        }
     }
 
     private static class PermissiveEnumDeserializers extends Deserializers.Base {


### PR DESCRIPTION
During load tests, there is significant lock contention in Jackson when
using the FuzzyEnumModule. For each deserialized enum type, there is a
synchronized block that attempts to create a deserializer in the cache and
ultimately since the PermissiveEnumDeserializer isn't marked as
cacheable, the underlying deserializer is recreated each time. Update
the PermissiveEnumDeserializer to be cacheable (similar to
EnumDeserializer from Jackson) to remove significant overhead during
deserialization.

See https://github.com/FasterXML/jackson-databind/issues/1394 for the relevant Jackson issue.