### PR TITLE
Prefer instanceof instead of getClass in equals

### DIFF
--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/PrincipalImpl.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/PrincipalImpl.java
@@ -20,7 +20,7 @@ public class PrincipalImpl implements Principal {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof PrincipalImpl)) {
             return false;
         }
 

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/basic/BasicCredentials.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/basic/BasicCredentials.java
@@ -51,7 +51,7 @@ public class BasicCredentials {
         if (this == obj) {
             return true;
         }
-        if (obj == null || getClass() != obj.getClass()) {
+        if (!(obj instanceof BasicCredentials)) {
             return false;
         }
         final BasicCredentials other = (BasicCredentials) obj;

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/ErrorMessage.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/ErrorMessage.java
@@ -52,7 +52,7 @@ public class ErrorMessage {
         if (this == obj) {
             return true;
         }
-        if ((obj == null) || (getClass() != obj.getClass())) {
+        if (!(obj instanceof ErrorMessage)) {
             return false;
         }
 

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/AbstractParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/AbstractParam.java
@@ -117,7 +117,7 @@ public abstract class AbstractParam<T> {
         if (this == obj) {
             return true;
         }
-        if ((obj == null) || (getClass() != obj.getClass())) {
+        if (!(obj instanceof AbstractParam)) {
             return false;
         }
         final AbstractParam<?> that = (AbstractParam<?>) obj;

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProviderTest.java
@@ -60,7 +60,7 @@ public class JacksonMessageBodyProviderTest {
             if (this == obj) {
                 return true;
             }
-            if (obj == null || getClass() != obj.getClass()) {
+            if (!(obj instanceof Example)) {
                 return false;
             }
             final Example other = (Example) obj;

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/Person.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/Person.java
@@ -39,7 +39,7 @@ public class Person {
         if (this == obj) {
             return true;
         }
-        if (obj == null || getClass() != obj.getClass()) {
+        if (!(obj instanceof Person)) {
             return false;
         }
         final Person other = (Person) obj;

--- a/dropwizard-util/src/main/java/io/dropwizard/util/Duration.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Duration.java
@@ -140,7 +140,7 @@ public class Duration implements Comparable<Duration> {
         if (this == obj) {
             return true;
         }
-        if ((obj == null) || (getClass() != obj.getClass())) {
+        if (!(obj instanceof Duration)) {
             return false;
         }
         final Duration duration = (Duration) obj;

--- a/dropwizard-util/src/main/java/io/dropwizard/util/Size.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Size.java
@@ -122,7 +122,7 @@ public class Size implements Comparable<Size> {
         if (this == obj) {
             return true;
         }
-        if ((obj == null) || (getClass() != obj.getClass())) {
+        if (!(obj instanceof Size)) {
             return false;
         }
         final Size size = (Size) obj;


### PR DESCRIPTION
###### Problem:
Another mini PR coming at you. This time fixing error prone's [EqualsGetClass](https://errorprone.info/bugpattern/EqualsGetClass) lint. From the site:

> Requiring the argument to equals to be of a specific concrete type is incorrect, because it precludes any subtype of this class from obeying the substitution principle.

###### Solution:
> Such code should be modified to use an instanceof test instead of getClass.

###### Result:
No behavior difference inside dropwizard though users that subtype classes like `Size`, `Duration`, etc may see a difference (unlikely)
