### PR TITLE
Remove sonatype snapshots from dropwizard-example

### DIFF
--- a/dropwizard-example/pom.xml
+++ b/dropwizard-example/pom.xml
@@ -22,14 +22,6 @@
         <maven.site.deploy.skip>true</maven.site.deploy.skip>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>http://oss.sonatype.org/content/repositories/snapshots</url>
-        </repository>
-    </repositories>
-
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION
###### Problem:
Dropwizard-example pom is bloated with Sonatype Nexus Snapshots

###### Solution:
Remove it

###### Result:
Closes #2664
