### PR TITLE
Pin circle ci jdk version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     environment:
       JAVA_TOOL_OPTIONS: -Xms512m -Xmx2g
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: circleci/openjdk:8u171-jdk
     steps:
       - checkout
       - run: mvn test


### PR DESCRIPTION
###### Problem:
Circle CI fails 100% of the time due to surefire exiting with an error (snipped)

```
[ERROR] Process Exit Code: 1
[ERROR] 	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.fork(ForkStarter.java:671)
[ERROR] 	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.fork(ForkStarter.java:533)
[ERROR] 	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:278)
```

###### Solution:

Turns out, a lot of people have this problem:

- [link 1](https://discuss.circleci.com/t/circleci-build-failure-on-openjdk-image/26104)
- [link 2](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=911925)
- [link 3](https://stackoverflow.com/q/53010200/433785)
- [link 4](https://github.com/apache/maven-surefire/pull/197)

The temporary solution is to pin the jdk version used to one that works until maven surefire + openjdk play nicely 😅 

###### Result:
Circle CI passes 🤞 