### PR TITLE
Use instrumented thread factory

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -489,7 +489,7 @@ For example, given a theoretical Riak__ client which needs to be started and sto
 
     public class MyApplication extends Application<MyConfiguration>{
         @Override
-        public void run(MyApplicationConfiguration configuration, Environment environment) {
+        public void run(MyConfiguration configuration, Environment environment) {
             RiakClient client = ...;
             RiakClientManager riakClientManager = new RiakClientManager(client);
             environment.lifecycle().manage(riakClientManager);
@@ -508,7 +508,7 @@ that monitors the number of threads created, running and terminated
 
     public class MyApplication extends Application<MyConfiguration> {
         @Override
-        public void run(MyApplicationConfiguration configuration, Environment environment) {
+        public void run(MyConfiguration configuration, Environment environment) {
 
             ExecutorService executorService = environment.lifecycle()
                 .executorService(nameFormat)

--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -217,7 +217,7 @@ Dropwizard then calls your ``Application`` subclass to initialize your applicati
     You can override configuration settings in maps like this:
 
     ``java -Ddw.database.properties.hibernate.hbm2ddl.auto=none server my-config.json``
-    
+
     If you need to use the '.' character in one of the values, you can escape it by using '\\.' instead.
 
     You can also override a configuration setting that is an array of strings by using the ',' character
@@ -501,8 +501,25 @@ application will not start and a full exception will be logged. If ``RiakClientM
 an exception, the exception will be logged but your application will still be able to shut down.
 
 It should be noted that ``Environment`` has built-in factory methods for ``ExecutorService`` and
-``ScheduledExecutorService`` instances which are managed. See ``LifecycleEnvironment#executorService``
-and ``LifecycleEnvironment#scheduledExecutorService`` for details.
+``ScheduledExecutorService`` instances which are managed. These managed instances use ``InstrumentedThreadFactory``
+that monitors the number of threads created, running and terminated
+
+.. code-block:: java
+
+    public class MyApplication extends Application<MyConfiguration> {
+        @Override
+        public void run(MyApplicationConfiguration configuration, Environment environment) {
+
+            ExecutorService executorService = environment.lifecycle()
+                .executorService(nameFormat)
+                .maxThreads(maxThreads)
+                .build();
+
+            ScheduledExecutorService scheduledExecutorService = environment.lifecycle()
+                .scheduledExecutorService(nameFormat)
+                .build();
+        }
+    }
 
 .. _man-core-bundles:
 

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
@@ -75,8 +75,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class JerseyClientBuilderTest {
-    private final JerseyClientBuilder builder = new JerseyClientBuilder(new MetricRegistry());
-    private final LifecycleEnvironment lifecycleEnvironment = spy(new LifecycleEnvironment());
+    private final MetricRegistry metricRegistry = new MetricRegistry();
+    private final JerseyClientBuilder builder = new JerseyClientBuilder(metricRegistry);
+    private final LifecycleEnvironment lifecycleEnvironment = spy(new LifecycleEnvironment(metricRegistry));
     private final Environment environment = mock(Environment.class);
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
     private final ObjectMapper objectMapper = mock(ObjectMapper.class);

--- a/dropwizard-core/src/main/java/io/dropwizard/setup/Environment.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/Environment.java
@@ -76,7 +76,7 @@ public class Environment {
 
         this.adminEnvironment = new AdminEnvironment(adminContext, healthCheckRegistry, metricRegistry);
 
-        this.lifecycleEnvironment = new LifecycleEnvironment();
+        this.lifecycleEnvironment = new LifecycleEnvironment(metricRegistry);
 
         final DropwizardResourceConfig jerseyConfig = new DropwizardResourceConfig(metricRegistry);
         jerseyConfig.setContextPath(servletContext.getContextPath());

--- a/dropwizard-lifecycle/pom.xml
+++ b/dropwizard-lifecycle/pom.xml
@@ -41,6 +41,10 @@
             <artifactId>dropwizard-util</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-logging</artifactId>
             <scope>test</scope>

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilder.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilder.java
@@ -1,5 +1,6 @@
 package io.dropwizard.lifecycle.setup;
 
+import com.codahale.metrics.InstrumentedThreadFactory;
 import io.dropwizard.lifecycle.ExecutorServiceManager;
 import io.dropwizard.util.Duration;
 import org.slf4j.Logger;
@@ -101,12 +102,14 @@ public class ExecutorServiceBuilder {
         if (corePoolSize != maximumPoolSize && maximumPoolSize > 1 && !isBoundedQueue()) {
             log.warn("Parameter 'maximumPoolSize' is conflicting with unbounded work queues");
         }
+        final InstrumentedThreadFactory instrumentedThreadFactory = new InstrumentedThreadFactory(threadFactory,
+            environment.getMetricRegistry(), nameFormat);
         final ThreadPoolExecutor executor = new ThreadPoolExecutor(corePoolSize,
                                                                    maximumPoolSize,
                                                                    keepAliveTime.getQuantity(),
                                                                    keepAliveTime.getUnit(),
                                                                    workQueue,
-                                                                   threadFactory,
+                                                                   instrumentedThreadFactory,
                                                                    handler);
         executor.allowCoreThreadTimeOut(allowCoreThreadTimeOut);
         environment.manage(new ExecutorServiceManager(executor, shutdownTime, nameFormat));

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/LifecycleEnvironment.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/LifecycleEnvironment.java
@@ -1,5 +1,6 @@
 package io.dropwizard.lifecycle.setup;
 
+import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.lifecycle.JettyManaged;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.lifecycle.ServerLifecycleListener;
@@ -21,10 +22,12 @@ public class LifecycleEnvironment {
 
     private final List<LifeCycle> managedObjects;
     private final List<LifeCycle.Listener> lifecycleListeners;
+    private final MetricRegistry metricRegistry;
 
-    public LifecycleEnvironment() {
+    public LifecycleEnvironment(MetricRegistry metricRegistry) {
         this.managedObjects = new ArrayList<>();
         this.lifecycleListeners = new ArrayList<>();
+        this.metricRegistry = metricRegistry;
     }
 
     public List<LifeCycle> getManagedObjects() {
@@ -54,7 +57,7 @@ public class LifecycleEnvironment {
     public ExecutorServiceBuilder executorService(String nameFormat) {
         return new ExecutorServiceBuilder(this, nameFormat);
     }
-    
+
     public ExecutorServiceBuilder executorService(String nameFormat, ThreadFactory factory) {
         return new ExecutorServiceBuilder(this, nameFormat, factory);
     }
@@ -62,7 +65,7 @@ public class LifecycleEnvironment {
     public ScheduledExecutorServiceBuilder scheduledExecutorService(String nameFormat) {
         return scheduledExecutorService(nameFormat, false);
     }
-    
+
     public ScheduledExecutorServiceBuilder scheduledExecutorService(String nameFormat, ThreadFactory factory) {
         return new ScheduledExecutorServiceBuilder(this, nameFormat, factory);
     }
@@ -92,6 +95,10 @@ public class LifecycleEnvironment {
         for (LifeCycle.Listener listener : lifecycleListeners) {
             container.addLifeCycleListener(listener);
         }
+    }
+
+    public MetricRegistry getMetricRegistry() {
+        return metricRegistry;
     }
 
     private static class ServerListener extends AbstractLifeCycle.AbstractLifeCycleListener {

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilder.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilder.java
@@ -1,5 +1,6 @@
 package io.dropwizard.lifecycle.setup;
 
+import com.codahale.metrics.InstrumentedThreadFactory;
 import io.dropwizard.lifecycle.ExecutorServiceManager;
 import io.dropwizard.util.Duration;
 
@@ -74,10 +75,13 @@ public class ScheduledExecutorServiceBuilder {
     }
 
     public ScheduledExecutorService build() {
-        final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(this.poolSize, this.threadFactory, this.handler);
-        executor.setRemoveOnCancelPolicy(this.removeOnCancel);
+        final InstrumentedThreadFactory instrumentedThreadFactory = new InstrumentedThreadFactory(threadFactory,
+            environment.getMetricRegistry(), nameFormat);
 
-        this.environment.manage(new ExecutorServiceManager(executor, this.shutdownTime, this.nameFormat));
+        final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(poolSize, instrumentedThreadFactory, handler);
+        executor.setRemoveOnCancelPolicy(removeOnCancel);
+
+        environment.manage(new ExecutorServiceManager(executor, shutdownTime, nameFormat));
         return executor;
     }
 }

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
@@ -1,5 +1,7 @@
 package io.dropwizard.lifecycle.setup;
 
+import com.codahale.metrics.InstrumentedThreadFactory;
+import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.util.Duration;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,6 +15,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.anyString;
@@ -29,7 +32,7 @@ public class ExecutorServiceBuilderTest {
 
     @Before
     public void setUp() throws Exception {
-        executorServiceBuilder = new ExecutorServiceBuilder(new LifecycleEnvironment(), "test");
+        executorServiceBuilder = new ExecutorServiceBuilder(new LifecycleEnvironment(new MetricRegistry()), "test");
         log = mock(Logger.class);
         ExecutorServiceBuilder.setLog(log);
     }
@@ -111,6 +114,14 @@ public class ExecutorServiceBuilderTest {
             // no warning has been given so we should be able to execute at least 2 things at once
             assertCanExecuteAtLeast2ConcurrentTasks(exe);
         }
+    }
+
+    @Test
+    public void shouldUseInstrumentedThreadFactory() {
+        ExecutorService exe = executorServiceBuilder.build();
+        final ThreadPoolExecutor castedExec = (ThreadPoolExecutor) exe;
+
+        assertThat(castedExec.getThreadFactory()).isInstanceOf(InstrumentedThreadFactory.class);
     }
 
     /**

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/LifecycleEnvironmentTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/LifecycleEnvironmentTest.java
@@ -1,5 +1,6 @@
 package io.dropwizard.lifecycle.setup;
 
+import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.lifecycle.JettyManaged;
 import io.dropwizard.lifecycle.Managed;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
@@ -20,7 +21,7 @@ import static org.mockito.Mockito.mock;
 
 public class LifecycleEnvironmentTest {
 
-    private final LifecycleEnvironment environment = new LifecycleEnvironment();
+    private final LifecycleEnvironment environment = new LifecycleEnvironment(new MetricRegistry());
 
     @Test
     public void managesLifeCycleObjects() throws Exception {

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilderTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilderTest.java
@@ -1,5 +1,7 @@
 package io.dropwizard.lifecycle.setup;
 
+import com.codahale.metrics.InstrumentedThreadFactory;
+import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.lifecycle.ExecutorServiceManager;
 import io.dropwizard.util.Duration;
 import org.junit.After;
@@ -15,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class ScheduledExecutorServiceBuilderTest {
 
@@ -28,6 +31,7 @@ public class ScheduledExecutorServiceBuilderTest {
     public ScheduledExecutorServiceBuilderTest() {
         this.execTracker = null;
         this.le = mock(LifecycleEnvironment.class);
+        when(le.getMetricRegistry()).thenReturn(new MetricRegistry());
     }
 
     @After
@@ -61,6 +65,7 @@ public class ScheduledExecutorServiceBuilderTest {
 
         final ScheduledThreadPoolExecutor castedExec = (ScheduledThreadPoolExecutor) this.execTracker;
         assertThat(castedExec.getRemoveOnCancelPolicy()).isFalse();
+        assertThat(castedExec.getThreadFactory()).isInstanceOf(InstrumentedThreadFactory.class);
 
         final ArgumentCaptor<ExecutorServiceManager> esmCaptor = ArgumentCaptor.forClass(ExecutorServiceManager.class);
         verify(this.le).manage(esmCaptor.capture());
@@ -131,7 +136,7 @@ public class ScheduledExecutorServiceBuilderTest {
 
         final ScheduledThreadPoolExecutor castedExec = (ScheduledThreadPoolExecutor) this.execTracker;
         assertThat(castedExec.getRemoveOnCancelPolicy()).isFalse();
-        assertThat(castedExec.getThreadFactory()).isSameAs(tfactory);
+        assertThat(castedExec.getThreadFactory()).isInstanceOf(InstrumentedThreadFactory.class);
 
         final ArgumentCaptor<ExecutorServiceManager> esmCaptor = ArgumentCaptor.forClass(ExecutorServiceManager.class);
         verify(this.le).manage(esmCaptor.capture());

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/CsvReporterFactoryTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/CsvReporterFactoryTest.java
@@ -41,7 +41,8 @@ public class CsvReporterFactoryTest {
         dir.delete();
 
         MetricsFactory config = factory.build(new File(Resources.getResource("yaml/metrics.yml").toURI()));
-        config.configure(new LifecycleEnvironment(), new MetricRegistry());
+        MetricRegistry metricRegistry = new MetricRegistry();
+        config.configure(new LifecycleEnvironment(metricRegistry), metricRegistry);
         assertThat(dir.exists()).isEqualTo(true);
     }
 }


### PR DESCRIPTION
###### Problem:
Currently the ```Environment``` factory methods for ```ExecutorService``` and ```ScheduledExecutorService``` don't come with instrumentation out of the box.

###### Solution:
I'm suggesting using ```InstrumentedThreadFactory``` which monitors  the number of threads created, running and terminated. I've added some documentation as well.

Please refer to https://github.com/dropwizard/dropwizard/pull/2639 as there's more context there