### PR TITLE
Use default maven repo on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ jdk:
   - openjdk10
   - openjdk11
 before_install:
+  - rm ~/.m2/settings.xml || true
   - ulimit -c unlimited -S
 script:
   - ./mvnw verify -B


### PR DESCRIPTION
###### Problem:

Travis CI provides a default `~/.m2/settings.xml` which is using repository.apache.org which can become slow.

###### Solution:

Remove default settings and use the Maven default of repo.maven.apache.org.  GRPC made a similar change in https://github.com/grpc/grpc-java/pull/4782

###### Result:

Builds are faster when it needs to fetch resources from Maven.
