### PR TITLE
Add support for logging caller data in dropwizard-json-logging

### DIFF
--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/AccessJsonLayoutBaseFactory.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/AccessJsonLayoutBaseFactory.java
@@ -38,11 +38,17 @@ import java.util.TimeZone;
  */
 @JsonTypeName("access-json")
 public class AccessJsonLayoutBaseFactory extends AbstractJsonLayoutBaseFactory<IAccessEvent> {
-
-    private EnumSet<AccessAttribute> includes = EnumSet.of(AccessAttribute.REMOTE_ADDRESS,
-        AccessAttribute.REMOTE_USER, AccessAttribute.REQUEST_TIME, AccessAttribute.REQUEST_URI,
-        AccessAttribute.STATUS_CODE, AccessAttribute.METHOD, AccessAttribute.PROTOCOL, AccessAttribute.CONTENT_LENGTH,
-        AccessAttribute.USER_AGENT, AccessAttribute.TIMESTAMP);
+    private EnumSet<AccessAttribute> includes = EnumSet.of(
+            AccessAttribute.REMOTE_ADDRESS,
+            AccessAttribute.REMOTE_USER,
+            AccessAttribute.REQUEST_TIME,
+            AccessAttribute.REQUEST_URI,
+            AccessAttribute.STATUS_CODE,
+            AccessAttribute.METHOD,
+            AccessAttribute.PROTOCOL,
+            AccessAttribute.CONTENT_LENGTH,
+            AccessAttribute.USER_AGENT,
+            AccessAttribute.TIMESTAMP);
 
     private Set<String> responseHeaders = Collections.emptySet();
     private Set<String> requestHeaders = Collections.emptySet();
@@ -79,8 +85,12 @@ public class AccessJsonLayoutBaseFactory extends AbstractJsonLayoutBaseFactory<I
 
     @Override
     public LayoutBase<IAccessEvent> build(LoggerContext context, TimeZone timeZone) {
-        final AccessJsonLayout jsonLayout = new AccessJsonLayout(createDropwizardJsonFormatter(),
-            createTimestampFormatter(timeZone), includes, getCustomFieldNames(), getAdditionalFields());
+        final AccessJsonLayout jsonLayout = new AccessJsonLayout(
+                createDropwizardJsonFormatter(),
+                createTimestampFormatter(timeZone),
+                includes,
+                getCustomFieldNames(),
+                getAdditionalFields());
         jsonLayout.setContext(context);
         jsonLayout.setRequestHeaders(requestHeaders);
         jsonLayout.setResponseHeaders(responseHeaders);

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/EventAttribute.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/EventAttribute.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * Represents event logging attributes.
  */
 public enum EventAttribute {
-
     @JsonProperty("level") LEVEL,
     @JsonProperty("threadName") THREAD_NAME,
     @JsonProperty("mdc") MDC,
@@ -14,5 +13,6 @@ public enum EventAttribute {
     @JsonProperty("message") MESSAGE,
     @JsonProperty("exception") EXCEPTION,
     @JsonProperty("contextName") CONTEXT_NAME,
-    @JsonProperty("timestamp") TIMESTAMP;
+    @JsonProperty("timestamp") TIMESTAMP,
+    @JsonProperty("callerData") CALLER_DATA
 }

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/EventJsonLayoutBaseFactory.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/EventJsonLayoutBaseFactory.java
@@ -28,7 +28,7 @@ import javax.annotation.Nullable;
  * </tr>
  * <tr>
  * <td>{@code includes}</td>
- * <td>(level, threadName, mdc, loggerName, message, exception, timestamp)</td>
+ * <td>(level, threadName, mdc, loggerName, message, exception, timestamp, callerData)</td>
  * <td>Set of logging event attributes to include in the JSON map.</td>
  * </tr>
  * <tr>

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/JsonFormatter.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/JsonFormatter.java
@@ -38,20 +38,19 @@ public class JsonFormatter {
      * @return the JSON as a string
      */
     @Nullable
-    public String toJson(Map<String, Object> map) {
+    public String toJson(@Nullable Map<String, Object> map) {
         if (map == null || map.isEmpty()) {
             return null;
         }
 
-        final StringWriter writer = new StringWriter(bufferSize);
-        try {
+        try (StringWriter writer = new StringWriter(bufferSize)) {
             objectMapper.writeValue(writer, map);
+            if (doesAppendLineSeparator) {
+                writer.append(CoreConstants.LINE_SEPARATOR);
+            }
+            return writer.toString();
         } catch (IOException e) {
             throw new IllegalArgumentException("Unable to format map as a JSON", e);
         }
-        if (doesAppendLineSeparator) {
-            writer.append(CoreConstants.LINE_SEPARATOR);
-        }
-        return writer.toString();
     }
 }

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
@@ -76,7 +76,8 @@ public class LayoutIntegrationTests {
             EventAttribute.MESSAGE,
             EventAttribute.LOGGER_NAME,
             EventAttribute.EXCEPTION,
-            EventAttribute.TIMESTAMP);
+            EventAttribute.TIMESTAMP,
+            EventAttribute.CALLER_DATA);
         assertThat(factory.isFlattenMdc()).isTrue();
         assertThat(factory.getCustomFieldNames()).containsOnly(entry("timestamp", "@timestamp"));
         assertThat(factory.getAdditionalFields()).containsOnly(entry("service-name", "user-service"),

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/EventJsonLayoutTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/EventJsonLayoutTest.java
@@ -17,35 +17,40 @@ import org.mockito.Mockito;
 import java.time.ZoneId;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class EventJsonLayoutTest {
-
-    private String timestamp = "2018-01-02T15:19:21.000+0000";
-    private String logger = "com.example.user.service";
-    private String message = "User[18] has been registered";
-    private Map<String, String> mdc = Maps.of(
+    private static final String timestamp = "2018-01-02T15:19:21.000+0000";
+    private static final String logger = "com.example.user.service";
+    private static final String message = "User[18] has been registered";
+    private static final Map<String, String> mdc = Maps.of(
             "userId", "18",
             "serviceId", "19",
             "orderId", "24");
-    private ThrowableProxyConverter throwableProxyConverter = Mockito.mock(ThrowableProxyConverter.class);
-    private TimestampFormatter timestampFormatter = new TimestampFormatter("yyyy-MM-dd'T'HH:mm:ss.SSSZ",
-        ZoneId.of("UTC"));
-    private ObjectMapper objectMapper = Jackson.newObjectMapper();
-    private JsonFormatter jsonFormatter = new JsonFormatter(objectMapper, false, true);
-    private ILoggingEvent event = Mockito.mock(ILoggingEvent.class);
 
-    private Set<EventAttribute> includes = EnumSet.of(EventAttribute.LEVEL,
-        EventAttribute.THREAD_NAME, EventAttribute.MDC, EventAttribute.LOGGER_NAME, EventAttribute.MESSAGE,
-        EventAttribute.EXCEPTION, EventAttribute.TIMESTAMP);
-    private EventJsonLayout eventJsonLayout = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter,
-        includes, Collections.emptyMap(), Collections.emptyMap(), Collections.emptySet(), false);
+    private static final Set<EventAttribute> DEFAULT_EVENT_ATTRIBUTES = Collections.unmodifiableSet(EnumSet.of(
+            EventAttribute.LEVEL,
+            EventAttribute.THREAD_NAME,
+            EventAttribute.MDC,
+            EventAttribute.LOGGER_NAME,
+            EventAttribute.MESSAGE,
+            EventAttribute.EXCEPTION,
+            EventAttribute.TIMESTAMP,
+            EventAttribute.CALLER_DATA));
+
+    private final TimestampFormatter timestampFormatter = new TimestampFormatter("yyyy-MM-dd'T'HH:mm:ss.SSSZ", ZoneId.of("UTC"));
+    private final JsonFormatter jsonFormatter = new JsonFormatter(Jackson.newObjectMapper(), false, true);
+    private ThrowableProxyConverter throwableProxyConverter = Mockito.mock(ThrowableProxyConverter.class);
+    private ILoggingEvent event = Mockito.mock(ILoggingEvent.class);
+    private Map<String, Object> defaultExpectedFields;
+
+    private EventJsonLayout eventJsonLayout;
 
     @Before
     public void setUp() {
@@ -56,17 +61,31 @@ public class EventJsonLayoutTest {
         when(event.getLoggerName()).thenReturn(logger);
         when(event.getFormattedMessage()).thenReturn(message);
         when(event.getLoggerContextVO()).thenReturn(new LoggerContextVO("test", Collections.emptyMap(), 0));
+        when(event.getCallerData()).thenReturn(new StackTraceElement[]{
+                new StackTraceElement("declaringClass", "methodName", "fileName", 42)
+        });
+
+        eventJsonLayout = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter,
+                DEFAULT_EVENT_ATTRIBUTES, Collections.emptyMap(), Collections.emptyMap(), Collections.emptySet(), false);
+
+        defaultExpectedFields = new HashMap<>();
+        defaultExpectedFields.put("timestamp", timestamp);
+        defaultExpectedFields.put("logger", logger);
+        defaultExpectedFields.put("message", message);
+        defaultExpectedFields.put("thread", "main");
+        defaultExpectedFields.put("level", "INFO");
+        defaultExpectedFields.put("mdc", mdc);
+        defaultExpectedFields.put("caller_class_name", "declaringClass");
+        defaultExpectedFields.put("caller_file_name", "fileName");
+        defaultExpectedFields.put("caller_line_number", 42);
+        defaultExpectedFields.put("caller_method_name", "methodName");
     }
 
     @Test
     public void testProducesDefaultMap() {
         Map<String, Object> map = eventJsonLayout.toJsonMap(event);
-        assertThat(map).containsOnly(entry("timestamp", timestamp),
-            entry("thread", "main"),
-            entry("level", "INFO"),
-            entry("logger", logger),
-            entry("message", message),
-            entry("mdc", mdc));
+        final HashMap<String, Object> expectedFields = new HashMap<>(defaultExpectedFields);
+        assertThat(map).isEqualTo(expectedFields);
     }
 
     @Test
@@ -74,39 +93,29 @@ public class EventJsonLayoutTest {
         when(event.getThrowableProxy()).thenReturn(new ThrowableProxyVO());
         when(throwableProxyConverter.convert(event)).thenReturn("Boom!");
 
-        assertThat(eventJsonLayout.toJsonMap(event)).containsOnly(entry("timestamp", timestamp),
-            entry("thread", "main"),
-            entry("level", "INFO"),
-            entry("logger", logger),
-            entry("message", message),
-            entry("mdc", mdc),
-            entry("exception", "Boom!"));
+        final HashMap<String, Object> expectedFields = new HashMap<>(defaultExpectedFields);
+        expectedFields.put("exception", "Boom!");
+        assertThat(eventJsonLayout.toJsonMap(event)).isEqualTo(expectedFields);
     }
 
     @Test
     public void testDisableTimestamp() {
-        includes.remove(EventAttribute.TIMESTAMP);
-        eventJsonLayout.setIncludes(includes);
+        EnumSet<EventAttribute> eventAttributes = EnumSet.copyOf(DEFAULT_EVENT_ATTRIBUTES);
+        eventAttributes.remove(EventAttribute.TIMESTAMP);
+        eventJsonLayout.setIncludes(eventAttributes);
 
-        assertThat(eventJsonLayout.toJsonMap(event)).containsOnly(
-            entry("thread", "main"),
-            entry("level", "INFO"),
-            entry("logger", logger),
-            entry("message", message),
-            entry("mdc", mdc));
+        final HashMap<String, Object> expectedFields = new HashMap<>(defaultExpectedFields);
+        expectedFields.remove("timestamp");
+        assertThat(eventJsonLayout.toJsonMap(event)).isEqualTo(expectedFields);
     }
 
     @Test
     public void testLogVersion() {
         eventJsonLayout.setJsonProtocolVersion("1.2");
 
-        assertThat(eventJsonLayout.toJsonMap(event)).containsOnly(entry("timestamp", timestamp),
-            entry("thread", "main"),
-            entry("level", "INFO"),
-            entry("logger", logger),
-            entry("message", message),
-            entry("mdc", mdc),
-            entry("version", "1.2"));
+        final HashMap<String, Object> expectedFields = new HashMap<>(defaultExpectedFields);
+        expectedFields.put("version", "1.2");
+        assertThat(eventJsonLayout.toJsonMap(event)).isEqualTo(expectedFields);
     }
 
     @Test
@@ -114,16 +123,16 @@ public class EventJsonLayoutTest {
         final Map<String, String> customFieldNames = Maps.of(
                 "timestamp", "@timestamp",
                 "message", "@message");
-        Map<String, Object> map = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter, includes,
-                customFieldNames, Collections.emptyMap(),
-            Collections.emptySet(), false)
+        Map<String, Object> map = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter, DEFAULT_EVENT_ATTRIBUTES,
+                customFieldNames, Collections.emptyMap(), Collections.emptySet(), false)
             .toJsonMap(event);
-        assertThat(map).containsOnly(entry("@timestamp", timestamp),
-            entry("thread", "main"),
-            entry("level", "INFO"),
-            entry("logger", logger),
-            entry("@message", message),
-            entry("mdc", mdc));
+
+        final HashMap<String, Object> expectedFields = new HashMap<>(defaultExpectedFields);
+        expectedFields.put("@timestamp", timestamp);
+        expectedFields.put("@message", message);
+        expectedFields.remove("timestamp");
+        expectedFields.remove("message");
+        assertThat(map).isEqualTo(expectedFields);
     }
 
     @Test
@@ -131,50 +140,42 @@ public class EventJsonLayoutTest {
         final Map<String, Object> additionalFields = Maps.of(
                 "serviceName", "userService",
                 "serviceBuild", 207);
-        Map<String, Object> map = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter, includes,
+        Map<String, Object> map = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter, DEFAULT_EVENT_ATTRIBUTES,
             Collections.emptyMap(), additionalFields,
             Collections.emptySet(), false)
             .toJsonMap(event);
-        assertThat(map).containsOnly(entry("timestamp", timestamp),
-            entry("thread", "main"),
-            entry("level", "INFO"),
-            entry("logger", logger),
-            entry("message", message),
-            entry("mdc", mdc),
-            entry("serviceName", "userService"),
-            entry("serviceBuild", 207));
+
+        final HashMap<String, Object> expectedFields = new HashMap<>(defaultExpectedFields);
+        expectedFields.put("serviceName", "userService");
+        expectedFields.put("serviceBuild", 207);
+        assertThat(map).isEqualTo(expectedFields);
     }
 
     @Test
     public void testFilterMdc() {
         final Set<String> includesMdcKeys = Sets.of("userId", "orderId");
-        Map<String, Object> map = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter, includes,
-            Collections.emptyMap(), Collections.emptyMap(),
-                includesMdcKeys, false).toJsonMap(event);
+        Map<String, Object> map = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter, DEFAULT_EVENT_ATTRIBUTES,
+            Collections.emptyMap(), Collections.emptyMap(), includesMdcKeys, false)
+                .toJsonMap(event);
 
         final Map<String, String> expectedMdc = Maps.of(
                 "userId", "18",
                 "orderId", "24");
-        assertThat(map).containsOnly(entry("timestamp", timestamp),
-            entry("thread", "main"),
-            entry("level", "INFO"),
-            entry("logger", logger),
-            entry("message", message),
-            entry("mdc", expectedMdc));
+        final HashMap<String, Object> expectedFields = new HashMap<>(defaultExpectedFields);
+        expectedFields.put("mdc", expectedMdc);
+        assertThat(map).isEqualTo(expectedFields);
     }
 
     @Test
     public void testFlattensMdcMap() {
         Map<String, Object> map = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter,
-            includes, Collections.emptyMap(), Collections.emptyMap(), Collections.emptySet(), true).toJsonMap(event);
-        assertThat(map).containsOnly(entry("timestamp", timestamp),
-                                     entry("thread", "main"),
-                                     entry("level", "INFO"),
-                                     entry("logger", logger),
-                                     entry("message", message),
-                                     entry("userId", "18"),
-                                     entry("serviceId", "19"),
-                                     entry("orderId", "24"));
+                DEFAULT_EVENT_ATTRIBUTES, Collections.emptyMap(), Collections.emptyMap(), Collections.emptySet(), true)
+                .toJsonMap(event);
+
+        final HashMap<String, Object> expectedFields = new HashMap<>(defaultExpectedFields);
+        expectedFields.putAll(mdc);
+        expectedFields.remove("mdc");
+        assertThat(map).isEqualTo(expectedFields);
     }
 
     @Test

--- a/dropwizard-json-logging/src/test/resources/yaml/json-log.yml
+++ b/dropwizard-json-logging/src/test/resources/yaml/json-log.yml
@@ -1,7 +1,6 @@
 type: console
 layout:
   type: json
-  prettyPrint: true
   timestampFormat: "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
   prettyPrint: false
   appendLineSeparator: true
@@ -12,6 +11,7 @@ layout:
     - message
     - exception
     - timestamp
+    - callerData
   exception:
     rootFirst: false
     depth: 10


### PR DESCRIPTION
The "callerData" event attribute in the "includes" configuration setting allows logging caller-specific details, such as:

* class name ("caller_class_name")
* method name ("caller_method_name")
* file name ("caller_file_name")
* line number ("caller_line_number")

Closes #2539