### PR TITLE
Fix date formatting pattern in test

### DIFF
--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
@@ -175,7 +175,7 @@ public class FileAppenderFactoryTest {
 
         final String file = rollingAppender.getFile();
         assertThat(new File(file)).hasName("test-archived-name-" +
-            LocalDateTime.now().format(DateTimeFormatter.ofPattern("YYYY-MM-dd")) + ".log");
+            LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")) + ".log");
     }
 
     @Test


### PR DESCRIPTION
"Y" is actually the year according to "week of year"-based calendars. This will be different from the calendar year on dates like 2018-12-30, which has a "y" of 2018 and a "Y" of 2019.

http://unicode.org/reports/tr35/tr35-10.html#Date_Format_Patterns