### PR TITLE
Upgrade Guava to 24.1.1

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <dropwizard.version>${project.version}</dropwizard.version>
-        <guava.version>24.0-jre</guava.version>
+        <guava.version>24.1.1-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
         <jackson.version>2.9.6</jackson.version>
         <jetty.version>9.4.11.v20180605</jetty.version>


### PR DESCRIPTION
Fixes the vulnerability CVE-2018-10237 reported in #2586

Details:

https://nvd.nist.gov/vuln/detail/CVE-2018-10237
https://groups.google.com/forum/#!topic/guava-announce/xqWALw4W1vs/discussion
