### PR TITLE
Remove unnecessary packaging from dropwizard-forms

### DIFF
--- a/dropwizard-forms/pom.xml
+++ b/dropwizard-forms/pom.xml
@@ -9,7 +9,6 @@
     </parent>
 
     <artifactId>dropwizard-forms</artifactId>
-    <packaging>jar</packaging>
     <name>Dropwizard Multipart Form Support</name>
 
     <dependencyManagement>


### PR DESCRIPTION
###### Problem:
`dropwizard-forms` is the only project that defines `<packaging>jar</packaging>` in `pom.xml`. I spent 3 minutes wondering why it was the only one like this. No reason, it's just stating the default value.

###### Solution:
Bring it inline by erasing the explicit setting and making it conform with the other modules

###### Result:
No difference 😄 
