### PR TITLE
Fallback to default Jackson enum handling when DeserializationFeature…

### DIFF
--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/FuzzyEnumModule.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/FuzzyEnumModule.java
@@ -74,8 +74,10 @@ public class FuzzyEnumModule extends Module {
                                                         DeserializationConfig config,
                                                         BeanDescription desc) throws JsonMappingException {
             // If the user configured to use `toString` method to deserialize enums
-            if (config.hasDeserializationFeatures(
-                    DeserializationFeature.READ_ENUMS_USING_TO_STRING.getMask())) {
+            if (config.hasDeserializationFeatures(DeserializationFeature.READ_ENUMS_USING_TO_STRING.getMask()) ||
+                config.hasDeserializationFeatures(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL.getMask()) ||
+                // The presence of @JsonEnumDefaultValue will cause a fallback to the default, however lets short circuit here
+                config.hasDeserializationFeatures(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE.getMask())) {
                 return null;
             }
 

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/FuzzyEnumModuleTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/FuzzyEnumModuleTest.java
@@ -1,6 +1,7 @@
 package io.dropwizard.jackson;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -66,6 +67,9 @@ public class FuzzyEnumModuleTest {
 
         @JsonProperty("forgot password")
         FORGOT_PASSWORD,
+
+        @JsonEnumDefaultValue
+        DEFAULT
     }
 
     @Before
@@ -144,6 +148,20 @@ public class FuzzyEnumModuleTest {
         final ObjectMapper toStringEnumsMapper = mapper.copy()
                 .configure(DeserializationFeature.READ_ENUMS_USING_TO_STRING, true);
         assertThat(toStringEnumsMapper.readValue("\"Pound sterling\"", CurrencyCode.class)).isEqualTo(CurrencyCode.GBP);
+    }
+
+    @Test
+    public void readsUnknownEnumValuesAsNull() throws Exception {
+        final ObjectMapper toStringEnumsMapper = mapper.copy()
+            .configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
+        assertThat(toStringEnumsMapper.readValue("\"Pound sterling\"", CurrencyCode.class)).isNull();
+    }
+
+    @Test
+    public void readsUnknownEnumValuesUsingDefaultValue() throws Exception {
+        final ObjectMapper toStringEnumsMapper = mapper.copy()
+            .configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE, true);
+        assertThat(toStringEnumsMapper.readValue("\"Pound sterling\"", EnumWithPropertyAnno.class)).isEqualTo(EnumWithPropertyAnno.DEFAULT);
     }
 
     @Test


### PR DESCRIPTION
Fallback to default Jackson enum handling when DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL or DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE is enabled.

###### Problem:
Dropwizard's default ObjectMapper comes with a custom enum deserializer "FuzzyEnumModule".
This deserializer does not handle DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, which causes unknown enums to throw an exception even when DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL is enabled.

###### Solution:
Updated the FuzzyEnumModule#findEnumDeserializer() method so that it returns null (and therefore falls back to the standard Jackson enum deserializer) when DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL is enabled.

Also added DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE to the condition so that the same behaviour applies when DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE is enabled (I know this would fall back to Jackson regardless due to the presence of @JsonEnumDefaultValue on the enum, however this addition short circuits the need to check every enum value for a Jackson annotation when the feature is enabled on the ObjectMapper).

###### Result:
When DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL is enabled the deserialzation of unknown enums does not throw an exception but instead deserialzes the value as 'null'. The is expected Jackson behavior when enabling DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL.
