### PR TITLE
Fixed flaky test in CachingAuthorizer

### DIFF
--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/CachingAuthorizer.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/CachingAuthorizer.java
@@ -7,6 +7,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.CaffeineSpec;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.util.Sets;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
@@ -41,7 +42,10 @@ public class CachingAuthorizer<P extends Principal> implements Authorizer<P> {
     //
     // `null` cache values are interpreted as cache misses, and will
     // thus result in read through to the underlying `Authorizer`.
-    private final LoadingCache<ImmutablePair<P, String>, Boolean> cache;
+    //
+    // Field is package-private to be visible for unit tests
+    @VisibleForTesting
+    final LoadingCache<ImmutablePair<P, String>, Boolean> cache;
 
     /**
      * Creates a new cached authorizer.

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/CachingAuthorizerTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/CachingAuthorizerTest.java
@@ -48,11 +48,11 @@ public class CachingAuthorizerTest {
     @Test
     public void respectsTheCacheConfiguration() throws Exception {
         cached.authorize(principal, role);
-        Thread.sleep(10L);
+        // We need to make sure that background cache invalidation is done before other requests
+        cached.cache.cleanUp();
         cached.authorize(principal2, role);
-        Thread.sleep(10L);
+        cached.cache.cleanUp();
         cached.authorize(principal, role);
-        Thread.sleep(10L);
 
         final InOrder inOrder = inOrder(underlying);
         inOrder.verify(underlying, times(1)).authorize(principal, role);


### PR DESCRIPTION
###### Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->
Travis build failed in #2682 because sleeping for any amount of time does not guarantee that Caffeine will have performed its background cleanup before performing the next call.

###### Solution:
<!-- Describe the modifications you've done. -->
Made `cache` field in CachingAuthorizer package private and manually called the `cleanup` function on the Caffeine instance instead of sleeping.

###### Result:
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->
Test should not fail randomly anymore.
