### PR TITLE
WIP: Update build dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,9 +66,9 @@
         <argLine>-Duser.language=en -Duser.region=US</argLine>
 
         <junit.version>4.12</junit.version>
-        <junit5.version>5.2.0</junit5.version>
+        <junit5.version>5.3.1</junit5.version>
         <assertj.version>3.11.1</assertj.version>
-        <mockito.version>2.22.0</mockito.version>
+        <mockito.version>2.23.0</mockito.version>
     </properties>
 
     <developers>
@@ -353,7 +353,7 @@
                                 <path>
                                     <groupId>com.uber.nullaway</groupId>
                                     <artifactId>nullaway</artifactId>
-                                    <version>0.5.4</version>
+                                    <version>0.6.0</version>
                                 </path>
                             </annotationProcessorPaths>
                             <compilerArgs>
@@ -367,12 +367,12 @@
                             <dependency>
                                 <groupId>org.codehaus.plexus</groupId>
                                 <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                                <version>2.8.4</version>
+                                <version>2.8.5</version>
                             </dependency>
                             <dependency>
                                 <groupId>com.google.errorprone</groupId>
                                 <artifactId>error_prone_core</artifactId>
-                                <version>2.3.1</version>
+                                <version>2.3.2</version>
                             </dependency>
                         </dependencies>
                     </plugin>
@@ -464,7 +464,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.2</version>
+                    <version>3.0.0-M1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -474,12 +474,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.0</version>
+                    <version>2.22.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.4.1</version>
+                    <version>3.0.0-M2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -536,7 +536,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.3.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.eluder.coveralls</groupId>
@@ -551,7 +551,7 @@
                 <plugin>
                     <groupId>kr.motd.maven</groupId>
                     <artifactId>sphinx-maven-plugin</artifactId>
-                    <version>2.2.2</version>
+                    <version>2.2.3</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
NullAway just merged in Errorprone 2.3.2 support the other day, so a new release may be imminent.