### PR TITLE
Update travis settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-dist: trusty
-sudo: false
 language: java
 jdk:
   - openjdk8


### PR DESCRIPTION
`sudo: false` is now the default on Travis CI - https://changelog.travis-ci.com/linux-builds-run-on-vms-by-default-77106
