### PR TITLE
Unpinned JDK version in CircleCI settings.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     environment:
       JAVA_TOOL_OPTIONS: -Xms512m -Xmx2g
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: circleci/openjdk:8u191-jdk
     steps:
       - checkout
       - run: mvn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     environment:
       JAVA_TOOL_OPTIONS: -Xms512m -Xmx2g
     docker:
-      - image: circleci/openjdk:8u171-jdk
+      - image: circleci/openjdk:8-jdk
     steps:
       - checkout
       - run: mvn test


### PR DESCRIPTION
It seems that Debian based distributions have moved to 8u191 and
replaced the one off 8u181b13 (current release for Ubuntu 18 is
8u191b12).

###### Problem:
Due to a strange one-off build of Java (8u181b13), a number of things broke within Maven builds (surefire, Jetty, etc...). With the release of an official OpenJDK build to Debian, CircleCI should in theory work without pinning the version to the older, 8u171.

I have tested building DropWizard under 8u191 and it builds without issue.

###### Solution:
Removed the pinned version.

###### Result:
The build should succeed.