### PR TITLE
Update JdbiFactory to use metrics' InstrumentedSqlLogger

### DIFF
--- a/dropwizard-jdbi3/src/main/java/io/dropwizard/jdbi3/JdbiFactory.java
+++ b/dropwizard-jdbi3/src/main/java/io/dropwizard/jdbi3/JdbiFactory.java
@@ -16,7 +16,7 @@ import org.jdbi.v3.jodatime2.JodaTimePlugin;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 
 public class JdbiFactory {
-    protected final StatementNameStrategy nameStrategy;
+    private final StatementNameStrategy nameStrategy;
 
     public JdbiFactory() {
         this(new SmartNameStrategy());
@@ -79,7 +79,7 @@ public class JdbiFactory {
             validationQuery));
 
         // Setup the SQL logger
-        jdbi.setSqlLogger(buildSQLLogger(environment.metrics()));
+        jdbi.setSqlLogger(buildSQLLogger(environment.metrics(), nameStrategy));
 
         if (configuration.isAutoCommentsEnabled()) {
             final TemplateEngine original = jdbi.getConfig(SqlStatements.class).getTemplateEngine();
@@ -96,9 +96,10 @@ public class JdbiFactory {
      * {@link MetricRegistry} and {@link #nameStrategy}. This can be overridden if required.
      *
      * @param metricRegistry The {@link MetricRegistry} to send to the {@link InstrumentedSqlLogger}.
+     * @param nameStrategy  The {@link StatementNameStrategy} to send to the {@link InstrumentedSqlLogger}.
      * @return The created {@link InstrumentedSqlLogger}.
      */
-    protected InstrumentedSqlLogger buildSQLLogger(MetricRegistry metricRegistry) {
+    protected InstrumentedSqlLogger buildSQLLogger(MetricRegistry metricRegistry, StatementNameStrategy nameStrategy) {
         return new InstrumentedSqlLogger(metricRegistry, nameStrategy);
     }
 

--- a/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/JdbiFactoryTest.java
+++ b/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/JdbiFactoryTest.java
@@ -2,7 +2,7 @@ package io.dropwizard.jdbi3;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
-import com.codahale.metrics.jdbi3.InstrumentedTimingCollector;
+import com.codahale.metrics.jdbi3.InstrumentedSqlLogger;
 import io.dropwizard.db.ManagedDataSource;
 import io.dropwizard.db.PooledDataSourceFactory;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
@@ -50,7 +50,8 @@ public class JdbiFactoryTest {
         assertThat(result).isSameAs(jdbi);
         verify(lifecycle).manage(dataSource);
         verify(healthChecks).register(eq(name), any(JdbiHealthCheck.class));
-        verify(jdbi).setTimingCollector(any(InstrumentedTimingCollector.class));
+        verify(jdbi).setSqlLogger(any(InstrumentedSqlLogger.class));
+        verify(factory).buildSQLLogger(metrics);
         verify(jdbi).setTemplateEngine(any(NamePrependingTemplateEngine.class));
         verify(factory).configure(jdbi);
     }

--- a/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/JdbiFactoryTest.java
+++ b/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/JdbiFactoryTest.java
@@ -3,6 +3,7 @@ package io.dropwizard.jdbi3;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.codahale.metrics.jdbi3.InstrumentedSqlLogger;
+import com.codahale.metrics.jdbi3.strategies.StatementNameStrategy;
 import io.dropwizard.db.ManagedDataSource;
 import io.dropwizard.db.PooledDataSourceFactory;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
@@ -51,7 +52,7 @@ public class JdbiFactoryTest {
         verify(lifecycle).manage(dataSource);
         verify(healthChecks).register(eq(name), any(JdbiHealthCheck.class));
         verify(jdbi).setSqlLogger(any(InstrumentedSqlLogger.class));
-        verify(factory).buildSQLLogger(metrics);
+        verify(factory).buildSQLLogger(same(metrics), any(StatementNameStrategy.class));
         verify(jdbi).setTemplateEngine(any(NamePrependingTemplateEngine.class));
         verify(factory).configure(jdbi);
     }


### PR DESCRIPTION
###### Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->
Metrics library was updated to use JDBI 3's `SqlLogger` instead of the deprecated `TimingCollector`, but Dropwizard is still using `TimingCollector`.

###### Solution:
<!-- Describe the modifications you've done. -->
Updated Dropwizard to use the new `SqlLogger`.

###### Result:
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->
