### PR TITLE
testing.rst: Make example use diamond operator

### DIFF
--- a/docs/source/manual/testing.rst
+++ b/docs/source/manual/testing.rst
@@ -372,7 +372,7 @@ and can be reused across tests.
 
         @ClassRule
         public static final DropwizardAppRule<TestConfiguration> RULE =
-                new DropwizardAppRule<TestConfiguration>(MyApp.class, ResourceHelpers.resourceFilePath("my-app-config.yaml"));
+                new DropwizardAppRule<>(MyApp.class, ResourceHelpers.resourceFilePath("my-app-config.yaml"));
 
         @Test
         public void loginHandlerRedirectsAfterPost() {


### PR DESCRIPTION
Just a tiny change in a code example in the documentation: Use the diamond operator to make it more modern/readable.