### PR TITLE
Fix for surefire crash in OpenJDK8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     environment:
       JAVA_TOOL_OPTIONS: -Xms512m -Xmx2g
     docker:
-      - image: circleci/openjdk:8u171-jdk
+      - image: circleci/openjdk:8-jdk
     steps:
       - checkout
       - run: mvn test

--- a/pom.xml
+++ b/pom.xml
@@ -474,7 +474,11 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.0</version>
+                    <version>2.22.1</version>
+                    <configuration>
+                        <!-- This fixes the surefire crash under certain versions of OpenJDK-8 -->
+                        <argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
###### Problem:
Some versions of 8u181 have been patched with fixes from 8u191 that have introduced problems for the surefire plugin.

###### Solution:
This disables the security fix that is not working right in the debian/ubuntu 8u181b13 package and
any other build that is using the patchset. I've also updated to the latest surefire version which is the only version I have tested this fix with.

###### Result:
Circle-ci should work without having to pin a JDK version.