### PR TITLE
Set maven.compiler.release to 8 when building on JDK9+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -385,6 +385,8 @@
                 <jdk>[9,)</jdk>
             </activation>
             <properties>
+                <!-- https://github.com/jacoco/jacoco/issues/663 -->
+                <jacoco.skip>true</jacoco.skip>
                 <maven.compiler.release>8</maven.compiler.release>
             </properties>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -380,13 +380,12 @@
             </build>
         </profile>
         <profile>
-            <id>jdk11</id>
+            <id>jdk9+</id>
             <activation>
-                <jdk>11</jdk>
+                <jdk>[9,)</jdk>
             </activation>
             <properties>
-                <!-- https://github.com/jacoco/jacoco/issues/663 -->
-                <jacoco.skip>true</jacoco.skip>
+                <maven.compiler.release>8</maven.compiler.release>
             </properties>
         </profile>
         <profile>
@@ -474,7 +473,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.0</version>
+                    <version>2.22.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Also removed skipping jacoco on JDK11 since https://github.com/jacoco/jacoco/issues/663 is now resolved.