### PR TITLE
Fix EofException spamming of logs

### DIFF
--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/NonblockingServletHolder.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/NonblockingServletHolder.java
@@ -1,5 +1,6 @@
 package io.dropwizard.jetty;
 
+import org.eclipse.jetty.io.EofException;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.servlet.ServletHolder;
 
@@ -47,6 +48,11 @@ public class NonblockingServletHolder extends ServletHolder {
         }
         try {
             servlet.service(request, response);
+        } catch (EofException ignored) {
+            // Want to ignore the EofException as this signifies the client has disconnected or the
+            // response has already been written. The problem with using an ExceptionMapper is that
+            // we don't actually want to write a response given that the connection has already been
+            // closed
         } finally {
             baseRequest.setAsyncSupported(asyncSupported, null);
         }

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NonblockingServletHolderTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NonblockingServletHolderTest.java
@@ -1,5 +1,7 @@
 package io.dropwizard.jetty;
 
+import java.io.IOException;
+import org.eclipse.jetty.io.EofException;
 import org.eclipse.jetty.server.Request;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -9,6 +11,10 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -31,6 +37,23 @@ public class NonblockingServletHolderTest {
         holder.handle(baseRequest, request, response);
 
         verify(servlet).service(request, response);
+    }
+
+    @Test
+    public void servicesRequestHandleEofException() throws Exception {
+        doThrow(new EofException()).when(servlet).service(eq(request), eq(response));
+        assertThatCode(() -> {
+            holder.handle(baseRequest, request, response);
+        }).doesNotThrowAnyException();
+        verify(servlet).service(request, response);
+    }
+
+    @Test
+    public void servicesRequestException() throws Exception {
+        doThrow(new IOException()).when(servlet).service(eq(request), eq(response));
+        assertThatExceptionOfType(IOException.class).isThrownBy(() -> {
+            holder.handle(baseRequest, request, response);
+        });
     }
 
     @Test


### PR DESCRIPTION
##### Problem:

This change is made to address https://github.com/dropwizard/dropwizard/issues/2482. When a client disconnects before the response is written, or the full response has already been written, an `EofException` is thrown. An exception mapper can't be used because this error arises when the response is attempting to be written. This causes a lot of `ERROR` logs which clutters logging.

##### Solution:

The solution that has been implemented is to catch and ignore the `EofException` during the response write. The ideal solution would be to catch the `EofException` and accept configuration to log at different levels. This is a much more involved change and can be implemented if there is want for it. This implementation shouldn't preclude such an effort.

##### Result:

No more `EofException` errors in logs