### PR TITLE
Documenting how to escape periods

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -218,6 +218,8 @@ Dropwizard then calls your ``Application`` subclass to initialize your applicati
     You can override configuration settings in maps like this:
 
     ``java -Ddw.database.properties.hibernate.hbm2ddl.auto=none server my-config.json``
+    
+    If you need to use the '.' character in one of the values, you can escape it by using '\\.' instead.
 
     You can also override a configuration setting that is an array of strings by using the ',' character
     as an array element separator. For example, to override a configuration setting myapp.myserver.hosts


### PR DESCRIPTION
Documenting how to escape periods in system property config overrides

###### Problem:

I've always wanted an easy way to tweak logging levels of individual loggers with a low touch approach (so I can debug issues without pushing an entire deployable change),  but had difficulty because the property for it contains periods. Finally, I spent some time today going through the code that makes these system property overrides happen, and found that there is a way to escape the period, it just wasn't explicitly documented.

###### Solution:
Document how periods are escaped in parsing system property overrides
