### PR TITLE
Add @JsonProperty to AbstractServerFactory setters

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
@@ -446,6 +446,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
         return registerDefaultExceptionMappers;
     }
 
+    @JsonProperty
     public void setRegisterDefaultExceptionMappers(Boolean registerDefaultExceptionMappers) {
         this.registerDefaultExceptionMappers = registerDefaultExceptionMappers;
     }
@@ -454,6 +455,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
         return detailedJsonProcessingExceptionMapper;
     }
 
+    @JsonProperty
     public void setDetailedJsonProcessingExceptionMapper(Boolean detailedJsonProcessingExceptionMapper) {
         this.detailedJsonProcessingExceptionMapper = detailedJsonProcessingExceptionMapper;
     }


### PR DESCRIPTION
A few setters were missing @JsonProperty, which makes deserialization fail
if the ObjectMapper is configured to not look at setter names.

Closes #2545

###### Problem:
A few setters were missing `@JsonProperty` in AbstractServerFactory, which makes deserialization fail if the ObjectMapper is configured to not look at setter names (e.g. configured like `mapper.setVisibility(PropertyAccessor.ALL, Visibility.NONE)`).

###### Solution:
Add `@JsonProperty` to the 2 setters that were missing it. This also makes all setters consistent in this class.
