### PR TITLE
Suppress cve in test dependency

### DIFF
--- a/suppressed-cves.xml
+++ b/suppressed-cves.xml
@@ -16,4 +16,8 @@
         <notes><![CDATA[false positive]]></notes>
         <cve>CVE-2015-8862</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[slf4j-ext module which the cve is listed for is only imported transitively for tests and can only be fixed by a beta version]]></notes>
+        <cve>CVE-2018-8088</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
###### Problem:
CI has started failing due to [CVE-2018-8088 ](https://nvd.nist.gov/vuln/detail/CVE-2018-8088#VulnChangeHistorySection)

###### Solution:
Suppress this error. The cve only covers slf4j-ext, which is a brought in by the test dependency: uk.org.lidalia:slf4j-test. Nothing to worry about.

###### Result:
CI passes 🤞 
