### PR TITLE
Deprecate Bundle in favor of ConfiguredBundle<T>

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -511,24 +511,18 @@ Bundles
 =======
 
 A Dropwizard bundle is a reusable group of functionality, used to define blocks of an application's
-behavior. For example, ``AssetBundle`` from the ``dropwizard-assets`` module provides a simple way
+behavior by implementing the ``ConfiguredBundle`` interface.
+
+For example, ``AssetBundle`` from the ``dropwizard-assets`` module provides a simple way
 to serve static assets from your application's ``src/main/resources/assets`` directory as files
 available from ``/assets/*`` (or any other path) in your application.
 
-Configured Bundles
-------------------
-
-Some bundles require configuration parameters. These bundles implement ``ConfiguredBundle`` and will
-require your application's ``Configuration`` subclass to implement a specific interface.
-
-
-For example: given the configured bundle ``MyConfiguredBundle`` and the interface ``MyConfiguredBundleConfig`` below.
-Your application's ``Configuration`` subclass would need to implement ``MyConfiguredBundleConfig``.
+Given the bundle ``MyConfiguredBundle`` and the interface ``MyConfiguredBundleConfig`` below,
+your application's ``Configuration`` subclass would need to implement ``MyConfiguredBundleConfig``.
 
 .. code-block:: java
 
-    public class MyConfiguredBundle implements ConfiguredBundle<MyConfiguredBundleConfig>{
-
+    public class MyConfiguredBundle implements ConfiguredBundle<MyConfiguredBundleConfig> {
         @Override
         public void run(MyConfiguredBundleConfig applicationConfig, Environment environment) {
             applicationConfig.getBundleSpecificConfig();
@@ -540,10 +534,8 @@ Your application's ``Configuration`` subclass would need to implement ``MyConfig
         }
     }
 
-    public interface MyConfiguredBundleConfig{
-
+    public interface MyConfiguredBundleConfig {
         String getBundleSpecificConfig();
-
     }
 
 

--- a/dropwizard-assets/src/main/java/io/dropwizard/assets/AssetsBundle.java
+++ b/dropwizard-assets/src/main/java/io/dropwizard/assets/AssetsBundle.java
@@ -1,8 +1,8 @@
 package io.dropwizard.assets;
 
-import io.dropwizard.Bundle;
+import io.dropwizard.Configuration;
+import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.servlets.assets.AssetServlet;
-import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,7 +12,7 @@ import java.nio.charset.StandardCharsets;
 /**
  * A bundle for serving static asset files from the classpath.
  */
-public class AssetsBundle implements Bundle {
+public class AssetsBundle implements ConfiguredBundle<Configuration> {
     private static final Logger LOGGER = LoggerFactory.getLogger(AssetsBundle.class);
 
     private static final String DEFAULT_ASSETS_NAME = "assets";
@@ -104,12 +104,7 @@ public class AssetsBundle implements Bundle {
     }
 
     @Override
-    public void initialize(Bootstrap<?> bootstrap) {
-        // nothing doing
-    }
-
-    @Override
-    public void run(Environment environment) {
+    public void run(Configuration configuration, Environment environment) {
         LOGGER.info("Registering AssetBundle with name: {} for path {}", assetsName, uriPath + '*');
         environment.servlets().addServlet(assetsName, createServlet()).addMapping(uriPath + '*');
     }

--- a/dropwizard-assets/src/test/java/io/dropwizard/assets/AssetsBundleTest.java
+++ b/dropwizard-assets/src/test/java/io/dropwizard/assets/AssetsBundleTest.java
@@ -1,5 +1,6 @@
 package io.dropwizard.assets;
 
+import io.dropwizard.Configuration;
 import io.dropwizard.jetty.setup.ServletEnvironment;
 import io.dropwizard.servlets.assets.AssetServlet;
 import io.dropwizard.servlets.assets.ResourceURL;
@@ -142,7 +143,7 @@ public class AssetsBundleTest {
         final ServletRegistration.Dynamic registration = mock(ServletRegistration.Dynamic.class);
         when(servletEnvironment.addServlet(anyString(), any(AssetServlet.class))).thenReturn(registration);
 
-        bundle.run(environment);
+        bundle.run(new Configuration(), environment);
 
         final ArgumentCaptor<AssetServlet> servletCaptor = ArgumentCaptor.forClass(AssetServlet.class);
         final ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);

--- a/dropwizard-core/src/main/java/io/dropwizard/Application.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/Application.java
@@ -66,7 +66,7 @@ public abstract class Application<T extends Configuration> {
     }
 
     /**
-     * When the application runs, this is called after the {@link Bundle}s are run. Override it to add
+     * When the application runs, this is called after the {@link ConfiguredBundle}s are run. Override it to add
      * providers, resources, etc. for your application.
      *
      * @param configuration the parsed {@link Configuration} object

--- a/dropwizard-core/src/main/java/io/dropwizard/Bundle.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/Bundle.java
@@ -1,23 +1,27 @@
 package io.dropwizard;
 
-import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 
 /**
  * A reusable bundle of functionality, used to define blocks of application behavior.
+ *
+ * @deprecated Use {@link ConfiguredBundle}
  */
-public interface Bundle {
-    /**
-     * Initializes the application bootstrap.
-     *
-     * @param bootstrap the application bootstrap
-     */
-    void initialize(Bootstrap<?> bootstrap);
+@Deprecated
+public interface Bundle extends ConfiguredBundle<Configuration> {
+    @Override
+    default void run(Configuration configuration, Environment environment) throws Exception {
+        run(environment);
+    }
 
     /**
      * Initializes the application environment.
      *
      * @param environment the application environment
+     * @deprecated Use {@link ConfiguredBundle#run(Configuration, Environment)}
      */
-    void run(Environment environment);
+    @Deprecated
+    default void run(Environment environment) {
+        // Do nothing
+    }
 }

--- a/dropwizard-core/src/main/java/io/dropwizard/ConfiguredBundle.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/ConfiguredBundle.java
@@ -9,7 +9,7 @@ import io.dropwizard.setup.Environment;
  *
  * @param <T>    the required configuration interface
  */
-public interface ConfiguredBundle<T> {
+public interface ConfiguredBundle<T extends Configuration> {
     /**
      * Initializes the environment.
      *
@@ -17,12 +17,16 @@ public interface ConfiguredBundle<T> {
      * @param environment      the application's {@link Environment}
      * @throws Exception if something goes wrong
      */
-    void run(T configuration, Environment environment) throws Exception;
+    default void run(T configuration, Environment environment) throws Exception {
+        // Do nothing
+    }
 
     /**
      * Initializes the application bootstrap.
      *
      * @param bootstrap the application bootstrap
      */
-    void initialize(Bootstrap<?> bootstrap);
+    default void initialize(Bootstrap<?> bootstrap) {
+        // Do nothing
+    }
 }

--- a/dropwizard-core/src/main/java/io/dropwizard/setup/Bootstrap.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/Bootstrap.java
@@ -39,7 +39,6 @@ import static java.util.Objects.requireNonNull;
  */
 public class Bootstrap<T extends Configuration> {
     private final Application<T> application;
-    private final List<Bundle> bundles;
     private final List<ConfiguredBundle<? super T>> configuredBundles;
     private final List<Command> commands;
 
@@ -61,7 +60,6 @@ public class Bootstrap<T extends Configuration> {
     public Bootstrap(Application<T> application) {
         this.application = application;
         this.objectMapper = Jackson.newObjectMapper();
-        this.bundles = new ArrayList<>();
         this.configuredBundles = new ArrayList<>();
         this.commands = new ArrayList<>();
         this.validatorFactory = Validators.newValidatorFactory();
@@ -131,16 +129,6 @@ public class Bootstrap<T extends Configuration> {
     /**
      * Adds the given bundle to the bootstrap.
      *
-     * @param bundle a {@link Bundle}
-     */
-    public void addBundle(Bundle bundle) {
-        bundle.initialize(this);
-        bundles.add(bundle);
-    }
-
-    /**
-     * Adds the given bundle to the bootstrap.
-     *
      * @param bundle a {@link ConfiguredBundle}
      */
     public void addBundle(ConfiguredBundle<? super T> bundle) {
@@ -192,9 +180,6 @@ public class Bootstrap<T extends Configuration> {
      * @throws Exception if a bundle throws an exception
      */
     public void run(T configuration, Environment environment) throws Exception {
-        for (Bundle bundle : bundles) {
-            bundle.run(environment);
-        }
         for (ConfiguredBundle<? super T> bundle : configuredBundles) {
             bundle.run(configuration, environment);
         }

--- a/dropwizard-core/src/main/java/io/dropwizard/sslreload/SslReloadBundle.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/sslreload/SslReloadBundle.java
@@ -1,9 +1,9 @@
 package io.dropwizard.sslreload;
 
-import io.dropwizard.Bundle;
+import io.dropwizard.Configuration;
+import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.jetty.MutableServletContextHandler;
 import io.dropwizard.jetty.SslReload;
-import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
 import org.eclipse.jetty.util.component.LifeCycle;
@@ -14,19 +14,17 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
-/** Bundle that gathers all the ssl connectors and registers an admin task that will
- *  refresh ssl configuration on request */
-public class SslReloadBundle implements Bundle {
+/**
+ * Bundle that gathers all the ssl connectors and registers an admin task that will
+ *  refresh ssl configuration on request
+ *  */
+public class SslReloadBundle implements ConfiguredBundle<Configuration> {
     private static final Logger LOGGER = LoggerFactory.getLogger(SslReloadBundle.class);
 
     private final SslReloadTask reloadTask = new SslReloadTask();
 
     @Override
-    public void initialize(Bootstrap<?> bootstrap) {
-    }
-
-    @Override
-    public void run(Environment environment) {
+    public void run(Configuration configuration, Environment environment) {
         environment.getApplicationContext().addLifeCycleListener(new AbstractLifeCycle.AbstractLifeCycleListener() {
             @Override
             public void lifeCycleStarted(LifeCycle event) {

--- a/dropwizard-core/src/main/java/io/dropwizard/validation/InjectValidatorBundle.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/validation/InjectValidatorBundle.java
@@ -1,6 +1,7 @@
 package io.dropwizard.validation;
 
-import io.dropwizard.Bundle;
+import io.dropwizard.Configuration;
+import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.jersey.validation.MutableValidatorFactory;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
@@ -13,7 +14,7 @@ import javax.ws.rs.container.ResourceContext;
 /**
  * Dropwizard Bundle that enables injecting into constraint validators
  */
-public class InjectValidatorBundle implements Bundle {
+public class InjectValidatorBundle implements ConfiguredBundle<Configuration> {
 
     @Nullable
     private MutableValidatorFactory mutableValidatorFactory;
@@ -30,7 +31,7 @@ public class InjectValidatorBundle implements Bundle {
     }
 
     @Override
-    public void run(Environment environment) {
+    public void run(Configuration configuration, Environment environment) {
         GetResourceContextFeature getResourceContext = new GetResourceContextFeature(this::setValidatorFactory);
         environment.jersey().register(getResourceContext);
     }

--- a/dropwizard-core/src/test/java/io/dropwizard/BundleTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/BundleTest.java
@@ -1,0 +1,88 @@
+package io.dropwizard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BundleTest {
+    @Test
+    public void deprecatedBundleWillBeInitializedAndRun() throws Exception {
+        final DeprecatedBundle deprecatedBundle = new DeprecatedBundle();
+        assertThat(deprecatedBundle.wasInitialized()).isFalse();
+        assertThat(deprecatedBundle.wasRun()).isFalse();
+
+        final File configFile = File.createTempFile("bundle-test", ".yml");
+        try {
+            Files.write(configFile.toPath(), Collections.singleton("text: Test"));
+            final TestApplication application = new TestApplication(deprecatedBundle);
+            application.run("server", configFile.getAbsolutePath());
+        } finally {
+            configFile.delete();
+        }
+
+        assertThat(deprecatedBundle.wasInitialized()).isTrue();
+        assertThat(deprecatedBundle.wasRun()).isTrue();
+    }
+
+    private static class TestConfiguration extends Configuration {
+        @JsonProperty
+        String text = "";
+
+        public void setText(String text) {
+            this.text = text;
+        }
+
+        public String getText() {
+            return text;
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private static class TestApplication extends Application<TestConfiguration> {
+        Bundle bundle;
+
+        public TestApplication(Bundle bundle) {
+            this.bundle = bundle;
+        }
+
+        @Override
+        public void initialize(Bootstrap<TestConfiguration> bootstrap) {
+            bootstrap.addBundle(bundle);
+        }
+
+        @Override
+        public void run(TestConfiguration configuration, Environment environment) {
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private static class DeprecatedBundle implements Bundle {
+        boolean wasInitialized = false;
+        boolean wasRun = false;
+
+        @Override
+        public void initialize(Bootstrap<?> bootstrap) {
+            wasInitialized = true;
+        }
+
+        @Override
+        public void run(Environment environment) {
+            wasRun = true;
+        }
+
+        public boolean wasInitialized() {
+            return wasInitialized;
+        }
+
+        public boolean wasRun() {
+            return wasRun;
+        }
+    }
+}

--- a/dropwizard-forms/src/main/java/io/dropwizard/forms/MultiPartBundle.java
+++ b/dropwizard-forms/src/main/java/io/dropwizard/forms/MultiPartBundle.java
@@ -1,23 +1,19 @@
 package io.dropwizard.forms;
 
-import io.dropwizard.Bundle;
-import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.Configuration;
+import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.setup.Environment;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 
 /**
- * A {@link Bundle}, which enables the processing of multi-part form data by your application.
+ * A {@link ConfiguredBundle}, which enables the processing of multi-part form data by your application.
  *
  * @see org.glassfish.jersey.media.multipart.MultiPartFeature
  * @see <a href="https://jersey.java.net/documentation/latest/media.html#multipart">Jersey Multipart</a>
  */
-public class MultiPartBundle implements Bundle {
+public class MultiPartBundle implements ConfiguredBundle<Configuration> {
     @Override
-    public void initialize(Bootstrap<?> bootstrap) {
-    }
-
-    @Override
-    public void run(Environment environment) {
+    public void run(Configuration configuration, Environment environment) {
         environment.jersey().register(MultiPartFeature.class);
     }
 }

--- a/dropwizard-forms/src/test/java/io/dropwizard/forms/MultiPartBundleTest.java
+++ b/dropwizard-forms/src/test/java/io/dropwizard/forms/MultiPartBundleTest.java
@@ -1,6 +1,7 @@
 package io.dropwizard.forms;
 
 import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.Configuration;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.logging.BootstrapLogging;
 import io.dropwizard.setup.Environment;
@@ -25,7 +26,7 @@ public class MultiPartBundleTest {
                 getClass().getClassLoader()
         );
 
-        new MultiPartBundle().run(environment);
+        new MultiPartBundle().run(new Configuration(), environment);
 
         assertThat(environment.jersey().getResourceConfig().getClasses()).contains(MultiPartFeature.class);
     }

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/bundles/DBIExceptionsBundle.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/bundles/DBIExceptionsBundle.java
@@ -1,22 +1,17 @@
 package io.dropwizard.jdbi.bundles;
 
-import io.dropwizard.Bundle;
+import io.dropwizard.Configuration;
+import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.jdbi.jersey.LoggingDBIExceptionMapper;
 import io.dropwizard.jdbi.jersey.LoggingSQLExceptionMapper;
-import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 
 /**
  * A bundle for logging SQLExceptions and DBIExceptions so that their actual causes aren't overlooked.
  */
-public class DBIExceptionsBundle implements Bundle {
+public class DBIExceptionsBundle implements ConfiguredBundle<Configuration> {
     @Override
-    public void initialize(Bootstrap<?> bootstrap) {
-        // nothing doing
-    }
-
-    @Override
-    public void run(Environment environment) {
+    public void run(Configuration configuration, Environment environment) {
         environment.jersey().register(new LoggingSQLExceptionMapper());
         environment.jersey().register(new LoggingDBIExceptionMapper());
     }

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/bundles/DBIExceptionsBundleTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/bundles/DBIExceptionsBundleTest.java
@@ -1,5 +1,6 @@
 package io.dropwizard.jdbi.bundles;
 
+import io.dropwizard.Configuration;
 import io.dropwizard.jdbi.jersey.LoggingDBIExceptionMapper;
 import io.dropwizard.jdbi.jersey.LoggingSQLExceptionMapper;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
@@ -20,7 +21,7 @@ public class DBIExceptionsBundleTest {
         JerseyEnvironment jerseyEnvironment = mock(JerseyEnvironment.class);
         when(environment.jersey()).thenReturn(jerseyEnvironment);
 
-        new DBIExceptionsBundle().run(environment);
+        new DBIExceptionsBundle().run(new Configuration(), environment);
 
         verify(jerseyEnvironment, times(1)).register(isA(LoggingSQLExceptionMapper.class));
         verify(jerseyEnvironment, times(1)).register(isA(LoggingDBIExceptionMapper.class));

--- a/dropwizard-jdbi3/src/main/java/io/dropwizard/jdbi3/bundles/JdbiExceptionsBundle.java
+++ b/dropwizard-jdbi3/src/main/java/io/dropwizard/jdbi3/bundles/JdbiExceptionsBundle.java
@@ -1,23 +1,18 @@
 package io.dropwizard.jdbi3.bundles;
 
-import io.dropwizard.Bundle;
+import io.dropwizard.Configuration;
+import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.jdbi3.jersey.LoggingJdbiExceptionMapper;
 import io.dropwizard.jdbi3.jersey.LoggingSQLExceptionMapper;
-import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 
 /**
  * A bundle for logging {@link java.sql.SQLException}s and {@link org.jdbi.v3.core.JdbiException}s
  * so that their actual causes aren't overlooked.
  */
-public class JdbiExceptionsBundle implements Bundle {
+public class JdbiExceptionsBundle implements ConfiguredBundle<Configuration> {
     @Override
-    public void initialize(Bootstrap<?> bootstrap) {
-        // nothing to do
-    }
-
-    @Override
-    public void run(Environment environment) {
+    public void run(Configuration configuration, Environment environment) {
         environment.jersey().register(new LoggingSQLExceptionMapper());
         environment.jersey().register(new LoggingJdbiExceptionMapper());
     }

--- a/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/bundles/JdbiExceptionsBundleTest.java
+++ b/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/bundles/JdbiExceptionsBundleTest.java
@@ -1,5 +1,6 @@
 package io.dropwizard.jdbi3.bundles;
 
+import io.dropwizard.Configuration;
 import io.dropwizard.jdbi3.jersey.LoggingJdbiExceptionMapper;
 import io.dropwizard.jdbi3.jersey.LoggingSQLExceptionMapper;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
@@ -19,7 +20,7 @@ public class JdbiExceptionsBundleTest {
         JerseyEnvironment jerseyEnvironment = mock(JerseyEnvironment.class);
         when(environment.jersey()).thenReturn(jerseyEnvironment);
 
-        new JdbiExceptionsBundle().run(environment);
+        new JdbiExceptionsBundle().run(new Configuration(), environment);
 
         verify(jerseyEnvironment).register(isA(LoggingSQLExceptionMapper.class));
         verify(jerseyEnvironment).register(isA(LoggingJdbiExceptionMapper.class));

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/MigrationsBundle.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/MigrationsBundle.java
@@ -1,12 +1,11 @@
 package io.dropwizard.migrations;
 
-import io.dropwizard.Bundle;
 import io.dropwizard.Configuration;
+import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.db.DatabaseConfiguration;
 import io.dropwizard.setup.Bootstrap;
-import io.dropwizard.setup.Environment;
 
-public abstract class MigrationsBundle<T extends Configuration> implements Bundle, DatabaseConfiguration<T> {
+public abstract class MigrationsBundle<T extends Configuration> implements ConfiguredBundle<T>, DatabaseConfiguration<T> {
     private static final String DEFAULT_NAME = "db";
     private static final String DEFAULT_MIGRATIONS_FILE = "migrations.xml";
 
@@ -23,10 +22,5 @@ public abstract class MigrationsBundle<T extends Configuration> implements Bundl
 
     public String name() {
         return DEFAULT_NAME;
-    }
-
-    @Override
-    public final void run(Environment environment) {
-        // nothing doing
     }
 }

--- a/dropwizard-views/src/main/java/io/dropwizard/views/ViewBundle.java
+++ b/dropwizard-views/src/main/java/io/dropwizard/views/ViewBundle.java
@@ -1,9 +1,7 @@
 package io.dropwizard.views;
 
-import io.dropwizard.Bundle;
 import io.dropwizard.Configuration;
 import io.dropwizard.ConfiguredBundle;
-import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Sets;
 
@@ -13,10 +11,10 @@ import java.util.ServiceLoader;
 
 
 /**
- * A {@link Bundle}, which by default, enables the rendering of FreeMarker & Mustache views by your application.
+ * A {@link ConfiguredBundle}, which by default, enables the rendering of FreeMarker & Mustache views by your application.
  *
  * <p>Other instances of {@link ViewRenderer} can be used by initializing your {@link ViewBundle} with a
- * {@link Iterable} of the {@link ViewRenderer} instances to be used when configuring your {@link Bundle}:</p>
+ * {@link Iterable} of the {@link ViewRenderer} instances to be used when configuring your {@link ConfiguredBundle}:</p>
  *
  * <pre><code>
  * new ViewBundle(ImmutableList.of(myViewRenderer))
@@ -111,10 +109,5 @@ public class ViewBundle<T extends Configuration> implements ConfiguredBundle<T>,
             viewRenderer.configure(viewOptions == null ? Collections.emptyMap() : viewOptions);
         }
         environment.jersey().register(new ViewMessageBodyWriter(environment.metrics(), viewRenderers));
-    }
-
-    @Override
-    public void initialize(Bootstrap<?> bootstrap) {
-        // nothing doing
     }
 }


### PR DESCRIPTION
Instead of supporting two types of bundles, `Bundle` and `ConfiguredBundle<T>`, this change deprecates `Bundle` in favor of `ConfiguredBundle<T>` in a backward-compatible way.

Closes #1360
Closes #2512