### PR TITLE
Remove most mentions of Guava from documentation

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -80,8 +80,6 @@ And Friends
 In addition to Jetty_, Jersey_, and Jackson_, Dropwizard also includes a number of libraries to help
 you ship more quickly and with fewer regrets.
 
-* Guava_, which, in addition to highly optimized immutable data structures, provides a growing
-  number of classes to speed up development in Java.
 * Logback_ and slf4j_ for performant and flexible logging.
 * `Hibernate Validator`_, the `JSR 349`_ reference implementation, provides an easy, declarative
   framework for validating user input and generating helpful and i18n-friendly error messages.
@@ -93,7 +91,6 @@ you ship more quickly and with fewer regrets.
 * Freemarker_ and Mustache_ are simple templating systems for more user-facing applications.
 * `Joda Time`_ is a very complete, sane library for handling dates and times.
 
-.. _Guava: https://github.com/google/guava
 .. _Logback: https://logback.qos.ch/
 .. _slf4j: https://www.slf4j.org/
 .. _Hibernate Validator: http://hibernate.org/validator/
@@ -460,7 +457,7 @@ the saying and the ``defaultName`` used when the user declines to tell us their 
 to the ``name`` parameter in the method. If the client sends a request to
 ``/hello-world?name=Dougie``, ``sayHello`` will be called with ``Optional.of("Dougie")``; if there
 is no ``name`` parameter in the query string, ``sayHello`` will be called with
-``Optional.absent()``. (Support for Guava's ``Optional`` is a little extra sauce that Dropwizard
+``Optional.absent()``. (Support for ``Optional`` is a little extra sauce that Dropwizard
 adds to Jersey's existing functionality.)
 
 .. note::

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -457,7 +457,7 @@ the saying and the ``defaultName`` used when the user declines to tell us their 
 to the ``name`` parameter in the method. If the client sends a request to
 ``/hello-world?name=Dougie``, ``sayHello`` will be called with ``Optional.of("Dougie")``; if there
 is no ``name`` parameter in the query string, ``sayHello`` will be called with
-``Optional.absent()``. (Support for ``Optional`` is a little extra sauce that Dropwizard
+``Optional.empty()``. (Support for ``Optional`` is a little extra sauce that Dropwizard
 adds to Jersey's existing functionality.)
 
 .. note::

--- a/docs/source/manual/auth.rst
+++ b/docs/source/manual/auth.rst
@@ -57,14 +57,14 @@ server, for example), Dropwizard provides a decorator class which provides cachi
                                metricRegistry, simpleAuthenticator,
                                config.getAuthenticationCachePolicy());
 
-Dropwizard can parse Guava's ``CacheBuilderSpec`` from the configuration policy, allowing your
+Dropwizard can parse Caffeine's ``CaffeineSpec`` from the configuration policy, allowing your
 configuration file to look like this:
 
 .. code-block:: yaml
 
     authenticationCachePolicy: maximumSize=10000, expireAfterAccess=10m
 
-This caches up to 10,000 principals with an LRU policy, evicting stale entries after 10 minutes.
+This caches up to 10,000 principals, evicting stale entries after 10 minutes.
 
 .. _man-auth-authorizer:
 

--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -15,7 +15,6 @@ It includes:
 * Jersey, a full-featured RESTful web framework.
 * Jackson, the best JSON library for the JVM.
 * Metrics, an excellent library for application metrics.
-* Guava, Google's excellent utility library.
 * Logback, the successor to Log4j, Java's most widely-used logging framework.
 * Hibernate Validator, the reference implementation of the Java Bean Validation standard.
 
@@ -1827,6 +1826,6 @@ your application resources are served from one ``Servlet``
 enable the following functionality:
 
     * Resource method requests with ``@Timed``, ``@Metered``, ``@ExceptionMetered`` are delegated to special dispatchers which decorate the metric telemetry
-    * Resources that return Guava Optional are unboxed. Present returns underlying type, and non-present 404s
+    * Resources that return Optional are unboxed. Present returns underlying type, and non-present 404s
     * Resource methods that are annotated with ``@CacheControl`` are delegated to a special dispatcher that decorates on the cache control headers
     * Enables using Jackson to parse request entities into objects and generate response entities from objects, all while performing validation


### PR DESCRIPTION
These changes should correspond to the code changes made in #2400

###### Problem:
While #2400 removed Guava from the Dropwizard code, the documentation wasn't updated.

###### Solution:
Update the documentation to reflect the changes made in #2400.