### PR TITLE
Improve Dropwizard test support

### DIFF
--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/LazyLoadingTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/LazyLoadingTest.java
@@ -155,7 +155,7 @@ public class LazyLoadingTest {
     private DropwizardTestSupport<?> dropwizardTestSupport = mock(DropwizardTestSupport.class);
     private Client client = new JerseyClientBuilder().build();
 
-    public void setup(Class<? extends Application<TestConfiguration>> applicationClass) {
+    public void setup(Class<? extends Application<TestConfiguration>> applicationClass) throws Exception {
         dropwizardTestSupport = new DropwizardTestSupport<>(applicationClass, ResourceHelpers.resourceFilePath("hibernate-integration-test.yaml"),
             ConfigOverride.config("dataSource.url", "jdbc:hsqldb:mem:DbTest" + System.nanoTime() + "?hsqldb.translate_dti_types=false"));
         dropwizardTestSupport.before();

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DropwizardAppRule.java
@@ -5,6 +5,7 @@ import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.cli.Command;
 import io.dropwizard.cli.ServerCommand;
+import io.dropwizard.configuration.ConfigurationSourceProvider;
 import io.dropwizard.jersey.jackson.JacksonFeature;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.setup.Environment;
@@ -90,19 +91,71 @@ public class DropwizardAppRule<C extends Configuration> extends ExternalResource
     public DropwizardAppRule(Class<? extends Application<C>> applicationClass,
                              @Nullable String configPath,
                              ConfigOverride... configOverrides) {
-        this(applicationClass, configPath, Optional.empty(), configOverrides);
+        this(applicationClass, configPath, (String) null, configOverrides);
     }
 
-    public DropwizardAppRule(Class<? extends Application<C>> applicationClass, @Nullable String configPath,
-                             Optional<String> customPropertyPrefix, ConfigOverride... configOverrides) {
+    public DropwizardAppRule(Class<? extends Application<C>> applicationClass,
+                             @Nullable String configPath,
+                             ConfigurationSourceProvider configSourceProvider,
+                             ConfigOverride... configOverrides) {
+        this(applicationClass, configPath, configSourceProvider, null, configOverrides);
+    }
+
+    /**
+     * @deprecated Use {@link #DropwizardAppRule(Class, String, String, ConfigOverride...)} instead.
+     */
+    @Deprecated
+    public DropwizardAppRule(Class<? extends Application<C>> applicationClass,
+                             @Nullable String configPath,
+                             Optional<String> customPropertyPrefix,
+                             ConfigOverride... configOverrides) {
+        this(applicationClass, configPath, customPropertyPrefix.orElse(null), configOverrides);
+    }
+
+    public DropwizardAppRule(Class<? extends Application<C>> applicationClass,
+                             @Nullable String configPath,
+                             @Nullable String customPropertyPrefix,
+                             ConfigOverride... configOverrides) {
         this(applicationClass, configPath, customPropertyPrefix, ServerCommand::new, configOverrides);
     }
 
-    public DropwizardAppRule(Class<? extends Application<C>> applicationClass, @Nullable String configPath,
-                             Optional<String> customPropertyPrefix, Function<Application<C>,
-                             Command> commandInstantiator, ConfigOverride... configOverrides) {
-        this(new DropwizardTestSupport<>(applicationClass, configPath, customPropertyPrefix, commandInstantiator,
-                configOverrides));
+    public DropwizardAppRule(Class<? extends Application<C>> applicationClass,
+                             @Nullable String configPath,
+                             ConfigurationSourceProvider configSourceProvider,
+                             @Nullable String customPropertyPrefix,
+                             ConfigOverride... configOverrides) {
+        this(applicationClass, configPath, configSourceProvider, customPropertyPrefix, ServerCommand::new, configOverrides);
+    }
+
+    /**
+     * @deprecated Use {@link #DropwizardAppRule(Class, String, String, Function, ConfigOverride...)} instead.
+     */
+    @Deprecated
+    public DropwizardAppRule(Class<? extends Application<C>> applicationClass,
+                             @Nullable String configPath,
+                             Optional<String> customPropertyPrefix,
+                             Function<Application<C>, Command> commandInstantiator,
+                             ConfigOverride... configOverrides) {
+        this(applicationClass, configPath, customPropertyPrefix.orElse(null), commandInstantiator, configOverrides);
+    }
+
+    public DropwizardAppRule(Class<? extends Application<C>> applicationClass,
+                             @Nullable String configPath,
+                             @Nullable String customPropertyPrefix,
+                             Function<Application<C>,
+                             Command> commandInstantiator,
+                             ConfigOverride... configOverrides) {
+        this(new DropwizardTestSupport<>(applicationClass, configPath, customPropertyPrefix, commandInstantiator, configOverrides));
+    }
+
+    public DropwizardAppRule(Class<? extends Application<C>> applicationClass,
+                             @Nullable String configPath,
+                             ConfigurationSourceProvider configSourceProvider,
+                             @Nullable String customPropertyPrefix,
+                             Function<Application<C>,
+                             Command> commandInstantiator,
+                             ConfigOverride... configOverrides) {
+        this(new DropwizardTestSupport<>(applicationClass, configPath, configSourceProvider, customPropertyPrefix, commandInstantiator, configOverrides));
     }
 
     /**
@@ -155,7 +208,7 @@ public class DropwizardAppRule<C extends Configuration> extends ExternalResource
     }
 
     @Override
-    protected void before() {
+    protected void before() throws Exception {
         if (recursiveCallCount.getAndIncrement() == 0) {
             testSupport.before();
         }

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardAppExtension.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardAppExtension.java
@@ -5,6 +5,7 @@ import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.cli.Command;
 import io.dropwizard.cli.ServerCommand;
+import io.dropwizard.configuration.ConfigurationSourceProvider;
 import io.dropwizard.jersey.jackson.JacksonFeature;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.setup.Environment;
@@ -87,19 +88,69 @@ public class DropwizardAppExtension<C extends Configuration> implements Dropwiza
     public DropwizardAppExtension(Class<? extends Application<C>> applicationClass,
                                   @Nullable String configPath,
                                   ConfigOverride... configOverrides) {
-        this(applicationClass, configPath, Optional.empty(), configOverrides);
+        this(applicationClass, configPath, (String) null, configOverrides);
     }
 
-    public DropwizardAppExtension(Class<? extends Application<C>> applicationClass, @Nullable String configPath,
-                                  Optional<String> customPropertyPrefix, ConfigOverride... configOverrides) {
+    public DropwizardAppExtension(Class<? extends Application<C>> applicationClass,
+                                  @Nullable String configPath,
+                                  ConfigurationSourceProvider configSourceProvider,
+                                  ConfigOverride... configOverrides) {
+        this(applicationClass, configPath, configSourceProvider, null, configOverrides);
+    }
+
+    /**
+     * @deprecated Use {@link #DropwizardAppExtension(Class, String, String, ConfigOverride...)} instead.
+     */
+    @Deprecated
+    public DropwizardAppExtension(Class<? extends Application<C>> applicationClass,
+                                  @Nullable String configPath,
+                                  Optional<String> customPropertyPrefix,
+                                  ConfigOverride... configOverrides) {
+        this(applicationClass, configPath, customPropertyPrefix.orElse(null), configOverrides);
+    }
+
+    public DropwizardAppExtension(Class<? extends Application<C>> applicationClass,
+                                  @Nullable String configPath,
+                                  @Nullable String customPropertyPrefix,
+                                  ConfigOverride... configOverrides) {
         this(applicationClass, configPath, customPropertyPrefix, ServerCommand::new, configOverrides);
     }
 
-    public DropwizardAppExtension(Class<? extends Application<C>> applicationClass, @Nullable String configPath,
-                                  Optional<String> customPropertyPrefix, Function<Application<C>,
-        Command> commandInstantiator, ConfigOverride... configOverrides) {
-        this(new DropwizardTestSupport<>(applicationClass, configPath, customPropertyPrefix, commandInstantiator,
-            configOverrides));
+    public DropwizardAppExtension(Class<? extends Application<C>> applicationClass,
+                                  @Nullable String configPath,
+                                  ConfigurationSourceProvider configSourceProvider,
+                                  @Nullable String customPropertyPrefix,
+                                  ConfigOverride... configOverrides) {
+        this(applicationClass, configPath, configSourceProvider, customPropertyPrefix, ServerCommand::new, configOverrides);
+    }
+
+    /**
+     * @deprecated Use {@link #DropwizardAppExtension(Class, String, String, Function, ConfigOverride...)} instead.
+     */
+    @Deprecated
+    public DropwizardAppExtension(Class<? extends Application<C>> applicationClass,
+                                  @Nullable String configPath,
+                                  Optional<String> customPropertyPrefix,
+                                  Function<Application<C>, Command> commandInstantiator,
+                                  ConfigOverride... configOverrides) {
+        this(applicationClass, configPath, customPropertyPrefix.orElse(null), commandInstantiator, configOverrides);
+    }
+
+    public DropwizardAppExtension(Class<? extends Application<C>> applicationClass,
+                                  @Nullable String configPath,
+                                  @Nullable String customPropertyPrefix,
+                                  Function<Application<C>, Command> commandInstantiator,
+                                  ConfigOverride... configOverrides) {
+        this(new DropwizardTestSupport<>(applicationClass, configPath, customPropertyPrefix, commandInstantiator, configOverrides));
+    }
+
+    public DropwizardAppExtension(Class<? extends Application<C>> applicationClass,
+                                  @Nullable String configPath,
+                                  ConfigurationSourceProvider configSourceProvider,
+                                  @Nullable String customPropertyPrefix,
+                                  Function<Application<C>, Command> commandInstantiator,
+                                  ConfigOverride... configOverrides) {
+        this(new DropwizardTestSupport<>(applicationClass, configPath, configSourceProvider, customPropertyPrefix, commandInstantiator, configOverrides));
     }
 
     /**
@@ -152,7 +203,7 @@ public class DropwizardAppExtension<C extends Configuration> implements Dropwiza
     }
 
     @Override
-    public void before() {
+    public void before() throws Exception {
         if (recursiveCallCount.getAndIncrement() == 0) {
             testSupport.before();
         }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportTest.java
@@ -1,31 +1,27 @@
 package io.dropwizard.testing;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
-import io.dropwizard.configuration.ConfigurationException;
 import io.dropwizard.configuration.JsonConfigurationFactory;
 import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
+import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.servlets.tasks.PostBodyTask;
 import io.dropwizard.servlets.tasks.Task;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.app.TestConfiguration;
 import io.dropwizard.validation.BaseValidator;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import javax.validation.Validator;
-import javax.validation.constraints.NotEmpty;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import java.io.File;
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Collections;
 import java.util.List;
@@ -35,48 +31,59 @@ import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DropwizardTestSupportTest {
-
-    public static final DropwizardTestSupport<TestConfiguration> TEST_SUPPORT =
-            new DropwizardTestSupport<>(TestApplication.class, resourceFilePath("test-config.yaml"));
+    private static final TestServiceListener<TestConfiguration> TEST_SERVICE_LISTENER = new TestServiceListener<>();
+    private static final TestManaged TEST_MANAGED = new TestManaged();
+    private static final DropwizardTestSupport<TestConfiguration> TEST_SUPPORT =
+            new DropwizardTestSupport<>(TestApplication.class, resourceFilePath("test-config.yaml"))
+                    .addListener(TEST_SERVICE_LISTENER)
+                    .manage(TEST_MANAGED);
 
     @BeforeAll
-    public static void setUp() {
+    static void setUp() throws Exception {
+        assertThat(TEST_SERVICE_LISTENER.executedOnRun).isFalse();
+        assertThat(TEST_MANAGED.executedStart).isFalse();
         TEST_SUPPORT.before();
+        assertThat(TEST_SERVICE_LISTENER.executedOnRun).isTrue();
+        assertThat(TEST_MANAGED.executedStart).isTrue();
     }
 
     @AfterAll
-    public static void tearDown() {
+    static void tearDown() {
+        assertThat(TEST_SERVICE_LISTENER.executedOnStop).isFalse();
+        assertThat(TEST_MANAGED.executedStop).isFalse();
         TEST_SUPPORT.after();
+        assertThat(TEST_SERVICE_LISTENER.executedOnStop).isTrue();
+        assertThat(TEST_MANAGED.executedStop).isTrue();
     }
 
     @Test
-    public void canGetExpectedResourceOverHttp() {
+    void canGetExpectedResourceOverHttp() {
         final String content = ClientBuilder.newClient().target(
-            "http://localhost:" + TEST_SUPPORT.getLocalPort() + "/test").request().get(String.class);
+                "http://localhost:" + TEST_SUPPORT.getLocalPort() + "/test").request().get(String.class);
 
         assertThat(content).isEqualTo("Yes, it's here");
     }
 
     @Test
-    public void returnsConfiguration() {
+    void returnsConfiguration() {
         final TestConfiguration config = TEST_SUPPORT.getConfiguration();
         assertThat(config.getMessage()).isEqualTo("Yes, it's here");
     }
 
     @Test
-    public void returnsApplication() {
+    void returnsApplication() {
         final TestApplication application = TEST_SUPPORT.getApplication();
         assertThat(application).isNotNull();
     }
 
     @Test
-    public void returnsEnvironment() {
+    void returnsEnvironment() {
         final Environment environment = TEST_SUPPORT.getEnvironment();
         assertThat(environment.getName()).isEqualTo("TestApplication");
     }
 
     @Test
-    public void canPerformAdminTask() {
+    void canPerformAdminTask() {
         final String response
                 = ClientBuilder.newClient().target("http://localhost:"
                 + TEST_SUPPORT.getAdminPort() + "/tasks/hello?name=test_user")
@@ -87,29 +94,29 @@ public class DropwizardTestSupportTest {
     }
 
     @Test
-    public void canPerformAdminTaskWithPostBody() {
+    void canPerformAdminTaskWithPostBody() {
         final String response
-            = ClientBuilder.newClient().target("http://localhost:"
-            + TEST_SUPPORT.getAdminPort() + "/tasks/echo")
-            .request()
-            .post(Entity.entity("Custom message", MediaType.TEXT_PLAIN), String.class);
+                = ClientBuilder.newClient().target("http://localhost:"
+                + TEST_SUPPORT.getAdminPort() + "/tasks/echo")
+                .request()
+                .post(Entity.entity("Custom message", MediaType.TEXT_PLAIN), String.class);
 
         assertThat(response).isEqualTo("Custom message");
     }
-    
+
     @Test
-    public void isCustomFactoryCalled() throws IOException, ConfigurationException {
+    void isCustomFactoryCalled() throws Exception {
         //load the test-config so that we can call the support with an explicit config
         TestConfiguration config = new YamlConfigurationFactory<>(
-            TestConfiguration.class, 
-            BaseValidator.newValidator(),
-            Jackson.newObjectMapper(),
-            "dw"
+                TestConfiguration.class,
+                BaseValidator.newValidator(),
+                Jackson.newObjectMapper(),
+                "dw"
         ).build(new File(resourceFilePath("test-config.yaml")));
-        
+
         DropwizardTestSupport<TestConfiguration> support = new DropwizardTestSupport<>(
-            FailingApplication.class, 
-            config
+                FailingApplication.class,
+                config
         );
         try {
             support.before();
@@ -119,72 +126,40 @@ public class DropwizardTestSupportTest {
     }
 
     public static class FailingApplication extends Application<TestConfiguration> {
-        
         @Override
         public void initialize(Bootstrap<TestConfiguration> bootstrap) {
             bootstrap.setConfigurationFactoryFactory(FailingConfigurationFactory::new);
         }
-        
-        @Override
-        public void run(TestConfiguration configuration, Environment environment) {}
-    }
-    
-    public static class FailingConfigurationFactory extends JsonConfigurationFactory<TestConfiguration> {
 
-        public FailingConfigurationFactory(Class<TestConfiguration> klass, Validator validator, ObjectMapper objectMapper, String propertyPrefix) {
+        @Override
+        public void run(TestConfiguration configuration, Environment environment) {
+        }
+    }
+
+    public static class FailingConfigurationFactory extends JsonConfigurationFactory<TestConfiguration> {
+        FailingConfigurationFactory(Class<TestConfiguration> klass, Validator validator, ObjectMapper objectMapper, String propertyPrefix) {
             super(klass, validator, objectMapper, propertyPrefix);
             throw new IllegalStateException();
         }
-        
+
     }
 
-    public static class TestApplication extends Application<TestConfiguration> {
+    public static class TestApplication extends io.dropwizard.testing.app.TestApplication {
         @Override
-        public void run(TestConfiguration configuration, Environment environment) {
-            environment.jersey().register(new TestResource(configuration.getMessage()));
+        public void run(TestConfiguration configuration, Environment environment) throws Exception {
+            super.run(configuration, environment);
             environment.admin().addTask(new HelloTask());
             environment.admin().addTask(new EchoTask());
         }
     }
 
-    @Path("/")
-    public static class TestResource {
-
-        private final String message;
-
-        public TestResource(String message) {
-            this.message = message;
-        }
-
-        @Path("test")
-        @GET
-        public String test() {
-            return message;
-        }
-    }
-
-    public static class TestConfiguration extends Configuration {
-        @NotEmpty
-        @JsonProperty
-        private String message = "";
-
-        @NotEmpty
-        @JsonProperty
-        private String extra = "";
-
-        public String getMessage() {
-            return message;
-        }
-    }
-
     public static class HelloTask extends Task {
-
-        public HelloTask() {
+        HelloTask() {
             super("hello");
         }
 
         @Override
-        public void execute(Map<String, List<String>> parameters, PrintWriter output) throws Exception {
+        public void execute(Map<String, List<String>> parameters, PrintWriter output) {
             List<String> names = parameters.getOrDefault("name", Collections.emptyList());
             String name = !names.isEmpty() ? names.get(0) : "Anonymous";
             output.print("Hello has been said to " + name);
@@ -193,15 +168,46 @@ public class DropwizardTestSupportTest {
     }
 
     public static class EchoTask extends PostBodyTask {
-
-        public EchoTask() {
+        EchoTask() {
             super("echo");
         }
 
         @Override
-        public void execute(Map<String, List<String>> parameters, String body, PrintWriter output) throws Exception {
+        public void execute(Map<String, List<String>> parameters, String body, PrintWriter output) {
             output.print(body);
             output.flush();
+        }
+    }
+
+    public static class TestServiceListener<T extends Configuration> extends DropwizardTestSupport.ServiceListener<T> {
+        volatile boolean executedOnRun = false;
+        volatile boolean executedOnStop = false;
+
+        @Override
+        public void onRun(T configuration, Environment environment, DropwizardTestSupport<T> rule) throws Exception {
+            super.onRun(configuration, environment, rule);
+            executedOnRun = true;
+        }
+
+        @Override
+        public void onStop(DropwizardTestSupport<T> rule) throws Exception {
+            super.onStop(rule);
+            executedOnStop = true;
+        }
+    }
+
+    public static class TestManaged implements Managed {
+        volatile boolean executedStart = false;
+        volatile boolean executedStop = false;
+
+        @Override
+        public void start() {
+            executedStart = true;
+        }
+
+        @Override
+        public void stop() {
+            executedStop = true;
         }
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportWithMissingConfigurationTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportWithMissingConfigurationTest.java
@@ -1,0 +1,21 @@
+package io.dropwizard.testing;
+
+import io.dropwizard.testing.app.TestApplication;
+import io.dropwizard.testing.app.TestConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.FileNotFoundException;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DropwizardTestSupportWithMissingConfigurationTest {
+    @Test
+    void configurationDoesNotExist() {
+        final DropwizardTestSupport<TestConfiguration> testSupport =
+                new DropwizardTestSupport<>(TestApplication.class, "not-found.yaml");
+
+        assertThatThrownBy(testSupport::before)
+                .isInstanceOf(FileNotFoundException.class)
+                .hasMessage("File not-found.yaml not found");
+    }
+}

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportWithResourceConfigProviderTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportWithResourceConfigProviderTest.java
@@ -1,0 +1,44 @@
+package io.dropwizard.testing;
+
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.app.TestApplication;
+import io.dropwizard.testing.app.TestConfiguration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DropwizardTestSupportWithResourceConfigProviderTest {
+    private static final DropwizardTestSupport<TestConfiguration> TEST_SUPPORT = new DropwizardTestSupport<>(
+            TestApplication.class, "test-config.yaml", new ResourceConfigurationSourceProvider());
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        TEST_SUPPORT.before();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        TEST_SUPPORT.after();
+    }
+
+    @Test
+    void returnsConfiguration() {
+        final TestConfiguration config = TEST_SUPPORT.getConfiguration();
+        assertThat(config.getMessage()).isEqualTo("Yes, it's here");
+    }
+
+    @Test
+    void returnsApplication() {
+        final TestApplication application = TEST_SUPPORT.getApplication();
+        assertThat(application).isNotNull();
+    }
+
+    @Test
+    void returnsEnvironment() {
+        final Environment environment = TEST_SUPPORT.getEnvironment();
+        assertThat(environment.getName()).isEqualTo("TestApplication");
+    }
+}

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportWithUrlConfigProviderTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportWithUrlConfigProviderTest.java
@@ -1,0 +1,46 @@
+package io.dropwizard.testing;
+
+import io.dropwizard.configuration.UrlConfigurationSourceProvider;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.app.TestApplication;
+import io.dropwizard.testing.app.TestConfiguration;
+import io.dropwizard.util.Resources;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DropwizardTestSupportWithUrlConfigProviderTest {
+    private static final String CONFIG_PATH = Resources.getResource("test-config.yaml").toString();
+    private static final DropwizardTestSupport<TestConfiguration> TEST_SUPPORT = new DropwizardTestSupport<>(
+            TestApplication.class, CONFIG_PATH, new UrlConfigurationSourceProvider());
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        TEST_SUPPORT.before();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        TEST_SUPPORT.after();
+    }
+
+    @Test
+    void returnsConfiguration() {
+        final TestConfiguration config = TEST_SUPPORT.getConfiguration();
+        assertThat(config.getMessage()).isEqualTo("Yes, it's here");
+    }
+
+    @Test
+    void returnsApplication() {
+        final TestApplication application = TEST_SUPPORT.getApplication();
+        assertThat(application).isNotNull();
+    }
+
+    @Test
+    void returnsEnvironment() {
+        final Environment environment = TEST_SUPPORT.getEnvironment();
+        assertThat(environment.getName()).isEqualTo("TestApplication");
+    }
+}

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/GzipDefaultVaryBehaviourTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/GzipDefaultVaryBehaviourTest.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class GzipDefaultVaryBehaviourTest {
 
+    @SuppressWarnings("deprecation")
     @ClassRule
     public static final DropwizardAppRule<TestConfiguration> RULE =
             new DropwizardAppRule<>(TestApplication.class, resourceFilePath("gzip-vary-test-config.yaml"));

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResourceExceptionMapperTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResourceExceptionMapperTest.java
@@ -24,6 +24,7 @@ public class PersonResourceExceptionMapperTest {
     private static final ObjectMapper OBJECT_MAPPER = Jackson.newObjectMapper()
         .registerModule(new GuavaModule());
 
+    @SuppressWarnings("deprecation")
     @ClassRule
     public static final ResourceTestRule RESOURCES = ResourceTestRule.builder()
         .addResource(new PersonResource(PEOPLE_STORE))

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestRuleTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestRuleTest.java
@@ -33,12 +33,13 @@ public class ResourceTestRuleTest {
         }
     }
 
-    @SuppressWarnings("NullAway.Init")
     @Mock
     private PeopleStore peopleStore;
 
     private final Person person = new Person("blah", "blah@example.com");
+    @SuppressWarnings("deprecation")
     private final MockitoTestRule mockitoTestRule = new MockitoTestRule(this, MockitoJUnit.rule());
+    @SuppressWarnings("deprecation")
     private final ResourceTestRule resourceTestRule = ResourceTestRule.builder()
             .addResource(() -> new PersonResource(peopleStore))
             .setClientConfigurator(cc -> cc.register(DummyExceptionMapper.class))

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestRuleWithGrizzlyTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestRuleWithGrizzlyTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * test container factory.
  */
 public class ResourceTestRuleWithGrizzlyTest {
+    @SuppressWarnings("deprecation")
     @Rule
     public final ResourceTestRule resourceTestRule = ResourceTestRule.builder()
             .addResource(ContextInjectionResource::new)

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestRuleWithoutLoggingBootstrap.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestRuleWithoutLoggingBootstrap.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ResourceTestRuleWithoutLoggingBootstrap {
+    @SuppressWarnings("deprecation")
     @Rule
     public final ResourceTestRule resourceTestRule = ResourceTestRule.builder()
             .addResource(TestResource::new)

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleConfigOverrideTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleConfigOverrideTest.java
@@ -5,8 +5,6 @@ import io.dropwizard.testing.app.TestConfiguration;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import java.util.Optional;
-
 import static io.dropwizard.testing.ConfigOverride.config;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,7 +14,7 @@ public class DropwizardAppRuleConfigOverrideTest {
     @ClassRule
     public static final DropwizardAppRule<TestConfiguration> RULE =
         new DropwizardAppRule<>(TestApplication.class, resourceFilePath("test-config.yaml"),
-            Optional.of("app-rule"),
+            "app-rule",
             config("app-rule", "message", "A new way to say Hooray!"),
             config("app-rule", "extra", () -> "supplied"),
             config("extra", () -> "supplied again"));

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleReentrantTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleReentrantTest.java
@@ -20,7 +20,6 @@ public class DropwizardAppRuleReentrantTest {
     @Rule
     public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
-    @SuppressWarnings("NullAway")
     @Mock
     DropwizardTestSupport<TestConfiguration> testSupport;
     private Statement statement = mock(Statement.class);

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleResetConfigOverrideTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleResetConfigOverrideTest.java
@@ -4,8 +4,6 @@ import io.dropwizard.testing.app.TestApplication;
 import io.dropwizard.testing.app.TestConfiguration;
 import org.junit.Test;
 
-import java.util.Optional;
-
 import static io.dropwizard.testing.ConfigOverride.config;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -15,7 +13,7 @@ public class DropwizardAppRuleResetConfigOverrideTest {
     private final DropwizardAppRule<TestConfiguration> dropwizardAppRule = new DropwizardAppRule<>(
         TestApplication.class,
         resourceFilePath("test-config.yaml"),
-        Optional.of("app-rule-reset"),
+        "app-rule-reset",
         config("app-rule-reset", "message", "A new way to say Hooray!"));
 
     @Test

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleWithExplicitTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleWithExplicitTest.java
@@ -20,9 +20,9 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
-@SuppressWarnings("deprecation")
 public class DropwizardAppRuleWithExplicitTest {
 
+    @SuppressWarnings("deprecation")
     @ClassRule
     public static final DropwizardAppRule<TestConfiguration> RULE;
 


### PR DESCRIPTION
* Allow specifying ConfigurationSourceProvider in DropwizardTestSupport, DropwizardAppRule, and DropwizardAppExtension
* Mark constructors with `Optional<String>` for configuration file as deprecated in favor of nullable versions
  * See https://rules.sonarsource.com/java/RSPEC-3553
* Better exceptions when initializing the test application fails
* Clean up tests and remove redundant test applications

Closes #1709
Closes #1830