### PR TITLE
Remove junit platform-surefire-provider

### DIFF
--- a/dropwizard-testing/pom.xml
+++ b/dropwizard-testing/pom.xml
@@ -82,11 +82,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <dependencies>
                     <dependency>
-                        <groupId>org.junit.platform</groupId>
-                        <artifactId>junit-platform-surefire-provider</artifactId>
-                        <version>1.3.2</version>
-                    </dependency>
-                    <dependency>
                         <groupId>org.junit.vintage</groupId>
                         <artifactId>junit-vintage-engine</artifactId>
                         <version>${junit5.version}</version>


### PR DESCRIPTION
###### Problem:

On builds, a warning pops up:

```
+-------------------------------------------------------------------------------+
| WARNING:                                                                      |
| The junit-platform-surefire-provider has been deprecated and is scheduled to  |
| be removed in JUnit Platform 1.4. Please use the built-in support in Maven    |
| Surefire >= 2.22.0 instead.                                                   |
| » https://junit.org/junit5/docs/current/user-guide/#running-tests-build-maven |
+-------------------------------------------------------------------------------+
```

###### Solution:

Remove from the offending pom dependency

###### Result:

No more warning!
