### PR TITLE
Add Jadira upgrade to 1.1.0 notes

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -355,6 +355,7 @@ v1.1.0: Mar 21 2017
 * Upgraded to Joda-Time 2.9.7
 * Upgraded to commons-lang3 3.5
 * Upgraded to Apache HTTP Client 4.5.3
+* Upgraded to Jadira Usertype Core 6.0.1.GA
 
 .. _rel-1.0.7:
 


### PR DESCRIPTION
Jadira was upgraded in the Hibernate 5.2 upgrade here(https://github.com/dropwizard/dropwizard/pull/1871/files) but not added to the release notes. Jadira 5.0.0 is incompatible with Hibernate 5.2 as well.