### PR TITLE
ConnectorProvider Not Set Silently

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
@@ -412,12 +412,14 @@ public class JerseyClientBuilder {
         }
 
         config.register(new DropwizardExecutorProvider(threadPool));
+
         if (connectorProvider == null) {
             final ConfiguredCloseableHttpClient apacheHttpClient =
                     apacheHttpClientBuilder.buildWithDefaultRequestConfiguration(name);
-            connectorProvider = (client, runtimeConfig) -> createDropwizardApacheConnector(apacheHttpClient);
+            config.connectorProvider((client, runtimeConfig) -> createDropwizardApacheConnector(apacheHttpClient));
+        } else {
+            config.connectorProvider(connectorProvider);
         }
-        config.connectorProvider(connectorProvider);
 
         return config;
     }

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
@@ -28,7 +28,9 @@ import org.apache.http.impl.client.SystemDefaultCredentialsProvider;
 import org.apache.http.impl.conn.SystemDefaultDnsResolver;
 import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
 import org.glassfish.jersey.client.ClientRequest;
+import org.glassfish.jersey.client.JerseyClient;
 import org.glassfish.jersey.client.rx.rxjava2.RxFlowableInvokerProvider;
+import org.glassfish.jersey.client.spi.ConnectorProvider;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -192,6 +194,25 @@ public class JerseyClientBuilderTest {
             }
         }
 
+    }
+
+    @Test
+    public void createsNewConnectorProvider(){
+        final JerseyClient clientA = (JerseyClient) builder.using(executorService, objectMapper).build("testA");
+        final JerseyClient clientB = (JerseyClient) builder.build("testB");
+        assertThat(clientA.getConfiguration().getConnectorProvider())
+            .isNotSameAs(clientB.getConfiguration().getConnectorProvider());
+    }
+
+    @Test
+    public void usesSameConnectorProvider(){
+        final JerseyClient clientA = (JerseyClient) builder.using(executorService, objectMapper)
+            .using(mock(ConnectorProvider.class))
+            .build("testA");
+        final JerseyClient clientB = (JerseyClient) builder.build("testB");
+
+        assertThat(clientA.getConfiguration().getConnectorProvider())
+            .isSameAs(clientB.getConfiguration().getConnectorProvider());
     }
 
     @Test


### PR DESCRIPTION
###### Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->
I wanted to build two different clients with the same builder, so I had some code sort of like this:

```
final private JerseyClientConfiguration clientConfigA = new JerseyClientConfiguration();
final private JerseyClientConfiguration clientConfigB = new JerseyClientConfiguration();
...
JerseyClientBuilder jerseyClientBuilder = new JerseyClientBuilder(environment);
Client a = jerseyClientBuilder.using(clientConfigA).build("client-A"));
Client b = jerseyClientBuilder.using(clientConfigB).build("client-B"));
```

I ran into these problems:
1. Only metrics for "client-A" were being reported
2. The connection timeout I set for client-A was the same for client-B. This especially confused me because client B's config had a different timeout value.  

I realized when `connectorProvider` is not explicitly set in the builder, then it gets silently set on the first build. From then on that builder will use the same `connectorProvider`. 

Current solutions to this are:
- instantiating a new builder for every client
- creating a unique `connectorProvider` for each client. 

However, I thought people might want to reuse the same builder without explicitly setting the `connectorProvider`. I'm not sure if this is a worthy change, as the current process may be the desired state. I think you all will know better.  

###### Solution:
<!-- Describe the modifications you've done. -->
When `connectorProvider` is null in the `JerseyClientBuilder`, build will not auto set it.
Instead, a new `connectorProvider` will be instantiated on each build. If users want to use the same `connectorProvider` across builds, they only need to explicitly set it once.