### PR TITLE
Upgrade dependencies

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <dropwizard.version>${project.version}</dropwizard.version>
-        <guava.version>26.0-jre</guava.version>
+        <guava.version>27.0-jre</guava.version>
         <jersey.version>2.27</jersey.version>
         <jackson.version>2.9.7</jackson.version>
         <jetty.version>9.4.12.v20180830</jetty.version>
@@ -28,7 +28,7 @@
         <slf4j.version>1.7.25</slf4j.version>
         <logback.version>1.2.3</logback.version>
         <h2.version>1.4.197</h2.version>
-        <jdbi3.version>3.4.0</jdbi3.version>
+        <jdbi3.version>3.5.1</jdbi3.version>
     </properties>
 
     <dependencyManagement>
@@ -36,7 +36,7 @@
             <dependency>
                 <groupId>org.objenesis</groupId>
                 <artifactId>objenesis</artifactId>
-                <version>2.6</version>
+                <version>3.0.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -46,7 +46,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>
-                <version>1.4</version>
+                <version>1.6</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
@@ -170,7 +170,7 @@
             <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
-                <version>1.8.21</version>
+                <version>1.9.2</version>
             </dependency>
             <dependency>
                 <groupId>org.hsqldb</groupId>
@@ -603,7 +603,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.12</version>
+                <version>${junit.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>

--- a/dropwizard-example/pom.xml
+++ b/dropwizard-example/pom.xml
@@ -171,7 +171,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -280,7 +280,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.1</version>
+                <version>0.8.2</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>

--- a/dropwizard-http2/pom.xml
+++ b/dropwizard-http2/pom.xml
@@ -97,9 +97,9 @@
          see http://www.eclipse.org/jetty/documentation/current/alpn-chapter.html for reference. -->
     <profiles>
         <profile>
-            <id>jdk10</id>
+            <id>jdk9+</id>
             <activation>
-                <jdk>[9, 11]</jdk>
+                <jdk>[9,)</jdk>
             </activation>
             <properties>
                 <argLine>-Duser.language=en -Duser.region=US</argLine>
@@ -505,6 +505,18 @@
                 <property>
                     <name>java.version</name>
                     <value>1.8.0_172</value>
+                </property>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.12.v20180117</alpn-boot.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_181</id>
+            <activation>
+                <property>
+                    <name>java.version</name>
+                    <value>1.8.0_181</value>
                 </property>
             </activation>
             <properties>

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilder.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilder.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public class ExecutorServiceBuilder {
     private static Logger log = LoggerFactory.getLogger(ExecutorServiceBuilder.class);
 
+    private static final AtomicLong COUNT = new AtomicLong(0);
     private final LifecycleEnvironment environment;
     private final String nameFormat;
     private int corePoolSize;
@@ -47,11 +48,10 @@ public class ExecutorServiceBuilder {
     }
 
     private static ThreadFactory buildThreadFactory(String nameFormat) {
-        final AtomicLong count = (nameFormat != null) ? new AtomicLong(0) : null;
         return r -> {
             final Thread thread = Executors.defaultThreadFactory().newThread(r);
             if (nameFormat != null) {
-                thread.setName(String.format(Locale.ROOT, nameFormat, count.incrementAndGet()));
+                thread.setName(String.format(Locale.ROOT, nameFormat, COUNT.incrementAndGet()));
             }
             return thread;
         };

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilder.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilder.java
@@ -42,7 +42,7 @@ public class ScheduledExecutorServiceBuilder {
         final AtomicLong count = (nameFormat != null) ? new AtomicLong(0) : null;
         return r -> {
             final Thread thread = Executors.defaultThreadFactory().newThread(r);
-            if (nameFormat != null) {
+            if (nameFormat != null && count != null) {
                 thread.setName(String.format(Locale.ROOT, nameFormat, count.incrementAndGet()));
             }
             thread.setDaemon(daemon);

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilder.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilder.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.Nullable;
 
 public class ScheduledExecutorServiceBuilder {
 
@@ -37,6 +38,7 @@ public class ScheduledExecutorServiceBuilder {
     }
 
     private static ThreadFactory buildThreadFactory(String nameFormat, boolean daemon) {
+        @Nullable
         final AtomicLong count = (nameFormat != null) ? new AtomicLong(0) : null;
         return r -> {
             final Thread thread = Executors.defaultThreadFactory().newThread(r);

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilder.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilder.java
@@ -11,10 +11,10 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicLong;
-import javax.annotation.Nullable;
 
 public class ScheduledExecutorServiceBuilder {
 
+    private static final AtomicLong COUNT = new AtomicLong(0);
     private final LifecycleEnvironment environment;
     private final String nameFormat;
     private int poolSize;
@@ -38,12 +38,10 @@ public class ScheduledExecutorServiceBuilder {
     }
 
     private static ThreadFactory buildThreadFactory(String nameFormat, boolean daemon) {
-        @Nullable
-        final AtomicLong count = (nameFormat != null) ? new AtomicLong(0) : null;
         return r -> {
             final Thread thread = Executors.defaultThreadFactory().newThread(r);
-            if (nameFormat != null && count != null) {
-                thread.setName(String.format(Locale.ROOT, nameFormat, count.incrementAndGet()));
+            if (nameFormat != null) {
+                thread.setName(String.format(Locale.ROOT, nameFormat, COUNT.incrementAndGet()));
             }
             thread.setDaemon(daemon);
             return thread;

--- a/dropwizard-testing/pom.xml
+++ b/dropwizard-testing/pom.xml
@@ -84,7 +84,7 @@
                     <dependency>
                         <groupId>org.junit.platform</groupId>
                         <artifactId>junit-platform-surefire-provider</artifactId>
-                        <version>1.2.0</version>
+                        <version>1.3.1</version>
                     </dependency>
                     <dependency>
                         <groupId>org.junit.vintage</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,9 +66,9 @@
         <argLine>-Duser.language=en -Duser.region=US</argLine>
 
         <junit.version>4.12</junit.version>
-        <junit5.version>5.2.0</junit5.version>
+        <junit5.version>5.3.1</junit5.version>
         <assertj.version>3.11.1</assertj.version>
-        <mockito.version>2.22.0</mockito.version>
+        <mockito.version>2.23.0</mockito.version>
     </properties>
 
     <developers>
@@ -353,7 +353,7 @@
                                 <path>
                                     <groupId>com.uber.nullaway</groupId>
                                     <artifactId>nullaway</artifactId>
-                                    <version>0.5.4</version>
+                                    <version>0.6.0</version>
                                 </path>
                             </annotationProcessorPaths>
                             <compilerArgs>
@@ -367,12 +367,12 @@
                             <dependency>
                                 <groupId>org.codehaus.plexus</groupId>
                                 <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                                <version>2.8.4</version>
+                                <version>2.8.5</version>
                             </dependency>
                             <dependency>
                                 <groupId>com.google.errorprone</groupId>
                                 <artifactId>error_prone_core</artifactId>
-                                <version>2.3.1</version>
+                                <version>2.3.2</version>
                             </dependency>
                         </dependencies>
                     </plugin>
@@ -551,7 +551,7 @@
                 <plugin>
                     <groupId>kr.motd.maven</groupId>
                     <artifactId>sphinx-maven-plugin</artifactId>
-                    <version>2.2.2</version>
+                    <version>2.2.3</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Replaces #2528

Note: Errorprone/Nullaway are currently not working on JDK11.  It fails to compile.