### PR TITLE
Satisfy optional check before unwrap analyses

### DIFF
--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthFilter.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthFilter.java
@@ -140,18 +140,19 @@ public abstract class AuthFilter<C, P extends Principal> implements ContainerReq
                 return false;
             }
 
+            final P prince = principal.get();
             final SecurityContext securityContext = requestContext.getSecurityContext();
             final boolean secure = securityContext != null && securityContext.isSecure();
 
             requestContext.setSecurityContext(new SecurityContext() {
                 @Override
                 public Principal getUserPrincipal() {
-                    return principal.get();
+                    return prince;
                 }
 
                 @Override
                 public boolean isUserInRole(String role) {
-                    return authorizer.authorize(principal.get(), role);
+                    return authorizer.authorize(prince, role);
                 }
 
                 @Override

--- a/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
+++ b/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
@@ -891,10 +891,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
         poolConfig.setMaxIdle(maxSize);
         poolConfig.setMinIdle(minSize);
 
-        if (getMaxConnectionAge().isPresent()) {
-            poolConfig.setMaxAge(getMaxConnectionAge().get().toMilliseconds());
-        }
-
+        getMaxConnectionAge().map(Duration::toMilliseconds).ifPresent(poolConfig::setMaxAge);
         poolConfig.setMaxWait((int) maxWaitForConnection.toMilliseconds());
         poolConfig.setMinEvictableIdleTimeMillis((int) minIdleTime.toMilliseconds());
         poolConfig.setName(name);
@@ -912,9 +909,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
         poolConfig.setTimeBetweenEvictionRunsMillis((int) evictionInterval.toMilliseconds());
         poolConfig.setValidationInterval(validationInterval.toMilliseconds());
 
-        if (getValidationQueryTimeout().isPresent()) {
-            poolConfig.setValidationQueryTimeout((int) getValidationQueryTimeout().get().toSeconds());
-        }
+        getValidationQueryTimeout().map(x -> (int)x.toSeconds()).ifPresent(poolConfig::setValidationQueryTimeout);
         validatorClassName.ifPresent(poolConfig::setValidatorClassName);
         jdbcInterceptors.ifPresent(poolConfig::setJdbcInterceptors);
         return new ManagedPooledDataSource(poolConfig, metricRegistry);

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/GuavaOptionalLocalDateArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/GuavaOptionalLocalDateArgumentFactory.java
@@ -25,6 +25,6 @@ public class GuavaOptionalLocalDateArgumentFactory implements ArgumentFactory<Op
     @Override
     public Argument build(Class<?> expectedType, Optional<LocalDate> value, StatementContext ctx) {
         // accepts guarantees that the value is present
-        return new LocalDateArgument(value.get());
+        return new LocalDateArgument(value.orNull());
     }
 }

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/GuavaOptionalLocalDateTimeArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/GuavaOptionalLocalDateTimeArgumentFactory.java
@@ -25,6 +25,6 @@ public class GuavaOptionalLocalDateTimeArgumentFactory implements ArgumentFactor
     @Override
     public Argument build(Class<?> expectedType, Optional<LocalDateTime> value, StatementContext ctx) {
         // accepts guarantees that the value is present
-        return new LocalDateTimeArgument(value.get());
+        return new LocalDateTimeArgument(value.orNull());
     }
 }

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/GuavaOptionalOffsetTimeArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/GuavaOptionalOffsetTimeArgumentFactory.java
@@ -39,6 +39,6 @@ public class GuavaOptionalOffsetTimeArgumentFactory implements ArgumentFactory<O
     @Override
     public Argument build(Class<?> expectedType, Optional<OffsetDateTime> value, StatementContext ctx) {
         // accepts guarantees that the value is present
-        return new OffsetDateTimeArgument(value.get(), calendar);
+        return new OffsetDateTimeArgument(value.orNull(), calendar);
     }
 }

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/GuavaOptionalZonedTimeArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/GuavaOptionalZonedTimeArgumentFactory.java
@@ -39,6 +39,6 @@ public class GuavaOptionalZonedTimeArgumentFactory implements ArgumentFactory<Op
     @Override
     public Argument build(Class<?> expectedType, Optional<ZonedDateTime> value, StatementContext ctx) {
         // accepts guarantees that the value is present
-        return new ZonedDateTimeArgument(value.get(), calendar);
+        return new ZonedDateTimeArgument(value.orNull(), calendar);
     }
 }

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/InstantMapper.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/InstantMapper.java
@@ -37,8 +37,9 @@ public class InstantMapper implements ResultColumnMapper<Instant> {
     @Override
     @Nullable
     public Instant mapColumn(ResultSet r, int columnNumber, StatementContext ctx) throws SQLException {
-        final Timestamp timestamp = calendar.isPresent() ?
-                r.getTimestamp(columnNumber, cloneCalendar()) :
+        final Optional<Calendar> instance = cloneCalendar();
+        final Timestamp timestamp = instance.isPresent() ?
+                r.getTimestamp(columnNumber, instance.get()) :
                 r.getTimestamp(columnNumber);
         return timestamp == null ? null : timestamp.toInstant();
     }
@@ -46,13 +47,14 @@ public class InstantMapper implements ResultColumnMapper<Instant> {
     @Override
     @Nullable
     public Instant mapColumn(ResultSet r, String columnLabel, StatementContext ctx) throws SQLException {
-        final Timestamp timestamp = calendar.isPresent() ?
-                r.getTimestamp(columnLabel, cloneCalendar()) :
+        final Optional<Calendar> instance = cloneCalendar();
+        final Timestamp timestamp = instance.isPresent() ?
+                r.getTimestamp(columnLabel, instance.get()) :
                 r.getTimestamp(columnLabel);
         return timestamp == null ? null : timestamp.toInstant();
     }
 
-    private Calendar cloneCalendar() {
-        return (Calendar) calendar.get().clone();
+    private Optional<Calendar> cloneCalendar() {
+        return calendar.map(Calendar::clone).map(x -> (Calendar) x);
     }
 }

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/JodaDateTimeMapper.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/JodaDateTimeMapper.java
@@ -46,14 +46,15 @@ public class JodaDateTimeMapper implements ResultColumnMapper<DateTime> {
      *
      * @return a clone of calendar, representing a database time zone
      */
-    private Calendar cloneCalendar() {
-        return (Calendar) calendar.get().clone();
+    private Optional<Calendar> cloneCalendar() {
+        return calendar.map(Calendar::clone).map(x -> (Calendar) x);
     }
 
     @Override
     @Nullable
     public DateTime mapColumn(ResultSet r, int columnNumber, StatementContext ctx) throws SQLException {
-        final Timestamp timestamp = calendar.isPresent() ? r.getTimestamp(columnNumber, cloneCalendar()) :
+        final Optional<Calendar> instance = cloneCalendar();
+        final Timestamp timestamp = instance.isPresent() ? r.getTimestamp(columnNumber, instance.get()) :
             r.getTimestamp(columnNumber);
         if (timestamp == null) {
             return null;
@@ -64,7 +65,8 @@ public class JodaDateTimeMapper implements ResultColumnMapper<DateTime> {
     @Override
     @Nullable
     public DateTime mapColumn(ResultSet r, String columnLabel, StatementContext ctx) throws SQLException {
-        final Timestamp timestamp = calendar.isPresent() ? r.getTimestamp(columnLabel, cloneCalendar()) :
+        final Optional<Calendar> instance = cloneCalendar();
+        final Timestamp timestamp = instance.isPresent() ? r.getTimestamp(columnLabel, instance.get()) :
             r.getTimestamp(columnLabel);
         if (timestamp == null) {
             return null;

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OffsetDateTimeMapper.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OffsetDateTimeMapper.java
@@ -48,14 +48,15 @@ public class OffsetDateTimeMapper implements ResultColumnMapper<OffsetDateTime> 
      *
      * @return a clone of calendar, representing a database time zone
      */
-    private Calendar cloneCalendar() {
-        return (Calendar) calendar.get().clone();
+    private Optional<Calendar> cloneCalendar() {
+        return calendar.map(Calendar::clone).map(x -> (Calendar) x);
     }
 
     @Override
     @Nullable
     public OffsetDateTime mapColumn(ResultSet r, int columnNumber, StatementContext ctx) throws SQLException {
-        final Timestamp timestamp = calendar.isPresent() ? r.getTimestamp(columnNumber, cloneCalendar()) :
+        final Optional<Calendar> instance = cloneCalendar();
+        final Timestamp timestamp = instance.isPresent() ? r.getTimestamp(columnNumber, instance.get()) :
             r.getTimestamp(columnNumber);
         return convertToOffsetDateTime(timestamp);
     }
@@ -63,7 +64,8 @@ public class OffsetDateTimeMapper implements ResultColumnMapper<OffsetDateTime> 
     @Override
     @Nullable
     public OffsetDateTime mapColumn(ResultSet r, String columnLabel, StatementContext ctx) throws SQLException {
-        final Timestamp timestamp = calendar.isPresent() ? r.getTimestamp(columnLabel, cloneCalendar()) :
+        final Optional<Calendar> instance = cloneCalendar();
+        final Timestamp timestamp = instance.isPresent() ? r.getTimestamp(columnLabel, instance.get()) :
             r.getTimestamp(columnLabel);
         return convertToOffsetDateTime(timestamp);
     }

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalInstantArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalInstantArgumentFactory.java
@@ -39,6 +39,6 @@ public class OptionalInstantArgumentFactory implements ArgumentFactory<Optional<
     @Override
     public Argument build(Class<?> expectedType, Optional<Instant> value, StatementContext ctx) {
         // accepts guarantees that the value is present
-        return new InstantArgument(value.get(), calendar);
+        return new InstantArgument(value.orElse(null), calendar);
     }
 }

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalJodaTimeArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalJodaTimeArgumentFactory.java
@@ -39,6 +39,6 @@ public class OptionalJodaTimeArgumentFactory implements ArgumentFactory<Optional
     @Override
     public Argument build(Class<?> expectedType, Optional<DateTime> value, StatementContext ctx) {
         // accepts guarantees that the value is present
-        return new JodaDateTimeArgument(value.get(), calendar);
+        return new JodaDateTimeArgument(value.orElse(null), calendar);
     }
 }

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalLocalDateArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalLocalDateArgumentFactory.java
@@ -25,6 +25,6 @@ public class OptionalLocalDateArgumentFactory implements ArgumentFactory<Optiona
     @Override
     public Argument build(Class<?> expectedType, Optional<LocalDate> value, StatementContext ctx) {
         // accepts guarantees that the value is present
-        return new LocalDateArgument(value.get());
+        return new LocalDateArgument(value.orElse(null));
     }
 }

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalLocalDateTimeArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalLocalDateTimeArgumentFactory.java
@@ -25,6 +25,6 @@ public class OptionalLocalDateTimeArgumentFactory implements ArgumentFactory<Opt
     @Override
     public Argument build(Class<?> expectedType, Optional<LocalDateTime> value, StatementContext ctx) {
         // accepts guarantees that the value is present
-        return new LocalDateTimeArgument(value.get());
+        return new LocalDateTimeArgument(value.orElse(null));
     }
 }

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalOffsetDateTimeArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalOffsetDateTimeArgumentFactory.java
@@ -39,6 +39,6 @@ public class OptionalOffsetDateTimeArgumentFactory implements ArgumentFactory<Op
     @Override
     public Argument build(Class<?> expectedType, Optional<OffsetDateTime> value, StatementContext ctx) {
         // accepts guarantees that the value is present
-        return new OffsetDateTimeArgument(value.get(), calendar);
+        return new OffsetDateTimeArgument(value.orElse(null), calendar);
     }
 }

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalZonedDateTimeArgumentFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/OptionalZonedDateTimeArgumentFactory.java
@@ -39,6 +39,6 @@ public class OptionalZonedDateTimeArgumentFactory implements ArgumentFactory<Opt
     @Override
     public Argument build(Class<?> expectedType, Optional<ZonedDateTime> value, StatementContext ctx) {
         // accepts guarantees that the value is present
-        return new ZonedDateTimeArgument(value.get(), calendar);
+        return new ZonedDateTimeArgument(value.orElse(null), calendar);
     }
 }

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/ZonedDateTimeMapper.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/args/ZonedDateTimeMapper.java
@@ -48,14 +48,15 @@ public class ZonedDateTimeMapper implements ResultColumnMapper<ZonedDateTime> {
      *
      * @return a clone of calendar, representing a database time zone
      */
-    private Calendar cloneCalendar() {
-        return (Calendar) calendar.get().clone();
+    private Optional<Calendar> cloneCalendar() {
+        return calendar.map(Calendar::clone).map(x -> (Calendar)x);
     }
 
     @Override
     @Nullable
     public ZonedDateTime mapColumn(ResultSet r, int columnNumber, StatementContext ctx) throws SQLException {
-        final Timestamp timestamp = calendar.isPresent() ? r.getTimestamp(columnNumber, cloneCalendar()) :
+        final Optional<Calendar> instance = cloneCalendar();
+        final Timestamp timestamp = instance.isPresent() ? r.getTimestamp(columnNumber, instance.get()) :
             r.getTimestamp(columnNumber);
         return convertToZonedDateTime(timestamp);
     }
@@ -63,7 +64,8 @@ public class ZonedDateTimeMapper implements ResultColumnMapper<ZonedDateTime> {
     @Override
     @Nullable
     public ZonedDateTime mapColumn(ResultSet r, String columnLabel, StatementContext ctx) throws SQLException {
-        final Timestamp timestamp = calendar.isPresent() ? r.getTimestamp(columnLabel, cloneCalendar()) :
+        final Optional<Calendar> instance = cloneCalendar();
+        final Timestamp timestamp = instance.isPresent() ? r.getTimestamp(columnLabel, instance.get()) :
             r.getTimestamp(columnLabel);
         return convertToZonedDateTime(timestamp);
     }

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilder.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilder.java
@@ -69,7 +69,7 @@ public class ScheduledExecutorServiceBuilder {
     }
 
     public ScheduledExecutorServiceBuilder removeOnCancelPolicy(boolean removeOnCancel) {
-        this.removeOnCancel = Boolean.valueOf(removeOnCancel);
+        this.removeOnCancel = removeOnCancel;
         return this;
     }
 


### PR DESCRIPTION
###### Problem:
I'm running dropwizard code through some static analysis checkers to make sure we're on good ground for 2.0. In this first PR, a lot of issues surrounded superfluous warnings about unwrapping an optional. 

###### Solution:
Implemented said fixes

###### Result:
Everything is behaviorally the same -- dropwizard just a little more static analysis friendly.
