### PR TITLE
Try to fix problems with deploying snapshots to Sonatype OSS repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
         <repository>
             <id>sonatype-nexus-snapshots</id>
             <name>Sonatype Nexus Snapshots</name>
-            <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
             <releases>
                 <enabled>false</enabled>
             </releases>
@@ -238,7 +238,7 @@
         <snapshotRepository>
             <id>sonatype-nexus-snapshots</id>
             <name>Sonatype Nexus Snapshots</name>
-            <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>
             <id>sonatype-nexus-staging</id>


### PR DESCRIPTION
###### Problem:
We use HTTP and the the build fails from time to time. Sonatype
automatically redirects traffic to HTTPS, so it may cause
problems for the client, because it has to perform 2 HTTP
requests.

###### Solution:
 Let's try to use HTTPS straight away.

###### Result:
Hopefully the Travis build will be more stable
