### PR TITLE
Upgrade JDBI3 to 3.4.0

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -28,7 +28,7 @@
         <slf4j.version>1.7.25</slf4j.version>
         <logback.version>1.2.3</logback.version>
         <h2.version>1.4.197</h2.version>
-        <jdbi3.version>3.2.1</jdbi3.version>
+        <jdbi3.version>3.4.0</jdbi3.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
###### Problem:
JDBI3 3.2.1 has a few bugs/issues that have been fixed in later versions.

###### Solution:
Updated dependencies to depend on 3.4.0.

###### Result:
Dropwizard will have the latest and greatest JDBI3.
