### PR TITLE
Update to jetty 9.4.12

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -303,11 +303,11 @@ HTTP
           bufferPoolIncrement: 1KiB
           maxBufferPoolSize: 64KiB
           minRequestDataRate: 0
+          minResponseDataRate: 0
           acceptorThreads: 1
           selectorThreads: 2
           acceptQueueSize: 1024
           reuseAddress: true
-          soLingerTime: 345s
           useServerHeader: false
           useDateHeader: true
           useForwardedHeaders: true
@@ -341,20 +341,17 @@ idleTimeout              30 seconds          The maximum idle time for a connect
                                              or when waiting for a new message to be sent on a connection.
                                              This value is interpreted as the maximum time between some progress being made on the
                                              connection. So if a single byte is read or written, then the timeout is reset.
-blockingTimeout          (none)              The timeout applied to blocking operations. This timeout is in addition to
-                                             the `idleTimeout`, and applies to the total operation (as opposed to the
-                                             idle timeout that applies to the time no data is being sent).
 minBufferPoolSize        64 bytes            The minimum size of the buffer pool.
 bufferPoolIncrement      1KiB                The increment by which the buffer pool should be increased.
 maxBufferPoolSize        64KiB               The maximum size of the buffer pool.
 minRequestDataRate       0                   The minimum request data rate in bytes per second; or <= 0 for no limit.
+minResponseDataRate      0                   The minimum response data rate in bytes per second; or <= 0 for no limit.
 acceptorThreads          (Jetty's default)   The number of worker threads dedicated to accepting connections.
                                              By default is *max(1, min(4, #CPUs/8))*.
 selectorThreads          (Jetty's default)   The number of worker threads dedicated to sending and receiving data.
                                              By default is *max(1, min(4, #CPUs/2))*.
 acceptQueueSize          (OS default)        The size of the TCP/IP accept queue for the listening socket.
 reuseAddress             true                Whether or not ``SO_REUSEADDR`` is enabled on the listening socket.
-soLingerTime             (disabled)          Enable/disable ``SO_LINGER`` with the specified linger time.
 useServerHeader          false               Whether or not to add the ``Server`` header to each response.
 useDateHeader            true                Whether or not to add the ``Date`` header to each response.
 useForwardedHeaders      true                Whether or not to look at ``X-Forwarded-*`` headers added by proxies. See

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -22,7 +22,7 @@
         <guava.version>26.0-jre</guava.version>
         <jersey.version>2.27</jersey.version>
         <jackson.version>2.9.6</jackson.version>
-        <jetty.version>9.4.11.v20180605</jetty.version>
+        <jetty.version>9.4.12.v20180830</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.0.3</metrics4.version>
         <slf4j.version>1.7.25</slf4j.version>

--- a/dropwizard-core/src/test/resources/yaml/server.yml
+++ b/dropwizard-core/src/test/resources/yaml/server.yml
@@ -18,7 +18,6 @@ applicationConnectors:
     acceptorThreads: 2
     acceptQueueSize: 100
     reuseAddress: false
-    soLingerTime: 2s
     useServerHeader: true
     useDateHeader: false
     useForwardedHeaders: false

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
@@ -120,14 +120,6 @@ import static com.codahale.metrics.MetricRegistry.name;
  *         </td>
  *     </tr>
  *     <tr>
- *         <td>{@code blockingTimeout}</td>
- *         <td>(none)</td>
- *         <td>The timeout applied to blocking operations. This timeout is in addition to the {@code idleTimeout},
- *             and applies to the total operation (as opposed to the idle timeout that applies to the time no data
- *             is being sent).
- *          </td>
- *     </tr>
- *     <tr>
  *         <td>{@code minBufferPoolSize}</td>
  *         <td>64 bytes</td>
  *         <td>The minimum size of the buffer pool.</td>
@@ -165,11 +157,6 @@ import static com.codahale.metrics.MetricRegistry.name;
  *         <td>Whether or not {@code SO_REUSEADDR} is enabled on the listening socket.</td>
  *     </tr>
  *     <tr>
- *         <td>{@code soLingerTime}</td>
- *         <td>(disabled)</td>
- *         <td>Enable/disable {@code SO_LINGER} with the specified linger time.</td>
- *     </tr>
- *     <tr>
  *         <td>{@code useServerHeader}</td>
  *         <td>false</td>
  *         <td>Whether or not to add the {@code Server} header to each response.</td>
@@ -178,6 +165,20 @@ import static com.codahale.metrics.MetricRegistry.name;
  *         <td>{@code useDateHeader}</td>
  *         <td>true</td>
  *         <td>Whether or not to add the {@code Date} header to each response.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code minResponseDataRate}</td>
+ *         <td>0</td>
+ *         <td>
+ *             The minimum response data rate in bytes per second; or &lt;=0 for no limit
+ *         </td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code minRequestDataRate}</td>
+ *         <td>0</td>
+ *         <td>
+ *             The minimum request data rate in bytes per second; or &lt;=0 for no limit
+ *         </td>
  *     </tr>
  *     <tr>
  *         <td>{@code useForwardedHeaders}</td>
@@ -250,8 +251,13 @@ public class HttpConnectorFactory implements ConnectorFactory {
     @MinDuration(value = 1, unit = TimeUnit.MILLISECONDS)
     private Duration idleTimeout = Duration.seconds(30);
 
-    @Nullable
-    private Duration blockingTimeout;
+    @NotNull
+    @Min(0)
+    private long minResponseDataRate = 0;
+
+    @NotNull
+    @Min(0)
+    private long minRequestDataRate = 0;
 
     @NotNull
     @MinSize(value = 1, unit = SizeUnit.BYTES)
@@ -264,8 +270,6 @@ public class HttpConnectorFactory implements ConnectorFactory {
     @NotNull
     @MinSize(value = 1, unit = SizeUnit.BYTES)
     private Size maxBufferPoolSize = Size.kilobytes(64);
-
-    private long minRequestDataRate = 0L;
 
     @Min(1)
     @UnwrapValidatedValue
@@ -281,8 +285,6 @@ public class HttpConnectorFactory implements ConnectorFactory {
 
     private boolean reuseAddress = true;
 
-    @Nullable
-    private Duration soLingerTime;
     private boolean useServerHeader = false;
     private boolean useDateHeader = true;
     private boolean useForwardedHeaders = true;
@@ -380,17 +382,6 @@ public class HttpConnectorFactory implements ConnectorFactory {
     }
 
     @JsonProperty
-    @Nullable
-    public Duration getBlockingTimeout() {
-        return blockingTimeout;
-    }
-
-    @JsonProperty
-    public void setBlockingTimeout(Duration blockingTimeout) {
-        this.blockingTimeout = blockingTimeout;
-    }
-
-    @JsonProperty
     public Size getMinBufferPoolSize() {
         return minBufferPoolSize;
     }
@@ -418,6 +409,16 @@ public class HttpConnectorFactory implements ConnectorFactory {
     @JsonProperty
     public void setMaxBufferPoolSize(Size maxBufferPoolSize) {
         this.maxBufferPoolSize = maxBufferPoolSize;
+    }
+
+    @JsonProperty
+    public long getMinResponseDataRate() {
+        return minResponseDataRate;
+    }
+
+    @JsonProperty
+    public void setMinResponseDataRate(long minResponseDataRate) {
+        this.minResponseDataRate = minResponseDataRate;
     }
 
     @JsonProperty
@@ -469,17 +470,6 @@ public class HttpConnectorFactory implements ConnectorFactory {
     @JsonProperty
     public void setReuseAddress(boolean reuseAddress) {
         this.reuseAddress = reuseAddress;
-    }
-
-    @JsonProperty
-    @Nullable
-    public Duration getSoLingerTime() {
-        return soLingerTime;
-    }
-
-    @JsonProperty
-    public void setSoLingerTime(Duration soLingerTime) {
-        this.soLingerTime = soLingerTime;
     }
 
     @JsonProperty
@@ -576,9 +566,6 @@ public class HttpConnectorFactory implements ConnectorFactory {
         }
 
         connector.setReuseAddress(reuseAddress);
-        if (soLingerTime != null) {
-            connector.setSoLingerTime((int) soLingerTime.toMilliseconds());
-        }
         connector.setIdleTimeout(idleTimeout.toMilliseconds());
         connector.setName(name);
 
@@ -599,14 +586,13 @@ public class HttpConnectorFactory implements ConnectorFactory {
         httpConfig.setResponseHeaderSize((int) maxResponseHeaderSize.toBytes());
         httpConfig.setSendDateHeader(useDateHeader);
         httpConfig.setSendServerVersion(useServerHeader);
+        httpConfig.setMinResponseDataRate(minResponseDataRate);
         httpConfig.setMinRequestDataRate(minRequestDataRate);
 
         if (useForwardedHeaders) {
             httpConfig.addCustomizer(new ForwardedRequestCustomizer());
         }
-        if (blockingTimeout != null) {
-            httpConfig.setBlockingTimeout(blockingTimeout.toMilliseconds());
-        }
+
         return httpConfig;
     }
 

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
@@ -68,16 +68,15 @@ public class HttpConnectorFactoryTest {
         assertThat(http.getMinBufferPoolSize()).isEqualTo(Size.bytes(64));
         assertThat(http.getBufferPoolIncrement()).isEqualTo(Size.bytes(1024));
         assertThat(http.getMaxBufferPoolSize()).isEqualTo(Size.kilobytes(64));
-        assertThat(http.getMinRequestDataRate()).isEqualTo(0L);
+        assertThat(http.getMinRequestDataRate()).isEqualTo(0);
+        assertThat(http.getMinResponseDataRate()).isEqualTo(0);
         assertThat(http.getAcceptorThreads()).isEmpty();
         assertThat(http.getSelectorThreads()).isEmpty();
         assertThat(http.getAcceptQueueSize()).isNull();
         assertThat(http.isReuseAddress()).isTrue();
-        assertThat(http.getSoLingerTime()).isNull();
         assertThat(http.isUseServerHeader()).isFalse();
         assertThat(http.isUseDateHeader()).isTrue();
         assertThat(http.isUseForwardedHeaders()).isTrue();
-        assertThat(http.getBlockingTimeout()).isNull();
         assertThat(http.getHttpCompliance()).isEqualTo(HttpCompliance.RFC7230);
     }
 
@@ -99,16 +98,15 @@ public class HttpConnectorFactoryTest {
         assertThat(http.getMinBufferPoolSize()).isEqualTo(Size.bytes(128));
         assertThat(http.getBufferPoolIncrement()).isEqualTo(Size.bytes(500));
         assertThat(http.getMaxBufferPoolSize()).isEqualTo(Size.kilobytes(32));
-        assertThat(http.getMinRequestDataRate()).isEqualTo(42L);
+        assertThat(http.getMinRequestDataRate()).isEqualTo(42);
+        assertThat(http.getMinResponseDataRate()).isEqualTo(200);
         assertThat(http.getAcceptorThreads()).contains(1);
         assertThat(http.getSelectorThreads()).contains(4);
         assertThat(http.getAcceptQueueSize()).isEqualTo(1024);
         assertThat(http.isReuseAddress()).isFalse();
-        assertThat(http.getSoLingerTime()).isEqualTo(Duration.seconds(30));
         assertThat(http.isUseServerHeader()).isTrue();
         assertThat(http.isUseDateHeader()).isFalse();
         assertThat(http.isUseForwardedHeaders()).isFalse();
-        assertThat(http.getBlockingTimeout()).isEqualTo(Duration.seconds(30));
         assertThat(http.getHttpCompliance()).isEqualTo(HttpCompliance.RFC2616);
     }
 
@@ -119,9 +117,8 @@ public class HttpConnectorFactoryTest {
         http.setAcceptorThreads(Optional.of(1));
         http.setSelectorThreads(Optional.of(2));
         http.setAcceptQueueSize(1024);
-        http.setSoLingerTime(Duration.seconds(30));
-        http.setBlockingTimeout(Duration.minutes(1));
-        http.setMinRequestDataRate(42L);
+        http.setMinResponseDataRate(200);
+        http.setMinRequestDataRate(42);
 
         Server server = new Server();
         MetricRegistry metrics = new MetricRegistry();
@@ -133,7 +130,6 @@ public class HttpConnectorFactoryTest {
         assertThat(connector.getHost()).isEqualTo("127.0.0.1");
         assertThat(connector.getAcceptQueueSize()).isEqualTo(1024);
         assertThat(connector.getReuseAddress()).isTrue();
-        assertThat(connector.getSoLingerTime()).isEqualTo(30000);
         assertThat(connector.getIdleTimeout()).isEqualTo(30000);
         assertThat(connector.getName()).isEqualTo("test-http-connector");
 
@@ -169,8 +165,8 @@ public class HttpConnectorFactoryTest {
         assertThat(httpConfiguration.getSendDateHeader()).isTrue();
         assertThat(httpConfiguration.getSendServerVersion()).isFalse();
         assertThat(httpConfiguration.getCustomizers()).hasAtLeastOneElementOfType(ForwardedRequestCustomizer.class);
-        assertThat(httpConfiguration.getBlockingTimeout()).isEqualTo(60000L);
-        assertThat(httpConfiguration.getMinRequestDataRate()).isEqualTo(42L);
+        assertThat(httpConfiguration.getMinRequestDataRate()).isEqualTo(42);
+        assertThat(httpConfiguration.getMinResponseDataRate()).isEqualTo(200);
 
         connector.stop();
         server.stop();
@@ -182,7 +178,6 @@ public class HttpConnectorFactoryTest {
         http.setBindHost("127.0.0.1");
         http.setAcceptorThreads(Optional.of(1));
         http.setSelectorThreads(Optional.of(2));
-        http.setSoLingerTime(Duration.seconds(30));
 
         Server server = new Server();
         MetricRegistry metrics = new MetricRegistry();

--- a/dropwizard-jetty/src/test/resources/yaml/http-connector.yml
+++ b/dropwizard-jetty/src/test/resources/yaml/http-connector.yml
@@ -8,16 +8,15 @@ maxRequestHeaderSize: 4KiB
 maxResponseHeaderSize: 4KiB
 inputBufferSize: 4KiB
 idleTimeout: 10 seconds
-blockingTimeout: 30 seconds
 minBufferPoolSize: 128B
 bufferPoolIncrement: 500B
 maxBufferPoolSize: 32KiB
 minRequestDataRate: 42
+minResponseDataRate: 200
 acceptorThreads: 1
 selectorThreads: 4
 acceptQueueSize: 1024
 reuseAddress: false
-soLingerTime: 30s
 useServerHeader: true
 useDateHeader: false
 useForwardedHeaders: false


### PR DESCRIPTION
What this PR entails:

- Update Jetty to latest (9.4.12) from (9.4.11)
- Remove deprecated configuration knobs (blockingTimeout and soLingerTime)
- Add minResponseDataRate

As for reasoning:

- Dropwizard should start with a clean slate with deprecations
- soLingerTime was literally a noop and a warning, so it has been removed (and not replaced with an alternate method)
- blockingTimeout has been rendered unnecessary (https://github.com/eclipse/jetty.project/issues/2525), and those interested in some sort rate limit  should see minResponseDataRate and minRequestDataRate (which was already part of 1.3.0 (https://github.com/dropwizard/dropwizard/pull/2184))
- Since minResponseDataRate was not present in our configuration, I added it, in case someone was using blockingTimeout in that fashion.

I'm torn on the what types minResponseDataRate / minRequestDataRate should be. They are currently numeric, but seeing just an `100` in a configuration file is not conducive to its meaning (number of bytes per second, as in if someone is sending less than `100` bytes per second, respond with a 408). I like how in https://github.com/dropwizard/dropwizard/pull/2384 we were able to use a `Duration` to convey how to throttle logging messages. I was looking into migrating to `Size` but I couldn't think of a descriptive name (and it would also be a breaking change), so I left it. But if we're going to make the switch from long to Size we should probably do it soon as the minRequestDataRate is a relatively new know (1.3.0), so it's usage may not be terribly widespread. (cc @patrox in case he has any thoughts on this)

###### Result:

Closes #2480 

Afterwards:

- [ ] update release notes
- [ ] write migration guide for removed configuration settings