### PR TITLE
Dependency updates

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -165,7 +165,7 @@
             <dependency>
                 <groupId>com.fasterxml</groupId>
                 <artifactId>classmate</artifactId>
-                <version>1.3.4</version>
+                <version>1.4.0</version>
             </dependency>
             <dependency>
                 <groupId>org.hsqldb</groupId>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.7</version>
+                <version>3.8.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -21,7 +21,7 @@
         <dropwizard.version>${project.version}</dropwizard.version>
         <guava.version>26.0-jre</guava.version>
         <jersey.version>2.27</jersey.version>
-        <jackson.version>2.9.6</jackson.version>
+        <jackson.version>2.9.7</jackson.version>
         <jetty.version>9.4.12.v20180830</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.0.3</metrics4.version>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -168,6 +168,11 @@
                 <version>1.4.0</version>
             </dependency>
             <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>1.8.21</version>
+            </dependency>
+            <dependency>
                 <groupId>org.hsqldb</groupId>
                 <artifactId>hsqldb</artifactId>
                 <version>2.4.1</version>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -149,7 +149,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-core</artifactId>
-                <version>5.3.3.Final</version>
+                <version>5.3.6.Final</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jboss.logging</groupId>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -120,7 +120,7 @@
             <dependency>
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-jdbc</artifactId>
-                <version>9.0.10</version>
+                <version>9.0.12</version>
             </dependency>
             <dependency>
                 <groupId>com.h2database</groupId>

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/YamlConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/YamlConfigurationFactoryTest.java
@@ -30,12 +30,6 @@ public class YamlConfigurationFactoryTest extends BaseConfigurationFactoryTest {
             .hasMessageContaining(String.format(
                 "%s has an error:%n" +
                 "  * Malformed YAML at line: 3, column: 22; while parsing a flow sequence\n" +
-                " in 'reader', line 2, column 7:\n" +
-                "    type: [ coder,wizard\n" +
-                "          ^\n" +
-                "expected ',' or ']', but got StreamEnd\n" +
-                " in 'reader', line 2, column 21:\n" +
-                "    wizard\n" +
-                "          ^", malformedAdvancedFile.getName()));
+                " in 'reader', line 2, column 7:\n", malformedAdvancedFile.getName()));
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/FuzzyEnumParamConverterProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/FuzzyEnumParamConverterProviderTest.java
@@ -173,9 +173,9 @@ public class FuzzyEnumParamConverterProviderTest {
         final WebApplicationException throwable = catchThrowableOfType(() -> converter.fromString("B"), WebApplicationException.class);
         assertThat(throwable.getResponse())
             .extracting(Response::getEntity)
-            .matches(e -> ((ErrorMessage) e.get(0)).getCode() == 400)
-            .matches(e -> ((ErrorMessage) e.get(0)).getMessage().contains("A_1"))
-            .matches(e -> ((ErrorMessage) e.get(0)).getMessage().contains("A_2"));
+            .matches(e -> ((ErrorMessage) e).getCode() == 400)
+            .matches(e -> ((ErrorMessage) e).getMessage().contains("A_1"))
+            .matches(e -> ((ErrorMessage) e).getMessage().contains("A_2"));
     }
 
 
@@ -198,8 +198,8 @@ public class FuzzyEnumParamConverterProviderTest {
         final WebApplicationException throwable = catchThrowableOfType(() -> converter.fromString("3"), WebApplicationException.class);
         assertThat(throwable.getResponse())
             .extracting(Response::getEntity)
-            .matches(e -> ((ErrorMessage) e.get(0)).getCode() == 400)
-            .matches(e -> ((ErrorMessage) e.get(0)).getMessage().contains("is not a valid ExplicitFromString"));
+            .matches(e -> ((ErrorMessage) e).getCode() == 400)
+            .matches(e -> ((ErrorMessage) e).getMessage().contains("is not a valid ExplicitFromString"));
     }
 
     @Test
@@ -209,8 +209,8 @@ public class FuzzyEnumParamConverterProviderTest {
         final WebApplicationException throwable = catchThrowableOfType(() -> converter.fromString("3"), WebApplicationException.class);
         assertThat(throwable.getResponse())
             .extracting(Response::getStatusInfo)
-            .matches(e -> ((Response.StatusType) e.get(0)).getStatusCode() == 418)
-            .matches(e -> ((Response.StatusType) e.get(0)).getReasonPhrase().contains("I am a teapot"));
+            .matches(e -> ((Response.StatusType) e).getStatusCode() == 418)
+            .matches(e -> ((Response.StatusType) e).getReasonPhrase().contains("I am a teapot"));
     }
 
     @Test
@@ -220,8 +220,8 @@ public class FuzzyEnumParamConverterProviderTest {
         final WebApplicationException throwable = catchThrowableOfType(() -> converter.fromString("1"), WebApplicationException.class);
         assertThat(throwable.getResponse())
             .extracting(Response::getEntity)
-            .matches(e -> ((ErrorMessage) e.get(0)).getCode() == 400)
-            .matches(e -> ((ErrorMessage) e.get(0)).getMessage().contains("Failed to convert"));
+            .matches(e -> ((ErrorMessage) e).getCode() == 400)
+            .matches(e -> ((ErrorMessage) e).getMessage().contains("Failed to convert"));
     }
 
     @Test
@@ -230,9 +230,9 @@ public class FuzzyEnumParamConverterProviderTest {
         final WebApplicationException throwable = catchThrowableOfType(() -> converter.fromString("1"), WebApplicationException.class);
         assertThat(throwable.getResponse())
             .extracting(Response::getEntity)
-            .matches(e -> ((ErrorMessage) e.get(0)).getCode() == 400)
-            .matches(e -> ((ErrorMessage) e.get(0)).getMessage().contains("A"))
-            .matches(e -> ((ErrorMessage) e.get(0)).getMessage().contains("B"));
+            .matches(e -> ((ErrorMessage) e).getCode() == 400)
+            .matches(e -> ((ErrorMessage) e).getMessage().contains("A"))
+            .matches(e -> ((ErrorMessage) e).getMessage().contains("B"));
 
         assertThat(converter.fromString("A")).isSameAs(ExplicitFromStringNonStatic.A);
     }
@@ -243,7 +243,7 @@ public class FuzzyEnumParamConverterProviderTest {
         final WebApplicationException throwable = catchThrowableOfType(() -> converter.fromString("1"), WebApplicationException.class);
         assertThat(throwable.getResponse())
             .extracting(Response::getEntity)
-            .matches(e -> ((ErrorMessage) e.get(0)).getCode() == 400)
-            .matches(e -> ((ErrorMessage) e.get(0)).getMessage().contains("Not permitted to call"));
+            .matches(e -> ((ErrorMessage) e).getCode() == 400)
+            .matches(e -> ((ErrorMessage) e).getMessage().contains("Not permitted to call"));
     }
 }

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/AppenderFactoryCustomLayoutTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/AppenderFactoryCustomLayoutTest.java
@@ -47,7 +47,7 @@ public class AppenderFactoryCustomLayoutTest {
         final ConsoleAppenderFactory<ILoggingEvent> appender = factory.build(loadResource());
         assertThat(appender.getLayout()).isNotNull().isInstanceOf(TestLayoutFactory.class);
         TestLayoutFactory layoutFactory = (TestLayoutFactory) appender.getLayout();
-        assertThat(layoutFactory).isNotNull().extracting(TestLayoutFactory::isIncludeSeparator).contains(true);
+        assertThat(layoutFactory).isNotNull().extracting(TestLayoutFactory::isIncludeSeparator).isEqualTo(true);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 
         <junit.version>4.12</junit.version>
         <junit5.version>5.2.0</junit5.version>
-        <assertj.version>3.10.0</assertj.version>
+        <assertj.version>3.11.1</assertj.version>
         <mockito.version>2.20.1</mockito.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <junit.version>4.12</junit.version>
         <junit5.version>5.2.0</junit5.version>
         <assertj.version>3.11.1</assertj.version>
-        <mockito.version>2.20.1</mockito.version>
+        <mockito.version>2.22.0</mockito.version>
     </properties>
 
     <developers>


### PR DESCRIPTION
* Add ByteBuddy 1.8.21 to dependency management
* Upgrade to ClassMate 1.4.0
  * https://github.com/FasterXML/java-classmate/blob/949000c18cc471007a730acc6e3f213ca18f3efc/VERSION.txt
* Upgrade to Hibernate ORM 5.3.6.Final
  * http://hibernate.org/orm/releases/5.3/#releases
* Upgrade to Apache Tomcat JDBC 9.0.12
  * https://tomcat.apache.org/tomcat-9.0-doc/changelog.html#Tomcat_9.0.12_(markt)
* Upgrade to Apache Commons Lang3 3.8.1
  * https://commons.apache.org/proper/commons-lang/release-notes/RELEASE-NOTES-3.8.txt
  * https://commons.apache.org/proper/commons-lang/release-notes/RELEASE-NOTES-3.8.1.txt
*Upgrade to Jackson 2.9.7
  * https://github.com/FasterXML/jackson-core/blob/jackson-core-2.9.7/release-notes/VERSION-2.x
* Upgrade to Mockito 2.22.0
  * https://github.com/mockito/mockito/blob/release/2.x/doc/release-notes/official.md#2220
* Upgrade to AssertJ 3.11.1
  * http://joel-costigliola.github.io/assertj/assertj-core-news.html#assertj-core-3.11.0
  * http://joel-costigliola.github.io/assertj/assertj-core-news.html#assertj-core-3.11.1