### PR TITLE
Support for system property in configured command

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/cli/ConfiguredCommand.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/ConfiguredCommand.java
@@ -71,6 +71,13 @@ public abstract class ConfiguredCommand<T extends Configuration> extends Command
     @SuppressWarnings("unchecked")
     public void run(Bootstrap<?> wildcardBootstrap, Namespace namespace) throws Exception {
         final Bootstrap<T> bootstrap = (Bootstrap<T>) wildcardBootstrap;
+        final String applicationName = bootstrap.getApplication().getName();
+
+        if (namespace.getString("file") == null && (applicationName != null && !applicationName.trim().isEmpty())) {
+            String key = applicationName.toLowerCase().replaceAll("\\s+", ".") + ".configurationFile";
+            namespace.getAttrs().put("file", System.getProperty(key));
+        }
+
         configuration = parseConfiguration(bootstrap.getConfigurationFactoryFactory(),
                                            bootstrap.getConfigurationSourceProvider(),
                                            bootstrap.getValidatorFactory().getValidator(),


### PR DESCRIPTION
Update to give the opportunity to inform the path of the configuration file via system property.
If no file path program argument is provided try to lookup to the system property key based on application's name to get the file path.

###### Problem:
There is no possibility of getting the path to the configuration file through system property.

###### Solution:
Before attempting to parse the configuration file, try to get the path via system property if no path has been informed via program argument. The key to get the path is based on the name of the application.

e.g:

```java
public class TempApp extends Application<...> {
    @Override
    public String getName() {
        return "Temp App";
    }
}
```

When the ConfiguredCommand#run(Bootstrap, Namespace) is invoked the application's name will be parsed to create the key to lookup in the system property for the configuration path (temp.app.configurationFile).

###### Result:
With this change, now the configuration path can be informed via program argument or via vm options -Dtemp.app.configurationFile=...