### PR TITLE
Add support for pathQuery json access log attribute

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -953,7 +953,8 @@ includes                 (timestamp, remoteAddress,
                                                       - ``userAgent``         *true*     Whether to include the user agent of the request as the ``userAgent`` field.
                                                       - ``requestParameters`` *false*    Whether to include the request parameters as the ``params`` field.
                                                       - ``requestContent``    *false*    Whether to include the body of the request as the ``requestContent`` field.
-                                                      - ``requestUrl``        *false*    Whether to include the request URL (method, URI, query parameters, protocol) as the ``contentLength`` field.
+                                                      - ``requestUrl``        *false*    Whether to include the request URL (method, URI, query parameters, protocol) as the ``url`` field.
+                                                      - ``pathQuery``         *false*    Whether to include the URI and query parameters of the request as the ``pathQuery`` field.
                                                       - ``remoteHost``        *false*    Whether to include the fully qualified name of the client or the last proxy that sent the request as the ``remoteHost`` field.
                                                       - ``responseContent``   *false*    Whether to include the response body as the ``responseContent`` field.
                                                       - ``serverName``        *false*    Whether to include the name of the server to which the request was sent as the ``serverName`` field.

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/AccessAttribute.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/AccessAttribute.java
@@ -14,6 +14,7 @@ public enum AccessAttribute {
     @JsonProperty("requestTime") REQUEST_TIME,
     @JsonProperty("requestUri") REQUEST_URI,
     @JsonProperty("requestUrl") REQUEST_URL,
+    @JsonProperty("pathQuery") PATH_QUERY,
     @JsonProperty("statusCode") STATUS_CODE,
     @JsonProperty("protocol") PROTOCOL,
     @JsonProperty("remoteHost") REMOTE_HOST,

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/AccessJsonLayout.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/AccessJsonLayout.java
@@ -58,6 +58,7 @@ public class AccessJsonLayout extends AbstractJsonLayout<IAccessEvent> {
             .addNumber("requestTime", isIncluded(AccessAttribute.REQUEST_TIME), event::getElapsedTime)
             .add("uri", isIncluded(AccessAttribute.REQUEST_URI), event::getRequestURI)
             .add("url", isIncluded(AccessAttribute.REQUEST_URL), event::getRequestURL)
+            .add("pathQuery", isIncluded(AccessAttribute.PATH_QUERY), () -> event.getRequestURI() + event.getQueryString())
             .add("remoteHost", isIncluded(AccessAttribute.REMOTE_HOST), event::getRemoteHost)
             .add("responseContent", isIncluded(AccessAttribute.RESPONSE_CONTENT), event::getResponseContent)
             .addMap("responseHeaders", !responseHeaders.isEmpty(),

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
@@ -107,7 +107,8 @@ public class LayoutIntegrationTests {
             AccessAttribute.REQUEST_PARAMETERS,
             AccessAttribute.REQUEST_CONTENT,
             AccessAttribute.TIMESTAMP,
-            AccessAttribute.USER_AGENT);
+            AccessAttribute.USER_AGENT,
+            AccessAttribute.PATH_QUERY);
         assertThat(factory.getResponseHeaders()).containsOnly("X-Request-Id");
         assertThat(factory.getRequestHeaders()).containsOnly("User-Agent", "X-Request-Id");
         assertThat(factory.getCustomFieldNames()).containsOnly(entry("statusCode", "status_code"),

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/AccessJsonLayoutTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/AccessJsonLayoutTest.java
@@ -26,7 +26,9 @@ public class AccessJsonLayoutTest {
     private String remoteHost = "nw-4.us.crawl.io";
     private String serverName = "sw-2.us.api.example.io";
     private String timestamp = "2018-01-01T14:35:21.000+0000";
-    private String uri = "/test/users?age=22&city=LA";
+    private String uri = "/test/users";
+    private String query = "?age=22&city=LA";
+    private String pathQuery = uri + query;
     private String url = "GET /test/users?age=22&city=LA HTTP/1.1";
     private String userAgent = "Mozilla/5.0";
     private Map<String, String> requestHeaders;
@@ -65,6 +67,7 @@ public class AccessJsonLayoutTest {
         when(event.getRequestParameterMap()).thenReturn(Collections.emptyMap());
         when(event.getElapsedTime()).thenReturn(100L);
         when(event.getRequestURI()).thenReturn(uri);
+        when(event.getQueryString()).thenReturn(query);
         when(event.getRequestURL()).thenReturn(url);
         when(event.getRemoteHost()).thenReturn(remoteHost);
         when(event.getResponseContent()).thenReturn(responseContent);
@@ -154,7 +157,8 @@ public class AccessJsonLayoutTest {
             entry("port", 8080), entry("requestContent", ""),
             entry("headers", this.requestHeaders),
             entry("remoteHost", remoteHost), entry("url", url),
-            entry("serverName", serverName));
+            entry("serverName", serverName),
+            entry("pathQuery", pathQuery));
     }
 
     @Test

--- a/dropwizard-json-logging/src/test/resources/yaml/json-access-log.yml
+++ b/dropwizard-json-logging/src/test/resources/yaml/json-access-log.yml
@@ -15,6 +15,7 @@ layout:
     - requestContent
     - userAgent
     - timestamp
+    - pathQuery
   responseHeaders:
     - X-Request-Id
   requestHeaders:


### PR DESCRIPTION
###### Problem:
Implementation from #2497 

> The standard request access logs default[1] to request URL. The JSON access logs introduced in #2232 default[3] to request URI. While it could be argued that a different output format doesn't have to remain passive to the previous layout. It did take a bit to trace down the issue as I assumed switching the format would produce logs with the same composite parts. What this change between uri/url intentional?

###### Design:

Been thinking about this quite a bit more trying to reason about the differences between uri/url. It isn't very clear from the [spec](https://tools.ietf.org/html/rfc3986#section-3) if there is a canonical name for the path+query part. The current dropwizard namings seem misleading according to spec, not sure if it was intended to align or if it carried over the logback naming conventions. [Logback](https://github.com/qos-ch/logback/blob/v_1.2.3/logback-access/src/main/java/ch/qos/logback/access/spi/AccessEvent.java#L147) appears to mostly align with [javax.servlet](https://docs.oracle.com/javaee/7/api/javax/servlet/http/HttpServletRequest.html#getRequestURI--).

```
         foo://example.com:8042/over/there?name=ferret#nose
         \_/   \______________/\_________/ \_________/ \__/
          |           |            |            |        |
       scheme     authority       path        query   fragment
          |   _____________________|__
         / \ /                        \
         urn:example:animal:ferret:nose
```

p.s. sorry for the bikeshedding...

###### Solution:
Introduce `pathQuery` attribute that includes the path/query segments as defined in RFC3986. Left all the existing attributes unchanged for passivity reasons and the possibility of backpatching depending on projected 2.0 release date.

Will defer to the maintainers if any more drastic resolutions should be considered for 2.x up to and including:
* Deprecate uri/url
* Change default of uri to pathQuery
* Rename uri to path
* Rename params to query

###### Result:
JSON access logs can include the combined path/query in a single named parameter.
