### PR TITLE
Rework resource config test for resilient CI

### DIFF
--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
@@ -3,11 +3,9 @@ package io.dropwizard.jersey;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.dropwizard.jersey.dummy.DummyResource;
-import io.dropwizard.logging.BootstrapLogging;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.server.model.Resource;
-import org.glassfish.jersey.test.JerseyTest;
-import org.junit.Before;
+import org.junit.After;
 import org.junit.Test;
 
 import javax.ws.rs.DELETE;
@@ -20,36 +18,26 @@ import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 
 public class DropwizardResourceConfigTest {
-    static {
-        BootstrapLogging.bootstrap();
+    private DropwizardResourceConfig rc = DropwizardResourceConfig.forTesting();
+    private AbstractJerseyTest jerseyTest = new AbstractJerseyTest() {
+        @Override
+        protected Application configure() {
+            return rc;
+        }
+    };
+
+    @After
+    public void teardown() throws Exception {
+        jerseyTest.tearDown();
     }
 
-    private DropwizardResourceConfig rc;
-
-    @Before
-    public void setUp() {
-        rc = DropwizardResourceConfig.forTesting();
-    }
-
-    // Start and stop a jersey test instance so that our resource config
+    // Start jersey test instance so that our resource config
     // successfully hooks into the Jersey start up application event
     private void runJersey() {
-        final JerseyTest jerseyTest = new JerseyTest() {
-            @Override
-            protected Application configure() {
-                return rc;
-            }
-        };
-
         try {
             jerseyTest.setUp();
         } catch (Exception e) {
             throw new RuntimeException("Could not start jersey", e);
-        } finally {
-            try {
-                jerseyTest.tearDown();
-            } catch (Exception ignored) {
-            }
         }
     }
 


### PR DESCRIPTION
###### Problem:
It is not uncommon for a DropwizardResourceConfigTest.java test to fail on Appveyor with a complaint about "Address already in use: bind"

###### Solution:
- Only teardown the jersey test after the test has finished instead of immediately after startup. This would avoid a race condition that may exist in the underlying test container
- Switch to `AbstractJerseyTest` instead of plain `JerseyTest` for conformity. Even though `DropwizardResourceConfig.forTesting` will have the port sent to the next available, so to will `AbstractJerseyTest` (which is used in other tests), so this is just another measure to ensure the next available port is used. Side benefit of this, is we get to remove `BootstrapLogging` as `AbstractJerseyTest` already incorporates that.

###### Result:
- Appveyor passed on the first time prepping this PR.