### PR TITLE
#2459 Include all apache ConnectionPoolMetrics

### DIFF
--- a/dropwizard-db/src/main/java/io/dropwizard/db/ManagedPooledDataSource.java
+++ b/dropwizard-db/src/main/java/io/dropwizard/db/ManagedPooledDataSource.java
@@ -46,6 +46,27 @@ public class ManagedPooledDataSource extends DataSourceProxy implements ManagedD
 
         metricRegistry.register(name(getClass(), connectionPool.getName(), "size"),
             (Gauge<Integer>) connectionPool::getSize);
+
+        metricRegistry.register(name(getClass(), connectionPool.getName(), "created"),
+            (Gauge<Long>) connectionPool::getCreatedCount);
+
+        metricRegistry.register(name(getClass(), connectionPool.getName(), "borrowed"),
+            (Gauge<Long>) connectionPool::getBorrowedCount);
+
+        metricRegistry.register(name(getClass(), connectionPool.getName(), "reconnected"),
+            (Gauge<Long>) connectionPool::getReconnectedCount);
+
+        metricRegistry.register(name(getClass(), connectionPool.getName(), "released"),
+            (Gauge<Long>) connectionPool::getReleasedCount);
+
+        metricRegistry.register(name(getClass(), connectionPool.getName(), "releasedIdle"),
+            (Gauge<Long>) connectionPool::getReleasedIdleCount);
+
+        metricRegistry.register(name(getClass(), connectionPool.getName(), "returned"),
+            (Gauge<Long>) connectionPool::getReturnedCount);
+
+        metricRegistry.register(name(getClass(), connectionPool.getName(), "removeAbandoned"),
+            (Gauge<Long>) connectionPool::getRemoveAbandonedCount);
     }
 
     @Override

--- a/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceFactoryTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceFactoryTest.java
@@ -1,5 +1,7 @@
 package io.dropwizard.db;
 
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
@@ -17,6 +19,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -138,4 +141,23 @@ public class DataSourceFactoryTest {
         assertThat(factory.getValidationQuery()).isEqualTo("/* Health Check */ SELECT 1");
         assertThat(factory.getValidationQueryTimeout()).isEqualTo(Optional.empty());
     }
+
+    @Test
+    public void metricsRecorded() throws Exception {
+        dataSource();
+        Map<String, Gauge> poolMetrics = metricRegistry.getGauges(MetricFilter.startsWith("io.dropwizard.db.ManagedPooledDataSource.test."));
+        assertThat(poolMetrics.keySet()).contains(
+            "io.dropwizard.db.ManagedPooledDataSource.test.active",
+            "io.dropwizard.db.ManagedPooledDataSource.test.idle",
+            "io.dropwizard.db.ManagedPooledDataSource.test.waiting",
+            "io.dropwizard.db.ManagedPooledDataSource.test.size",
+            "io.dropwizard.db.ManagedPooledDataSource.test.created",
+            "io.dropwizard.db.ManagedPooledDataSource.test.borrowed",
+            "io.dropwizard.db.ManagedPooledDataSource.test.reconnected",
+            "io.dropwizard.db.ManagedPooledDataSource.test.released",
+            "io.dropwizard.db.ManagedPooledDataSource.test.releasedIdle",
+            "io.dropwizard.db.ManagedPooledDataSource.test.returned",
+            "io.dropwizard.db.ManagedPooledDataSource.test.removeAbandoned");
+    }
+
 }


### PR DESCRIPTION
###### Problem:
Current metrics in JDBI and Hibernate modules include some of the available metrics in apache connection pool, It would be useful to have all available metrics,
###### Solution:
<!-- Describe the modifications you've done. -->
Add the missing metrics
###### Result:
The metrics, when including dropwizard-db module, will now include created, borrowed, reconnected, released, releasedIdle, returned and removeAbandoned counts.
