### PR TITLE
Upgrade to latest Guava (26.0-jre) and exclude jsr305 from Guava dependencies

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <dropwizard.version>${project.version}</dropwizard.version>
-        <guava.version>25.1-jre</guava.version>
+        <guava.version>26.0-jre</guava.version>
         <jersey.version>2.27</jersey.version>
         <jackson.version>2.9.6</jackson.version>
         <jetty.version>9.4.11.v20180605</jetty.version>
@@ -52,6 +52,12 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>jsr305</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.github.ben-manes.caffeine</groupId>


### PR DESCRIPTION
While trying to work through some JDK10 building issues, JSR305 is causing a lot of issues:

- https://blog.codefx.org/java/jsr-305-java-9/
- https://stackoverflow.com/questions/4963300/which-notnull-java-annotation-should-i-use
- https://github.com/google/guava/issues/2960
- https://github.com/ben-manes/caffeine/issues/242
- http://openjdk.java.net/jeps/320

Dropwizard is explicitly pulling in jsr305 as a dependency and using it internally.  I'm not sure if this will continue to work with JDK10+ or not.  We could do a future PR to replace our jsr305 usage with another library.