### PR TITLE
Migrate jetty min data rates to Sizes

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -302,8 +302,8 @@ HTTP
           minBufferPoolSize: 64 bytes
           bufferPoolIncrement: 1KiB
           maxBufferPoolSize: 64KiB
-          minRequestDataRate: 0
-          minResponseDataRate: 0
+          minRequestDataPerSecond: '0 bytes'
+          minResponseDataPerSecond: '0 bytes'
           acceptorThreads: 1
           selectorThreads: 2
           acceptQueueSize: 1024
@@ -344,8 +344,8 @@ idleTimeout              30 seconds          The maximum idle time for a connect
 minBufferPoolSize        64 bytes            The minimum size of the buffer pool.
 bufferPoolIncrement      1KiB                The increment by which the buffer pool should be increased.
 maxBufferPoolSize        64KiB               The maximum size of the buffer pool.
-minRequestDataRate       0                   The minimum request data rate in bytes per second; or <= 0 for no limit.
-minResponseDataRate      0                   The minimum response data rate in bytes per second; or <= 0 for no limit.
+minRequestDataPerSecond       0                   The minimum request data rate in bytes per second; or <= 0 for no limit.
+minResponseDataPerSecond      0                   The minimum response data rate in bytes per second; or <= 0 for no limit.
 acceptorThreads          (Jetty's default)   The number of worker threads dedicated to accepting connections.
                                              By default is *max(1, min(4, #CPUs/8))*.
 selectorThreads          (Jetty's default)   The number of worker threads dedicated to sending and receiving data.

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
@@ -167,15 +167,15 @@ import static com.codahale.metrics.MetricRegistry.name;
  *         <td>Whether or not to add the {@code Date} header to each response.</td>
  *     </tr>
  *     <tr>
- *         <td>{@code minResponseDataRate}</td>
- *         <td>0</td>
+ *         <td>{@code minResponseDataPerSecond}</td>
+ *         <td>0 bytes</td>
  *         <td>
  *             The minimum response data rate in bytes per second; or &lt;=0 for no limit
  *         </td>
  *     </tr>
  *     <tr>
- *         <td>{@code minRequestDataRate}</td>
- *         <td>0</td>
+ *         <td>{@code minRequestDataPerSecond}</td>
+ *         <td>0 bytes</td>
  *         <td>
  *             The minimum request data rate in bytes per second; or &lt;=0 for no limit
  *         </td>
@@ -252,12 +252,12 @@ public class HttpConnectorFactory implements ConnectorFactory {
     private Duration idleTimeout = Duration.seconds(30);
 
     @NotNull
-    @Min(0)
-    private long minResponseDataRate = 0;
+    @MinSize(0)
+    private Size minResponseDataPerSecond = Size.bytes(0);
 
     @NotNull
-    @Min(0)
-    private long minRequestDataRate = 0;
+    @MinSize(0)
+    private Size minRequestDataPerSecond = Size.bytes(0);
 
     @NotNull
     @MinSize(value = 1, unit = SizeUnit.BYTES)
@@ -412,23 +412,23 @@ public class HttpConnectorFactory implements ConnectorFactory {
     }
 
     @JsonProperty
-    public long getMinResponseDataRate() {
-        return minResponseDataRate;
+    public Size getMinResponseDataPerSecond() {
+        return minResponseDataPerSecond;
     }
 
     @JsonProperty
-    public void setMinResponseDataRate(long minResponseDataRate) {
-        this.minResponseDataRate = minResponseDataRate;
+    public void setMinResponseDataPerSecond(Size minResponseDataPerSecond) {
+        this.minResponseDataPerSecond = minResponseDataPerSecond;
     }
 
     @JsonProperty
-    public long getMinRequestDataRate() {
-        return minRequestDataRate;
+    public Size getMinRequestDataPerSecond() {
+        return minRequestDataPerSecond;
     }
 
     @JsonProperty
-    public void setMinRequestDataRate(long minRequestDataRate) {
-        this.minRequestDataRate = minRequestDataRate;
+    public void setMinRequestDataPerSecond(Size minRequestDataPerSecond) {
+        this.minRequestDataPerSecond = minRequestDataPerSecond;
     }
 
     @JsonProperty
@@ -586,8 +586,8 @@ public class HttpConnectorFactory implements ConnectorFactory {
         httpConfig.setResponseHeaderSize((int) maxResponseHeaderSize.toBytes());
         httpConfig.setSendDateHeader(useDateHeader);
         httpConfig.setSendServerVersion(useServerHeader);
-        httpConfig.setMinResponseDataRate(minResponseDataRate);
-        httpConfig.setMinRequestDataRate(minRequestDataRate);
+        httpConfig.setMinResponseDataRate(minResponseDataPerSecond.toBytes());
+        httpConfig.setMinRequestDataRate(minRequestDataPerSecond.toBytes());
 
         if (useForwardedHeaders) {
             httpConfig.addCustomizer(new ForwardedRequestCustomizer());

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
@@ -68,8 +68,8 @@ public class HttpConnectorFactoryTest {
         assertThat(http.getMinBufferPoolSize()).isEqualTo(Size.bytes(64));
         assertThat(http.getBufferPoolIncrement()).isEqualTo(Size.bytes(1024));
         assertThat(http.getMaxBufferPoolSize()).isEqualTo(Size.kilobytes(64));
-        assertThat(http.getMinRequestDataRate()).isEqualTo(0);
-        assertThat(http.getMinResponseDataRate()).isEqualTo(0);
+        assertThat(http.getMinRequestDataPerSecond()).isEqualTo(Size.bytes(0));
+        assertThat(http.getMinResponseDataPerSecond()).isEqualTo(Size.bytes(0));
         assertThat(http.getAcceptorThreads()).isEmpty();
         assertThat(http.getSelectorThreads()).isEmpty();
         assertThat(http.getAcceptQueueSize()).isNull();
@@ -98,8 +98,8 @@ public class HttpConnectorFactoryTest {
         assertThat(http.getMinBufferPoolSize()).isEqualTo(Size.bytes(128));
         assertThat(http.getBufferPoolIncrement()).isEqualTo(Size.bytes(500));
         assertThat(http.getMaxBufferPoolSize()).isEqualTo(Size.kilobytes(32));
-        assertThat(http.getMinRequestDataRate()).isEqualTo(42);
-        assertThat(http.getMinResponseDataRate()).isEqualTo(200);
+        assertThat(http.getMinRequestDataPerSecond()).isEqualTo(Size.bytes(42));
+        assertThat(http.getMinResponseDataPerSecond()).isEqualTo(Size.bytes(200));
         assertThat(http.getAcceptorThreads()).contains(1);
         assertThat(http.getSelectorThreads()).contains(4);
         assertThat(http.getAcceptQueueSize()).isEqualTo(1024);
@@ -117,8 +117,8 @@ public class HttpConnectorFactoryTest {
         http.setAcceptorThreads(Optional.of(1));
         http.setSelectorThreads(Optional.of(2));
         http.setAcceptQueueSize(1024);
-        http.setMinResponseDataRate(200);
-        http.setMinRequestDataRate(42);
+        http.setMinResponseDataPerSecond(Size.bytes(200));
+        http.setMinRequestDataPerSecond(Size.bytes(42));
 
         Server server = new Server();
         MetricRegistry metrics = new MetricRegistry();

--- a/dropwizard-jetty/src/test/resources/yaml/http-connector.yml
+++ b/dropwizard-jetty/src/test/resources/yaml/http-connector.yml
@@ -11,8 +11,8 @@ idleTimeout: 10 seconds
 minBufferPoolSize: 128B
 bufferPoolIncrement: 500B
 maxBufferPoolSize: 32KiB
-minRequestDataRate: 42
-minResponseDataRate: 200
+minRequestDataPerSecond: '42 bytes'
+minResponseDataPerSecond: '200 bytes'
 acceptorThreads: 1
 selectorThreads: 4
 acceptQueueSize: 1024


### PR DESCRIPTION
Follow up to #2490

###### Problem:

`minRequestDataRate` and `minResponseDataRate` configured via numeric values are not indicative of they are configuring.

###### Solution:

Migrate both to `Size` and rename to contain a `PerSecond` suffix.

```yaml
minRequestDataPerSecond: '42 bytes'
minResponseDataPerSecond: '200 bytes'
```

###### Result:

A backwards incompatible change (`minRequestDataRate` shipped with dropwizard 1.3)

###### Alternatives:

- Avoid the rename, as one should strive for a 1:1 mapping between configuration fields and jetty API 
- Avoid the rename by creating a `Rate` class that will parse something like `10 bytes/s`