### PR TITLE
Remove openjdk9 and openjdk10 from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ language: java
 jdk:
   - openjdk8
   - oraclejdk8
-  - openjdk9
-  - openjdk10
   - openjdk11
 before_install:
   - rm ~/.m2/settings.xml || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: java
 jdk:
   - openjdk8
-  - oraclejdk8
   - openjdk11
 before_install:
   - rm ~/.m2/settings.xml || true


### PR DESCRIPTION
Now that JDK11 is officially released, we can probably stop building on openjdk9 and 10