### PR TITLE
Update dependencies to latest patch-level

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -66,7 +66,7 @@
             <dependency>
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
-                <version>2.9.9</version>
+                <version>2.10.1</version>
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>
@@ -86,7 +86,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.5.5</version>
+                <version>4.5.7</version>
                 <exclusions>
                     <exclusion>
                         <groupId>commons-logging</groupId>
@@ -97,7 +97,7 @@
             <dependency>
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-jdbc</artifactId>
-                <version>9.0.5</version>
+                <version>9.0.14</version>
             </dependency>
             <dependency>
                 <groupId>com.h2database</groupId>
@@ -126,7 +126,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-core</artifactId>
-                <version>5.2.15.Final</version>
+                <version>5.2.18.Final</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jboss.logging</groupId>
@@ -137,22 +137,22 @@
             <dependency>
                 <groupId>org.javassist</groupId>
                 <artifactId>javassist</artifactId>
-                <version>3.22.0-GA</version>
+                <version>3.24.1-GA</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml</groupId>
                 <artifactId>classmate</artifactId>
-                <version>1.3.4</version>
+                <version>1.4.0</version>
             </dependency>
             <dependency>
                 <groupId>org.hsqldb</groupId>
                 <artifactId>hsqldb</artifactId>
-                <version>2.4.0</version>
+                <version>2.4.1</version>
             </dependency>
             <dependency>
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-core</artifactId>
-                <version>3.6.1</version>
+                <version>3.6.3</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.yaml</groupId>
@@ -183,7 +183,7 @@
             <dependency>
                 <groupId>com.github.spullara.mustache.java</groupId>
                 <artifactId>compiler</artifactId>
-                <version>0.9.5</version>
+                <version>0.9.6</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.google.guava</groupId>
@@ -194,7 +194,7 @@
             <dependency>
                 <groupId>org.freemarker</groupId>
                 <artifactId>freemarker</artifactId>
-                <version>2.3.27-incubating</version>
+                <version>2.3.28</version>
             </dependency>
             <dependency>
                 <groupId>org.jdbi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <junit.version>4.12</junit.version>
         <junit5.version>5.2.0</junit5.version>
         <assertj.version>3.9.1</assertj.version>
-        <mockito.version>2.15.0</mockito.version>
+        <mockito.version>2.24.0</mockito.version>
     </properties>
 
     <developers>


### PR DESCRIPTION
* Joda-Time 2.10.1
* Apache HttpClient 4.5.7
* Apache Tomcat JDBC Pool: 9.0.14
* Hibernate ORM 5.2.18.Final
* Liquibase 3.6.3
* Freemarker 2.3.28
* Mustache 0.9.6
* Javassist 3.24.1-GA
* Classmate 1.4.0
* HSQLDB 2.4.1
* Mockito 2.24.0