### PR TITLE
Upgrade commons-lang3 in release/1.3.x to make bom java11 compatible

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.7</version>
+                <version>3.8.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
###### Problem:
There is a bug in older versions of commons-lang3 that affects users running on java11
See further details in https://issues.apache.org/jira/browse/LANG-1384
Using the recent commons-lang3 version in dropwizard-bom eases java11 transitioning for dropwizard users.

###### Solution:
Updating to the most recent release of commons-lang3 (atm 3.8.1) solves the problem

###### Result:
Dropwizard users relying on dropwizard-bom do not need to manually version manage commons-lang3 to a newer version themselves