### PR TITLE
Ensure DropwizardResourceConfig#forTesting() is using a random port

### DIFF
--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/AbstractAuthResourceConfig.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/AbstractAuthResourceConfig.java
@@ -1,9 +1,9 @@
 package io.dropwizard.auth;
 
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
+import org.glassfish.jersey.test.TestProperties;
 
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.DynamicFeature;
@@ -12,7 +12,8 @@ import java.security.Principal;
 public abstract class AbstractAuthResourceConfig extends DropwizardResourceConfig {
 
     public AbstractAuthResourceConfig() {
-        super(true, new MetricRegistry());
+        super();
+        property(TestProperties.CONTAINER_PORT, "0");
         register(getAuthDynamicFeature(getAuthFilter()));
         register(getAuthBinder());
         register(RolesAllowedDynamicFeature.class);

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/chained/ChainedAuthProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/chained/ChainedAuthProviderTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.auth.chained;
 
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.auth.AuthBaseTest;
 import io.dropwizard.auth.AuthDynamicFeature;
 import io.dropwizard.auth.AuthFilter;
@@ -13,6 +12,7 @@ import io.dropwizard.auth.oauth.OAuthCredentialAuthFilter;
 import io.dropwizard.auth.util.AuthUtil;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
+import org.glassfish.jersey.test.TestProperties;
 import org.junit.Test;
 
 import javax.ws.rs.core.HttpHeaders;
@@ -27,7 +27,7 @@ public class ChainedAuthProviderTest extends AuthBaseTest<ChainedAuthProviderTes
     public static class ChainedAuthTestResourceConfig extends DropwizardResourceConfig {
         @SuppressWarnings("unchecked")
         public ChainedAuthTestResourceConfig() {
-            super(true, new MetricRegistry());
+            super();
 
             final Authorizer<Principal> authorizer = AuthUtil.getTestAuthorizer(ADMIN_USER, ADMIN_ROLE);
             final AuthFilter<BasicCredentials, Principal> basicAuthFilter = new BasicCredentialAuthFilter.Builder<>()
@@ -41,6 +41,7 @@ public class ChainedAuthProviderTest extends AuthBaseTest<ChainedAuthProviderTes
                 .setAuthorizer(authorizer)
                 .buildAuthFilter();
 
+            property(TestProperties.CONTAINER_PORT, "0");
             register(new AuthValueFactoryProvider.Binder(Principal.class));
             register(new AuthDynamicFeature(new ChainedAuthFilter<>(buildHandlerList(basicAuthFilter, oAuthFilter))));
             register(RolesAllowedDynamicFeature.class);

--- a/dropwizard-benchmarks/src/main/java/io/dropwizard/benchmarks/jersey/DropwizardResourceConfigBenchmark.java
+++ b/dropwizard-benchmarks/src/main/java/io/dropwizard/benchmarks/jersey/DropwizardResourceConfigBenchmark.java
@@ -1,6 +1,5 @@
 package io.dropwizard.benchmarks.jersey;
 
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -29,8 +28,7 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Benchmark)
 public class DropwizardResourceConfigBenchmark {
 
-    private DropwizardResourceConfig dropwizardResourceConfig =
-            new DropwizardResourceConfig(true, new MetricRegistry());
+    private DropwizardResourceConfig dropwizardResourceConfig = DropwizardResourceConfig.forTesting();
 
     @Setup
     public void setUp() throws Exception {

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
@@ -12,7 +12,6 @@ import io.dropwizard.logging.BootstrapLogging;
 import io.dropwizard.setup.Environment;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.test.JerseyTest;
-import org.glassfish.jersey.test.TestProperties;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
@@ -98,8 +97,6 @@ public class JerseyIntegrationTest extends JerseyTest {
 
     @Override
     protected Application configure() {
-        forceSet(TestProperties.CONTAINER_PORT, "0");
-
         final MetricRegistry metricRegistry = new MetricRegistry();
         final SessionFactoryFactory factory = new SessionFactoryFactory();
         final DataSourceFactory dbConfig = new DataSourceFactory();
@@ -133,7 +130,7 @@ public class JerseyIntegrationTest extends JerseyTest {
             transaction.commit();
         }
 
-        final DropwizardResourceConfig config = DropwizardResourceConfig.forTesting(new MetricRegistry());
+        final DropwizardResourceConfig config = DropwizardResourceConfig.forTesting();
         config.register(new UnitOfWorkApplicationListener("hr-db", sessionFactory));
         config.register(new PersonResource(new PersonDAO(sessionFactory)));
         config.register(new PersistenceExceptionMapper());

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -44,15 +44,11 @@ public class DropwizardResourceConfig extends ResourceConfig {
     private String contextPath = "/";
     private final ComponentLoggingListener loggingListener = new ComponentLoggingListener(this);
 
-    public DropwizardResourceConfig(MetricRegistry metricRegistry) {
-        this(false, metricRegistry);
-    }
-
     public DropwizardResourceConfig() {
-        this(true, null);
+        this(null);
     }
 
-    public DropwizardResourceConfig(boolean testOnly, @Nullable MetricRegistry metricRegistry) {
+    public DropwizardResourceConfig(@Nullable MetricRegistry metricRegistry) {
         super();
 
         if (metricRegistry == null) {
@@ -76,8 +72,23 @@ public class DropwizardResourceConfig extends ResourceConfig {
         register(new SessionFactoryProvider.Binder());
     }
 
-    public static DropwizardResourceConfig forTesting(MetricRegistry metricRegistry) {
-        return new DropwizardResourceConfig(true, metricRegistry);
+    /**
+     * Build a {@link DropwizardResourceConfig} which makes Jersey Test run on a random port,
+     * also see {@code org.glassfish.jersey.test.TestProperties#CONTAINER_PORT}.
+     */
+    public static DropwizardResourceConfig forTesting() {
+        return forTesting(null);
+    }
+
+    /**
+     * Build a {@link DropwizardResourceConfig} which makes Jersey Test run on a random port,
+     * also see {@code org.glassfish.jersey.test.TestProperties#CONTAINER_PORT}.
+     */
+    public static DropwizardResourceConfig forTesting(@Nullable MetricRegistry metricRegistry) {
+        final DropwizardResourceConfig config = new DropwizardResourceConfig(metricRegistry);
+        // See org.glassfish.jersey.test.TestProperties#CONTAINER_PORT
+        config.property("jersey.config.test.container.port", "0");
+        return config;
     }
 
     public String getUrlPattern() {
@@ -92,7 +103,7 @@ public class DropwizardResourceConfig extends ResourceConfig {
         return contextPath;
     }
 
-    public void setContextPath(String contextPath){
+    public void setContextPath(String contextPath) {
         this.contextPath = contextPath;
     }
 
@@ -162,12 +173,12 @@ public class DropwizardResourceConfig extends ResourceConfig {
                 providers = event.getProviders();
 
                 final String resourceClasses = resources.stream()
-                    .map(x -> x.getClass().getCanonicalName())
-                    .collect(Collectors.joining(", "));
+                        .map(x -> x.getClass().getCanonicalName())
+                        .collect(Collectors.joining(", "));
 
                 final String providerClasses = providers.stream()
-                    .map(Class::getCanonicalName)
-                    .collect(Collectors.joining(", "));
+                        .map(Class::getCanonicalName)
+                        .collect(Collectors.joining(", "));
 
                 LOGGER.debug("resources = {}", resourceClasses);
                 LOGGER.debug("providers = {}", providerClasses);
@@ -190,10 +201,10 @@ public class DropwizardResourceConfig extends ResourceConfig {
                         break;
                     case SUB_RESOURCE_LOCATOR:
                         final ResolvedType responseType = TYPE_RESOLVER
-                            .resolve(method.getInvocable().getResponseType());
+                                .resolve(method.getInvocable().getResponseType());
                         final Class<?> erasedType = !responseType.getTypeBindings().isEmpty() ?
-                            responseType.getTypeBindings().getBoundType(0).getErasedType() :
-                            responseType.getErasedType();
+                                responseType.getTypeBindings().getBoundType(0).getErasedType() :
+                                responseType.getErasedType();
 
                         final Resource res = Resource.from(erasedType);
                         if (res == null) {
@@ -227,10 +238,10 @@ public class DropwizardResourceConfig extends ResourceConfig {
             final Set<EndpointLogLine> endpointLogLines = new TreeSet<>(new EndpointComparator());
             final String contextPath = config.getContextPath();
             final String normalizedContextPath = contextPath.isEmpty() || contextPath.equals("/") ? "" :
-                contextPath.startsWith("/") ? contextPath : "/" + contextPath;
+                    contextPath.startsWith("/") ? contextPath : "/" + contextPath;
             final String pattern = config.getUrlPattern().endsWith("/*") ?
-                config.getUrlPattern().substring(0, config.getUrlPattern().length() - 1) :
-                config.getUrlPattern();
+                    config.getUrlPattern().substring(0, config.getUrlPattern().length() - 1) :
+                    config.getUrlPattern();
 
             final String path = cleanUpPath(normalizedContextPath + pattern);
 
@@ -242,10 +253,10 @@ public class DropwizardResourceConfig extends ResourceConfig {
             }
 
             final List<EndpointLogLine> providerLines = providers.stream()
-                .map(Resource::from)
-                .filter(Objects::nonNull)
-                .flatMap(res -> logResourceLines(res, path).stream())
-                .collect(Collectors.toList());
+                    .map(Resource::from)
+                    .filter(Objects::nonNull)
+                    .flatMap(res -> logResourceLines(res, path).stream())
+                    .collect(Collectors.toList());
 
             endpointLogLines.addAll(providerLines);
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/AsyncServletTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/AsyncServletTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey;
 
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.dummy.DummyResource;
 import org.junit.Test;
 
@@ -14,7 +13,7 @@ public class AsyncServletTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {
-        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+        return DropwizardResourceConfig.forTesting()
                 .register(DummyResource.class);
     }
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey;
 
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.dummy.DummyResource;
 import io.dropwizard.logging.BootstrapLogging;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
@@ -29,7 +28,7 @@ public class DropwizardResourceConfigTest {
 
     @Before
     public void setUp() {
-        rc = DropwizardResourceConfig.forTesting(new MetricRegistry());
+        rc = DropwizardResourceConfig.forTesting();
     }
 
     // Start and stop a jersey test instance so that our resource config

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/JerseyContentTypeTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/JerseyContentTypeTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey;
 
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.dummy.DummyResource;
 import org.junit.Test;
 
@@ -14,7 +13,7 @@ public class JerseyContentTypeTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {
-        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+        return DropwizardResourceConfig.forTesting()
                 .register(DummyResource.class);
     }
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/caching/CacheControlledResponseFeatureTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/caching/CacheControlledResponseFeatureTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey.caching;
 
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.AbstractJerseyTest;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -16,7 +15,7 @@ public class CacheControlledResponseFeatureTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {
-        ResourceConfig rc = DropwizardResourceConfig.forTesting(new MetricRegistry());
+        ResourceConfig rc = DropwizardResourceConfig.forTesting();
         rc = rc.register(CachingResource.class);
         return rc;
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/ErrorEntityWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/ErrorEntityWriterTest.java
@@ -1,12 +1,12 @@
 package io.dropwizard.jersey.errors;
 
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.AbstractJerseyTest;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletProperties;
 import org.glassfish.jersey.test.DeploymentContext;
 import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.glassfish.jersey.test.TestProperties;
 import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
 import org.glassfish.jersey.test.spi.TestContainerException;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
@@ -23,8 +23,9 @@ public class ErrorEntityWriterTest extends AbstractJerseyTest {
 
     public static class ErrorEntityWriterTestResourceConfig extends DropwizardResourceConfig {
         public ErrorEntityWriterTestResourceConfig() {
-            super(true, new MetricRegistry());
+            super();
 
+            property(TestProperties.CONTAINER_PORT, "0");
             register(DefaultLoggingExceptionMapper.class);
             register(DefaultJacksonMessageBodyProvider.class);
             register(ExceptionResource.class);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/LoggingExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/LoggingExceptionMapperTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey.errors;
 
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.AbstractJerseyTest;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import org.junit.Test;
@@ -21,7 +20,7 @@ public class LoggingExceptionMapperTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {
-        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+        return DropwizardResourceConfig.forTesting()
                 .register(DefaultLoggingExceptionMapper.class)
                 .register(DefaultJacksonMessageBodyProvider.class)
                 .register(ExceptionResource.class);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/AllowedMethodsFilterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/AllowedMethodsFilterTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey.filter;
 
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.AbstractJerseyTest;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -58,7 +57,7 @@ public class AllowedMethodsFilterTest extends AbstractJerseyTest {
 
     @Override
     protected DeploymentContext configureDeployment() {
-        final ResourceConfig rc = DropwizardResourceConfig.forTesting(new MetricRegistry());
+        final ResourceConfig rc = DropwizardResourceConfig.forTesting();
 
         final Map<String, String> filterParams = Collections.singletonMap(AllowedMethodsFilter.ALLOWED_METHODS_PARAM, "GET,POST");
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalCookieParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalCookieParamResourceTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey.guava;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Optional;
 import io.dropwizard.jersey.AbstractJerseyTest;
 import io.dropwizard.jersey.DropwizardResourceConfig;
@@ -22,7 +21,7 @@ public class OptionalCookieParamResourceTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {
-        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+        return DropwizardResourceConfig.forTesting()
                 .register(OptionalCookieParamResource.class)
                 .register(MyMessageParamConverterProvider.class);
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalFormParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalFormParamResourceTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey.guava;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Optional;
 import io.dropwizard.jersey.AbstractJerseyTest;
 import io.dropwizard.jersey.DropwizardResourceConfig;
@@ -25,7 +24,7 @@ public class OptionalFormParamResourceTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {
-        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+        return DropwizardResourceConfig.forTesting()
                 .register(OptionalFormParamResource.class)
                 .register(MyMessageParamConverterProvider.class);
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalHeaderParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalHeaderParamResourceTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey.guava;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Optional;
 import io.dropwizard.jersey.AbstractJerseyTest;
 import io.dropwizard.jersey.DropwizardResourceConfig;
@@ -22,7 +21,7 @@ public class OptionalHeaderParamResourceTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {
-        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+        return DropwizardResourceConfig.forTesting()
                 .register(OptionalHeaderParamResource.class)
                 .register(MyMessageParamConverterProvider.class);
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalMessageBodyWriterTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey.guava;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Optional;
 import io.dropwizard.jersey.AbstractJerseyTest;
 import io.dropwizard.jersey.DropwizardResourceConfig;
@@ -24,7 +23,7 @@ public class OptionalMessageBodyWriterTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {
-        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+        return DropwizardResourceConfig.forTesting()
                 .register(new EmptyOptionalExceptionMapper())
                 .register(OptionalReturnResource.class);
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalQueryParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalQueryParamResourceTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey.guava;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Optional;
 import io.dropwizard.jersey.AbstractJerseyTest;
 import io.dropwizard.jersey.DropwizardResourceConfig;
@@ -22,7 +21,7 @@ public class OptionalQueryParamResourceTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {
-        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+        return DropwizardResourceConfig.forTesting()
                 .register(OptionalQueryParamResource.class)
                 .register(MyMessageParamConverterProvider.class);
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapperTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey.jackson;
 
-import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jersey.AbstractJerseyTest;
@@ -23,7 +22,7 @@ public class JsonProcessingExceptionMapperTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {
-        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+        return DropwizardResourceConfig.forTesting()
                 .packages("io.dropwizard.jersey.jackson")
                 .register(new LoggingExceptionMapper<Throwable>() { });
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalCookieParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalCookieParamResourceTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey.optional;
 
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.AbstractJerseyTest;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.MyMessage;
@@ -22,7 +21,7 @@ public class OptionalCookieParamResourceTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {
-        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+        return DropwizardResourceConfig.forTesting()
                 .register(OptionalCookieParamResource.class)
                 .register(MyMessageParamConverterProvider.class);
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalDoubleMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalDoubleMessageBodyWriterTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey.optional;
 
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.AbstractJerseyTest;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import org.junit.Test;
@@ -24,7 +23,7 @@ public class OptionalDoubleMessageBodyWriterTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {
-        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+        return DropwizardResourceConfig.forTesting()
                     .register(new EmptyOptionalExceptionMapper())
                     .register(OptionalDoubleReturnResource.class);
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalFormParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalFormParamResourceTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey.optional;
 
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.AbstractJerseyTest;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.MyMessage;
@@ -25,7 +24,7 @@ public class OptionalFormParamResourceTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {
-        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+        return DropwizardResourceConfig.forTesting()
                 .register(OptionalFormParamResource.class)
                 .register(MyMessageParamConverterProvider.class);
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalHeaderParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalHeaderParamResourceTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey.optional;
 
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.AbstractJerseyTest;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.MyMessage;
@@ -22,7 +21,7 @@ public class OptionalHeaderParamResourceTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {
-        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+        return DropwizardResourceConfig.forTesting()
                 .register(OptionalHeaderParamResource.class)
                 .register(MyMessageParamConverterProvider.class);
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalIntMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalIntMessageBodyWriterTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey.optional;
 
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.AbstractJerseyTest;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import org.junit.Test;
@@ -24,7 +23,7 @@ public class OptionalIntMessageBodyWriterTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {
-        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+        return DropwizardResourceConfig.forTesting()
                 .register(new EmptyOptionalExceptionMapper())
                 .register(OptionalIntReturnResource.class);
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalLongMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalLongMessageBodyWriterTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey.optional;
 
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.AbstractJerseyTest;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import org.junit.Test;
@@ -24,7 +23,7 @@ public class OptionalLongMessageBodyWriterTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {
-        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+        return DropwizardResourceConfig.forTesting()
                 .register(new EmptyOptionalExceptionMapper())
                 .register(OptionalLongReturnResource.class);
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalMessageBodyWriterTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey.optional;
 
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.AbstractJerseyTest;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import org.junit.Test;
@@ -24,7 +23,7 @@ public class OptionalMessageBodyWriterTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {
-        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+        return DropwizardResourceConfig.forTesting()
                 .register(new EmptyOptionalExceptionMapper())
                 .register(OptionalReturnResource.class);
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalQueryParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalQueryParamResourceTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey.optional;
 
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.AbstractJerseyTest;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.MyMessage;
@@ -22,7 +21,7 @@ public class OptionalQueryParamResourceTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {
-        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+        return DropwizardResourceConfig.forTesting()
                 .register(OptionalQueryParamResource.class)
                 .register(MyMessageParamConverterProvider.class);
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/NonEmptyStringParamProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/NonEmptyStringParamProviderTest.java
@@ -1,7 +1,6 @@
 package io.dropwizard.jersey.params;
 
 
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.AbstractJerseyTest;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import org.junit.Test;
@@ -17,7 +16,7 @@ public class NonEmptyStringParamProviderTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {
-        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+        return DropwizardResourceConfig.forTesting()
                 .register(NonEmptyStringParamResource.class);
     }
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/sessions/FlashFactoryTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/sessions/FlashFactoryTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey.sessions;
 
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.AbstractJerseyTest;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -32,7 +31,7 @@ public class FlashFactoryTest extends AbstractJerseyTest {
 
     @Override
     protected DeploymentContext configureDeployment() {
-        final ResourceConfig rc = DropwizardResourceConfig.forTesting(new MetricRegistry());
+        final ResourceConfig rc = DropwizardResourceConfig.forTesting();
 
         return ServletDeploymentContext.builder(rc)
                 .initParam(ServletProperties.JAXRS_APPLICATION_CLASS, DropwizardResourceConfig.class.getName())

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/sessions/HttpSessionFactoryTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/sessions/HttpSessionFactoryTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey.sessions;
 
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.AbstractJerseyTest;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -33,7 +32,7 @@ public class HttpSessionFactoryTest extends AbstractJerseyTest {
 
     @Override
     protected DeploymentContext configureDeployment() {
-        final ResourceConfig rc = DropwizardResourceConfig.forTesting(new MetricRegistry());
+        final ResourceConfig rc = DropwizardResourceConfig.forTesting();
         return ServletDeploymentContext.builder(rc)
                 .initParam(ServletProperties.JAXRS_APPLICATION_CLASS, DropwizardResourceConfig.class.getName())
                 .initParam(ServerProperties.PROVIDER_CLASSNAMES, SessionResource.class.getName())

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jersey.validation;
 
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.AbstractJerseyTest;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.jackson.JacksonMessageBodyProviderTest.Example;
@@ -31,7 +30,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {
-        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+        return DropwizardResourceConfig.forTesting()
                 .packages("io.dropwizard.jersey.validation")
                 .register(new ValidatingResource2())
                 .register(new HibernateValidationBinder(Validators.newValidator()));

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/common/DropwizardTestResourceConfig.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/common/DropwizardTestResourceConfig.java
@@ -1,11 +1,11 @@
 package io.dropwizard.testing.common;
 
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.jackson.JacksonFeature;
 import io.dropwizard.jersey.validation.HibernateValidationBinder;
 import io.dropwizard.setup.ExceptionMapperBinder;
 import org.glassfish.jersey.server.ServerProperties;
+import org.glassfish.jersey.test.TestProperties;
 
 import javax.servlet.ServletConfig;
 import javax.ws.rs.core.Context;
@@ -30,8 +30,9 @@ class DropwizardTestResourceConfig extends DropwizardResourceConfig {
     static final String CONFIGURATION_ID = "io.dropwizard.testing.junit.resourceTestJerseyConfigurationId";
 
     DropwizardTestResourceConfig(ResourceTestJerseyConfiguration configuration) {
-        super(true, new MetricRegistry());
+        super();
 
+        property(TestProperties.CONTAINER_PORT, "0");
         if (configuration.registerDefaultExceptionMappers) {
             register(new ExceptionMapperBinder(false));
         }

--- a/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/MultipleContentTypeTest.java
+++ b/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/MultipleContentTypeTest.java
@@ -8,7 +8,6 @@ import io.dropwizard.views.View;
 import io.dropwizard.views.ViewMessageBodyWriter;
 import io.dropwizard.views.ViewRenderer;
 import org.glassfish.jersey.test.JerseyTest;
-import org.glassfish.jersey.test.TestProperties;
 import org.junit.Test;
 
 import javax.ws.rs.GET;
@@ -36,9 +35,8 @@ public class MultipleContentTypeTest extends JerseyTest {
 
     @Override
     protected Application configure() {
-        forceSet(TestProperties.CONTAINER_PORT, "0");
         final ViewRenderer renderer = new FreemarkerViewRenderer();
-        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+        return DropwizardResourceConfig.forTesting()
                 .register(new ViewMessageBodyWriter(new MetricRegistry(), Collections.singletonList(renderer)))
                 .register(new InfoMessageBodyWriter())
                 .register(new ExampleResource());

--- a/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererFileSystemTest.java
+++ b/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererFileSystemTest.java
@@ -1,13 +1,13 @@
 package io.dropwizard.views.mustache;
 
 import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.logging.BootstrapLogging;
 import io.dropwizard.views.ViewMessageBodyWriter;
 import io.dropwizard.views.ViewRenderExceptionMapper;
 import io.dropwizard.views.ViewRenderer;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
-import org.glassfish.jersey.test.TestProperties;
 import org.junit.Test;
 
 import javax.ws.rs.GET;
@@ -62,8 +62,7 @@ public class MustacheViewRendererFileSystemTest extends JerseyTest {
 
     @Override
     protected Application configure() {
-        forceSet(TestProperties.CONTAINER_PORT, "0");
-        ResourceConfig config = new ResourceConfig();
+        ResourceConfig config = DropwizardResourceConfig.forTesting();
         final ViewRenderer renderer = new MustacheViewRenderer();
         renderer.configure(Collections.singletonMap("fileRoot", "src/test/resources"));
         config.register(new ViewMessageBodyWriter(new MetricRegistry(), Collections.singletonList(renderer)));

--- a/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererTest.java
+++ b/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererTest.java
@@ -1,13 +1,13 @@
 package io.dropwizard.views.mustache;
 
 import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.logging.BootstrapLogging;
 import io.dropwizard.views.ViewMessageBodyWriter;
 import io.dropwizard.views.ViewRenderExceptionMapper;
 import io.dropwizard.views.ViewRenderer;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
-import org.glassfish.jersey.test.TestProperties;
 import org.junit.Test;
 
 import javax.ws.rs.GET;
@@ -56,8 +56,7 @@ public class MustacheViewRendererTest extends JerseyTest {
 
     @Override
     protected Application configure() {
-        forceSet(TestProperties.CONTAINER_PORT, "0");
-        ResourceConfig config = new ResourceConfig();
+        ResourceConfig config = DropwizardResourceConfig.forTesting();
         final ViewRenderer renderer = new MustacheViewRenderer();
         config.register(new ViewMessageBodyWriter(new MetricRegistry(), Collections.singletonList(renderer)));
         config.register(new ViewRenderExceptionMapper());


### PR DESCRIPTION
The Jersey Test framework is using port 9998/tcp by default for starting the test container.

If tests are running in parallel and multiple tests are trying to start a container on the same port, they will fail with a java.net.BindException: Address already in use.

By using port "0" (i. e. a random free port) in tests via `DropwizardResourceConfig#forTesting()`, users won't have to manually set the respective property.