### PR TITLE
Updated documentation and comments that mentioned StrSubstitutor.

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -259,7 +259,7 @@ value of environment variables using a ``SubstitutingSourceProvider`` and ``Envi
     }
 
 The configuration settings which should be substituted need to be explicitly written in the configuration file and
-follow the substitution rules of StrSubstitutor_ from the Apache Commons Lang library.
+follow the substitution rules of StringSubstitutor_ from the Apache Commons Text library.
 
 .. code-block:: yaml
 
@@ -267,9 +267,9 @@ follow the substitution rules of StrSubstitutor_ from the Apache Commons Lang li
     defaultSetting: ${DW_DEFAULT_SETTING:-default value}
 
 In general ``SubstitutingSourceProvider`` isn't restricted to substitute environment variables but can be used to replace
-variables in the configuration source with arbitrary values by passing a custom ``StrSubstitutor`` implementation.
+variables in the configuration source with arbitrary values by passing a custom ``StringSubstitutor`` implementation.
 
-.. _StrSubstitutor: https://commons.apache.org/proper/commons-lang/javadocs/api-release/org/apache/commons/lang3/text/StrSubstitutor.html
+.. _StringSubstitutor: http://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/StringSubstitutor.html
 
 .. _man-core-ssl:
 

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/EnvironmentVariableSubstitutor.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/EnvironmentVariableSubstitutor.java
@@ -3,7 +3,7 @@ package io.dropwizard.configuration;
 import org.apache.commons.text.StringSubstitutor;
 
 /**
- * A custom {@link StrSubstitutor} using environment variables as lookup source.
+ * A custom {@link StringSubstitutor} using environment variables as lookup source.
  */
 public class EnvironmentVariableSubstitutor extends StringSubstitutor {
     public EnvironmentVariableSubstitutor() {
@@ -19,7 +19,7 @@ public class EnvironmentVariableSubstitutor extends StringSubstitutor {
      *                                {@link UndefinedEnvironmentVariableException}, {@code false} otherwise.
      * @param substitutionInVariables a flag whether substitution is done in variable names.
      * @see io.dropwizard.configuration.EnvironmentVariableLookup#EnvironmentVariableLookup(boolean)
-     * @see org.apache.commons.text.StrSubstitutor#setEnableSubstitutionInVariables(boolean)
+     * @see org.apache.commons.text.StringSubstitutor#setEnableSubstitutionInVariables(boolean)
      */
     public EnvironmentVariableSubstitutor(boolean strict, boolean substitutionInVariables) {
         super(new EnvironmentVariableLookup(strict));


### PR DESCRIPTION
###### Problem:
StrSubstitutor was recently replaced by StringSubstitutor in the code, but some mentions in the comments and documentation were not updated.

###### Solution:
Replaced mentions, including naming of library that the replacement came from.

###### Result:
Docs a little more up to date with the code.