### PR TITLE
Document asynchronous logging

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -619,10 +619,11 @@ Name                   Default                                  Description
 type                   REQUIRED                                 The appender type. Must be ``console``.
 threshold              ALL                                      The lowest level of events to print to the console.
 queueSize              256                                      The maximum capacity of the blocking queue.
-discardingThreshold    51                                       When the blocking queue has only the capacity mentioned in
+discardingThreshold    -1                                       When the blocking queue has only the capacity mentioned in
                                                                 discardingThreshold remaining, it will drop events of level TRACE,
                                                                 DEBUG and INFO, keeping only events of level WARN and ERROR.
-                                                                If no discarding threshold is specified, then a default of queueSize / 5 is used.
+                                                                If no discarding threshold is specified (-1), then a default of 
+                                                                queueSize / 5 (logback's default ratio) is used.
                                                                 To keep all events, set discardingThreshold to 0.
 timeZone               UTC                                      The time zone to which event timestamps will be converted.
                                                                 To use the system/default time zone, set it to ``system``.
@@ -673,10 +674,11 @@ type                         REQUIRED                                   The appe
 currentLogFilename           REQUIRED                                   The filename where current events are logged.
 threshold                    ALL                                        The lowest level of events to write to the file.
 queueSize                    256                                        The maximum capacity of the blocking queue.
-discardingThreshold          51                                         When the blocking queue has only the capacity mentioned in discardingThreshold
+discardingThreshold          -1                                         When the blocking queue has only the capacity mentioned in discardingThreshold
                                                                         remaining, it will drop events of level TRACE, DEBUG and INFO, keeping only events
-                                                                        of level WARN and ERROR. If no discarding threshold is specified, then a default
-                                                                        of queueSize / 5 is used. To keep all events, set discardingThreshold to 0.
+                                                                        of level WARN and ERROR. If no discarding threshold is specified (-1), then a default
+                                                                        of queueSize / 5 (logback's default ratio) is used. To keep all events, set 
+                                                                        discardingThreshold to 0.
 archive                      true                                       Whether or not to archive old events in separate files.
 archivedLogFilenamePattern   (none)                                     Required if ``archive`` is ``true``.
                                                                         The filename pattern for archived files.

--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -925,6 +925,33 @@ acceptable.
               currentLogFilename: ./logs/example-sql.log
               archivedLogFilenamePattern: ./logs/example-sql-%d.log.gz
               archivedFileCount: 5
+
+.. _man-core-logging-asynchronous-logging:
+
+Asynchronous Logging
+--------------------
+
+By default, all logging in Dropwizard is asynchronous, even to typically
+synchronous sinks such as files and the console. When a slow logger (like file
+logger on an overloaded disk) is coupled with a high load, Dropwizard will
+seemlessly drop events of lower importance (``TRACE``, ``DEBUG``, ``INFO``) in
+an attempt to maintain reasonable latency. 
+
+.. TIP::
+   Instead of logging business critical statements under ``INFO``, insert them
+   into a database, durable message queue, or another mechanism that gives
+   confidence that the request has satisfied business requirements before
+   returning the response to the client.
+
+This logging behavior :ref:`can be configured <man-configuration-logging>`:
+
+* Set ``discardingThreshold`` to 0 so that no events are dropped
+* At the opposite end, set ``neverBlock`` to ``true`` so that even ``WARN`` and ``ERROR`` levels will be discarded from logging under heavy load
+
+Request access logging has the same logging behavior, and since all request
+logging is done under ``INFO``, each log statement has an equal chance of being
+dropped if the log queue is nearing full.
+
 .. _man-core-logging-console:
 
 Console Logging
@@ -932,8 +959,6 @@ Console Logging
 
 By default, Dropwizard applications log ``INFO`` and higher to ``STDOUT``. You can configure this by
 editing the ``logging`` section of your YAML configuration file:
-
-
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Document that Dropwizard defaults to asynchronous and will drop lower priority logging events if the log queue buffer starts to fill up. Closes #2681