### PR TITLE
Tweak throttler test for CI

### DIFF
--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/ThrottlingAppenderWrapperTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/ThrottlingAppenderWrapperTest.java
@@ -151,11 +151,11 @@ public class ThrottlingAppenderWrapperTest {
             logger.info("{} {}", APP_LOG_PREFIX, i);
         }
 
-        final long elapsed = System.nanoTime() - start;
-
         // We need to sleep for at least message duration to ensure our line
         // will be written and thus invoke the countdown on the latch.
         Thread.sleep(messageRate.toMilliseconds() + 1L);
+
+        final long elapsed = System.nanoTime() - start;
 
         final LogWait lwait = new LogWait(1);
         logger.info("Log termination {}", lwait);


### PR DESCRIPTION
###### Problem:
Travis CI has been extra flaky with the `overThrottlingLimit` logging throttle appender. The test has been failing as it sees 12 lines instead (at max) 11 logged.

###### Solution:
Calculate the total elapsed time after the sleep to "clear" the rate limiter. By delaying the calculation, it encapsulates the time for the async log to write out the last line, which in turn allows the test to pass when 12 lines are logged.

###### Result:
If this test passes 10 times on travis CI, I'll mark this as good to go.
