### PR TITLE
Fix flaky DefaultLoggingFactoryPrintErrorMessagesTest.testLogbackStatusPrinterPrintStreamIsRestoredToSystemOut

### DIFF
--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/ThrottlingAppenderWrapperTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/ThrottlingAppenderWrapperTest.java
@@ -95,6 +95,8 @@ public class ThrottlingAppenderWrapperTest {
         }
 
         this.bos.reset();
+
+        new DefaultLoggingFactory().configure(new MetricRegistry(), "test-logger");
     }
 
     @Test


### PR DESCRIPTION
###### Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->
The test DefaultLoggingFactoryPrintErrorMessagesTest.testLogbackStatusPrinterPrintStreamIsRestoredToSystemOut fails when run after ThrottlingAppenderWrapperTest.overThrottlingLimit.

Steps to reproduce:
```
git clone https://github.com/dropwizard/dropwizard
cd dropwizard
mvn install -DskipTests
cd dropwizard-logging
mvn test -Dtest="ThrottlingAppenderWrapperTest#overThrottlingLimit,DefaultLoggingFactoryPrintErrorMessagesTest#testLogbackStatusPrinterPrintStreamIsRestoredToSystemOut" -Dsurefire.runOrder=reversealphabetical
```

###### Solution:
Reconfigure in the teardown of ThrottlingAppenderWrapperTest so that the default logging factory resets the StatusPrinter's print stream to the default System.out.

###### Result:
The tests run by the command listed will pass in both orders.
