### PR TITLE
Run downstream Maven builds in quiet mode

### DIFF
--- a/.travis_after_success.sh
+++ b/.travis_after_success.sh
@@ -5,4 +5,4 @@ if [[ "${TRAVIS_JDK_VERSION}" != "openjdk8" ]]; then
     exit
 fi
 
-./mvnw test jacoco:report coveralls:report -P code-coverage
+./mvnw test jacoco:report coveralls:report -P code-coverage -B -q

--- a/.travis_deploy.sh
+++ b/.travis_deploy.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-./mvnw -B deploy --settings maven_deploy_settings.xml -Dmaven.test.skip=true -Dfindbugs.skip=true
+./mvnw -B -q deploy --settings maven_deploy_settings.xml -Dmaven.test.skip=true -Dfindbugs.skip=true


### PR DESCRIPTION
Reduce output of downstream Maven builds to reduce the overall log size of the Travis CI builds.

Otherwise, we might run into problems with the overall log output:
> The job exceeded the maximum log length, and has been terminated.