### PR TITLE
Fixed deprecated class usage (Apache StrSubstitutor)

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -17,6 +17,7 @@ v2.0.0: Unreleased
 * Fix ``UUIDParams`` accepting input of incorrect length (`#2382 <https://github.com/dropwizard/dropwizard/pull/2382>`_)
 * Fix usage ``@SelfValidating`` with ``@BeanParam`` (`#2334 <https://github.com/dropwizard/dropwizard/pull/2334>`_)
 * Fix resource endpoints injected via DI not being logged on startup (`#2389 <https://github.com/dropwizard/dropwizard/pull/2389>`_)
+* Retired use of deprecated Apache ``StrSubstitutor`` and ``StrLookup`` classes and replaced them with Apache's ``StringSubstitutor`` and ``StringLookup`` (`#2462 <https://github.com/dropwizard/dropwizard/pull/2462>`_)
 
 .. _rel-1.3.5:
 

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/EnvironmentVariableLookup.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/EnvironmentVariableLookup.java
@@ -1,11 +1,11 @@
 package io.dropwizard.configuration;
 
-import org.apache.commons.text.StrLookup;
+import org.apache.commons.text.lookup.StringLookup;
 
 /**
  * A custom {@link org.apache.commons.text.StrLookup} implementation using environment variables as lookup source.
  */
-public class EnvironmentVariableLookup extends StrLookup<Object> {
+public class EnvironmentVariableLookup implements StringLookup {
     private final boolean strict;
 
     /**

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/EnvironmentVariableSubstitutor.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/EnvironmentVariableSubstitutor.java
@@ -1,11 +1,11 @@
 package io.dropwizard.configuration;
 
-import org.apache.commons.text.StrSubstitutor;
+import org.apache.commons.text.StringSubstitutor;
 
 /**
  * A custom {@link StrSubstitutor} using environment variables as lookup source.
  */
-public class EnvironmentVariableSubstitutor extends StrSubstitutor {
+public class EnvironmentVariableSubstitutor extends StringSubstitutor {
     public EnvironmentVariableSubstitutor() {
         this(true, false);
     }

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/SubstitutingSourceProvider.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/SubstitutingSourceProvider.java
@@ -1,30 +1,32 @@
 package io.dropwizard.configuration;
 
 import io.dropwizard.util.ByteStreams;
-import org.apache.commons.text.StrSubstitutor;
+
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
+import org.apache.commons.text.StringSubstitutor;
+
 import static java.util.Objects.requireNonNull;
 
 /**
  * A delegating {@link ConfigurationSourceProvider} which replaces variables in the underlying configuration
- * source according to the rules of a custom {@link org.apache.commons.text.StrSubstitutor}.
+ * source according to the rules of a custom {@link org.apache.commons.text.StringSubstitutor}.
  */
 public class SubstitutingSourceProvider implements ConfigurationSourceProvider {
     private final ConfigurationSourceProvider delegate;
-    private final StrSubstitutor substitutor;
+    private final StringSubstitutor substitutor;
 
     /**
      * Create a new instance.
      *
      * @param delegate    The underlying {@link io.dropwizard.configuration.ConfigurationSourceProvider}.
-     * @param substitutor The custom {@link org.apache.commons.text.StrSubstitutor} implementation.
+     * @param substitutor The custom {@link org.apache.commons.text.StringSubstitutor} implementation.
      */
-    public SubstitutingSourceProvider(ConfigurationSourceProvider delegate, StrSubstitutor substitutor) {
+    public SubstitutingSourceProvider(ConfigurationSourceProvider delegate, StringSubstitutor substitutor) {
         this.delegate = requireNonNull(delegate);
         this.substitutor = requireNonNull(substitutor);
     }

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/EnvironmentVariableSubstitutorTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/EnvironmentVariableSubstitutorTest.java
@@ -1,12 +1,13 @@
 package io.dropwizard.configuration;
 
-import org.junit.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
+import org.junit.Test;
+
 public class EnvironmentVariableSubstitutorTest {
+
     @Test
     public void defaultConstructorDisablesSubstitutionInVariables() {
         EnvironmentVariableSubstitutor substitutor = new EnvironmentVariableSubstitutor();
@@ -30,7 +31,7 @@ public class EnvironmentVariableSubstitutorTest {
     @Test
     public void substitutorUsesEnvironmentVariableLookup() {
         EnvironmentVariableSubstitutor substitutor = new EnvironmentVariableSubstitutor();
-        assertThat(substitutor.getVariableResolver()).isInstanceOf(EnvironmentVariableLookup.class);
+        assertThat(substitutor.getStringLookup()).isInstanceOf(EnvironmentVariableLookup.class);
     }
 
     @Test

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/SubstitutingSourceProviderTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/SubstitutingSourceProviderTest.java
@@ -1,30 +1,24 @@
 package io.dropwizard.configuration;
 
-import org.apache.commons.text.StrLookup;
-import org.apache.commons.text.StrSubstitutor;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import javax.annotation.Nullable;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.apache.commons.text.StringSubstitutor;
+import org.apache.commons.text.lookup.StringLookup;
+import org.junit.Test;
 
 public class SubstitutingSourceProviderTest {
     @Test
     public void shouldSubstituteCorrectly() throws IOException {
-        StrLookup<?> dummyLookup = new StrLookup<Object>() {
-            @Override
-            public String lookup(String key) {
-                return "baz";
-            }
-        };
+        StringLookup dummyLookup = (x) -> "baz";
         DummySourceProvider dummyProvider = new DummySourceProvider();
-        SubstitutingSourceProvider provider = new SubstitutingSourceProvider(dummyProvider, new StrSubstitutor(dummyLookup));
+        SubstitutingSourceProvider provider = new SubstitutingSourceProvider(dummyProvider, new StringSubstitutor(dummyLookup));
 
         assertThat(provider.open("foo: ${bar}")).hasSameContentAs(new ByteArrayInputStream("foo: baz".getBytes(StandardCharsets.UTF_8)));
 
@@ -36,28 +30,16 @@ public class SubstitutingSourceProviderTest {
 
     @Test
     public void shouldSubstituteOnlyExistingVariables() throws IOException {
-        StrLookup<?> dummyLookup = new StrLookup<Object>() {
-            @Override
-            @Nullable
-            public String lookup(String key) {
-                return null;
-            }
-        };
-        SubstitutingSourceProvider provider = new SubstitutingSourceProvider(new DummySourceProvider(), new StrSubstitutor(dummyLookup));
+        StringLookup dummyLookup = (x) -> null;
+        SubstitutingSourceProvider provider = new SubstitutingSourceProvider(new DummySourceProvider(), new StringSubstitutor(dummyLookup));
 
         assertThat(provider.open("foo: ${bar}")).hasSameContentAs(new ByteArrayInputStream("foo: ${bar}".getBytes(StandardCharsets.UTF_8)));
     }
 
     @Test
     public void shouldSubstituteWithDefaultValue() throws IOException {
-        StrLookup<?> dummyLookup = new StrLookup<Object>() {
-            @Override
-            @Nullable
-            public String lookup(String key) {
-                return null;
-            }
-        };
-        SubstitutingSourceProvider provider = new SubstitutingSourceProvider(new DummySourceProvider(), new StrSubstitutor(dummyLookup));
+        StringLookup dummyLookup = (x) -> null;
+        SubstitutingSourceProvider provider = new SubstitutingSourceProvider(new DummySourceProvider(), new StringSubstitutor(dummyLookup));
 
         assertThat(provider.open("foo: ${bar:-default}")).hasSameContentAs(new ByteArrayInputStream("foo: default".getBytes(StandardCharsets.UTF_8)));
     }

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/DefaultLoggingFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/DefaultLoggingFactoryTest.java
@@ -19,7 +19,7 @@ import io.dropwizard.util.Maps;
 import io.dropwizard.util.Resources;
 import io.dropwizard.validation.BaseValidator;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.text.StrSubstitutor;
+import org.apache.commons.text.StringSubstitutor;
 import org.assertj.core.data.MapEntry;
 import org.junit.Before;
 import org.junit.Rule;
@@ -96,7 +96,7 @@ public class DefaultLoggingFactoryTest {
         final File newAppLog = folder.newFile("example-new-app.log");
         final File newAppNotAdditiveLog = folder.newFile("example-new-app-not-additive.log");
         final File defaultLog = folder.newFile("example.log");
-        final StrSubstitutor substitutor = new StrSubstitutor(Maps.of(
+        final StringSubstitutor substitutor = new StringSubstitutor(Maps.of(
                 "new_app", StringUtils.removeEnd(newAppLog.getAbsolutePath(), ".log"),
                 "new_app_not_additive", StringUtils.removeEnd(newAppNotAdditiveLog.getAbsolutePath(), ".log"),
                 "default", StringUtils.removeEnd(defaultLog.getAbsolutePath(), ".log")

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/TcpSocketAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/TcpSocketAppenderFactoryTest.java
@@ -11,7 +11,7 @@ import io.dropwizard.util.Duration;
 import io.dropwizard.util.Resources;
 import io.dropwizard.util.Size;
 import io.dropwizard.validation.BaseValidator;
-import org.apache.commons.text.StrSubstitutor;
+import org.apache.commons.text.StringSubstitutor;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -70,7 +70,7 @@ public class TcpSocketAppenderFactoryTest {
     public void testTestTcpLogging() throws Exception {
         DefaultLoggingFactory loggingFactory = yamlConfigurationFactory.build(new SubstitutingSourceProvider(
                 new ResourceConfigurationSourceProvider(),
-                new StrSubstitutor(Collections.singletonMap("tcp.server.port", tcpServer.getPort()))),
+                new StringSubstitutor(Collections.singletonMap("tcp.server.port", tcpServer.getPort()))),
             "yaml/logging-tcp.yml");
         loggingFactory.configure(new MetricRegistry(), "tcp-test");
 
@@ -88,7 +88,7 @@ public class TcpSocketAppenderFactoryTest {
     public void testBufferingTcpLogging() throws Exception {
         DefaultLoggingFactory loggingFactory = yamlConfigurationFactory.build(new SubstitutingSourceProvider(
             new ResourceConfigurationSourceProvider(),
-                new StrSubstitutor(Collections.singletonMap("tcp.server.port", tcpServer.getPort()))),
+                new StringSubstitutor(Collections.singletonMap("tcp.server.port", tcpServer.getPort()))),
             "yaml/logging-tcp-buffered.yml");
         loggingFactory.configure(new MetricRegistry(), "tcp-test");
 

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/ThrottlingAppenderWrapperTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/ThrottlingAppenderWrapperTest.java
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
 
-import org.apache.commons.text.StrSubstitutor;
+import org.apache.commons.text.StringSubstitutor;
 import org.assertj.core.api.Condition;
 import org.junit.After;
 import org.junit.Before;
@@ -127,7 +127,7 @@ public class ThrottlingAppenderWrapperTest {
 
         @SuppressWarnings("unchecked")
         final ConsoleAppenderFactory<ILoggingEvent> config = this.factory.build(
-            new SubstitutingSourceProvider(new FileConfigurationSourceProvider(), new StrSubstitutor(variables)),
+            new SubstitutingSourceProvider(new FileConfigurationSourceProvider(), new StringSubstitutor(variables)),
             this.findResource("/yaml/logging-message-rate.yml").getPath());
 
         final DefaultLoggingFactory defaultLoggingFactory = new DefaultLoggingFactory();

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/TlsSocketAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/TlsSocketAppenderFactoryTest.java
@@ -10,7 +10,7 @@ import io.dropwizard.jackson.Jackson;
 import io.dropwizard.util.Maps;
 import io.dropwizard.util.Resources;
 import io.dropwizard.validation.BaseValidator;
-import org.apache.commons.text.StrSubstitutor;
+import org.apache.commons.text.StringSubstitutor;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.Before;
 import org.junit.Rule;
@@ -62,7 +62,7 @@ public class TlsSocketAppenderFactoryTest {
     @Test
     public void testTlsLogging() throws Exception {
         DefaultLoggingFactory loggingFactory = yamlConfigurationFactory.build(new SubstitutingSourceProvider(
-            new ResourceConfigurationSourceProvider(), new StrSubstitutor(Maps.of(
+            new ResourceConfigurationSourceProvider(), new StringSubstitutor(Maps.of(
             "tls.trust_store.path", resourcePath("stores/tls_client.jks").getAbsolutePath(),
             "tls.trust_store.pass", "client_pass",
             "tls.server_port", tcpServer.getPort()


### PR DESCRIPTION
###### Problem:
The `StrSubstitutor` class is deprecated as of Apache commons-text 1.3. This will be removed in 2.0. See: https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/StrSubstitutor.html

**NOTE:** This is a breaking change.

###### Solution:
I have replaced the deprecated classes with their replacements as per the Apache documentation (with the exception of `StrLookup`; its documentation states to use `StringLookupFactory` but in our case, we needed to instead implement `StringLookup` which is the interface that replaced the abstract `StrLookup` class).

###### Result:
This eliminates compiler warnings related to using a deprecated class. It also will allow a smooth upgrade path for commons-text when the time comes.