### PR TITLE
Add support for instrumented executors

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -217,7 +217,7 @@ Dropwizard then calls your ``Application`` subclass to initialize your applicati
     You can override configuration settings in maps like this:
 
     ``java -Ddw.database.properties.hibernate.hbm2ddl.auto=none server my-config.json``
-    
+
     If you need to use the '.' character in one of the values, you can escape it by using '\\.' instead.
 
     You can also override a configuration setting that is an array of strings by using the ',' character
@@ -501,8 +501,26 @@ application will not start and a full exception will be logged. If ``RiakClientM
 an exception, the exception will be logged but your application will still be able to shut down.
 
 It should be noted that ``Environment`` has built-in factory methods for ``ExecutorService`` and
-``ScheduledExecutorService`` instances which are managed. See ``LifecycleEnvironment#executorService``
-and ``LifecycleEnvironment#scheduledExecutorService`` for details.
+``ScheduledExecutorService`` instances which are managed. These managed instances use ``InstrumentedExecutorService``
+and ```InstrumentedScheduledExecutorService``` respectively, that monitors the number of tasks submitted, running,
+completed and also keeps track of task durations.
+
+.. code-block:: java
+
+    public class MyApplication extends Application<MyConfiguration> {
+        @Override
+        public void run(MyApplicationConfiguration configuration, Environment environment) {
+
+            ExecutorService executorService = environment.lifecycle()
+                .executorService(nameFormat)
+                .maxThreads(maxThreads)
+                .build();
+
+            ScheduledExecutorService scheduledExecutorService = environment.lifecycle()
+                .scheduledExecutorService(nameFormat)
+                .build();
+        }
+    }
 
 .. _man-core-bundles:
 

--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -489,7 +489,7 @@ For example, given a theoretical Riak__ client which needs to be started and sto
 
     public class MyApplication extends Application<MyConfiguration>{
         @Override
-        public void run(MyApplicationConfiguration configuration, Environment environment) {
+        public void run(MyConfiguration configuration, Environment environment) {
             RiakClient client = ...;
             RiakClientManager riakClientManager = new RiakClientManager(client);
             environment.lifecycle().manage(riakClientManager);
@@ -509,7 +509,7 @@ completed and also keeps track of task durations.
 
     public class MyApplication extends Application<MyConfiguration> {
         @Override
-        public void run(MyApplicationConfiguration configuration, Environment environment) {
+        public void run(MyConfiguration configuration, Environment environment) {
 
             ExecutorService executorService = environment.lifecycle()
                 .executorService(nameFormat)

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
@@ -75,8 +75,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class JerseyClientBuilderTest {
-    private final JerseyClientBuilder builder = new JerseyClientBuilder(new MetricRegistry());
-    private final LifecycleEnvironment lifecycleEnvironment = spy(new LifecycleEnvironment());
+    private final MetricRegistry metricRegistry = new MetricRegistry();
+    private final JerseyClientBuilder builder = new JerseyClientBuilder(metricRegistry);
+    private final LifecycleEnvironment lifecycleEnvironment = spy(new LifecycleEnvironment(metricRegistry));
     private final Environment environment = mock(Environment.class);
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
     private final ObjectMapper objectMapper = mock(ObjectMapper.class);

--- a/dropwizard-core/src/main/java/io/dropwizard/setup/Environment.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/Environment.java
@@ -76,7 +76,7 @@ public class Environment {
 
         this.adminEnvironment = new AdminEnvironment(adminContext, healthCheckRegistry, metricRegistry);
 
-        this.lifecycleEnvironment = new LifecycleEnvironment();
+        this.lifecycleEnvironment = new LifecycleEnvironment(metricRegistry);
 
         final DropwizardResourceConfig jerseyConfig = new DropwizardResourceConfig(metricRegistry);
         jerseyConfig.setContextPath(servletContext.getContextPath());

--- a/dropwizard-lifecycle/pom.xml
+++ b/dropwizard-lifecycle/pom.xml
@@ -41,6 +41,10 @@
             <artifactId>dropwizard-util</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-logging</artifactId>
             <scope>test</scope>

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilder.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilder.java
@@ -1,5 +1,6 @@
 package io.dropwizard.lifecycle.setup;
 
+import com.codahale.metrics.InstrumentedExecutorService;
 import io.dropwizard.lifecycle.ExecutorServiceManager;
 import io.dropwizard.util.Duration;
 import org.slf4j.Logger;
@@ -110,7 +111,7 @@ public class ExecutorServiceBuilder {
                                                                    handler);
         executor.allowCoreThreadTimeOut(allowCoreThreadTimeOut);
         environment.manage(new ExecutorServiceManager(executor, shutdownTime, nameFormat));
-        return executor;
+        return new InstrumentedExecutorService(executor, environment.getMetricRegistry(), nameFormat);
     }
 
     private boolean isBoundedQueue() {

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/LifecycleEnvironment.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/LifecycleEnvironment.java
@@ -1,5 +1,6 @@
 package io.dropwizard.lifecycle.setup;
 
+import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.lifecycle.JettyManaged;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.lifecycle.ServerLifecycleListener;
@@ -21,10 +22,12 @@ public class LifecycleEnvironment {
 
     private final List<LifeCycle> managedObjects;
     private final List<LifeCycle.Listener> lifecycleListeners;
+    private final MetricRegistry metricRegistry;
 
-    public LifecycleEnvironment() {
+    public LifecycleEnvironment(MetricRegistry metricRegistry) {
         this.managedObjects = new ArrayList<>();
         this.lifecycleListeners = new ArrayList<>();
+        this.metricRegistry = metricRegistry;
     }
 
     public List<LifeCycle> getManagedObjects() {
@@ -54,7 +57,7 @@ public class LifecycleEnvironment {
     public ExecutorServiceBuilder executorService(String nameFormat) {
         return new ExecutorServiceBuilder(this, nameFormat);
     }
-    
+
     public ExecutorServiceBuilder executorService(String nameFormat, ThreadFactory factory) {
         return new ExecutorServiceBuilder(this, nameFormat, factory);
     }
@@ -62,7 +65,7 @@ public class LifecycleEnvironment {
     public ScheduledExecutorServiceBuilder scheduledExecutorService(String nameFormat) {
         return scheduledExecutorService(nameFormat, false);
     }
-    
+
     public ScheduledExecutorServiceBuilder scheduledExecutorService(String nameFormat, ThreadFactory factory) {
         return new ScheduledExecutorServiceBuilder(this, nameFormat, factory);
     }
@@ -92,6 +95,10 @@ public class LifecycleEnvironment {
         for (LifeCycle.Listener listener : lifecycleListeners) {
             container.addLifeCycleListener(listener);
         }
+    }
+
+    public MetricRegistry getMetricRegistry() {
+        return metricRegistry;
     }
 
     private static class ServerListener extends AbstractLifeCycle.AbstractLifeCycleListener {

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilder.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilder.java
@@ -1,5 +1,6 @@
 package io.dropwizard.lifecycle.setup;
 
+import com.codahale.metrics.InstrumentedScheduledExecutorService;
 import io.dropwizard.lifecycle.ExecutorServiceManager;
 import io.dropwizard.util.Duration;
 
@@ -74,10 +75,10 @@ public class ScheduledExecutorServiceBuilder {
     }
 
     public ScheduledExecutorService build() {
-        final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(this.poolSize, this.threadFactory, this.handler);
-        executor.setRemoveOnCancelPolicy(this.removeOnCancel);
+        final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(poolSize, threadFactory, handler);
+        executor.setRemoveOnCancelPolicy(removeOnCancel);
 
-        this.environment.manage(new ExecutorServiceManager(executor, this.shutdownTime, this.nameFormat));
-        return executor;
+        environment.manage(new ExecutorServiceManager(executor, shutdownTime, nameFormat));
+        return new InstrumentedScheduledExecutorService(executor, environment.getMetricRegistry(), nameFormat);
     }
 }

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
@@ -1,5 +1,7 @@
 package io.dropwizard.lifecycle.setup;
 
+import com.codahale.metrics.InstrumentedExecutorService;
+import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.util.Duration;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,7 +31,7 @@ public class ExecutorServiceBuilderTest {
 
     @Before
     public void setUp() throws Exception {
-        executorServiceBuilder = new ExecutorServiceBuilder(new LifecycleEnvironment(), "test");
+        executorServiceBuilder = new ExecutorServiceBuilder(new LifecycleEnvironment(new MetricRegistry()), "test");
         log = mock(Logger.class);
         ExecutorServiceBuilder.setLog(log);
     }
@@ -140,5 +142,12 @@ public class ExecutorServiceBuilderTest {
         } catch (InterruptedException ex) {
             throw new RuntimeException(ex);
         }
+    }
+
+    @Test
+    public void shouldReturnInstrumentedExecutor() {
+        ExecutorService exe = executorServiceBuilder.build();
+
+        assertThat(exe).isInstanceOf(InstrumentedExecutorService.class);
     }
 }

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/LifecycleEnvironmentTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/LifecycleEnvironmentTest.java
@@ -1,5 +1,6 @@
 package io.dropwizard.lifecycle.setup;
 
+import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.lifecycle.JettyManaged;
 import io.dropwizard.lifecycle.Managed;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
@@ -20,7 +21,7 @@ import static org.mockito.Mockito.mock;
 
 public class LifecycleEnvironmentTest {
 
-    private final LifecycleEnvironment environment = new LifecycleEnvironment();
+    private final LifecycleEnvironment environment = new LifecycleEnvironment(new MetricRegistry());
 
     @Test
     public void managesLifeCycleObjects() throws Exception {

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/CsvReporterFactoryTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/CsvReporterFactoryTest.java
@@ -41,7 +41,8 @@ public class CsvReporterFactoryTest {
         dir.delete();
 
         MetricsFactory config = factory.build(new File(Resources.getResource("yaml/metrics.yml").toURI()));
-        config.configure(new LifecycleEnvironment(), new MetricRegistry());
+        MetricRegistry metricRegistry = new MetricRegistry();
+        config.configure(new LifecycleEnvironment(metricRegistry), metricRegistry);
         assertThat(dir.exists()).isEqualTo(true);
     }
 }


### PR DESCRIPTION
###### Problem:
Currently the ```Environment``` factory methods for ```ExecutorService``` and ```ScheduledExecutorService``` don't come with instrumentation out of the box.

###### Solution:
I'm suggesting using ```InstrumentedExecutorService``` and ```InstrumentedScheduledExecutorService``` that monitors the number of tasks submitted, running,
completed and also keeps track of task durations.

Please refer to https://github.com/dropwizard/dropwizard/pull/2639 as there's more context there