### PR TITLE
Deprecate *Param classes (removed in 2.0.0)

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -4,6 +4,13 @@
 Release Notes
 #############
 
+.. _rel-1.3.9:
+
+v1.3.9: TBD
+===========
+
+* Deprecate IntParam and LongParam (`#2625 <https://github.com/dropwizard/dropwizard/pull/2625>`_)
+
 .. _rel-1.3.8:
 
 v1.3.8: Jan 2, 2018

--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -9,7 +9,7 @@ Release Notes
 v1.3.9: TBD
 ===========
 
-* Deprecate IntParam and LongParam (`#2625 <https://github.com/dropwizard/dropwizard/pull/2625>`_)
+* Deprecate *Param classes and will be removed in 2.0.0 (`#2625 <https://github.com/dropwizard/dropwizard/pull/2625>`_)
 
 .. _rel-1.3.8:
 

--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -1224,7 +1224,7 @@ mapping various aspects of POJOs to outgoing HTTP responses. Here's a basic reso
 
         @GET
         public NotificationList fetch(@PathParam("user") LongParam userId,
-                                      @QueryParam("count") @DefaultValue("20") IntParam count) {
+                                      @QueryParam("count") @DefaultValue("20") OptionalInt count) {
             final List<Notification> notifications = store.fetch(userId.get(), count.get());
             if (notifications != null) {
                 return new NotificationList(userId, notifications);
@@ -1313,10 +1313,10 @@ For example:
 
 * A ``@PathParam("user")``-annotated ``String`` takes the raw value from the ``user`` variable in
   the matched URI template and passes it into the method as a ``String``.
-* A ``@QueryParam("count")``-annotated ``IntParam`` parameter takes the first ``count`` value from
-  the request's query string and passes it as a ``String`` to ``IntParam``'s constructor.
-  ``IntParam`` (and all other ``io.dropwizard.jersey.params.*`` classes) parses the string
-  as an ``Integer``, returning a ``400 Bad Request`` if the value is malformed.
+* A ``@QueryParam("isMore")``-annotated ``BooleanParam`` parameter takes the first ``isMore`` value from
+  the request's query string and passes it as a ``String`` to ``BooleanParam``'s constructor.
+  ``BooleanParam`` (and all other ``io.dropwizard.jersey.params.*`` classes) parses the string
+  as an ``Boolean``, returning a ``400 Bad Request`` if the value is malformed.
 * A ``@FormParam("name")``-annotated ``Set<String>`` parameter takes all the ``name`` values from a
   posted form and passes them to the method as a set of strings.
 * A ``*Param``--annotated ``NonEmptyStringParam`` will interpret empty strings as absent strings,
@@ -1522,7 +1522,7 @@ Testing, then, consists of creating an instance of your resource class and passi
             final List<Notification> notifications = mock(List.class);
             when(store.fetch(1, 20)).thenReturn(notifications);
 
-            final NotificationList list = resource.fetch(new LongParam("1"), new IntParam("20"));
+            final NotificationList list = resource.fetch(OptionalLong.of(1), OptionalInt.of(20));
 
             assertThat(list.getUserId(),
                       is(1L));

--- a/docs/source/manual/validation.rst
+++ b/docs/source/manual/validation.rst
@@ -101,7 +101,7 @@ inner value can still be constrained with the ``@UnwrapValidatedValue`` annotati
 
 .. note::
 
-    Param types such as ``IntParam`` and ``NonEmptyStringParam`` can also be constrained.
+    Param types such as ``BooleanParam`` and ``NonEmptyStringParam`` can also be constrained.
 
 There is a caveat regarding ``@UnwrapValidatedValue`` and ``*Param`` types, as there still are some
 cumbersome situations when constraints need to be applied to the container and the value.
@@ -111,16 +111,9 @@ cumbersome situations when constraints need to be applied to the container and t
     @POST
     // The @NotNull is supposed to mean that the parameter is required but the Max(3) is supposed to
     // apply to the contained integer. Currently, this code will fail saying that Max can't
-    // be applied on an IntParam
+    // be applied on an OptionalInt
     public List<Person> createNum(@QueryParam("num") @UnwrapValidatedValue(false)
-                                  @NotNull @Max(3) IntParam num) {
-        // ...
-    }
-
-    @GET
-    // Similarly, the underlying validation framework can't unwrap nested types (an integer wrapped
-    // in an IntParam wrapped in an Optional), regardless if the @UnwrapValidatedValue is used
-    public Person retrieve(@QueryParam("num") @Max(3) Optional<IntParam> num) {
+                                  @NotNull @Max(3) OptionalInt num) {
         // ...
     }
 
@@ -131,7 +124,7 @@ throw an exception, else use ``@DefaultValue`` or move the ``Optional`` into the
 
     @POST
     // Workaround to handle required int params and validations
-    public List<Person> createNum(@QueryParam("num") @Max(3) IntParam num) {
+    public List<Person> createNum(@QueryParam("num") @Max(3) OptionalInt num) {
         if (num == null) {
             throw new WebApplicationException("query param num must not be null", 400);
         }
@@ -140,14 +133,13 @@ throw an exception, else use ``@DefaultValue`` or move the ``Optional`` into the
 
     @GET
     // Workaround to handle optional int params and validations with DefaultValue
-    public Person retrieve(@QueryParam("num") @DefaultValue("0") @Max(3) IntParam num) {
+    public Person retrieve(@QueryParam("num") @DefaultValue("0") @Max(3) OptionalInt num) {
         // ...
     }
 
     @GET
     // Workaround to handle optional int params and validations with Optional
-    public Person retrieve2(@QueryParam("num") @Max(3) IntParam num) {
-        Optional.fromNullable(num);
+    public Person retrieve2(@QueryParam("num") @Max(3) OptionalInt num) {
         // ...
     }
 

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/BooleanParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/BooleanParam.java
@@ -7,7 +7,10 @@ import javax.annotation.Nullable;
  * regardless of case, the returned value is {@link Boolean#TRUE}. If the query parameter value is
  * {@code "false"}, regardless of case, the returned value is {@link Boolean#FALSE}. All other
  * values will return a {@code 400 Bad Request} response.
+ *
+ * @deprecated As of release 1.3.9, will be removed in 2.0.0.
  */
+@Deprecated
 public class BooleanParam extends AbstractParam<Boolean> {
     public BooleanParam(@Nullable String input) {
         super(input);

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/DateTimeParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/DateTimeParam.java
@@ -8,7 +8,10 @@ import javax.annotation.Nullable;
 /**
  * A parameter encapsulating date/time values. All non-parsable values will return a {@code 400 Bad
  * Request} response. All values returned are in UTC.
+ *
+ * @deprecated As of release 1.3.9, will be removed in 2.0.0.
  */
+@Deprecated
 public class DateTimeParam extends AbstractParam<DateTime> {
     public DateTimeParam(@Nullable String input) {
         super(input);

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/DurationParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/DurationParam.java
@@ -9,7 +9,10 @@ import static java.util.Objects.requireNonNull;
 /**
  * A parameter encapsulating duration values. All non-parsable values will return a {@code 400 Bad
  * Request} response. Supports all input formats the {@link Duration} class supports.
+ *
+ * @deprecated As of release 1.3.9, will be removed in 2.0.0.
  */
+@Deprecated
 public class DurationParam extends AbstractParam<Duration> {
 
     public DurationParam(@Nullable String input) {

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/InstantParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/InstantParam.java
@@ -5,7 +5,10 @@ import java.time.Instant;
 
 /**
  * A parameter encapsulating date/time values. All non-parsable values will return a {@code 400 Bad Request} response.
+ *
+ * @deprecated As of release 1.3.9, will be removed in 2.0.0.
  */
+@Deprecated
 public class InstantParam extends AbstractParam<Instant> {
     public InstantParam(@Nullable final String input) {
         super(input);

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/IntParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/IntParam.java
@@ -6,7 +6,7 @@ import javax.annotation.Nullable;
  * A parameter encapsulating integer values. All non-decimal values will return a
  * {@code 400 Bad Request} response.
  * 
- * @deprecated As of release 1.3.9, will be removed in 2.0.0. Please use {@link java.util.OptionalInt} instead.
+ * @deprecated As of release 1.3.9, will be removed in 2.0.0.
  */
 @Deprecated
 public class IntParam extends AbstractParam<Integer> {

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/IntParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/IntParam.java
@@ -5,7 +5,10 @@ import javax.annotation.Nullable;
 /**
  * A parameter encapsulating integer values. All non-decimal values will return a
  * {@code 400 Bad Request} response.
+ * 
+ * @deprecated As of release 1.3.9, will be removed in 2.0.0. Please use {@link java.util.OptionalInt} instead.
  */
+@Deprecated
 public class IntParam extends AbstractParam<Integer> {
     public IntParam(@Nullable String input) {
         super(input);

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/LocalDateParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/LocalDateParam.java
@@ -7,7 +7,10 @@ import javax.annotation.Nullable;
 /**
  * A parameter encapsulating local date values. All non-parsable values will return a {@code 400 Bad
  * Request} response.
+ *
+ * @deprecated As of release 1.3.9, will be removed in 2.0.0.
  */
+@Deprecated
 public class LocalDateParam extends AbstractParam<LocalDate> {
     public LocalDateParam(@Nullable String input) {
         super(input);

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/LongParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/LongParam.java
@@ -6,7 +6,7 @@ import javax.annotation.Nullable;
  * A parameter encapsulating long values. All non-decimal values will return a {@code 400 Bad
  * Request} response.
  * 
- * @deprecated As of release 1.3.9, will be removed in 2.0.0. Please use {@link java.util.OptionalLong} instead.
+ * @deprecated As of release 1.3.9, will be removed in 2.0.0.
  */
 @Deprecated
 public class LongParam extends AbstractParam<Long> {

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/LongParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/LongParam.java
@@ -5,7 +5,10 @@ import javax.annotation.Nullable;
 /**
  * A parameter encapsulating long values. All non-decimal values will return a {@code 400 Bad
  * Request} response.
+ * 
+ * @deprecated As of release 1.3.9, will be removed in 2.0.0. Please use {@link java.util.OptionalLong} instead.
  */
+@Deprecated
 public class LongParam extends AbstractParam<Long> {
     public LongParam(@Nullable String input) {
         super(input);

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/SizeParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/SizeParam.java
@@ -9,7 +9,10 @@ import static java.util.Objects.requireNonNull;
 /**
  * A parameter encapsulating size values. All non-parsable values will return a {@code 400 Bad
  * Request} response. Supports all input formats the {@link Size} class supports.
+ *
+ * @deprecated As of release 1.3.9, will be removed in 2.0.0.
  */
+@Deprecated
 public class SizeParam extends AbstractParam<Size> {
 
     public SizeParam(@Nullable String input) {

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/UUIDParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/UUIDParam.java
@@ -6,7 +6,10 @@ import java.util.UUID;
 /**
  * A parameter encapsulating UUID values. All non-parsable values will return a {@code 400 Bad
  * Request} response.
+ *
+ * @deprecated As of release 1.3.9, will be removed in 2.0.0.
  */
+@Deprecated
 public class UUIDParam extends AbstractParam<UUID> {
 
     public UUIDParam(@Nullable String input) {


### PR DESCRIPTION
The `*Param` classes, except for `NonEmptyStringParam` will be removed in #2613.

This PR, deprecates them in the 1.3.x releases.