### PR TITLE
Add totalSizeCap to file log appender

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -690,6 +690,8 @@ maxFileSize                  (unlimited)                                The maxi
                                                                         expressed in bytes, kilobytes, megabytes, gigabytes, and terabytes by appending B, K, MB, GB, or
                                                                         TB to the numeric value.  Examples include 100MB, 1GB, 1TB.  Sizes can also be spelled out, such
                                                                         as 100 megabytes, 1 gigabyte, 1 terabyte.
+totalSizeCap                 (unlimited)                                Controls the total size of all files.
+                                                                        Oldest archives are deleted asynchronously when the total size cap is exceeded.
 timeZone                     UTC                                        The time zone to which event timestamps will be converted.
 logFormat                    %-5p [%d{ISO8601,UTC}] %c: %m%n%rEx        The Logback pattern with which events will be formatted. See
                                                                         the Logback_ documentation for details.

--- a/dropwizard-logging/src/test/resources/yaml/appender_file_cap.yaml
+++ b/dropwizard-logging/src/test/resources/yaml/appender_file_cap.yaml
@@ -1,0 +1,7 @@
+type: file
+threshold: ALL
+currentLogFilename: ./logs/example.log
+archivedLogFilenamePattern: ./logs/example-%d-%i.log.gz
+archivedFileCount: 5
+maxFileSize: "10mb"
+totalSizeCap: "50mb"

--- a/dropwizard-logging/src/test/resources/yaml/appender_file_cap2.yaml
+++ b/dropwizard-logging/src/test/resources/yaml/appender_file_cap2.yaml
@@ -1,0 +1,6 @@
+type: file
+threshold: ALL
+currentLogFilename: ./logs/example.log
+archivedLogFilenamePattern: ./logs/example-%d.log.gz
+archivedFileCount: 5
+totalSizeCap: "50mb"

--- a/dropwizard-logging/src/test/resources/yaml/appender_file_cap_invalid.yaml
+++ b/dropwizard-logging/src/test/resources/yaml/appender_file_cap_invalid.yaml
@@ -1,0 +1,6 @@
+type: file
+threshold: ALL
+currentLogFilename: ./logs/example.log
+archivedLogFilenamePattern: ./logs/example-%i.log.gz
+maxFileSize: "10mb"
+totalSizeCap: "50mb"


### PR DESCRIPTION
###### Problem:
There are several scenarios when configuring the file log appender when one might think they have capped the upper bound of their logging (but it's not the case), for example:

```yaml
archivedLogFilenamePattern: ./logs/example-%d-%i.log.gz
archivedFileCount: 5
maxFileSize: "10mb"
```

One may think this config states "keep 5 files that are a max of 10mb. On slow weeks, there will be 5 files representing 5 days, and on busy weeks there will be 5 files representing the most current date". What's confusing is that `archivedFileCount` is for how many days (in this example) of logs to keep and the `10mb` is when to trigger a rollover, which will not count for the `archivedFileCount`, resulting in an unbounded size for logs.

###### Solution:
The scenario desired warrants [`totalSizeCap`](https://logback.qos.ch/manual/appenders.html#tbrpTotalSizeCap), so the example earlier should be rewritten:

```yaml
archivedLogFilenamePattern: ./logs/example-%d-%i.log.gz
archivedFileCount: 5
maxFileSize: "10mb"
totalSizeCap: "50mb"
```

- totalSizeCap will ensure that the upper bound is not reached for a log files.
- totalSizeCap has no effect when using maxFileSize and an archivedLogFilenamePattern without %d, as archivedFileCount implicitly controls the total size cap (this is a configuration validation error) 

###### Result:
Closes #2435
