### PR TITLE
Support configuration of exception details with JSON logging

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -840,6 +840,11 @@ JSON layout
       additionalFields:
         service-name: "user-service"
       includesMdcKeys: [userId]
+      flattenMDC: true
+      exception:
+        rootFirst: true
+        depth: full
+        evaluators: [org.apache]
 
 
 =======================  =====================  ================
@@ -866,9 +871,37 @@ includes                 (timestamp, level,
 customFieldNames         (empty)                Map of field name replacements . For example ``(requestTime:request_time, userAgent:user_agent)``.
 additionalFields         (empty)                Map of fields to add in the JSON map.
 includesMdcKeys          (empty)                Set of MDC keys which should be included in the JSON map. By default includes everything.
+flattenMdc               false                  Flatten the MDC to the root of the JSON object instead of nested in the ``mdc`` field.
+exception                (empty)                The :ref:`exception <man-configuration-json-layout-exception>` configuration for the ``exception`` field.
 =======================  =====================  ================
 
 .. _DateTimeFormatter:  https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html
+
+.. _man-configuration-json-layout-exception:
+
+Exception
+.........
+
+.. code-block:: yaml
+
+    layout:
+      type: json
+      exception:
+        rootFirst: false
+        depth: 25
+        evaluators: [org.apache]
+
+
+====================== ===========  ================================
+Name                   Default      Description
+====================== ===========  ================================
+rootFirst              true         Whether the root cause should be displayed first.
+depth                  full         The stack trace depth_.
+evaluators             (empty)      The packages to filter_ from the stacktrace.
+====================== ===========  ================================
+
+.. _depth:  https://logback.qos.ch/manual/layouts.html#ex
+.. _filter:  https://github.com/qos-ch/logback/pull/244
 
 .. _man-configuration-json-access-layout:
 

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/EventJsonLayoutBaseFactory.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/EventJsonLayoutBaseFactory.java
@@ -1,6 +1,7 @@
 package io.dropwizard.logging.json;
 
 import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.pattern.ExtendedThrowableProxyConverter;
 import ch.qos.logback.classic.pattern.RootCauseFirstThrowableProxyConverter;
 import ch.qos.logback.classic.pattern.ThrowableHandlingConverter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
@@ -9,10 +10,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.dropwizard.logging.json.layout.EventJsonLayout;
 
+import io.dropwizard.logging.json.layout.ExceptionFormat;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Set;
 import java.util.TimeZone;
+import javax.annotation.Nullable;
 
 /**
  * <table>
@@ -48,6 +53,9 @@ public class EventJsonLayoutBaseFactory extends AbstractJsonLayoutBaseFactory<IL
     private Set<String> includesMdcKeys = Collections.emptySet();
     private boolean flattenMdc = false;
 
+    @Nullable
+    private ExceptionFormat exceptionFormat;
+
     @JsonProperty
     public EnumSet<EventAttribute> getIncludes() {
         return includes;
@@ -78,17 +86,47 @@ public class EventJsonLayoutBaseFactory extends AbstractJsonLayoutBaseFactory<IL
         this.flattenMdc = flattenMdc;
     }
 
+    @JsonProperty("exception")
+    public void setExceptionFormat(ExceptionFormat exceptionFormat) {
+        this.exceptionFormat = exceptionFormat;
+    }
+
+    @JsonProperty("exception")
+    @Nullable
+    public ExceptionFormat getExceptionFormat() {
+        return exceptionFormat;
+    }
+
     @Override
     public LayoutBase<ILoggingEvent> build(LoggerContext context, TimeZone timeZone) {
         final EventJsonLayout jsonLayout = new EventJsonLayout(createDropwizardJsonFormatter(),
-            createTimestampFormatter(timeZone), createThrowableProxyConverter(), includes, getCustomFieldNames(),
+            createTimestampFormatter(timeZone), createThrowableProxyConverter(context), includes, getCustomFieldNames(),
             getAdditionalFields(), includesMdcKeys, flattenMdc);
         jsonLayout.setContext(context);
         return jsonLayout;
     }
 
-    protected ThrowableHandlingConverter createThrowableProxyConverter() {
-        return new RootCauseFirstThrowableProxyConverter();
+    protected ThrowableHandlingConverter createThrowableProxyConverter(LoggerContext context) {
+        if (exceptionFormat == null) {
+            return new RootCauseFirstThrowableProxyConverter();
+        }
+
+        ThrowableHandlingConverter throwableHandlingConverter;
+        if (exceptionFormat.isRootFirst()) {
+            throwableHandlingConverter = new RootCauseFirstThrowableProxyConverter();
+        } else {
+            throwableHandlingConverter = new ExtendedThrowableProxyConverter();
+        }
+
+        List<String> options = new ArrayList<>();
+        // depth must be added first
+        options.add(exceptionFormat.getDepth());
+        options.addAll(exceptionFormat.getEvaluators());
+
+        throwableHandlingConverter.setOptionList(options);
+        throwableHandlingConverter.setContext(context);
+
+        return throwableHandlingConverter;
     }
 
 }

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/ExceptionFormat.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/ExceptionFormat.java
@@ -1,0 +1,41 @@
+package io.dropwizard.logging.json.layout;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Collections;
+import java.util.List;
+
+public class ExceptionFormat {
+    private boolean rootFirst = true;
+    private String depth = "full";
+    private List<String> evaluators = Collections.emptyList();
+
+    @JsonProperty
+    public boolean isRootFirst() {
+        return rootFirst;
+    }
+
+    @JsonProperty
+    public void setRootFirst(boolean rootFirst) {
+        this.rootFirst = rootFirst;
+    }
+
+    @JsonProperty
+    public String getDepth() {
+        return depth;
+    }
+
+    @JsonProperty
+    public void setDepth(String depth) {
+        this.depth = depth;
+    }
+
+    @JsonProperty
+    public List<String> getEvaluators() {
+        return evaluators;
+    }
+
+    @JsonProperty
+    public void setEvaluators(List<String> evaluators) {
+        this.evaluators = evaluators;
+    }
+}

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/EventJsonLayoutBaseFactoryTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/EventJsonLayoutBaseFactoryTest.java
@@ -1,0 +1,79 @@
+package io.dropwizard.logging.json;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.pattern.ThrowableHandlingConverter;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.ThrowableProxy;
+import com.google.common.base.Throwables;
+import io.dropwizard.logging.json.layout.ExceptionFormat;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.regex.Pattern;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class EventJsonLayoutBaseFactoryTest {
+
+    private static final String LINE_SEPERATOR = System.getProperty("line.separator");
+    // Use unique spelling to guard against false positive matches
+    private ThrowableProxy proxy = new ThrowableProxy(new RuntimeException("wrapp3d", new IOException("r00t")));
+    private String packageFilter = "org.junit";
+    private ILoggingEvent event = Mockito.mock(ILoggingEvent.class);
+
+    @Before
+    public void before() {
+        when(event.getThrowableProxy()).thenReturn(proxy);
+    }
+
+    @Test
+    public void testCreateThrowableProxyConverter_Configured() {
+        ExceptionFormat format = new ExceptionFormat();
+        format.setDepth("8");
+        format.setRootFirst(false);
+        format.setEvaluators(Collections.singletonList(packageFilter));
+
+        EventJsonLayoutBaseFactory factory = new EventJsonLayoutBaseFactory();
+        factory.setExceptionFormat(format);
+
+        ThrowableHandlingConverter converter = factory.createThrowableProxyConverter(new LoggerContext());
+        converter.start();
+
+        // Verify the original stack includes the excluded packages
+        assertThat(Throwables.getStackTraceAsString(proxy.getThrowable())).contains(packageFilter);
+
+        String conversion = converter.convert(event);
+
+        // Verify the conversion depth
+        // 2 messages and 8 lines of stack per throwable
+        assertThat(conversion.split(LINE_SEPERATOR)).hasSize(18);
+
+        // Verify that the root is not first
+        assertThat(conversion).containsPattern(Pattern.compile("wrapp3d.*r00t", Pattern.DOTALL));
+
+        // Verify the conversion does not includes the excluded packages and contains skipped lines
+        assertThat(conversion).doesNotContain(packageFilter);
+        assertThat(conversion).containsPattern(Pattern.compile("\\[\\d+ skipped\\]"));
+    }
+
+    @Test
+    public void testCreateThrowableProxyConverter_Default() {
+        EventJsonLayoutBaseFactory factory = new EventJsonLayoutBaseFactory();
+
+        ThrowableHandlingConverter converter = factory.createThrowableProxyConverter(new LoggerContext());
+        converter.start();
+
+        String conversion = converter.convert(event);
+
+        int originalSize = Throwables.getStackTraceAsString(proxy.getThrowable()).split(LINE_SEPERATOR).length;
+
+        // Verify that the full stack is included
+        assertThat(conversion.split(LINE_SEPERATOR)).hasSize(originalSize);
+
+        // Verify that the root is first
+        assertThat(conversion).containsPattern(Pattern.compile("r00t.*wrapp3d", Pattern.DOTALL));
+    }
+}

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/ExceptionFormatTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/ExceptionFormatTest.java
@@ -1,0 +1,28 @@
+package io.dropwizard.logging.json.layout;
+
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExceptionFormatTest {
+
+    @Test
+    public void testDefaults() {
+        ExceptionFormat ef = new ExceptionFormat();
+        assertThat(ef.isRootFirst()).isTrue();
+        assertThat(ef.getDepth()).isEqualTo("full");
+        assertThat(ef.getEvaluators()).isEmpty();
+    }
+
+    @Test
+    public void testSetDepth() {
+        ExceptionFormat ef = new ExceptionFormat();
+        assertThat(ef.getDepth()).isEqualTo("full");
+
+        ef.setDepth("short");
+        assertThat(ef.getDepth()).isEqualTo("short");
+
+        // Verify depth can be set to a number as well
+        ef.setDepth("25");
+        assertThat(ef.getDepth()).isEqualTo("25");
+    }
+}

--- a/dropwizard-json-logging/src/test/resources/yaml/json-log.yml
+++ b/dropwizard-json-logging/src/test/resources/yaml/json-log.yml
@@ -12,6 +12,11 @@ layout:
     - message
     - exception
     - timestamp
+  exception:
+    rootFirst: false
+    depth: 10
+    evaluators:
+    - io.dropwizard
   customFieldNames:
     timestamp: "@timestamp"
   additionalFields:


### PR DESCRIPTION
###### Problem:
JSON logging is missing some features that standard logging supplies due to the lack of a format override.

###### Solution:
Support configuration of exception cause placement, depth and package filtering with JSON logging.

See also #2488 and #2489
