### PR TITLE
Remove redundant "the"

### DIFF
--- a/docs/source/manual/client.rst
+++ b/docs/source/manual/client.rst
@@ -242,7 +242,7 @@ Basic Auth against a proxy is simple:
             - '192.168.52.*'
             - '*.example.com'
 
-NTLM Auth is configured by setting the the relevant windows properties.
+NTLM Auth is configured by setting the relevant windows properties.
 
 .. code-block:: yaml
 

--- a/docs/source/manual/internals.rst
+++ b/docs/source/manual/internals.rst
@@ -34,7 +34,7 @@ Startup Sequence
 	  cli.run(arguments); 
 	}
 
-``Bootstrap`` is the the pre-start (temp) application environment, containing everything required to bootstrap a Dropwizard command. Here is a simplified code snippet to illustrate its structure:
+``Bootstrap`` is the pre-start (temp) application environment, containing everything required to bootstrap a Dropwizard command. Here is a simplified code snippet to illustrate its structure:
 
 .. code-block:: java
 


### PR DESCRIPTION

###### Problem:
Redundant the

###### Solution:
Remove it

###### Result:


Signed-off-by: Benny Zlotnik <uber442@gmail.com>
