### PR TITLE
Fixing a documentation typo in release date

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -25,7 +25,7 @@ v2.0.0: Unreleased
 
 .. _rel-1.3.8:
 
-v1.3.8: Jan 2, 2018
+v1.3.8: Jan 2, 2019
 ===================
 
 * Fix CVE-2018-10237 by upgrading Guava to 24.1.1 (`#2587 <https://github.com/dropwizard/dropwizard/pull/2587>`_)


### PR DESCRIPTION
###### Problem:
There was a typo in the release notes. The release v1.3.8 seems to be done in 2019 but the date is mentioned as Jan 2, 2018.

###### Solution:
Corrected the year from 2018 to 2019. 


