### PR TITLE
Add support for instrumented executors

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -501,8 +501,26 @@ application will not start and a full exception will be logged. If ``RiakClientM
 an exception, the exception will be logged but your application will still be able to shut down.
 
 It should be noted that ``Environment`` has built-in factory methods for ``ExecutorService`` and
-``ScheduledExecutorService`` instances which are managed. See ``LifecycleEnvironment#executorService``
-and ``LifecycleEnvironment#scheduledExecutorService`` for details.
+``ScheduledExecutorService`` instances which are managed.
+
+.. code-block:: java
+
+    public class MyApplication extends Application<MyConfiguration> {
+        @Override
+        public void run(MyApplicationConfiguration configuration, Environment environment) {
+
+            ExecutorService executorService = environment.lifecycle()
+                .executorService(nameFormat)
+                .maxThreads(maxThreads)
+                .metricRegistry(environment.metrics()) // Returns InstrumentedExecutorService if metricRegistry is passed
+                .build();
+
+            ScheduledExecutorService scheduledExecutorService = environment.lifecycle()
+                .scheduledExecutorService(nameFormat)
+                .metricRegistry(environment.metrics()) // Returns InstrumentedScheduledExecutorService if metricRegistry is passed
+                .build();
+        }
+    }
 
 .. _man-core-bundles:
 

--- a/dropwizard-lifecycle/pom.xml
+++ b/dropwizard-lifecycle/pom.xml
@@ -41,6 +41,10 @@
             <artifactId>dropwizard-util</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-logging</artifactId>
             <scope>test</scope>

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
@@ -1,5 +1,7 @@
 package io.dropwizard.lifecycle.setup;
 
+import com.codahale.metrics.InstrumentedExecutorService;
+import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.util.Duration;
 import org.junit.Before;
 import org.junit.Test;
@@ -140,5 +142,22 @@ public class ExecutorServiceBuilderTest {
         } catch (InterruptedException ex) {
             throw new RuntimeException(ex);
         }
+    }
+
+    @Test
+    public void shouldReturnInstrumentedExecutorWhenMetricRegistryIsProvided() {
+        ExecutorService exe = executorServiceBuilder
+                .metricRegistry(new MetricRegistry())
+                .build();
+
+        assertThat(exe).isInstanceOf(InstrumentedExecutorService.class);
+    }
+
+    @Test
+    public void shouldNotReturnInstrumentedExecutorWhenMetricRegistryIsProvided() {
+        ExecutorService exe = executorServiceBuilder
+                .build();
+
+        assertThat(exe).isNotInstanceOf(InstrumentedExecutorService.class);
     }
 }

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilderTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilderTest.java
@@ -1,5 +1,7 @@
 package io.dropwizard.lifecycle.setup;
 
+import com.codahale.metrics.InstrumentedScheduledExecutorService;
+import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.lifecycle.ExecutorServiceManager;
 import io.dropwizard.util.Duration;
 import org.junit.After;
@@ -140,5 +142,31 @@ public class ScheduledExecutorServiceBuilderTest {
         assertThat(esmCaptured.getExecutor()).isSameAs(this.execTracker);
         assertThat(esmCaptured.getShutdownPeriod()).isEqualTo(DEFAULT_SHUTDOWN_PERIOD);
         assertThat(esmCaptured.getPoolName()).isSameAs(poolName);
+    }
+
+    @Test
+    public void shouldReturnInstrumentedScheduledExecutorWhenMetricRegistryIsProvided() {
+        final String poolName = this.getClass().getSimpleName();
+
+        final ScheduledExecutorServiceBuilder test = new ScheduledExecutorServiceBuilder(this.le,
+                poolName,
+                false);
+
+        this.execTracker = test.metricRegistry(new MetricRegistry()).build();
+
+        assertThat(execTracker).isInstanceOf(InstrumentedScheduledExecutorService.class);
+    }
+
+    @Test
+    public void shouldNotReturnInstrumentedScheduledExecutorWhenMetricRegistryIsProvided() {
+        final String poolName = this.getClass().getSimpleName();
+
+        final ScheduledExecutorServiceBuilder test = new ScheduledExecutorServiceBuilder(this.le,
+                poolName,
+                false);
+
+        this.execTracker = test.build();
+
+        assertThat(execTracker).isNotInstanceOf(InstrumentedScheduledExecutorService.class);
     }
 }


### PR DESCRIPTION
###### Problem:
I'm attempting to improve visibility of [InstrumentedExecutorService](https://github.com/dropwizard/metrics/blob/4.1-development/metrics-core/src/main/java/com/codahale/metrics/InstrumentedExecutorService.java) / [InstrumentedScheduledExecutorService](https://github.com/dropwizard/metrics/blob/4.1-development/metrics-core/src/main/java/com/codahale/metrics/InstrumentedScheduledExecutorService.java) which is available in dropwizard metrics. I've worked with the dropwizard/metrics framework for close to four years now, and I wasn't aware that they existed. Hoping this helps others.

###### Solution:
I'm suggesting adding a method to the builders to provide the metricRegistry. If the metricRegistry is provided, it will return the instrumented executor service. 
```java
ExecutorService executorService = environment.lifecycle()
    .executorService(nameFormat)
    .maxThreads(maxThreads)
    .metricRegistry(environment.metrics()) // Returns InstrumentedExecutorService if metricRegistry is passed
    .build();

ScheduledExecutorService scheduledExecutorService = environment.lifecycle()
    .scheduledExecutorService(nameFormat)
    .metricRegistry(environment.metrics()) // Returns InstrumentedScheduledExecutorService if metricRegistry is passed
    .build();
```
I've added some documentation as well.