### PR TITLE
Remove entries covered by the jdbi3-bom

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -236,21 +236,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <dependency>
-                <groupId>org.jdbi</groupId>
-                <artifactId>jdbi3-core</artifactId>
-                <version>${jdbi3.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jdbi</groupId>
-                <artifactId>jdbi3-jodatime2</artifactId>
-                <version>${jdbi3.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jdbi</groupId>
-                <artifactId>jdbi3-guava</artifactId>
-                <version>${jdbi3.version}</version>
-            </dependency>
 
             <!-- Jetty -->
             <dependency>


### PR DESCRIPTION
I think these three entries can be removed since we're importing the `jdbi3-bom` above them.