### PR TITLE
Allow reporting Metrics on stop

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -974,7 +974,7 @@ additionalFields         (empty)                      Map of fields to add in th
 Metrics
 =======
 
-The metrics configuration has two fields; frequency and reporters.
+The metrics configuration has three fields; frequency, reporters and reportOnStop.
 
 .. code-block:: yaml
 
@@ -982,6 +982,7 @@ The metrics configuration has two fields; frequency and reporters.
       frequency: 1 minute
       reporters:
         - type: <type>
+      reportOnStop: false
 
 
 ====================== ===========  ===========
@@ -989,6 +990,7 @@ Name                   Default      Description
 ====================== ===========  ===========
 frequency              1 minute     The frequency to report metrics. Overridable per-reporter.
 reporters              (none)       A list of reporters to report metrics.
+reportOnStop           false        To report metrics one last time when stopping Dropwizard.
 ====================== ===========  ===========
 
 

--- a/dropwizard-metrics/src/main/java/io/dropwizard/metrics/MetricsFactory.java
+++ b/dropwizard-metrics/src/main/java/io/dropwizard/metrics/MetricsFactory.java
@@ -36,6 +36,11 @@ import java.util.List;
  *         <td>No reporters.</td>
  *         <td>A list of {@link ReporterFactory reporters} to report metrics.</td>
  *     </tr>
+ *     <tr>
+ *         <td>reportOnStop</td>
+ *         <td>{@code false}</td>
+ *         <td>To report metrics one last time when stopping Dropwizard.</td>
+ *     </tr>
  * </table>
  */
 public class MetricsFactory {

--- a/dropwizard-metrics/src/main/java/io/dropwizard/metrics/MetricsFactory.java
+++ b/dropwizard-metrics/src/main/java/io/dropwizard/metrics/MetricsFactory.java
@@ -69,6 +69,9 @@ public class MetricsFactory {
         this.frequency = frequency;
     }
 
+    @JsonProperty
+    public boolean reportOnStop = false;
+
     /**
      * Configures the given lifecycle with the {@link com.codahale.metrics.ScheduledReporter
      * reporters} configured for the given registry.
@@ -86,7 +89,8 @@ public class MetricsFactory {
             try {
                 final ScheduledReporterManager manager =
                         new ScheduledReporterManager(reporter.build(registry),
-                                                     reporter.getFrequency().orElseGet(this::getFrequency));
+                                                     reporter.getFrequency().orElseGet(this::getFrequency),
+                                                     reportOnStop);
                 environment.manage(manager);
             } catch (Exception e) {
                 LOGGER.warn("Failed to create reporter, metrics may not be properly reported.", e);
@@ -96,6 +100,6 @@ public class MetricsFactory {
 
     @Override
     public String toString() {
-        return "MetricsFactory{frequency=" + frequency + ", reporters=" + reporters + '}';
+        return "MetricsFactory{frequency=" + frequency + ", reporters=" + reporters + ", reportOnStop=" + reportOnStop + '}';
     }
 }

--- a/dropwizard-metrics/src/main/java/io/dropwizard/metrics/ScheduledReporterManager.java
+++ b/dropwizard-metrics/src/main/java/io/dropwizard/metrics/ScheduledReporterManager.java
@@ -10,16 +10,30 @@ import io.dropwizard.util.Duration;
 public class ScheduledReporterManager implements Managed {
     private final ScheduledReporter reporter;
     private final Duration period;
+    private final boolean reportOnStop;
 
     /**
      * Manages the given {@code reporter} by reporting with the given {@code period}.
      *
      * @param reporter the reporter to manage.
-     * @param period the frequency to report metrics at.
+     * @param period   the frequency to report metrics at.
+     * @see #ScheduledReporterManager(ScheduledReporter, Duration, boolean)
      */
     public ScheduledReporterManager(ScheduledReporter reporter, Duration period) {
+        this(reporter, period, false);
+    }
+
+    /**
+     * Manages the given {@code reporter} by reporting with the given {@code period}.
+     *
+     * @param reporter     the reporter to manage.
+     * @param period       the frequency to report metrics at.
+     * @param reportOnStop whether the reporter should send one last report upon stopping
+     */
+    public ScheduledReporterManager(ScheduledReporter reporter, Duration period, boolean reportOnStop) {
         this.reporter = reporter;
         this.period = period;
+        this.reportOnStop = reportOnStop;
     }
 
     /**
@@ -39,6 +53,12 @@ public class ScheduledReporterManager implements Managed {
      */
     @Override
     public void stop() throws Exception {
-        reporter.stop();
+        try {
+            if (reportOnStop) {
+                reporter.report();
+            }
+        } finally {
+            reporter.stop();
+        }
     }
 }

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/MetricsFactoryTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/MetricsFactoryTest.java
@@ -66,4 +66,16 @@ public class MetricsFactoryTest {
         assertThat(csvReporterFactory.getIncludesAttributes()).isEqualTo(EnumSet.allOf(MetricAttribute.class));
         assertThat(csvReporterFactory.getExcludesAttributes()).isEmpty();
     }
+
+    @Test
+    public void reportOnStopFalseByDefault() {
+        assertThat(config.reportOnStop).isFalse();
+    }
+
+    @Test
+    public void reportOnStopCanBeTrue() throws Exception {
+        config = factory.build(new File(Resources.getResource("yaml/metrics-report-on-stop.yml").toURI()));
+        assertThat(config.reportOnStop).isTrue();
+    }
+
 }

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/ScheduledReporterManagerTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/ScheduledReporterManagerTest.java
@@ -1,0 +1,41 @@
+package io.dropwizard.metrics;
+
+import com.codahale.metrics.ScheduledReporter;
+import io.dropwizard.util.Duration;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.concurrent.TimeUnit;
+
+public class ScheduledReporterManagerTest {
+
+    @Test
+    public void testStopWithoutReporting() throws Exception {
+        final boolean reportOnStop = false;
+        ScheduledReporter mockReporter = Mockito.mock(ScheduledReporter.class);
+        ScheduledReporterManager manager = new ScheduledReporterManager(mockReporter, Duration.minutes(5), reportOnStop);
+
+        manager.start();
+        manager.stop();
+
+        Mockito.verify(mockReporter).start(Mockito.eq(5L), Mockito.eq(TimeUnit.MINUTES));
+        Mockito.verify(mockReporter).stop();
+        Mockito.verifyNoMoreInteractions(mockReporter);
+    }
+
+    @Test
+    public void testStopWithReporting() throws Exception {
+        final boolean reportOnStop = true;
+        ScheduledReporter mockReporter = Mockito.mock(ScheduledReporter.class);
+        ScheduledReporterManager manager = new ScheduledReporterManager(mockReporter, Duration.minutes(5), reportOnStop);
+
+        manager.start();
+        manager.stop();
+
+        Mockito.verify(mockReporter).start(Mockito.eq(5L), Mockito.eq(TimeUnit.MINUTES));
+        Mockito.verify(mockReporter).report();
+        Mockito.verify(mockReporter).stop();
+        Mockito.verifyNoMoreInteractions(mockReporter);
+    }
+
+}

--- a/dropwizard-metrics/src/test/resources/yaml/metrics-report-on-stop.yml
+++ b/dropwizard-metrics/src/test/resources/yaml/metrics-report-on-stop.yml
@@ -1,0 +1,1 @@
+reportOnStop: true


### PR DESCRIPTION
###### Problem:
We use dropwizard extensively and are fans of how relatively quick it starts and stops.

When testing locally, we start our application from its all-in-one jar file and shut it down again after the tests, configuring metrics as local .csv files. However, we never see them :disappointed:
This is because dropwizard starts, we run tests and dropwizard stops again without ever getting the `report()` called from `ScheduledReporterManager `.

###### Solution:
Add a `reportOnStop` boolean setting in `MetricsFactory` that would cause one last report() by the `ScheduledReporterManager` when stopping.

###### Result:
This should have no other impact, as the default for this boolean is `false` to remain backwards-compatible.  
This fixes #2557 
