### PR TITLE
Test support cleanup on before exceptions

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
@@ -147,7 +147,16 @@ public class DropwizardTestSupport<C extends Configuration> {
 
     public void before() {
         applyConfigOverrides();
-        startIfRequired();
+        try {
+            startIfRequired();
+        } catch (Exception e) {
+
+            // If there's an exception when setting up the server / application,
+            // manually call after as junit does not call the after method if
+            // the `before` method throws.
+            after();
+            throw e;
+        }
     }
 
     public void after() {


### PR DESCRIPTION
###### Problem:

As documented in https://github.com/dropwizard/dropwizard/issues/2523, if a `DropwizardTestSupport::before` throws an exception this cancels `DropwizardTestSupport::after` (under `DropwizardAppRule` / `DropwizardClientRule`) [as documented](https://junit.org/junit4/javadoc/4.12/org/junit/rules/ExternalResource.html). This can cause config overrides (and potentially other aspects like logging) to leak into other tests -- causing headache during debugs.

###### Solution:
If `DropwizardTestSupport::before` throws, it will cleanup after itself before propagating the exception.

###### Result:
No more leakage. Closes #2523