### PR TITLE
Remove unnecessary pom mods for grizzly container

### DIFF
--- a/docs/source/manual/testing.rst
+++ b/docs/source/manual/testing.rst
@@ -240,18 +240,7 @@ dependency for the Jersey Test Framework providers to your Maven POM and set ``G
     <dependency>
         <groupId>org.glassfish.jersey.test-framework.providers</groupId>
         <artifactId>jersey-test-framework-provider-grizzly2</artifactId>
-        <version>${jersey.version}</version>
         <scope>test</scope>
-        <exclusions>
-            <exclusion>
-                <groupId>javax.servlet</groupId>
-                <artifactId>javax.servlet-api</artifactId>
-            </exclusion>
-            <exclusion>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-            </exclusion>
-        </exclusions>
     </dependency>
 
 


### PR DESCRIPTION
###### Problem:
In the testing docs in the "Test Containers" section regarding adding the grizzly test container; unnecessary reference to 

```xml
<version>${jersey.version}</version>
```

will cause users to provide their own (potentially incompatible) property (like jersey 2.28 in dropwizard 1.x). The dropwizard bom renders any need to specify the property unnecessary. 


Additionally, the dependency exclusions are unnecessary as well, as there is no difference in `mvn dependency:tree` before and after the exclusions (eg: notice that "javax.servlet-api" doesn't appear):

```
\- org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:jar:2.25.1:test
   +- org.glassfish.jersey.test-framework:jersey-test-framework-core:jar:2.25.1:test
   |  \- org.glassfish.jersey.containers:jersey-container-servlet-core:jar:2.25.1:compile
   +- org.glassfish.jersey.containers:jersey-container-grizzly2-http:jar:2.25.1:test
   |  +- org.glassfish.hk2.external:javax.inject:jar:2.5.0-b32:compile
   |  +- org.glassfish.grizzly:grizzly-http-server:jar:2.3.28:test
   |  |  \- org.glassfish.grizzly:grizzly-http:jar:2.3.28:test
   |  |     \- org.glassfish.grizzly:grizzly-framework:jar:2.3.28:test
   |  +- org.glassfish.jersey.core:jersey-common:jar:2.25.1:compile
   |  |  +- org.glassfish.jersey.bundles.repackaged:jersey-guava:jar:2.25.1:compile
   |  |  \- org.glassfish.hk2:osgi-resource-locator:jar:1.0.1:compile
   |  \- javax.ws.rs:javax.ws.rs-api:jar:2.0.1:compile
   \- org.glassfish.jersey.containers:jersey-container-grizzly2-servlet:jar:2.25.1:test
      \- org.glassfish.grizzly:grizzly-http-servlet:jar:2.3.28:test
```

###### Solution:
Update the docs to remove unnecessary pom modifications

