### PR TITLE
Update broken and old links in configuration.rst

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -367,8 +367,8 @@ httpCompliance           RFC7230             This sets the http compliance level
                                              * RFC2616: Allow header folding.
 ======================== ==================  ======================================================================================
 
-.. _`java.net.Socket#setSoTimeout(int)`: http://docs.oracle.com/javase/7/docs/api/java/net/Socket.html#setSoTimeout(int)
-.. _`ForwardedRequestCustomizer`: http://download.eclipse.org/jetty/stable-9/apidocs/org/eclipse/jetty/server/ForwardedRequestCustomizer.html
+.. _`java.net.Socket#setSoTimeout(int)`: https://docs.oracle.com/javase/8/docs/api/java/net/Socket.html#setSoTimeout-int-
+.. _`ForwardedRequestCustomizer`: https://www.eclipse.org/jetty/javadoc/current/org/eclipse/jetty/server/ForwardedRequestCustomizer.html
 
 .. _`Server::Starter`:  https://github.com/kazuho/p5-Server-Starter
 

--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -368,7 +368,7 @@ httpCompliance           RFC7230             This sets the http compliance level
 ======================== ==================  ======================================================================================
 
 .. _`java.net.Socket#setSoTimeout(int)`: https://docs.oracle.com/javase/8/docs/api/java/net/Socket.html#setSoTimeout-int-
-.. _`ForwardedRequestCustomizer`: https://www.eclipse.org/jetty/javadoc/current/org/eclipse/jetty/server/ForwardedRequestCustomizer.html
+.. _`ForwardedRequestCustomizer`: https://www.eclipse.org/jetty/javadoc/9.4.12.v20180830/org/eclipse/jetty/server/ForwardedRequestCustomizer.html
 
 .. _`Server::Starter`:  https://github.com/kazuho/p5-Server-Starter
 


### PR DESCRIPTION
###### Problem:
Broken and outdated links in the documentation:

 - The link to JavaDoc for ForwardedRequestCustomizer was broken (HTTP 404).
 - The link to JavaDoc for java.net.Socket was outdated (Java 7, which is no longer supported by Dropwizard).

###### Solution:
Updated a couple of broken and outdated links.
