### PR TITLE
Convert to lazy evaluation for json event creation

### DIFF
--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/AccessJsonLayout.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/AccessJsonLayout.java
@@ -43,34 +43,34 @@ public class AccessJsonLayout extends AbstractJsonLayout<IAccessEvent> {
 
     @Override
     protected Map<String, Object> toJsonMap(IAccessEvent event) {
-        return new MapBuilder(timestampFormatter, customFieldNames, additionalFields, 20)
-            .add("port", isIncluded(AccessAttribute.LOCAL_PORT), event.getLocalPort())
-            .add("contentLength", isIncluded(AccessAttribute.CONTENT_LENGTH), event.getContentLength())
+        return new MapBuilder(timestampFormatter, customFieldNames, additionalFields, includes.size())
+            .addNumber("port", isIncluded(AccessAttribute.LOCAL_PORT), event::getLocalPort)
+            .addNumber("contentLength", isIncluded(AccessAttribute.CONTENT_LENGTH), event::getContentLength)
             .addTimestamp("timestamp", isIncluded(AccessAttribute.TIMESTAMP), event.getTimeStamp())
-            .add("method", isIncluded(AccessAttribute.METHOD), event.getMethod())
-            .add("protocol", isIncluded(AccessAttribute.PROTOCOL), event.getProtocol())
-            .add("requestContent", isIncluded(AccessAttribute.REQUEST_CONTENT), event.getRequestContent())
-            .add("remoteAddress", isIncluded(AccessAttribute.REMOTE_ADDRESS), event.getRemoteAddr())
-            .add("remoteUser", isIncluded(AccessAttribute.REMOTE_USER), event.getRemoteUser())
-            .add("headers", !requestHeaders.isEmpty(),
-                filterHeaders(event.getRequestHeaderMap(), requestHeaders))
-            .add("params", isIncluded(AccessAttribute.REQUEST_PARAMETERS), event.getRequestParameterMap())
-            .add("requestTime", isIncluded(AccessAttribute.REQUEST_TIME), event.getElapsedTime())
-            .add("uri", isIncluded(AccessAttribute.REQUEST_URI), event.getRequestURI())
-            .add("url", isIncluded(AccessAttribute.REQUEST_URL), event.getRequestURL())
-            .add("remoteHost", isIncluded(AccessAttribute.REMOTE_HOST), event.getRemoteHost())
-            .add("responseContent", isIncluded(AccessAttribute.RESPONSE_CONTENT), event.getResponseContent())
-            .add("responseHeaders", !responseHeaders.isEmpty(),
-                filterHeaders(event.getResponseHeaderMap(), responseHeaders))
-            .add("serverName", isIncluded(AccessAttribute.SERVER_NAME), event.getServerName())
-            .add("status", isIncluded(AccessAttribute.STATUS_CODE), event.getStatusCode())
-            .add("userAgent", isIncluded(AccessAttribute.USER_AGENT), event.getRequestHeader(USER_AGENT))
+            .add("method", isIncluded(AccessAttribute.METHOD), event::getMethod)
+            .add("protocol", isIncluded(AccessAttribute.PROTOCOL), event::getProtocol)
+            .add("requestContent", isIncluded(AccessAttribute.REQUEST_CONTENT), event::getRequestContent)
+            .add("remoteAddress", isIncluded(AccessAttribute.REMOTE_ADDRESS), event::getRemoteAddr)
+            .add("remoteUser", isIncluded(AccessAttribute.REMOTE_USER), event::getRemoteUser)
+            .addMap("headers", !requestHeaders.isEmpty(),
+                () -> filterHeaders(event.getRequestHeaderMap(), requestHeaders))
+            .addMap("params", isIncluded(AccessAttribute.REQUEST_PARAMETERS), event::getRequestParameterMap)
+            .addNumber("requestTime", isIncluded(AccessAttribute.REQUEST_TIME), event::getElapsedTime)
+            .add("uri", isIncluded(AccessAttribute.REQUEST_URI), event::getRequestURI)
+            .add("url", isIncluded(AccessAttribute.REQUEST_URL), event::getRequestURL)
+            .add("remoteHost", isIncluded(AccessAttribute.REMOTE_HOST), event::getRemoteHost)
+            .add("responseContent", isIncluded(AccessAttribute.RESPONSE_CONTENT), event::getResponseContent)
+            .addMap("responseHeaders", !responseHeaders.isEmpty(),
+                () -> filterHeaders(event.getResponseHeaderMap(), responseHeaders))
+            .add("serverName", isIncluded(AccessAttribute.SERVER_NAME), event::getServerName)
+            .addNumber("status", isIncluded(AccessAttribute.STATUS_CODE), event::getStatusCode)
+            .add("userAgent", isIncluded(AccessAttribute.USER_AGENT), () -> event.getRequestHeader(USER_AGENT))
             .add("version", jsonProtocolVersion != null, jsonProtocolVersion)
             .build();
     }
 
-    private boolean isIncluded(AccessAttribute userAgent) {
-        return includes.contains(userAgent);
+    private boolean isIncluded(AccessAttribute attribute) {
+        return includes.contains(attribute);
     }
 
     private Map<String, String> filterHeaders(Map<String, String> headers, Set<String> filteredHeaderNames) {

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/MapBuilder.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/MapBuilder.java
@@ -1,6 +1,8 @@
 package io.dropwizard.logging.json.layout;
 
 import javax.annotation.Nullable;
+
+import java.util.function.Supplier;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,7 +37,7 @@ public class MapBuilder {
 
     /**
      * Adds the string value to the provided map under the provided field name,
-     * if it's should be included.
+     * if it should be included.
      */
     public MapBuilder add(String fieldName, boolean include, @Nullable String value) {
         if (include && value != null) {
@@ -45,11 +47,39 @@ public class MapBuilder {
     }
 
     /**
+     * Adds the string value to the provided map under the provided field name,
+     * if it should be included. The supplier is only invoked if the field is to be included.
+     */
+    public MapBuilder add(String fieldName, boolean include, Supplier<String> supplier) {
+        if (include) {
+            String value = supplier.get();
+            if (value != null) {
+                map.put(getFieldName(fieldName), value);
+            }
+        }
+        return this;
+    }
+
+    /**
      * Adds the number to the provided map under the provided field name if it's should be included.
      */
-    public MapBuilder add(String fieldName, boolean include, @Nullable Number number) {
+    public MapBuilder addNumber(String fieldName, boolean include, @Nullable Number number) {
         if (include && number != null) {
             map.put(getFieldName(fieldName), number);
+        }
+        return this;
+    }
+
+    /**
+     * Adds the number value to the provided map under the provided field name,
+     * if it should be included. The supplier is only invoked if the field is to be included.
+     */
+    public MapBuilder addNumber(String fieldName, boolean include, Supplier<Number> supplier) {
+        if (include) {
+            Number value = supplier.get();
+            if (value != null) {
+                map.put(getFieldName(fieldName), value);
+            }
         }
         return this;
     }
@@ -63,6 +93,21 @@ public class MapBuilder {
         }
         return this;
     }
+
+    /**
+    * Adds the map value to the provided map under the provided field name, if it should be
+    * included. The supplier is only invoked if the field is to be included.
+    */
+    public MapBuilder addMap(String fieldName, boolean include, Supplier<Map<String, ?>> supplier) {
+        if (include) {
+            Map<String, ?> value = supplier.get();
+            if (value != null && !value.isEmpty()) {
+                map.put(getFieldName(fieldName), value);
+            }
+        }
+        return this;
+    }
+
 
     /**
      * Adds and optionally formats the timestamp to the provided map under the provided field name,

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/MapBuilderTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/MapBuilderTest.java
@@ -34,7 +34,7 @@ public class MapBuilderTest {
 
     @Test
     public void testIncludeNumberValue() {
-        assertThat(mapBuilder.add("status", true, 200)
+        assertThat(mapBuilder.addNumber("status", true, 200)
             .build()).containsOnly(entry("status", 200));
     }
 
@@ -52,7 +52,7 @@ public class MapBuilderTest {
     @Test
     public void testDoNotIncludeNullNumberValue() {
         Double value = null;
-        assertThat(mapBuilder.add("status", true, value).build()).isEmpty();
+        assertThat(mapBuilder.addNumber("status", true, value).build()).isEmpty();
     }
 
     @Test
@@ -79,7 +79,7 @@ public class MapBuilderTest {
     @Test
     public void testReplaceNumberFieldName() {
         assertThat(new MapBuilder(timestampFormatter, Collections.singletonMap("status", "@status"), Collections.emptyMap(), size)
-            .add("status", true, 200)
+            .addNumber("status", true, 200)
             .build()).containsOnly(entry("@status", 200));
     }
 
@@ -88,5 +88,34 @@ public class MapBuilderTest {
         assertThat(new MapBuilder(timestampFormatter, Collections.emptyMap(), Collections.singletonMap("version", "1.8.3"), size)
             .add("message", true, message).build())
             .containsOnly(entry("message", message), entry("version", "1.8.3"));
+    }
+
+    @Test
+    public void testAddSupplier() {
+        assertThat(mapBuilder.add("message", true, () -> message).build())
+            .containsOnly(entry("message", message));
+    }
+    @Test
+    public void testAddNumberSupplier() {
+        assertThat(mapBuilder.addNumber("status", true, () -> 200)
+            .build()).containsOnly(entry("status", 200));
+    }
+    @Test
+    public void testAddMapSupplier() {
+        assertThat(mapBuilder.addMap("headers", true, () -> Collections.singletonMap("userAgent", "Lynx/2.8.7"))
+            .build()).containsOnly(entry("headers", Collections.singletonMap("userAgent", "Lynx/2.8.7")));
+    }
+
+    @Test
+    public void testAddSupplierNotInvoked() {
+        assertThat(mapBuilder.add("status", false, () -> {throw new RuntimeException();}).build()).isEmpty();
+    }
+    @Test
+    public void testAddNumberSupplierNotInvoked() {
+        assertThat(mapBuilder.addNumber("status", false, () -> {throw new RuntimeException();}).build()).isEmpty();
+    }
+    @Test
+    public void testAddMapSupplierNotInvoked() {
+        assertThat(mapBuilder.addMap("status", false, () -> {throw new RuntimeException();}).build()).isEmpty();
     }
 }


### PR DESCRIPTION
###### Problem:
json event creation calls into the I*Event objects to get the value before it is known if the value should be included in the log message.

###### Solution:
* Convert to lazy evaluation for json event creation
* Initialize maps to the size of the includes list.

###### Result:
json log message creation should be more performant by delaying method invocations until necessary.
