### PR TITLE
NPE if /admin/tasks is requested. Now it returns a 404 (#2626)

### DIFF
--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/TaskServlet.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/TaskServlet.java
@@ -116,7 +116,8 @@ public class TaskServlet extends HttpServlet {
     @Override
     protected void doPost(HttpServletRequest req,
                           HttpServletResponse resp) throws ServletException, IOException {
-        final Task task = tasks.get(req.getPathInfo());
+        final String pathInfo = req.getPathInfo();
+        final Task task = pathInfo != null ? tasks.get(pathInfo) : null;
         if (task != null) {
             resp.setContentType(CONTENT_TYPE);
             final PrintWriter output = resp.getWriter();

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/TaskServletTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/TaskServletTest.java
@@ -8,6 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import javax.servlet.ReadListener;
+import javax.servlet.ServletException;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -234,6 +235,16 @@ public class TaskServletTest {
 
         assertThat(metricRegistry.getMeters()).containsKey(name(exceptionMeteredTask.getClass(),
             "vacuum-cleaning-exceptions"));
+    }
+
+    @Test
+    public void testReturnsA404ForTaskRoot() throws ServletException, IOException {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn(null);
+
+        servlet.service(request, response);
+
+        verify(response).sendError(404);
     }
 
     @SuppressWarnings("InputStreamSlowMultibyteRead")


### PR DESCRIPTION
###### Problem:
There's a NPE when asking for /admin/tasks. 

###### Solution:
Check the `request.getPathInfo()` return value before passing it to the map. `HttpServletRequest.getPathInfo()` will return null if there's no path information.

###### Result:
Instead of a 500 response it will return a 404
