### PR TITLE
Add data size class adhering to the correct SI and IEC prefixes

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -660,7 +660,7 @@ File
           archivedFileCount: 5
           timeZone: UTC
           logFormat: "%-5p [%d{ISO8601,UTC}] %c: %m%n%rEx"
-          bufferSize: 8KB
+          bufferSize: 8KiB
           immediateFlush: true
           filterFactories:
             - type: URI
@@ -688,9 +688,10 @@ archivedLogFilenamePattern   (none)                                     Required
 archivedFileCount            5                                          The number of archived files to keep. Must be greater than or equal to ``0``. Zero is a
                                                                         special value signifying to keep infinite logs (use with caution)
 maxFileSize                  (unlimited)                                The maximum size of the currently active file before a rollover is triggered. The value can be
-                                                                        expressed in bytes, kilobytes, megabytes, gigabytes, and terabytes by appending B, K, MB, GB, or
-                                                                        TB to the numeric value.  Examples include 100MB, 1GB, 1TB.  Sizes can also be spelled out, such
-                                                                        as 100 megabytes, 1 gigabyte, 1 terabyte.
+                                                                        expressed in bytes, kibibytes, kilobytes, mebibytes, megabytes, gibibytes, gigabytes, tebibytes,
+                                                                        terabytes, pebibytes, and petabytes by appending B, KiB, KB, MiB, MB, GiB, GB, TiB, TB, PiB, or PB
+                                                                        to the numeric value.  Examples include 5KiB, 100MiB, 1GiB, 1TB.  Sizes can also be spelled out, such
+                                                                        as 5 kibibytes, 100 mebibytes, 1 gibibyte, 1 terabyte.
 totalSizeCap                 (unlimited)                                Controls the total size of all files.
                                                                         Oldest archives are deleted asynchronously when the total size cap is exceeded.
 timeZone                     UTC                                        The time zone to which event timestamps will be converted.
@@ -701,8 +702,8 @@ filterFactories              (none)                                     The list
                                                                         the threshold.
 neverBlock                   false                                      Prevent the wrapping asynchronous appender from blocking when its underlying queue is full.
                                                                         Set to true to disable blocking.
-bufferSize                   8KB                                        The buffer size of the underlying FileAppender (setting added in logback 1.1.10). Increasing this
-                                                                        from the default of 8KB to 256KB is reported to significantly reduce thread contention.
+bufferSize                   8KiB                                       The buffer size of the underlying FileAppender (setting added in logback 1.1.10). Increasing this
+                                                                        from the default of 8KiB to 256KiB is reported to significantly reduce thread contention.
 immediateFlush               true                                       If set to true, log events will be immediately flushed to disk. Immediate flushing is safer, but
                                                                         it degrades logging throughput.
 ============================ =========================================  ==================================================================================================
@@ -767,7 +768,7 @@ TCP
           port: 4560
           connectionTimeout: 500ms
           immediateFlush: true
-          sendBufferSize: 8KB
+          sendBufferSize: 8KiB
 
 
 ============================ =============  ==================================================================
@@ -778,7 +779,7 @@ port                         4560           The port on which the TCP server is 
 connectionTimeout            500ms          The timeout to connect to the TCP server.
 immediateFlush               true           If set to true, log events will be immediately send to the server
                                             Immediate flushing is safer, but it degrades logging throughput.
-sendBufferSize               8KB            The buffer size of the underlying SocketAppender.
+sendBufferSize               8KiB           The buffer size of the underlying SocketAppender.
                                             Takes into effect if immediateFlush is disabled.
 ============================ =============  ==================================================================
 

--- a/dropwizard-benchmarks/src/main/java/io/dropwizard/benchmarks/util/DataSizeBenchmark.java
+++ b/dropwizard-benchmarks/src/main/java/io/dropwizard/benchmarks/util/DataSizeBenchmark.java
@@ -1,0 +1,39 @@
+package io.dropwizard.benchmarks.util;
+
+import io.dropwizard.util.DataSize;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class DataSizeBenchmark {
+
+    /**
+     * Don't trust the IDE, it's advisedly non-final to avoid constant folding
+     */
+    private String size = "256KiB";
+
+    @Benchmark
+    public DataSize parseSize() {
+        return DataSize.parse(size);
+    }
+
+    public static void main(String[] args) throws Exception {
+        new Runner(new OptionsBuilder()
+                .include(DataSizeBenchmark.class.getSimpleName())
+                .forks(1)
+                .warmupIterations(5)
+                .measurementIterations(5)
+                .build())
+                .run();
+    }
+}

--- a/dropwizard-example/example.yml
+++ b/dropwizard-example/example.yml
@@ -76,7 +76,7 @@ logging:
       archivedLogFilenamePattern: /tmp/application-%d{yyyy-MM-dd}-%i.log.gz
       archivedFileCount: 7
       timeZone: UTC
-      maxFileSize: 10MB
+      maxFileSize: 10MiB
 
 # the key needs to match the configuration key of the renderer (ViewRenderer::getConfigurationKey)
 viewRendererConfiguration:

--- a/dropwizard-example/src/test/resources/test-example.yml
+++ b/dropwizard-example/src/test/resources/test-example.yml
@@ -25,5 +25,5 @@ logging:
       archivedLogFilenamePattern: './logs/application-%d-%i.log.gz'
       archive: true
       archivedFileCount: 7
-      maxFileSize: '1mb'
+      maxFileSize: '1MiB'
 

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/GzipHandlerFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/GzipHandlerFactory.java
@@ -1,7 +1,7 @@
 package io.dropwizard.jetty;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.dropwizard.util.Size;
+import io.dropwizard.util.DataSize;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 
@@ -36,12 +36,12 @@ import static java.util.Objects.requireNonNull;
  *     <tr>
  *         <td>{@code minimumEntitySize}</td>
  *         <td>256 bytes</td>
- *         <td>All response entities under this size are not compressed.</td>
+ *         <td>All response entities under this DataSize are not compressed.</td>
  *     </tr>
  *     <tr>
  *         <td>{@code bufferSize}</td>
  *         <td>8KiB</td>
- *         <td>The size of the buffer to use when compressing.</td>
+ *         <td>The DataSize of the buffer to use when compressing.</td>
  *     </tr>
  *     <tr>
  *         <td>{@code excludedUserAgentPatterns}</td>
@@ -96,10 +96,10 @@ public class GzipHandlerFactory {
     private boolean enabled = true;
 
     @NotNull
-    private Size minimumEntitySize = Size.bytes(256);
+    private DataSize minimumEntitySize = DataSize.bytes(256);
 
     @NotNull
-    private Size bufferSize = Size.kilobytes(8);
+    private DataSize bufferSize = DataSize.kibibytes(8);
 
     // By default compress responses for all user-agents
     private Set<String> excludedUserAgentPatterns = new HashSet<>();
@@ -138,22 +138,22 @@ public class GzipHandlerFactory {
     }
 
     @JsonProperty
-    public Size getMinimumEntitySize() {
+    public DataSize getMinimumEntitySize() {
         return minimumEntitySize;
     }
 
     @JsonProperty
-    public void setMinimumEntitySize(Size size) {
+    public void setMinimumEntitySize(DataSize size) {
         this.minimumEntitySize = requireNonNull(size);
     }
 
     @JsonProperty
-    public Size getBufferSize() {
+    public DataSize getBufferSize() {
         return bufferSize;
     }
 
     @JsonProperty
-    public void setBufferSize(Size size) {
+    public void setBufferSize(DataSize size) {
         this.bufferSize = requireNonNull(size);
     }
 

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
@@ -3,11 +3,11 @@ package io.dropwizard.jetty;
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.dropwizard.util.DataSize;
+import io.dropwizard.util.DataSizeUnit;
 import io.dropwizard.util.Duration;
-import io.dropwizard.util.Size;
-import io.dropwizard.util.SizeUnit;
+import io.dropwizard.validation.MinDataSize;
 import io.dropwizard.validation.MinDuration;
-import io.dropwizard.validation.MinSize;
 import io.dropwizard.validation.PortRange;
 import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.io.ArrayByteBufferPool;
@@ -228,48 +228,48 @@ public class HttpConnectorFactory implements ConnectorFactory {
     private boolean inheritChannel = false;
 
     @NotNull
-    @MinSize(128)
-    private Size headerCacheSize = Size.bytes(512);
+    @MinDataSize(128)
+    private DataSize headerCacheSize = DataSize.bytes(512);
 
     @NotNull
-    @MinSize(value = 8, unit = SizeUnit.KILOBYTES)
-    private Size outputBufferSize = Size.kilobytes(32);
+    @MinDataSize(value = 8, unit = DataSizeUnit.KIBIBYTES)
+    private DataSize outputBufferSize = DataSize.kibibytes(32);
 
     @NotNull
-    @MinSize(value = 1, unit = SizeUnit.KILOBYTES)
-    private Size maxRequestHeaderSize = Size.kilobytes(8);
+    @MinDataSize(value = 1, unit = DataSizeUnit.KIBIBYTES)
+    private DataSize maxRequestHeaderSize = DataSize.kibibytes(8);
 
     @NotNull
-    @MinSize(value = 1, unit = SizeUnit.KILOBYTES)
-    private Size maxResponseHeaderSize = Size.kilobytes(8);
+    @MinDataSize(value = 1, unit = DataSizeUnit.KIBIBYTES)
+    private DataSize maxResponseHeaderSize = DataSize.kibibytes(8);
 
     @NotNull
-    @MinSize(value = 1, unit = SizeUnit.KILOBYTES)
-    private Size inputBufferSize = Size.kilobytes(8);
+    @MinDataSize(value = 1, unit = DataSizeUnit.KIBIBYTES)
+    private DataSize inputBufferSize = DataSize.kibibytes(8);
 
     @NotNull
     @MinDuration(value = 1, unit = TimeUnit.MILLISECONDS)
     private Duration idleTimeout = Duration.seconds(30);
 
     @NotNull
-    @MinSize(0)
-    private Size minResponseDataPerSecond = Size.bytes(0);
+    @MinDataSize(0)
+    private DataSize minResponseDataPerSecond = DataSize.bytes(0);
 
     @NotNull
-    @MinSize(0)
-    private Size minRequestDataPerSecond = Size.bytes(0);
+    @MinDataSize(0)
+    private DataSize minRequestDataPerSecond = DataSize.bytes(0);
 
     @NotNull
-    @MinSize(value = 1, unit = SizeUnit.BYTES)
-    private Size minBufferPoolSize = Size.bytes(64);
+    @MinDataSize(value = 1, unit = DataSizeUnit.BYTES)
+    private DataSize minBufferPoolSize = DataSize.bytes(64);
 
     @NotNull
-    @MinSize(value = 1, unit = SizeUnit.BYTES)
-    private Size bufferPoolIncrement = Size.bytes(1024);
+    @MinDataSize(value = 1, unit = DataSizeUnit.BYTES)
+    private DataSize bufferPoolIncrement = DataSize.bytes(1024);
 
     @NotNull
-    @MinSize(value = 1, unit = SizeUnit.BYTES)
-    private Size maxBufferPoolSize = Size.kilobytes(64);
+    @MinDataSize(value = 1, unit = DataSizeUnit.BYTES)
+    private DataSize maxBufferPoolSize = DataSize.kibibytes(64);
 
     @Min(value = 1, payload = Unwrapping.Unwrap.class)
     private Optional<Integer> acceptorThreads = Optional.empty();
@@ -320,52 +320,52 @@ public class HttpConnectorFactory implements ConnectorFactory {
     }
 
     @JsonProperty
-    public Size getHeaderCacheSize() {
+    public DataSize getHeaderCacheSize() {
         return headerCacheSize;
     }
 
     @JsonProperty
-    public void setHeaderCacheSize(Size headerCacheSize) {
+    public void setHeaderCacheSize(DataSize headerCacheSize) {
         this.headerCacheSize = headerCacheSize;
     }
 
     @JsonProperty
-    public Size getOutputBufferSize() {
+    public DataSize getOutputBufferSize() {
         return outputBufferSize;
     }
 
     @JsonProperty
-    public void setOutputBufferSize(Size outputBufferSize) {
+    public void setOutputBufferSize(DataSize outputBufferSize) {
         this.outputBufferSize = outputBufferSize;
     }
 
     @JsonProperty
-    public Size getMaxRequestHeaderSize() {
+    public DataSize getMaxRequestHeaderSize() {
         return maxRequestHeaderSize;
     }
 
     @JsonProperty
-    public void setMaxRequestHeaderSize(Size maxRequestHeaderSize) {
+    public void setMaxRequestHeaderSize(DataSize maxRequestHeaderSize) {
         this.maxRequestHeaderSize = maxRequestHeaderSize;
     }
 
     @JsonProperty
-    public Size getMaxResponseHeaderSize() {
+    public DataSize getMaxResponseHeaderSize() {
         return maxResponseHeaderSize;
     }
 
     @JsonProperty
-    public void setMaxResponseHeaderSize(Size maxResponseHeaderSize) {
+    public void setMaxResponseHeaderSize(DataSize maxResponseHeaderSize) {
         this.maxResponseHeaderSize = maxResponseHeaderSize;
     }
 
     @JsonProperty
-    public Size getInputBufferSize() {
+    public DataSize getInputBufferSize() {
         return inputBufferSize;
     }
 
     @JsonProperty
-    public void setInputBufferSize(Size inputBufferSize) {
+    public void setInputBufferSize(DataSize inputBufferSize) {
         this.inputBufferSize = inputBufferSize;
     }
 
@@ -380,52 +380,52 @@ public class HttpConnectorFactory implements ConnectorFactory {
     }
 
     @JsonProperty
-    public Size getMinBufferPoolSize() {
+    public DataSize getMinBufferPoolSize() {
         return minBufferPoolSize;
     }
 
     @JsonProperty
-    public void setMinBufferPoolSize(Size minBufferPoolSize) {
+    public void setMinBufferPoolSize(DataSize minBufferPoolSize) {
         this.minBufferPoolSize = minBufferPoolSize;
     }
 
     @JsonProperty
-    public Size getBufferPoolIncrement() {
+    public DataSize getBufferPoolIncrement() {
         return bufferPoolIncrement;
     }
 
     @JsonProperty
-    public void setBufferPoolIncrement(Size bufferPoolIncrement) {
+    public void setBufferPoolIncrement(DataSize bufferPoolIncrement) {
         this.bufferPoolIncrement = bufferPoolIncrement;
     }
 
     @JsonProperty
-    public Size getMaxBufferPoolSize() {
+    public DataSize getMaxBufferPoolSize() {
         return maxBufferPoolSize;
     }
 
     @JsonProperty
-    public void setMaxBufferPoolSize(Size maxBufferPoolSize) {
+    public void setMaxBufferPoolSize(DataSize maxBufferPoolSize) {
         this.maxBufferPoolSize = maxBufferPoolSize;
     }
 
     @JsonProperty
-    public Size getMinResponseDataPerSecond() {
+    public DataSize getMinResponseDataPerSecond() {
         return minResponseDataPerSecond;
     }
 
     @JsonProperty
-    public void setMinResponseDataPerSecond(Size minResponseDataPerSecond) {
+    public void setMinResponseDataPerSecond(DataSize minResponseDataPerSecond) {
         this.minResponseDataPerSecond = minResponseDataPerSecond;
     }
 
     @JsonProperty
-    public Size getMinRequestDataPerSecond() {
+    public DataSize getMinRequestDataPerSecond() {
         return minRequestDataPerSecond;
     }
 
     @JsonProperty
-    public void setMinRequestDataPerSecond(Size minRequestDataPerSecond) {
+    public void setMinRequestDataPerSecond(DataSize minRequestDataPerSecond) {
         this.minRequestDataPerSecond = minRequestDataPerSecond;
     }
 

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/GzipHandlerFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/GzipHandlerFactoryTest.java
@@ -2,9 +2,9 @@ package io.dropwizard.jetty;
 
 import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
+import io.dropwizard.util.DataSize;
 import io.dropwizard.util.Resources;
 import io.dropwizard.util.Sets;
-import io.dropwizard.util.Size;
 import io.dropwizard.validation.BaseValidator;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
@@ -18,48 +18,48 @@ import java.util.zip.Deflater;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-public class GzipHandlerFactoryTest {
+class GzipHandlerFactoryTest {
     private GzipHandlerFactory gzip;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         this.gzip = new YamlConfigurationFactory<>(GzipHandlerFactory.class,
                 BaseValidator.newValidator(), Jackson.newObjectMapper(), "dw")
                 .build(new File(Resources.getResource("yaml/gzip.yml").toURI()));
     }
 
     @Test
-    public void canBeEnabled() throws Exception {
+    void canBeEnabled() {
         assertThat(gzip.isEnabled())
                 .isFalse();
     }
 
     @Test
-    public void hasAMinimumEntitySize() throws Exception {
+    void hasAMinimumEntitySize() {
         assertThat(gzip.getMinimumEntitySize())
-                .isEqualTo(Size.kilobytes(12));
+                .isEqualTo(DataSize.kibibytes(12));
     }
 
     @Test
-    public void hasABufferSize() throws Exception {
+    void hasABufferSize() {
         assertThat(gzip.getBufferSize())
-                .isEqualTo(Size.kilobytes(32));
+                .isEqualTo(DataSize.kibibytes(32));
     }
 
     @Test
-    public void hasExcludedUserAgentPatterns() throws Exception {
+    void hasExcludedUserAgentPatterns() {
         assertThat(gzip.getExcludedUserAgentPatterns())
                 .isEqualTo(Collections.singleton("OLD-2.+"));
     }
 
     @Test
-    public void hasCompressedMimeTypes() throws Exception {
+    void hasCompressedMimeTypes() {
         assertThat(gzip.getCompressedMimeTypes())
                 .isEqualTo(Collections.singleton("text/plain"));
     }
 
     @Test
-    public void testBuild() {
+    void testBuild() {
         final GzipHandler handler = gzip.build(null);
 
         assertThat(handler.getMinGzipSize()).isEqualTo((int) gzip.getMinimumEntitySize().toBytes());
@@ -71,7 +71,7 @@ public class GzipHandlerFactoryTest {
     }
 
     @Test
-    public void testBuildDefault() throws Exception {
+    void testBuildDefault() throws Exception {
         final GzipHandler handler = new YamlConfigurationFactory<>(GzipHandlerFactory.class,
                 BaseValidator.newValidator(), Jackson.newObjectMapper(), "dw")
                 .build(new File(Resources.getResource("yaml/default_gzip.yml").toURI()))
@@ -85,9 +85,9 @@ public class GzipHandlerFactoryTest {
     }
 
     @Test
-    public void testBuilderProperties() {
+    void testBuilderProperties() {
         GzipHandlerFactory gzip = new GzipHandlerFactory();
-        gzip.setMinimumEntitySize(Size.bytes(4096));
+        gzip.setMinimumEntitySize(DataSize.bytes(4096));
         gzip.setIncludedMethods(Sets.of("GET", "POST"));
         gzip.setExcludedUserAgentPatterns(Collections.singleton("MSIE 6.0"));
         gzip.setCompressedMimeTypes(Sets.of("text/html", "application/json"));

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/GzipHandlerTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/GzipHandlerTest.java
@@ -1,8 +1,8 @@
 package io.dropwizard.jetty;
 
 import io.dropwizard.util.CharStreams;
+import io.dropwizard.util.DataSize;
 import io.dropwizard.util.Resources;
-import io.dropwizard.util.Size;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -24,7 +23,7 @@ import java.util.zip.GZIPOutputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class GzipHandlerTest {
+class GzipHandlerTest {
 
     private static final String PLAIN_TEXT_UTF_8 = "text/plain;charset=UTF-8";
 
@@ -33,14 +32,14 @@ public class GzipHandlerTest {
     private final ServletTester servletTester = new ServletTester();
     private final HttpTester.Request request = HttpTester.newRequest();
 
-    public GzipHandlerTest() {
+    GzipHandlerTest() {
         final GzipHandlerFactory gzipHandlerFactory = new GzipHandlerFactory();
-        gzipHandlerFactory.setMinimumEntitySize(Size.bytes(0));
+        gzipHandlerFactory.setMinimumEntitySize(DataSize.bytes(0L));
         gzipHandler = gzipHandlerFactory.build(null);
     }
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         request.setHeader(HttpHeader.HOST.asString(), "localhost");
         request.setHeader("Connection", "close");
         request.setURI("/banner");
@@ -53,12 +52,12 @@ public class GzipHandlerTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         servletTester.stop();
     }
 
     @Test
-    public void testCompressResponse() throws Exception {
+    void testCompressResponse() throws Exception {
         request.setMethod("GET");
         request.setHeader(HttpHeader.ACCEPT_ENCODING.asString(), "gzip");
 
@@ -76,7 +75,7 @@ public class GzipHandlerTest {
     }
 
     @Test
-    public void testDecompressRequest() throws Exception {
+    void testDecompressRequest() throws Exception {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (GZIPOutputStream gz = new GZIPOutputStream(baos)) {
             Resources.copy(Resources.getResource("assets/new-banner.txt"), gz);
@@ -105,14 +104,14 @@ public class GzipHandlerTest {
     public static class BannerServlet extends HttpServlet {
 
         @Override
-        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
             resp.setCharacterEncoding(StandardCharsets.UTF_8.toString());
             resp.setContentType(PLAIN_TEXT_UTF_8);
             resp.getWriter().write(Resources.toString(Resources.getResource("assets/banner.txt"), StandardCharsets.UTF_8));
         }
 
         @Override
-        protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
             assertThat(req.getHeader(HttpHeader.CONTENT_TYPE.asString())).isEqualToIgnoringCase(PLAIN_TEXT_UTF_8);
             assertThat(req.getHeader(HttpHeader.CONTENT_ENCODING.asString())).isNull();
             assertThat(req.getHeader(HttpHeader.CONTENT_LENGTH.asString())).isNull();

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
@@ -8,9 +8,9 @@ import io.dropwizard.jackson.Jackson;
 import io.dropwizard.logging.ConsoleAppenderFactory;
 import io.dropwizard.logging.FileAppenderFactory;
 import io.dropwizard.logging.SyslogAppenderFactory;
+import io.dropwizard.util.DataSize;
 import io.dropwizard.util.Duration;
 import io.dropwizard.util.Resources;
-import io.dropwizard.util.Size;
 import io.dropwizard.validation.BaseValidator;
 import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.io.ArrayByteBufferPool;
@@ -33,25 +33,25 @@ import java.util.Optional;
 import static org.apache.commons.lang3.reflect.FieldUtils.getField;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class HttpConnectorFactoryTest {
+class HttpConnectorFactoryTest {
 
     private final ObjectMapper objectMapper = Jackson.newObjectMapper();
     private final Validator validator = BaseValidator.newValidator();
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() {
         objectMapper.getSubtypeResolver().registerSubtypes(ConsoleAppenderFactory.class,
                 FileAppenderFactory.class, SyslogAppenderFactory.class, HttpConnectorFactory.class);
     }
 
     @Test
-    public void isDiscoverable() throws Exception {
+    void isDiscoverable() {
         assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
                 .contains(HttpConnectorFactory.class);
     }
 
     @Test
-    public void testParseMinimalConfiguration() throws Exception {
+    void testParseMinimalConfiguration() throws Exception {
         HttpConnectorFactory http =
                 new YamlConfigurationFactory<>(HttpConnectorFactory.class, validator, objectMapper, "dw")
                 .build(new File(Resources.getResource("yaml/http-connector-minimal.yml").toURI()));
@@ -59,17 +59,17 @@ public class HttpConnectorFactoryTest {
         assertThat(http.getPort()).isEqualTo(8080);
         assertThat(http.getBindHost()).isNull();
         assertThat(http.isInheritChannel()).isEqualTo(false);
-        assertThat(http.getHeaderCacheSize()).isEqualTo(Size.bytes(512));
-        assertThat(http.getOutputBufferSize()).isEqualTo(Size.kilobytes(32));
-        assertThat(http.getMaxRequestHeaderSize()).isEqualTo(Size.kilobytes(8));
-        assertThat(http.getMaxResponseHeaderSize()).isEqualTo(Size.kilobytes(8));
-        assertThat(http.getInputBufferSize()).isEqualTo(Size.kilobytes(8));
+        assertThat(http.getHeaderCacheSize()).isEqualTo(DataSize.bytes(512));
+        assertThat(http.getOutputBufferSize()).isEqualTo(DataSize.kibibytes(32));
+        assertThat(http.getMaxRequestHeaderSize()).isEqualTo(DataSize.kibibytes(8));
+        assertThat(http.getMaxResponseHeaderSize()).isEqualTo(DataSize.kibibytes(8));
+        assertThat(http.getInputBufferSize()).isEqualTo(DataSize.kibibytes(8));
         assertThat(http.getIdleTimeout()).isEqualTo(Duration.seconds(30));
-        assertThat(http.getMinBufferPoolSize()).isEqualTo(Size.bytes(64));
-        assertThat(http.getBufferPoolIncrement()).isEqualTo(Size.bytes(1024));
-        assertThat(http.getMaxBufferPoolSize()).isEqualTo(Size.kilobytes(64));
-        assertThat(http.getMinRequestDataPerSecond()).isEqualTo(Size.bytes(0));
-        assertThat(http.getMinResponseDataPerSecond()).isEqualTo(Size.bytes(0));
+        assertThat(http.getMinBufferPoolSize()).isEqualTo(DataSize.bytes(64));
+        assertThat(http.getBufferPoolIncrement()).isEqualTo(DataSize.bytes(1024));
+        assertThat(http.getMaxBufferPoolSize()).isEqualTo(DataSize.kibibytes(64));
+        assertThat(http.getMinRequestDataPerSecond()).isEqualTo(DataSize.bytes(0));
+        assertThat(http.getMinResponseDataPerSecond()).isEqualTo(DataSize.bytes(0));
         assertThat(http.getAcceptorThreads()).isEmpty();
         assertThat(http.getSelectorThreads()).isEmpty();
         assertThat(http.getAcceptQueueSize()).isNull();
@@ -81,7 +81,7 @@ public class HttpConnectorFactoryTest {
     }
 
     @Test
-    public void testParseFullConfiguration() throws Exception {
+    void testParseFullConfiguration() throws Exception {
         HttpConnectorFactory http =
                 new YamlConfigurationFactory<>(HttpConnectorFactory.class, validator, objectMapper, "dw")
                 .build(new File(Resources.getResource("yaml/http-connector.yml").toURI()));
@@ -89,17 +89,17 @@ public class HttpConnectorFactoryTest {
         assertThat(http.getPort()).isEqualTo(9090);
         assertThat(http.getBindHost()).isEqualTo("127.0.0.1");
         assertThat(http.isInheritChannel()).isEqualTo(true);
-        assertThat(http.getHeaderCacheSize()).isEqualTo(Size.bytes(256));
-        assertThat(http.getOutputBufferSize()).isEqualTo(Size.kilobytes(128));
-        assertThat(http.getMaxRequestHeaderSize()).isEqualTo(Size.kilobytes(4));
-        assertThat(http.getMaxResponseHeaderSize()).isEqualTo(Size.kilobytes(4));
-        assertThat(http.getInputBufferSize()).isEqualTo(Size.kilobytes(4));
+        assertThat(http.getHeaderCacheSize()).isEqualTo(DataSize.bytes(256));
+        assertThat(http.getOutputBufferSize()).isEqualTo(DataSize.kibibytes(128));
+        assertThat(http.getMaxRequestHeaderSize()).isEqualTo(DataSize.kibibytes(4));
+        assertThat(http.getMaxResponseHeaderSize()).isEqualTo(DataSize.kibibytes(4));
+        assertThat(http.getInputBufferSize()).isEqualTo(DataSize.kibibytes(4));
         assertThat(http.getIdleTimeout()).isEqualTo(Duration.seconds(10));
-        assertThat(http.getMinBufferPoolSize()).isEqualTo(Size.bytes(128));
-        assertThat(http.getBufferPoolIncrement()).isEqualTo(Size.bytes(500));
-        assertThat(http.getMaxBufferPoolSize()).isEqualTo(Size.kilobytes(32));
-        assertThat(http.getMinRequestDataPerSecond()).isEqualTo(Size.bytes(42));
-        assertThat(http.getMinResponseDataPerSecond()).isEqualTo(Size.bytes(200));
+        assertThat(http.getMinBufferPoolSize()).isEqualTo(DataSize.bytes(128));
+        assertThat(http.getBufferPoolIncrement()).isEqualTo(DataSize.bytes(500));
+        assertThat(http.getMaxBufferPoolSize()).isEqualTo(DataSize.kibibytes(32));
+        assertThat(http.getMinRequestDataPerSecond()).isEqualTo(DataSize.bytes(42));
+        assertThat(http.getMinResponseDataPerSecond()).isEqualTo(DataSize.bytes(200));
         assertThat(http.getAcceptorThreads()).contains(1);
         assertThat(http.getSelectorThreads()).contains(4);
         assertThat(http.getAcceptQueueSize()).isEqualTo(1024);
@@ -111,14 +111,14 @@ public class HttpConnectorFactoryTest {
     }
 
     @Test
-    public void testBuildConnector() throws Exception {
+    void testBuildConnector() throws Exception {
         HttpConnectorFactory http = new HttpConnectorFactory();
         http.setBindHost("127.0.0.1");
         http.setAcceptorThreads(Optional.of(1));
         http.setSelectorThreads(Optional.of(2));
         http.setAcceptQueueSize(1024);
-        http.setMinResponseDataPerSecond(Size.bytes(200));
-        http.setMinRequestDataPerSecond(Size.bytes(42));
+        http.setMinResponseDataPerSecond(DataSize.bytes(200));
+        http.setMinRequestDataPerSecond(DataSize.bytes(42));
 
         Server server = new Server();
         MetricRegistry metrics = new MetricRegistry();
@@ -137,7 +137,7 @@ public class HttpConnectorFactoryTest {
         assertThat(connector.getScheduler()).isInstanceOf(ScheduledExecutorScheduler.class);
         assertThat(connector.getExecutor()).isSameAs(threadPool);
 
-        // That's gross, but unfortunately ArrayByteBufferPool doesn't have public API for configuration
+        // That's gross, but unfortunately ArrayByteBufferPool doesn't have API for configuration
         ByteBufferPool byteBufferPool = connector.getByteBufferPool();
         assertThat(byteBufferPool).isInstanceOf(ArrayByteBufferPool.class);
         assertThat(getField(ArrayByteBufferPool.class, "_min", true).get(byteBufferPool)).isEqualTo(64);
@@ -173,7 +173,7 @@ public class HttpConnectorFactoryTest {
     }
 
     @Test
-    public void testDefaultAcceptQueueSize() throws Exception {
+    void testDefaultAcceptQueueSize() throws Exception {
         HttpConnectorFactory http = new HttpConnectorFactory();
         http.setBindHost("127.0.0.1");
         http.setAcceptorThreads(Optional.of(1));

--- a/dropwizard-jetty/src/test/resources/yaml/gzip.yml
+++ b/dropwizard-jetty/src/test/resources/yaml/gzip.yml
@@ -1,6 +1,6 @@
 enabled: false
-minimumEntitySize: 12KB
-bufferSize: 32KB
+minimumEntitySize: 12KiB
+bufferSize: 32KiB
 excludedUserAgentPatterns: ["OLD-2.+"]
 compressedMimeTypes: ["text/plain"]
 includedMethods: ["GET", "POST"]

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
@@ -15,8 +15,8 @@ import ch.qos.logback.core.util.FileSize;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import io.dropwizard.util.Size;
-import io.dropwizard.validation.MinSize;
+import io.dropwizard.util.DataSize;
+import io.dropwizard.validation.MinDataSize;
 import io.dropwizard.validation.ValidationMethod;
 
 import javax.annotation.Nullable;
@@ -80,9 +80,9 @@ import static java.util.Objects.requireNonNull;
  *         <td>(unlimited)</td>
  *         <td>
  *             The maximum size of the currently active file before a rollover is triggered. The value can be expressed
- *             in bytes, kilobytes, megabytes, gigabytes, and terabytes by appending B, K, MB, GB, or TB to the
- *             numeric value.  Examples include 100MB, 1GB, 1TB.  Sizes can also be spelled out, such as 100 megabytes,
- *             1 gigabyte, 1 terabyte.
+ *             with SI and IEC prefixes, see {@link io.dropwizard.util.DataSizeUnit}.
+ *             Examples include 100MiB, 1GiB, 1TiB.  Sizes can also be spelled out, such as 100 mebibytes,
+ *             1 gibibyte, 1 tebibyte.
  *         </td>
  *     </tr>
  *     <tr>
@@ -109,10 +109,10 @@ import static java.util.Objects.requireNonNull;
  *     </tr>
  *     <tr>
  *         <td>{@code bufferSize}</td>
- *         <td>8KB</td>
+ *         <td>8KiB</td>
  *         <td>
  *             The buffer size of the underlying FileAppender (setting added in logback 1.1.10). Increasing this from
- *             the default of 8KB to 256KB is reported to significantly reduce thread contention.
+ *             the default of 8KiB to 256KiB is reported to significantly reduce thread contention.
  *         </td>
  *     </tr>
  *      <tr>
@@ -144,13 +144,13 @@ public class FileAppenderFactory<E extends DeferredProcessingAware> extends Abst
     private int archivedFileCount = 5;
 
     @Nullable
-    private Size maxFileSize;
+    private DataSize maxFileSize;
 
     @Nullable
-    private Size totalSizeCap;
+    private DataSize totalSizeCap;
 
-    @MinSize(1)
-    private Size bufferSize = Size.bytes(FileAppender.DEFAULT_BUFFER_SIZE);
+    @MinDataSize(1)
+    private DataSize bufferSize = DataSize.bytes(FileAppender.DEFAULT_BUFFER_SIZE);
 
     private boolean immediateFlush = true;
 
@@ -198,33 +198,33 @@ public class FileAppenderFactory<E extends DeferredProcessingAware> extends Abst
 
     @JsonProperty
     @Nullable
-    public Size getMaxFileSize() {
+    public DataSize getMaxFileSize() {
         return maxFileSize;
     }
 
     @JsonProperty
-    public void setMaxFileSize(Size maxFileSize) {
+    public void setMaxFileSize(@Nullable DataSize maxFileSize) {
         this.maxFileSize = maxFileSize;
     }
 
     @JsonProperty
     @Nullable
-    public Size getTotalSizeCap() {
+    public DataSize getTotalSizeCap() {
         return totalSizeCap;
     }
 
     @JsonProperty
-    public void setTotalSizeCap(@Nullable Size totalSizeCap) {
+    public void setTotalSizeCap(@Nullable DataSize totalSizeCap) {
         this.totalSizeCap = totalSizeCap;
     }
 
     @JsonProperty
-    public Size getBufferSize() {
+    public DataSize getBufferSize() {
         return bufferSize;
     }
 
     @JsonProperty
-    public void setBufferSize(Size bufferSize) {
+    public void setBufferSize(DataSize bufferSize) {
         this.bufferSize = bufferSize;
     }
 

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/TcpSocketAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/TcpSocketAppenderFactory.java
@@ -7,8 +7,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.dropwizard.logging.socket.DropwizardSocketAppender;
 import io.dropwizard.util.Duration;
-import io.dropwizard.util.Size;
-import io.dropwizard.validation.MinSize;
+import io.dropwizard.util.DataSize;
+import io.dropwizard.validation.MinDataSize;
 import io.dropwizard.validation.PortRange;
 import javax.validation.constraints.NotEmpty;
 
@@ -48,7 +48,7 @@ import javax.validation.constraints.NotNull;
  * </tr>
  * <tr>
  * <td>{@code sendBufferSize}</td>
- * <td>8KB</td>
+ * <td>8KiB</td>
  * <td>The buffer size of the underlying SocketAppender. Takes into effect if immediateFlush is disabled.</td>
  * </tr>
  * </table>
@@ -67,8 +67,8 @@ public class TcpSocketAppenderFactory<E extends DeferredProcessingAware> extends
 
     private boolean immediateFlush = true;
 
-    @MinSize(1)
-    private Size sendBufferSize = Size.kilobytes(8);
+    @MinDataSize(1)
+    private DataSize sendBufferSize = DataSize.kibibytes(8);
 
     @JsonProperty
     public String getHost() {
@@ -111,12 +111,12 @@ public class TcpSocketAppenderFactory<E extends DeferredProcessingAware> extends
     }
 
     @JsonProperty
-    public Size getSendBufferSize() {
+    public DataSize getSendBufferSize() {
         return sendBufferSize;
     }
 
     @JsonProperty
-    public void setSendBufferSize(Size sendBufferSize) {
+    public void setSendBufferSize(DataSize sendBufferSize) {
         this.sendBufferSize = sendBufferSize;
     }
 

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/DefaultLoggingFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/DefaultLoggingFactoryTest.java
@@ -74,7 +74,7 @@ public class DefaultLoggingFactoryTest {
         assertThat(fileAppenderFactory.getCurrentLogFilename()).isEqualTo("${new_app}.log");
         assertThat(fileAppenderFactory.getArchivedLogFilenamePattern()).isEqualTo("${new_app}-%d.log.gz");
         assertThat(fileAppenderFactory.getArchivedFileCount()).isEqualTo(5);
-        assertThat(fileAppenderFactory.getBufferSize().toKilobytes()).isEqualTo(256);
+        assertThat(fileAppenderFactory.getBufferSize().toKibibytes()).isEqualTo(256);
         final List<FilterFactory<ILoggingEvent>> filterFactories = fileAppenderFactory.getFilterFactories();
         assertThat(filterFactories).hasSize(2);
         assertThat(filterFactories.get(0)).isExactlyInstanceOf(TestFilterFactory.class);

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
@@ -22,8 +22,8 @@ import io.dropwizard.jackson.Jackson;
 import io.dropwizard.logging.async.AsyncLoggingEventAppenderFactory;
 import io.dropwizard.logging.filter.NullLevelFilterFactory;
 import io.dropwizard.logging.layout.DropwizardLayoutFactory;
+import io.dropwizard.util.DataSize;
 import io.dropwizard.util.Resources;
-import io.dropwizard.util.Size;
 import io.dropwizard.validation.BaseValidator;
 import io.dropwizard.validation.ConstraintViolations;
 import org.junit.jupiter.api.Test;
@@ -42,7 +42,7 @@ import java.util.Collection;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class FileAppenderFactoryTest {
+class FileAppenderFactoryTest {
 
     static {
         BootstrapLogging.bootstrap();
@@ -52,13 +52,13 @@ public class FileAppenderFactoryTest {
     private final Validator validator = BaseValidator.newValidator();
 
     @Test
-    public void isDiscoverable() throws Exception {
+    void isDiscoverable() throws Exception {
         assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
                 .contains(FileAppenderFactory.class);
     }
 
     @Test
-    public void includesCallerData() {
+    void includesCallerData() {
         FileAppenderFactory<ILoggingEvent> fileAppenderFactory = new FileAppenderFactory<>();
         fileAppenderFactory.setArchive(false);
         AsyncAppender asyncAppender = (AsyncAppender) fileAppenderFactory.build(new LoggerContext(), "test", new DropwizardLayoutFactory(), new NullLevelFilterFactory<>(), new AsyncLoggingEventAppenderFactory());
@@ -70,7 +70,7 @@ public class FileAppenderFactoryTest {
     }
 
     @Test
-    public void isRolling(@TempDir Path tempDir) throws Exception {
+    void isRolling(@TempDir Path tempDir) throws Exception {
         // the method we want to test is protected, so we need to override it so we can see it
         FileAppenderFactory<ILoggingEvent> fileAppenderFactory = new FileAppenderFactory<ILoggingEvent>() {
             @Override
@@ -86,7 +86,7 @@ public class FileAppenderFactoryTest {
     }
 
     @Test
-    public void hasArchivedLogFilenamePattern(@TempDir Path tempDir) throws Exception {
+    void hasArchivedLogFilenamePattern(@TempDir Path tempDir) {
         FileAppenderFactory<?> fileAppenderFactory = new FileAppenderFactory<>();
         fileAppenderFactory.setCurrentLogFilename(tempDir.resolve("logfile.log").toString());
         Collection<String> errors =
@@ -100,7 +100,7 @@ public class FileAppenderFactoryTest {
     }
 
     @Test
-    public void isValidForInfiniteRolledFiles(@TempDir Path tempDir) throws Exception {
+    void isValidForInfiniteRolledFiles(@TempDir Path tempDir) {
         FileAppenderFactory<?> fileAppenderFactory = new FileAppenderFactory<>();
         fileAppenderFactory.setCurrentLogFilename(tempDir.resolve("logfile.log").toString());
         fileAppenderFactory.setArchivedFileCount(0);
@@ -112,10 +112,10 @@ public class FileAppenderFactoryTest {
     }
 
     @Test
-    public void isValidForMaxFileSize(@TempDir Path tempDir) throws Exception {
+    void isValidForMaxFileSize(@TempDir Path tempDir) {
         FileAppenderFactory<?> fileAppenderFactory = new FileAppenderFactory<>();
         fileAppenderFactory.setCurrentLogFilename(tempDir.resolve("logfile.log").toString());
-        fileAppenderFactory.setMaxFileSize(Size.kilobytes(1));
+        fileAppenderFactory.setMaxFileSize(DataSize.kibibytes(1));
         fileAppenderFactory.setArchivedLogFilenamePattern(tempDir.resolve("example-%d.log.gz").toString());
         Collection<String> errors =
                 ConstraintViolations.format(validator.validate(fileAppenderFactory));
@@ -127,7 +127,7 @@ public class FileAppenderFactoryTest {
     }
 
     @Test
-    public void hasMaxFileSizeValidation(@TempDir Path tempDir) throws Exception {
+    void hasMaxFileSizeValidation(@TempDir Path tempDir) {
         FileAppenderFactory<?> fileAppenderFactory = new FileAppenderFactory<>();
         fileAppenderFactory.setCurrentLogFilename(tempDir.resolve("logfile.log").toString());
         fileAppenderFactory.setArchivedLogFilenamePattern(tempDir.resolve("example-%i.log.gz").toString());
@@ -135,13 +135,13 @@ public class FileAppenderFactoryTest {
                 ConstraintViolations.format(validator.validate(fileAppenderFactory));
         assertThat(errors)
                 .containsOnly("when archivedLogFilenamePattern contains %i, maxFileSize must be specified");
-        fileAppenderFactory.setMaxFileSize(Size.kilobytes(1));
+        fileAppenderFactory.setMaxFileSize(DataSize.kibibytes(1));
         errors = ConstraintViolations.format(validator.validate(fileAppenderFactory));
         assertThat(errors).isEmpty();
     }
 
     @Test
-    public void testCurrentFileNameErrorWhenArchiveIsNotEnabled() throws Exception {
+    void testCurrentFileNameErrorWhenArchiveIsNotEnabled() {
         FileAppenderFactory<?> fileAppenderFactory = new FileAppenderFactory<>();
         fileAppenderFactory.setArchive(false);
         Collection<String> errors =
@@ -154,7 +154,7 @@ public class FileAppenderFactoryTest {
     }
 
     @Test
-    public void testCurrentFileNameCanBeNullWhenArchiveIsEnabled() throws Exception {
+    void testCurrentFileNameCanBeNullWhenArchiveIsEnabled() {
         FileAppenderFactory<?> fileAppenderFactory = new FileAppenderFactory<>();
         fileAppenderFactory.setArchive(true);
         fileAppenderFactory.setArchivedLogFilenamePattern("name-to-be-used");
@@ -165,7 +165,7 @@ public class FileAppenderFactoryTest {
     }
 
     @Test
-    public void testCurrentLogFileNameIsEmptyAndAppenderUsesArchivedNameInstead(@TempDir Path tempDir) throws Exception {
+    void testCurrentLogFileNameIsEmptyAndAppenderUsesArchivedNameInstead(@TempDir Path tempDir) {
         final FileAppenderFactory<ILoggingEvent> appenderFactory = new FileAppenderFactory<>();
         appenderFactory.setArchivedLogFilenamePattern(tempDir.resolve("test-archived-name-%d.log").toString());
         final FileAppender<ILoggingEvent> rollingAppender = appenderFactory.buildAppender(new LoggerContext());
@@ -176,11 +176,11 @@ public class FileAppenderFactoryTest {
     }
 
     @Test
-    public void hasMaxFileSize(@TempDir Path tempDir) throws Exception {
+    void hasMaxFileSize(@TempDir Path tempDir) throws Exception {
         FileAppenderFactory<ILoggingEvent> fileAppenderFactory = new FileAppenderFactory<>();
         fileAppenderFactory.setCurrentLogFilename(tempDir.resolve("logfile.log").toString());
         fileAppenderFactory.setArchive(true);
-        fileAppenderFactory.setMaxFileSize(Size.kilobytes(1));
+        fileAppenderFactory.setMaxFileSize(DataSize.kibibytes(1));
         fileAppenderFactory.setArchivedLogFilenamePattern(tempDir.resolve("example-%d-%i.log.gz").toString());
         RollingFileAppender<ILoggingEvent> appender = (RollingFileAppender<ILoggingEvent>) fileAppenderFactory.buildAppender(new LoggerContext());
 
@@ -192,11 +192,11 @@ public class FileAppenderFactoryTest {
     }
 
     @Test
-    public void hasMaxFileSizeFixedWindow(@TempDir Path tempDir) throws Exception {
+    void hasMaxFileSizeFixedWindow(@TempDir Path tempDir) throws Exception {
         FileAppenderFactory<ILoggingEvent> fileAppenderFactory = new FileAppenderFactory<>();
         fileAppenderFactory.setCurrentLogFilename(tempDir.resolve("logfile.log").toString());
         fileAppenderFactory.setArchive(true);
-        fileAppenderFactory.setMaxFileSize(Size.kilobytes(1));
+        fileAppenderFactory.setMaxFileSize(DataSize.kibibytes(1));
         fileAppenderFactory.setArchivedLogFilenamePattern(tempDir.resolve("example-%i.log.gz").toString());
         RollingFileAppender<ILoggingEvent> appender = (RollingFileAppender<ILoggingEvent>) fileAppenderFactory.buildAppender(new LoggerContext());
 
@@ -212,7 +212,7 @@ public class FileAppenderFactoryTest {
     }
 
     @Test
-    public void appenderContextIsSet(@TempDir Path tempDir) throws Exception {
+    void appenderContextIsSet(@TempDir Path tempDir) {
         final Logger root = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
         final FileAppenderFactory<ILoggingEvent> appenderFactory = new FileAppenderFactory<>();
         appenderFactory.setArchivedLogFilenamePattern(tempDir.resolve("example-%d.log.gz").toString());
@@ -228,7 +228,7 @@ public class FileAppenderFactoryTest {
     }
 
     @Test
-    public void appenderNameIsSet(@TempDir Path tempDir) throws Exception {
+    void appenderNameIsSet(@TempDir Path tempDir) {
         final Logger root = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
         final FileAppenderFactory<ILoggingEvent> appenderFactory = new FileAppenderFactory<>();
         appenderFactory.setArchivedLogFilenamePattern(tempDir.resolve("example-%d.log.gz").toString());
@@ -244,7 +244,7 @@ public class FileAppenderFactoryTest {
     }
 
     @Test
-    public void isNeverBlock() throws Exception {
+    void isNeverBlock() {
         FileAppenderFactory<ILoggingEvent> fileAppenderFactory = new FileAppenderFactory<>();
         fileAppenderFactory.setArchive(false);
         fileAppenderFactory.setNeverBlock(true);
@@ -254,7 +254,7 @@ public class FileAppenderFactoryTest {
     }
 
     @Test
-    public void isNotNeverBlock() throws Exception {
+    void isNotNeverBlock() {
         FileAppenderFactory<ILoggingEvent> fileAppenderFactory = new FileAppenderFactory<>();
         fileAppenderFactory.setArchive(false);
         fileAppenderFactory.setNeverBlock(false);
@@ -264,7 +264,7 @@ public class FileAppenderFactoryTest {
     }
 
     @Test
-    public void defaultIsNotNeverBlock() throws Exception {
+    void defaultIsNotNeverBlock() throws Exception {
         FileAppenderFactory<ILoggingEvent> fileAppenderFactory = new FileAppenderFactory<>();
         fileAppenderFactory.setArchive(false);
         // default neverBlock
@@ -274,10 +274,10 @@ public class FileAppenderFactoryTest {
     }
 
     @Test
-    public void overrideBufferSize() throws NoSuchFieldException, IllegalAccessException {
+    void overrideBufferSize() throws NoSuchFieldException, IllegalAccessException {
         FileAppenderFactory<ILoggingEvent> fileAppenderFactory = new FileAppenderFactory<>();
         fileAppenderFactory.setArchive(false);
-        fileAppenderFactory.setBufferSize(Size.kilobytes(256));
+        fileAppenderFactory.setBufferSize(DataSize.kibibytes(256));
         AsyncAppender asyncAppender = (AsyncAppender) fileAppenderFactory.build(new LoggerContext(), "test", new DropwizardLayoutFactory(), new NullLevelFilterFactory<>(), new AsyncLoggingEventAppenderFactory());
         final Appender<ILoggingEvent> fileAppender = asyncAppender.getAppender("file-appender");
         assertThat(fileAppender).isInstanceOf(FileAppender.class);
@@ -288,7 +288,7 @@ public class FileAppenderFactoryTest {
     }
 
     @Test
-    public void isImmediateFlushed() throws Exception {
+    void isImmediateFlushed() throws Exception {
         FileAppenderFactory<ILoggingEvent> fileAppenderFactory = new FileAppenderFactory<>();
         fileAppenderFactory.setArchive(false);
 
@@ -307,7 +307,7 @@ public class FileAppenderFactoryTest {
     }
 
     @Test
-    public void validSetTotalSizeCap() throws IOException, ConfigurationException, NoSuchFieldException {
+    void validSetTotalSizeCap() throws IOException, ConfigurationException, NoSuchFieldException {
         final Field totalSizeCap = TimeBasedRollingPolicy.class.getDeclaredField("totalSizeCap");
         totalSizeCap.setAccessible(true);
 
@@ -324,11 +324,11 @@ public class FileAppenderFactoryTest {
                 try {
                     assertThat(totalSizeCap.get(policy))
                         .isInstanceOfSatisfying(FileSize.class, x ->
-                            assertThat(x.getSize()).isEqualTo(Size.megabytes(50).toBytes()));
+                            assertThat(x.getSize()).isEqualTo(DataSize.mebibytes(50).toBytes()));
 
                     assertThat(maxFileSize.get(policy))
                         .isInstanceOfSatisfying(FileSize.class, x ->
-                            assertThat(x.getSize()).isEqualTo(Size.megabytes(10).toBytes()));
+                            assertThat(x.getSize()).isEqualTo(DataSize.mebibytes(10).toBytes()));
 
                     assertThat(policy.getMaxHistory()).isEqualTo(5);
                 } catch (IllegalAccessException e) {
@@ -339,7 +339,7 @@ public class FileAppenderFactoryTest {
     }
 
     @Test
-    public void validSetTotalSizeCapNoMaxFileSize() throws IOException, ConfigurationException, NoSuchFieldException {
+    void validSetTotalSizeCapNoMaxFileSize() throws IOException, ConfigurationException, NoSuchFieldException {
         final Field totalSizeCap = TimeBasedRollingPolicy.class.getDeclaredField("totalSizeCap");
         totalSizeCap.setAccessible(true);
 
@@ -353,7 +353,7 @@ public class FileAppenderFactoryTest {
                 try {
                     assertThat(totalSizeCap.get(policy))
                         .isInstanceOfSatisfying(FileSize.class, x ->
-                            assertThat(x.getSize()).isEqualTo(Size.megabytes(50).toBytes()));
+                            assertThat(x.getSize()).isEqualTo(DataSize.mebibytes(50).toBytes()));
 
                     assertThat(policy.getMaxHistory()).isEqualTo(5);
                 } catch (IllegalAccessException e) {
@@ -364,7 +364,7 @@ public class FileAppenderFactoryTest {
     }
 
     @Test
-    public void invalidUseOfTotalSizeCap() {
+    void invalidUseOfTotalSizeCap() {
         final YamlConfigurationFactory<FileAppenderFactory> factory =
             new YamlConfigurationFactory<>(FileAppenderFactory.class, validator, mapper, "dw");
         assertThatThrownBy(() ->

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/TcpSocketAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/TcpSocketAppenderFactoryTest.java
@@ -7,9 +7,9 @@ import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
+import io.dropwizard.util.DataSize;
 import io.dropwizard.util.Duration;
 import io.dropwizard.util.Resources;
-import io.dropwizard.util.Size;
 import io.dropwizard.validation.BaseValidator;
 import org.apache.commons.text.StringSubstitutor;
 import org.junit.jupiter.api.AfterEach;
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TcpSocketAppenderFactoryTest {
+class TcpSocketAppenderFactoryTest {
 
     private TcpServer tcpServer = new TcpServer(createServerSocket());
     private ObjectMapper objectMapper = Jackson.newObjectMapper();
@@ -35,7 +35,7 @@ public class TcpSocketAppenderFactoryTest {
         DefaultLoggingFactory.class, BaseValidator.newValidator(), objectMapper, "dw-tcp");
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         tcpServer.setUp();
         objectMapper.getSubtypeResolver().registerSubtypes(TcpSocketAppenderFactory.class);
     }
@@ -58,7 +58,7 @@ public class TcpSocketAppenderFactoryTest {
     }
 
     @Test
-    public void testParseConfig() throws Exception {
+    void testParseConfig() throws Exception {
         DefaultLoggingFactory loggingFactory = yamlConfigurationFactory.build(resourcePath("yaml/logging-tcp-custom.yml"));
         assertThat(loggingFactory.getAppenders()).hasSize(1);
         TcpSocketAppenderFactory<ILoggingEvent> tcpAppenderFactory = (TcpSocketAppenderFactory<ILoggingEvent>)
@@ -66,12 +66,12 @@ public class TcpSocketAppenderFactoryTest {
         assertThat(tcpAppenderFactory.getHost()).isEqualTo("172.16.11.245");
         assertThat(tcpAppenderFactory.getPort()).isEqualTo(17001);
         assertThat(tcpAppenderFactory.getConnectionTimeout()).isEqualTo(Duration.milliseconds(100));
-        assertThat(tcpAppenderFactory.getSendBufferSize()).isEqualTo(Size.kilobytes(2));
+        assertThat(tcpAppenderFactory.getSendBufferSize()).isEqualTo(DataSize.kibibytes(2));
         assertThat(tcpAppenderFactory.isImmediateFlush()).isFalse();
     }
 
     @Test
-    public void testTestTcpLogging() throws Exception {
+    void testTestTcpLogging() throws Exception {
         DefaultLoggingFactory loggingFactory = yamlConfigurationFactory.build(new SubstitutingSourceProvider(
                 new ResourceConfigurationSourceProvider(),
                 new StringSubstitutor(Collections.singletonMap("tcp.server.port", tcpServer.getPort()))),
@@ -89,7 +89,7 @@ public class TcpSocketAppenderFactoryTest {
     }
 
     @Test
-    public void testBufferingTcpLogging() throws Exception {
+    void testBufferingTcpLogging() throws Exception {
         DefaultLoggingFactory loggingFactory = yamlConfigurationFactory.build(new SubstitutingSourceProvider(
             new ResourceConfigurationSourceProvider(),
                 new StringSubstitutor(Collections.singletonMap("tcp.server.port", tcpServer.getPort()))),

--- a/dropwizard-logging/src/test/resources/yaml/appender_file_cap.yaml
+++ b/dropwizard-logging/src/test/resources/yaml/appender_file_cap.yaml
@@ -3,5 +3,5 @@ threshold: ALL
 currentLogFilename: ./logs/example.log
 archivedLogFilenamePattern: ./logs/example-%d-%i.log.gz
 archivedFileCount: 5
-maxFileSize: "10mb"
-totalSizeCap: "50mb"
+maxFileSize: "10mib"
+totalSizeCap: "50mib"

--- a/dropwizard-logging/src/test/resources/yaml/appender_file_cap2.yaml
+++ b/dropwizard-logging/src/test/resources/yaml/appender_file_cap2.yaml
@@ -3,4 +3,4 @@ threshold: ALL
 currentLogFilename: ./logs/example.log
 archivedLogFilenamePattern: ./logs/example-%d.log.gz
 archivedFileCount: 5
-totalSizeCap: "50mb"
+totalSizeCap: "50mib"

--- a/dropwizard-logging/src/test/resources/yaml/appender_file_cap_invalid.yaml
+++ b/dropwizard-logging/src/test/resources/yaml/appender_file_cap_invalid.yaml
@@ -2,5 +2,5 @@ type: file
 threshold: ALL
 currentLogFilename: ./logs/example.log
 archivedLogFilenamePattern: ./logs/example-%i.log.gz
-maxFileSize: "10mb"
-totalSizeCap: "50mb"
+maxFileSize: "10mib"
+totalSizeCap: "50mib"

--- a/dropwizard-logging/src/test/resources/yaml/logging-tcp-buffered.yml
+++ b/dropwizard-logging/src/test/resources/yaml/logging-tcp-buffered.yml
@@ -4,4 +4,4 @@ appenders:
     host: localhost
     port: ${tcp.server.port}
     immediateFlush: false
-    sendBufferSize: 1KB
+    sendBufferSize: 1KiB

--- a/dropwizard-logging/src/test/resources/yaml/logging-tcp-custom.yml
+++ b/dropwizard-logging/src/test/resources/yaml/logging-tcp-custom.yml
@@ -5,4 +5,4 @@ appenders:
     port: 17001
     connectionTimeout: 100ms
     immediateFlush: false
-    sendBufferSize: 2KB
+    sendBufferSize: 2KiB

--- a/dropwizard-logging/src/test/resources/yaml/logging.yml
+++ b/dropwizard-logging/src/test/resources/yaml/logging.yml
@@ -11,13 +11,13 @@ appenders:
     archivedFileCount: 5
   - type: file
     threshold: ALL
-    maxFileSize: 100MB
+    maxFileSize: 100MiB
     currentLogFilename: ./logs/max-file-size-example.log
     archivedLogFilenamePattern: ./logs/max-file-size-example-%d-%i.log.gz
     archivedFileCount: 5
   - type: file
     threshold: ALL
-    maxFileSize: 100MB
+    maxFileSize: 100MiB
     currentLogFilename: ./logs/max-file-size-example.log
     archivedLogFilenamePattern: ./logs/max-file-size-example-%i.log.gz
     archivedFileCount: 5

--- a/dropwizard-logging/src/test/resources/yaml/logging_advanced.yml
+++ b/dropwizard-logging/src/test/resources/yaml/logging_advanced.yml
@@ -12,7 +12,7 @@ loggers:
         archivedLogFilenamePattern: '${new_app}-%d.log.gz'
         logFormat: "%-5level %logger: %msg%n"
         archivedFileCount: 5
-        bufferSize: 256KB
+        bufferSize: 256KiB
   "com.example.legacyApp":
     level: DEBUG
   "com.example.notAdditive":

--- a/dropwizard-util/pom.xml
+++ b/dropwizard-util/pom.xml
@@ -41,6 +41,11 @@
             <artifactId>joda-time</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>

--- a/dropwizard-util/src/main/java/io/dropwizard/util/DataSize.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/DataSize.java
@@ -1,0 +1,274 @@
+package io.dropwizard.util;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Collections;
+import java.util.Locale;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A data size with SI or IEC prefix, such as "128KB" or "5 Gibibytes".
+ * This class models a size in terms of bytes and is immutable and thread-safe.
+ *
+ * @see DataSizeUnit
+ * @since 2.0
+ */
+public class DataSize implements Comparable<DataSize> {
+    private static final Pattern SIZE_PATTERN = Pattern.compile("(\\d+)\\s*(\\S*)");
+
+    private static final SortedMap<String, DataSizeUnit> SUFFIXES;
+
+    static {
+        final SortedMap<String, DataSizeUnit> suffixes = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        suffixes.put("B", DataSizeUnit.BYTES);
+        suffixes.put("byte", DataSizeUnit.BYTES);
+        suffixes.put("bytes", DataSizeUnit.BYTES);
+        suffixes.put("K", DataSizeUnit.KILOBYTES);
+        suffixes.put("KB", DataSizeUnit.KILOBYTES);
+        suffixes.put("KiB", DataSizeUnit.KIBIBYTES);
+        suffixes.put("kilobyte", DataSizeUnit.KILOBYTES);
+        suffixes.put("kibibyte", DataSizeUnit.KIBIBYTES);
+        suffixes.put("kilobytes", DataSizeUnit.KILOBYTES);
+        suffixes.put("kibibytes", DataSizeUnit.KIBIBYTES);
+        suffixes.put("M", DataSizeUnit.MEGABYTES);
+        suffixes.put("MB", DataSizeUnit.MEGABYTES);
+        suffixes.put("MiB", DataSizeUnit.MEBIBYTES);
+        suffixes.put("megabyte", DataSizeUnit.MEGABYTES);
+        suffixes.put("mebibyte", DataSizeUnit.MEBIBYTES);
+        suffixes.put("megabytes", DataSizeUnit.MEGABYTES);
+        suffixes.put("mebibytes", DataSizeUnit.MEBIBYTES);
+        suffixes.put("G", DataSizeUnit.GIGABYTES);
+        suffixes.put("GB", DataSizeUnit.GIGABYTES);
+        suffixes.put("GiB", DataSizeUnit.GIBIBYTES);
+        suffixes.put("gigabyte", DataSizeUnit.GIGABYTES);
+        suffixes.put("gibibyte", DataSizeUnit.GIBIBYTES);
+        suffixes.put("gigabytes", DataSizeUnit.GIGABYTES);
+        suffixes.put("gibibytes", DataSizeUnit.GIBIBYTES);
+        suffixes.put("T", DataSizeUnit.TERABYTES);
+        suffixes.put("TB", DataSizeUnit.TERABYTES);
+        suffixes.put("TiB", DataSizeUnit.TEBIBYTES);
+        suffixes.put("terabyte", DataSizeUnit.TERABYTES);
+        suffixes.put("tebibyte", DataSizeUnit.TEBIBYTES);
+        suffixes.put("terabytes", DataSizeUnit.TERABYTES);
+        suffixes.put("tebibytes", DataSizeUnit.TEBIBYTES);
+        suffixes.put("P", DataSizeUnit.PETABYTES);
+        suffixes.put("PB", DataSizeUnit.PETABYTES);
+        suffixes.put("PiB", DataSizeUnit.PEBIBYTES);
+        suffixes.put("petabyte", DataSizeUnit.PETABYTES);
+        suffixes.put("pebibyte", DataSizeUnit.PEBIBYTES);
+        suffixes.put("petabytes", DataSizeUnit.PETABYTES);
+        suffixes.put("pebibytes", DataSizeUnit.PEBIBYTES);
+        SUFFIXES = Collections.unmodifiableSortedMap(suffixes);
+    }
+
+    public static DataSize bytes(long count) {
+        return new DataSize(count, DataSizeUnit.BYTES);
+    }
+
+    public static DataSize kilobytes(long count) {
+        return new DataSize(count, DataSizeUnit.KILOBYTES);
+    }
+
+    public static DataSize megabytes(long count) {
+        return new DataSize(count, DataSizeUnit.MEGABYTES);
+    }
+
+    public static DataSize gigabytes(long count) {
+        return new DataSize(count, DataSizeUnit.GIGABYTES);
+    }
+
+    public static DataSize terabytes(long count) {
+        return new DataSize(count, DataSizeUnit.TERABYTES);
+    }
+
+    public static DataSize petabytes(long count) {
+        return new DataSize(count, DataSizeUnit.PETABYTES);
+    }
+
+    public static DataSize kibibytes(long count) {
+        return new DataSize(count, DataSizeUnit.KIBIBYTES);
+    }
+
+    public static DataSize mebibytes(long count) {
+        return new DataSize(count, DataSizeUnit.MEBIBYTES);
+    }
+
+    public static DataSize gibibytes(long count) {
+        return new DataSize(count, DataSizeUnit.GIBIBYTES);
+    }
+
+    public static DataSize tebibytes(long count) {
+        return new DataSize(count, DataSizeUnit.TEBIBYTES);
+    }
+
+    public static DataSize pebibytes(long count) {
+        return new DataSize(count, DataSizeUnit.PEBIBYTES);
+    }
+
+    @JsonCreator
+    public static DataSize parse(CharSequence size) {
+        return parse(size, DataSizeUnit.BYTES);
+    }
+
+    public static DataSize parse(CharSequence size, DataSizeUnit defaultUnit) {
+        final Matcher matcher = SIZE_PATTERN.matcher(size);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Invalid size: " + size);
+        }
+
+        final long count = Long.parseLong(matcher.group(1));
+        final DataSizeUnit unit = SUFFIXES.getOrDefault(matcher.group(2), defaultUnit);
+        if (unit == null) {
+            throw new IllegalArgumentException("Invalid size: " + size + ". Wrong size unit");
+        }
+
+        return new DataSize(count, unit);
+    }
+
+    private final long count;
+    private final DataSizeUnit unit;
+
+    private DataSize(long count, DataSizeUnit unit) {
+        this.count = count;
+        this.unit = requireNonNull(unit);
+    }
+
+    public long getQuantity() {
+        return count;
+    }
+
+    public DataSizeUnit getUnit() {
+        return unit;
+    }
+
+    public long toBytes() {
+        return DataSizeUnit.BYTES.convert(count, unit);
+    }
+
+    public long toKilobytes() {
+        return DataSizeUnit.KILOBYTES.convert(count, unit);
+    }
+
+    public long toMegabytes() {
+        return DataSizeUnit.MEGABYTES.convert(count, unit);
+    }
+
+    public long toGigabytes() {
+        return DataSizeUnit.GIGABYTES.convert(count, unit);
+    }
+
+    public long toTerabytes() {
+        return DataSizeUnit.TERABYTES.convert(count, unit);
+    }
+
+    public long toPetabytes() {
+        return DataSizeUnit.PETABYTES.convert(count, unit);
+    }
+
+    public long toKibibytes() {
+        return DataSizeUnit.KIBIBYTES.convert(count, unit);
+    }
+
+    public long toMebibytes() {
+        return DataSizeUnit.MEBIBYTES.convert(count, unit);
+    }
+
+    public long toGibibytes() {
+        return DataSizeUnit.GIBIBYTES.convert(count, unit);
+    }
+
+    public long toTebibytes() {
+        return DataSizeUnit.TEBIBYTES.convert(count, unit);
+    }
+
+    public long toPebibytes() {
+        return DataSizeUnit.PEBIBYTES.convert(count, unit);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        final DataSize size = (DataSize) obj;
+        return (count == size.count) && (unit == size.unit);
+    }
+
+    @Override
+    public int hashCode() {
+        return (31 * (int) (count ^ (count >>> 32))) + unit.hashCode();
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        String units = unit.toString().toLowerCase(Locale.ENGLISH);
+        if (count == 1L) {
+            units = units.substring(0, units.length() - 1);
+        }
+        return Long.toString(count) + ' ' + units;
+    }
+
+    @Override
+    public int compareTo(DataSize other) {
+        if (unit == other.unit) {
+            return Long.compare(count, other.count);
+        }
+
+        return Long.compare(toBytes(), other.toBytes());
+    }
+
+    @SuppressWarnings("deprecation")
+    public Size toSize() {
+        switch (unit) {
+            case BYTES:
+                return Size.bytes(count);
+            case KIBIBYTES:
+                return Size.kilobytes(count);
+            case MEBIBYTES:
+                return Size.megabytes(count);
+            case GIBIBYTES:
+                return Size.gigabytes(count);
+            case TEBIBYTES:
+                return Size.terabytes(count);
+            case PEBIBYTES:
+                return Size.terabytes(count * 1024L);
+            case KILOBYTES:
+            case MEGABYTES:
+            case GIGABYTES:
+            case TERABYTES:
+            case PETABYTES:
+                return Size.bytes(toBytes());
+
+            default:
+                throw new IllegalArgumentException("Unknown unit: " + getUnit());
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    public static DataSize fromSize(Size size) {
+        switch (size.getUnit()) {
+            case BYTES:
+                return DataSize.bytes(size.toBytes());
+            case KILOBYTES:
+                return DataSize.kibibytes(size.toKilobytes());
+            case MEGABYTES:
+                return DataSize.mebibytes(size.toMegabytes());
+            case GIGABYTES:
+                return DataSize.gibibytes(size.toGigabytes());
+            case TERABYTES:
+                return DataSize.tebibytes(size.toTerabytes());
+            default:
+                throw new IllegalArgumentException("Unknown unit: " + size.getUnit());
+        }
+    }
+}

--- a/dropwizard-util/src/main/java/io/dropwizard/util/DataSize.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/DataSize.java
@@ -123,12 +123,13 @@ public class DataSize implements Comparable<DataSize> {
         }
 
         final long count = Long.parseLong(matcher.group(1));
-        final DataSizeUnit unit = SUFFIXES.getOrDefault(matcher.group(2), defaultUnit);
-        if (unit == null) {
+        final String unit = matcher.group(2);
+        final DataSizeUnit dataSizeUnit = Strings.isNullOrEmpty(unit) ? defaultUnit : SUFFIXES.get(unit);
+        if (dataSizeUnit == null) {
             throw new IllegalArgumentException("Invalid size: " + size + ". Wrong size unit");
         }
 
-        return new DataSize(count, unit);
+        return new DataSize(count, dataSizeUnit);
     }
 
     private final long count;

--- a/dropwizard-util/src/main/java/io/dropwizard/util/DataSizeUnit.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/DataSizeUnit.java
@@ -1,0 +1,214 @@
+package io.dropwizard.util;
+
+/**
+ * A unit of information using SI and IEC prefixes.
+ *
+ * @see <a href="https://en.wikipedia.org/wiki/Units_of_information#Systematic_multiples">Units of information on Wikipedia</a>
+ * @see <a href="https://en.wikipedia.org/wiki/Binary_prefix">Binary prefix on Wikipedia</a>
+ */
+public enum DataSizeUnit {
+    /**
+     * Bytes (8 bits).
+     */
+    BYTES(8L),
+
+    // OSI Decimal Size Units
+
+    /**
+     * Kilobytes (1000 bytes).
+     *
+     * @see <a href="https://en.wikipedia.org/wiki/Kilo-">Kilo-</a>
+     */
+    KILOBYTES(8L * 1000L),
+
+    /**
+     * Megabytes (1000 kilobytes).
+     *
+     * @see <a href="https://en.wikipedia.org/wiki/Mega-">Mega-</a>
+     */
+    MEGABYTES(8L * 1000L * 1000L),
+
+    /**
+     * Gigabytes (1000 megabytes).
+     *
+     * @see <a href="https://en.wikipedia.org/wiki/Giga-">Giga-</a>
+     */
+    GIGABYTES(8L * 1000L * 1000L * 1000L),
+
+    /**
+     * Terabytes (1000 gigabytes).
+     *
+     * @see <a href="https://en.wikipedia.org/wiki/Tera-">Tera-</a>
+     */
+    TERABYTES(8L * 1000L * 1000L * 1000L * 1000L),
+
+    /**
+     * Petabytes (1000 terabytes).
+     *
+     * @see <a href="https://en.wikipedia.org/wiki/Peta-">Peta-</a>
+     */
+    PETABYTES(8L * 1000L * 1000L * 1000L * 1000L * 1000L),
+
+    // IEC Binary Size Units
+    /**
+     * Kibibytes (1024 bytes).
+     *
+     * @see <a href="https://en.wikipedia.org/wiki/Kibi-">Kibi-</a>
+     */
+    KIBIBYTES(8L * 1024L),
+
+    /**
+     * Mebibytes (1024 kibibytes).
+     *
+     * @see <a href="https://en.wikipedia.org/wiki/Mebi-">Mebi-</a>
+     */
+    MEBIBYTES(8L * 1024L * 1024L),
+
+    /**
+     * Gibibytes (1024 mebibytes).
+     *
+     * @see <a href="https://en.wikipedia.org/wiki/Gibi-">Gibi-</a>
+     */
+    GIBIBYTES(8L * 1024L * 1024L * 1024L),
+
+    /**
+     * Tebibytes (1024 gibibytes).
+     *
+     * @see <a href="https://en.wikipedia.org/wiki/Tebi-">Tebi-</a>
+     */
+    TEBIBYTES(8L * 1024L * 1024L * 1024L * 1024L),
+
+    /**
+     * Pebibytes (1024 tebibytes).
+     *
+     * @see <a href="https://en.wikipedia.org/wiki/Pebi-">Pebi-</a>
+     */
+    PEBIBYTES(8L * 1024L * 1024L * 1024L * 1024L * 1024L);
+
+    private final long bits;
+
+    DataSizeUnit(long bits) {
+        this.bits = bits;
+    }
+
+    /**
+     * Converts a size of the given unit into the current unit.
+     *
+     * @param size the magnitude of the size
+     * @param unit the unit of the size
+     * @return the given size in the current unit.
+     */
+    public long convert(long size, DataSizeUnit unit) {
+        return (size * unit.bits) / bits;
+    }
+
+    /**
+     * Converts the given number of the current units into bytes.
+     *
+     * @param l the magnitude of the size in the current unit
+     * @return {@code l} of the current units in bytes
+     */
+    public long toBytes(long l) {
+        return BYTES.convert(l, this);
+    }
+
+    /**
+     * Converts the given number of the current units into kilobytes.
+     *
+     * @param l the magnitude of the size in the current unit
+     * @return {@code l} of the current units in kilobytes
+     */
+    public long toKilobytes(long l) {
+        return KILOBYTES.convert(l, this);
+    }
+
+    /**
+     * Converts the given number of the current units into megabytes.
+     *
+     * @param l the magnitude of the size in the current unit
+     * @return {@code l} of the current units in megabytes
+     */
+    public long toMegabytes(long l) {
+        return MEGABYTES.convert(l, this);
+    }
+
+    /**
+     * Converts the given number of the current units into gigabytes.
+     *
+     * @param l the magnitude of the size in the current unit
+     * @return {@code l} of the current units in gigabytes
+     */
+    public long toGigabytes(long l) {
+        return GIGABYTES.convert(l, this);
+    }
+
+    /**
+     * Converts the given number of the current units into terabytes.
+     *
+     * @param l the magnitude of the size in the current unit
+     * @return {@code l} of the current units in terabytes
+     */
+    public long toTerabytes(long l) {
+        return TERABYTES.convert(l, this);
+    }
+
+    /**
+     * Converts the given number of the current units into petabytes.
+     *
+     * @param l the magnitude of the size in the current unit
+     * @return {@code l} of the current units in petabytes
+     */
+    public long toPetabytes(long l) {
+        return PETABYTES.convert(l, this);
+    }
+
+    /**
+     * Converts the given number of the current units into kibibytes.
+     *
+     * @param l the magnitude of the size in the current unit
+     * @return {@code l} of the current units in kibibytes
+     */
+    public long toKibibytes(long l) {
+        return KIBIBYTES.convert(l, this);
+    }
+
+    /**
+     * Converts the given number of the current units into mebibytes.
+     *
+     * @param l the magnitude of the size in the current unit
+     * @return {@code l} of the current units in mebibytes
+     */
+    public long toMebibytes(long l) {
+        return MEBIBYTES.convert(l, this);
+    }
+
+    /**
+     * Converts the given number of the current units into gibibytes.
+     *
+     * @param l the magnitude of the size in the current unit
+     * @return {@code l} of the current units in gibibytes
+     */
+    public long toGibibytes(long l) {
+        return GIBIBYTES.convert(l, this);
+    }
+
+    /**
+     * Converts the given number of the current units into tebibytes.
+     *
+     * @param l the magnitude of the size in the current unit
+     * @return {@code l} of the current units in tebibytes
+     */
+    public long toTebibytes(long l) {
+        return TEBIBYTES.convert(l, this);
+    }
+
+    /**
+     * Converts the given number of the current units into pebibytes.
+     *
+     * @param l the magnitude of the size in the current unit
+     * @return {@code l} of the current units in pebibytes
+     */
+    public long toPebibytes(long l) {
+        return PEBIBYTES.convert(l, this);
+    }
+}

--- a/dropwizard-util/src/main/java/io/dropwizard/util/Size.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Size.java
@@ -12,6 +12,10 @@ import java.util.regex.Pattern;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * @deprecated Use {@link DataSize} for correct SI and IEC prefixes.
+ */
+@Deprecated
 public class Size implements Comparable<Size> {
     private static final Pattern SIZE_PATTERN = Pattern.compile("(\\d+)\\s*(\\S+)");
 
@@ -151,5 +155,51 @@ public class Size implements Comparable<Size> {
         }
 
         return Long.compare(toBytes(), other.toBytes());
+    }
+
+    public DataSize toDataSize() {
+        switch (unit) {
+            case BYTES:
+                return DataSize.bytes(count);
+            case KILOBYTES:
+                return DataSize.kibibytes(count);
+            case MEGABYTES:
+                return DataSize.mebibytes(count);
+            case GIGABYTES:
+                return DataSize.gibibytes(count);
+            case TERABYTES:
+                return DataSize.tebibytes(count);
+            default:
+                throw new IllegalArgumentException("Unknown unit: " + getUnit());
+        }
+    }
+
+    public static Size fromDataSize(DataSize dataSize) {
+        switch (dataSize.getUnit()) {
+            case BYTES:
+                return Size.bytes(dataSize.getQuantity());
+            case KIBIBYTES:
+                return Size.kilobytes(dataSize.getQuantity());
+            case KILOBYTES:
+                return Size.bytes(dataSize.toBytes());
+            case MEBIBYTES:
+                return Size.megabytes(dataSize.getQuantity());
+            case MEGABYTES:
+                return Size.bytes(dataSize.toBytes());
+            case GIBIBYTES:
+                return Size.gigabytes(dataSize.getQuantity());
+            case GIGABYTES:
+                return Size.bytes(dataSize.toBytes());
+            case TEBIBYTES:
+                return Size.terabytes(dataSize.getQuantity());
+            case TERABYTES:
+                return Size.bytes(dataSize.toBytes());
+            case PEBIBYTES:
+                return Size.terabytes(dataSize.toTebibytes() * 1024L);
+            case PETABYTES:
+                return Size.bytes(dataSize.toBytes());
+            default:
+                throw new IllegalArgumentException("Unknown unit: " + dataSize.getUnit());
+        }
     }
 }

--- a/dropwizard-util/src/main/java/io/dropwizard/util/SizeUnit.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/SizeUnit.java
@@ -2,7 +2,10 @@ package io.dropwizard.util;
 
 /**
  * A unit of size.
+ *
+ * @deprecated Use {@link DataSizeUnit} for correct SI and IEC prefixes.
  */
+@Deprecated
 public enum SizeUnit {
     /**
      * Bytes.
@@ -94,5 +97,28 @@ public enum SizeUnit {
      */
     public long toTerabytes(long l) {
         return TERABYTES.convert(l, this);
+    }
+
+    /**
+     * Convert this size unit into a data size unit with correct SI and IEC prefix.
+     *
+     * @return the {@link DataSizeUnit} corresponding to this size unit
+     * @see DataSizeUnit
+     */
+    public DataSizeUnit toDataSizeUnit() {
+        switch (this) {
+            case BYTES:
+                return DataSizeUnit.BYTES;
+            case KILOBYTES:
+                return DataSizeUnit.KIBIBYTES;
+            case MEGABYTES:
+                return DataSizeUnit.MEBIBYTES;
+            case GIGABYTES:
+                return DataSizeUnit.GIBIBYTES;
+            case TERABYTES:
+                return DataSizeUnit.TEBIBYTES;
+            default:
+                throw new IllegalArgumentException("Unknown unit: " + this);
+        }
     }
 }

--- a/dropwizard-util/src/test/java/io/dropwizard/util/DataSizeTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/DataSizeTest.java
@@ -1,0 +1,696 @@
+package io.dropwizard.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DataSizeTest {
+    @Test
+    void convertsToPetabytes() {
+        assertThat(DataSize.petabytes(2).toPetabytes())
+                .isEqualTo(2);
+    }
+
+    @Test
+    void convertsToTerabytes() {
+        assertThat(DataSize.terabytes(2).toTerabytes())
+                .isEqualTo(2);
+    }
+
+    @Test
+    void convertsToGigabytes() {
+        assertThat(DataSize.terabytes(2).toGigabytes())
+                .isEqualTo(2000);
+    }
+
+    @Test
+    void convertsToMegabytes() {
+        assertThat(DataSize.gigabytes(2).toMegabytes())
+                .isEqualTo(2000);
+    }
+
+    @Test
+    void convertsToKilobytes() {
+        assertThat(DataSize.megabytes(2).toKilobytes())
+                .isEqualTo(2000);
+    }
+
+    @Test
+    void convertsToBytes() {
+        assertThat(DataSize.kilobytes(2).toBytes())
+                .isEqualTo(2000L);
+    }
+
+    @Test
+    void parsesPetabytes() {
+        assertThat(DataSize.parse("2P"))
+                .isEqualTo(DataSize.petabytes(2));
+
+        assertThat(DataSize.parse("2PB"))
+                .isEqualTo(DataSize.petabytes(2));
+
+        assertThat(DataSize.parse("1 petabyte"))
+                .isEqualTo(DataSize.petabytes(1));
+
+        assertThat(DataSize.parse("2 petabytes"))
+                .isEqualTo(DataSize.petabytes(2));
+    }
+
+    @Test
+    void parsesPebibytes() {
+        assertThat(DataSize.parse("2PiB"))
+                .isEqualTo(DataSize.pebibytes(2));
+
+        assertThat(DataSize.parse("1 pebibyte"))
+                .isEqualTo(DataSize.pebibytes(1));
+
+        assertThat(DataSize.parse("2 pebibytes"))
+                .isEqualTo(DataSize.pebibytes(2));
+    }
+
+    @Test
+    void parsesTerabytes() {
+        assertThat(DataSize.parse("2T"))
+                .isEqualTo(DataSize.terabytes(2));
+
+        assertThat(DataSize.parse("2TB"))
+                .isEqualTo(DataSize.terabytes(2));
+
+        assertThat(DataSize.parse("1 terabyte"))
+                .isEqualTo(DataSize.terabytes(1));
+
+        assertThat(DataSize.parse("2 terabytes"))
+                .isEqualTo(DataSize.terabytes(2));
+    }
+
+    @Test
+    void parsesTebibytes() {
+        assertThat(DataSize.parse("2TiB"))
+                .isEqualTo(DataSize.tebibytes(2));
+
+        assertThat(DataSize.parse("1 tebibyte"))
+                .isEqualTo(DataSize.tebibytes(1));
+
+        assertThat(DataSize.parse("2 tebibytes"))
+                .isEqualTo(DataSize.tebibytes(2));
+    }
+
+    @Test
+    void parsesGigabytes() {
+        assertThat(DataSize.parse("2G"))
+                .isEqualTo(DataSize.gigabytes(2));
+
+        assertThat(DataSize.parse("2GB"))
+                .isEqualTo(DataSize.gigabytes(2));
+
+        assertThat(DataSize.parse("1 gigabyte"))
+                .isEqualTo(DataSize.gigabytes(1));
+
+        assertThat(DataSize.parse("2 gigabytes"))
+                .isEqualTo(DataSize.gigabytes(2));
+    }
+
+    @Test
+    void parsesGibibytes() {
+        assertThat(DataSize.parse("2GiB"))
+                .isEqualTo(DataSize.gibibytes(2));
+
+        assertThat(DataSize.parse("1 gibibyte"))
+                .isEqualTo(DataSize.gibibytes(1));
+
+        assertThat(DataSize.parse("2 gibibytes"))
+                .isEqualTo(DataSize.gibibytes(2));
+    }
+
+    @Test
+    void parsesMegabytes() {
+        assertThat(DataSize.parse("2M"))
+                .isEqualTo(DataSize.megabytes(2));
+
+        assertThat(DataSize.parse("2MB"))
+                .isEqualTo(DataSize.megabytes(2));
+
+        assertThat(DataSize.parse("1 megabyte"))
+                .isEqualTo(DataSize.megabytes(1));
+
+        assertThat(DataSize.parse("2 megabytes"))
+                .isEqualTo(DataSize.megabytes(2));
+    }
+
+    @Test
+    void parsesMebibytes() {
+        assertThat(DataSize.parse("2MiB"))
+                .isEqualTo(DataSize.mebibytes(2));
+
+        assertThat(DataSize.parse("1 mebibyte"))
+                .isEqualTo(DataSize.mebibytes(1));
+
+        assertThat(DataSize.parse("2 mebibytes"))
+                .isEqualTo(DataSize.mebibytes(2));
+    }
+
+    @Test
+    void parsesKilobytes() {
+        assertThat(DataSize.parse("2K"))
+                .isEqualTo(DataSize.kilobytes(2));
+
+        assertThat(DataSize.parse("2KB"))
+                .isEqualTo(DataSize.kilobytes(2));
+
+        assertThat(DataSize.parse("1 kilobyte"))
+                .isEqualTo(DataSize.kilobytes(1));
+
+        assertThat(DataSize.parse("2 kilobytes"))
+                .isEqualTo(DataSize.kilobytes(2));
+    }
+
+    @Test
+    void parsesKibibytes() {
+        assertThat(DataSize.parse("2KiB"))
+                .isEqualTo(DataSize.kibibytes(2));
+
+        assertThat(DataSize.parse("1 kibibyte"))
+                .isEqualTo(DataSize.kibibytes(1));
+
+        assertThat(DataSize.parse("2 kibibytes"))
+                .isEqualTo(DataSize.kibibytes(2));
+    }
+
+    @Test
+    void parsesBytes() {
+        assertThat(DataSize.parse("2B"))
+                .isEqualTo(DataSize.bytes(2));
+
+        assertThat(DataSize.parse("1 byte"))
+                .isEqualTo(DataSize.bytes(1));
+
+        assertThat(DataSize.parse("2 bytes"))
+                .isEqualTo(DataSize.bytes(2));
+
+        assertThat(DataSize.parse("2"))
+                .isEqualTo(DataSize.bytes(2));
+    }
+
+    @Test
+    void parseDataSizeWithWhiteSpaces() {
+        assertThat(DataSize.parse("64   kilobytes"))
+                .isEqualTo(DataSize.kilobytes(64));
+    }
+
+    @Test
+    void parseCaseInsensitive() {
+        assertThat(DataSize.parse("1b")).isEqualTo(DataSize.parse("1B"));
+    }
+
+    @Test
+    void parseSingleLetterSuffix() {
+        assertThat(DataSize.parse("1B")).isEqualTo(DataSize.bytes(1));
+        assertThat(DataSize.parse("1K")).isEqualTo(DataSize.kilobytes(1));
+        assertThat(DataSize.parse("1M")).isEqualTo(DataSize.megabytes(1));
+        assertThat(DataSize.parse("1G")).isEqualTo(DataSize.gigabytes(1));
+        assertThat(DataSize.parse("1T")).isEqualTo(DataSize.terabytes(1));
+        assertThat(DataSize.parse("1P")).isEqualTo(DataSize.petabytes(1));
+    }
+
+    @Test
+    void unableParseWrongDataSizeCount() {
+        assertThatThrownBy(() -> DataSize.parse("three bytes"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid size: three bytes");
+    }
+
+    @Test
+    void unableParseWrongDataSizeUnit() {
+        assertThatThrownBy(() -> DataSize.parse("1EB"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid size: 1EB. Wrong size unit");
+    }
+
+    @Test
+    void unableParseWrongDataSizeFormat() {
+        assertThatThrownBy(() -> DataSize.parse("1 mega byte"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid size: 1 mega byte");
+    }
+
+    @Test
+    void isHumanReadable() {
+        assertThat(DataSize.gigabytes(3).toString())
+                .isEqualTo("3 gigabytes");
+
+        assertThat(DataSize.kilobytes(1).toString())
+                .isEqualTo("1 kilobyte");
+    }
+
+    @Test
+    void hasAQuantity() {
+        assertThat(DataSize.gigabytes(3).getQuantity())
+                .isEqualTo(3);
+    }
+
+    @Test
+    void hasAUnit() {
+        assertThat(DataSize.gigabytes(3).getUnit())
+                .isEqualTo(DataSizeUnit.GIGABYTES);
+    }
+
+    @Test
+    void isComparable() {
+        // both zero
+        assertThat(DataSize.bytes(0).compareTo(DataSize.bytes(0))).isEqualTo(0);
+        assertThat(DataSize.bytes(0).compareTo(DataSize.kilobytes(0))).isEqualTo(0);
+        assertThat(DataSize.bytes(0).compareTo(DataSize.megabytes(0))).isEqualTo(0);
+        assertThat(DataSize.bytes(0).compareTo(DataSize.gigabytes(0))).isEqualTo(0);
+        assertThat(DataSize.bytes(0).compareTo(DataSize.terabytes(0))).isEqualTo(0);
+
+        assertThat(DataSize.kilobytes(0).compareTo(DataSize.bytes(0))).isEqualTo(0);
+        assertThat(DataSize.kilobytes(0).compareTo(DataSize.kilobytes(0))).isEqualTo(0);
+        assertThat(DataSize.kilobytes(0).compareTo(DataSize.megabytes(0))).isEqualTo(0);
+        assertThat(DataSize.kilobytes(0).compareTo(DataSize.gigabytes(0))).isEqualTo(0);
+        assertThat(DataSize.kilobytes(0).compareTo(DataSize.terabytes(0))).isEqualTo(0);
+
+        assertThat(DataSize.megabytes(0).compareTo(DataSize.bytes(0))).isEqualTo(0);
+        assertThat(DataSize.megabytes(0).compareTo(DataSize.kilobytes(0))).isEqualTo(0);
+        assertThat(DataSize.megabytes(0).compareTo(DataSize.megabytes(0))).isEqualTo(0);
+        assertThat(DataSize.megabytes(0).compareTo(DataSize.gigabytes(0))).isEqualTo(0);
+        assertThat(DataSize.megabytes(0).compareTo(DataSize.terabytes(0))).isEqualTo(0);
+
+        assertThat(DataSize.gigabytes(0).compareTo(DataSize.bytes(0))).isEqualTo(0);
+        assertThat(DataSize.gigabytes(0).compareTo(DataSize.kilobytes(0))).isEqualTo(0);
+        assertThat(DataSize.gigabytes(0).compareTo(DataSize.megabytes(0))).isEqualTo(0);
+        assertThat(DataSize.gigabytes(0).compareTo(DataSize.gigabytes(0))).isEqualTo(0);
+        assertThat(DataSize.gigabytes(0).compareTo(DataSize.terabytes(0))).isEqualTo(0);
+
+        assertThat(DataSize.terabytes(0).compareTo(DataSize.bytes(0))).isEqualTo(0);
+        assertThat(DataSize.terabytes(0).compareTo(DataSize.kilobytes(0))).isEqualTo(0);
+        assertThat(DataSize.terabytes(0).compareTo(DataSize.megabytes(0))).isEqualTo(0);
+        assertThat(DataSize.terabytes(0).compareTo(DataSize.gigabytes(0))).isEqualTo(0);
+        assertThat(DataSize.terabytes(0).compareTo(DataSize.terabytes(0))).isEqualTo(0);
+
+        // one zero, one negative
+        assertThat(DataSize.bytes(0)).isGreaterThan(DataSize.bytes(-1));
+        assertThat(DataSize.bytes(0)).isGreaterThan(DataSize.kilobytes(-1));
+        assertThat(DataSize.bytes(0)).isGreaterThan(DataSize.megabytes(-1));
+        assertThat(DataSize.bytes(0)).isGreaterThan(DataSize.gigabytes(-1));
+        assertThat(DataSize.bytes(0)).isGreaterThan(DataSize.terabytes(-1));
+
+        assertThat(DataSize.kilobytes(0)).isGreaterThan(DataSize.bytes(-1));
+        assertThat(DataSize.kilobytes(0)).isGreaterThan(DataSize.kilobytes(-1));
+        assertThat(DataSize.kilobytes(0)).isGreaterThan(DataSize.megabytes(-1));
+        assertThat(DataSize.kilobytes(0)).isGreaterThan(DataSize.gigabytes(-1));
+        assertThat(DataSize.kilobytes(0)).isGreaterThan(DataSize.terabytes(-1));
+
+        assertThat(DataSize.megabytes(0)).isGreaterThan(DataSize.bytes(-1));
+        assertThat(DataSize.megabytes(0)).isGreaterThan(DataSize.kilobytes(-1));
+        assertThat(DataSize.megabytes(0)).isGreaterThan(DataSize.megabytes(-1));
+        assertThat(DataSize.megabytes(0)).isGreaterThan(DataSize.gigabytes(-1));
+        assertThat(DataSize.megabytes(0)).isGreaterThan(DataSize.terabytes(-1));
+
+        assertThat(DataSize.gigabytes(0)).isGreaterThan(DataSize.bytes(-1));
+        assertThat(DataSize.gigabytes(0)).isGreaterThan(DataSize.kilobytes(-1));
+        assertThat(DataSize.gigabytes(0)).isGreaterThan(DataSize.megabytes(-1));
+        assertThat(DataSize.gigabytes(0)).isGreaterThan(DataSize.gigabytes(-1));
+        assertThat(DataSize.gigabytes(0)).isGreaterThan(DataSize.terabytes(-1));
+
+        assertThat(DataSize.terabytes(0)).isGreaterThan(DataSize.bytes(-1));
+        assertThat(DataSize.terabytes(0)).isGreaterThan(DataSize.kilobytes(-1));
+        assertThat(DataSize.terabytes(0)).isGreaterThan(DataSize.megabytes(-1));
+        assertThat(DataSize.terabytes(0)).isGreaterThan(DataSize.gigabytes(-1));
+        assertThat(DataSize.terabytes(0)).isGreaterThan(DataSize.terabytes(-1));
+
+        assertThat(DataSize.bytes(-1)).isLessThan(DataSize.bytes(0));
+        assertThat(DataSize.bytes(-1)).isLessThan(DataSize.kilobytes(0));
+        assertThat(DataSize.bytes(-1)).isLessThan(DataSize.megabytes(0));
+        assertThat(DataSize.bytes(-1)).isLessThan(DataSize.gigabytes(0));
+        assertThat(DataSize.bytes(-1)).isLessThan(DataSize.terabytes(0));
+
+        assertThat(DataSize.kilobytes(-1)).isLessThan(DataSize.bytes(0));
+        assertThat(DataSize.kilobytes(-1)).isLessThan(DataSize.kilobytes(0));
+        assertThat(DataSize.kilobytes(-1)).isLessThan(DataSize.megabytes(0));
+        assertThat(DataSize.kilobytes(-1)).isLessThan(DataSize.gigabytes(0));
+        assertThat(DataSize.kilobytes(-1)).isLessThan(DataSize.terabytes(0));
+
+        assertThat(DataSize.megabytes(-1)).isLessThan(DataSize.bytes(0));
+        assertThat(DataSize.megabytes(-1)).isLessThan(DataSize.kilobytes(0));
+        assertThat(DataSize.megabytes(-1)).isLessThan(DataSize.megabytes(0));
+        assertThat(DataSize.megabytes(-1)).isLessThan(DataSize.gigabytes(0));
+        assertThat(DataSize.megabytes(-1)).isLessThan(DataSize.terabytes(0));
+
+        assertThat(DataSize.gigabytes(-1)).isLessThan(DataSize.bytes(0));
+        assertThat(DataSize.gigabytes(-1)).isLessThan(DataSize.kilobytes(0));
+        assertThat(DataSize.gigabytes(-1)).isLessThan(DataSize.megabytes(0));
+        assertThat(DataSize.gigabytes(-1)).isLessThan(DataSize.gigabytes(0));
+        assertThat(DataSize.gigabytes(-1)).isLessThan(DataSize.terabytes(0));
+
+        assertThat(DataSize.terabytes(-1)).isLessThan(DataSize.bytes(0));
+        assertThat(DataSize.terabytes(-1)).isLessThan(DataSize.kilobytes(0));
+        assertThat(DataSize.terabytes(-1)).isLessThan(DataSize.megabytes(0));
+        assertThat(DataSize.terabytes(-1)).isLessThan(DataSize.gigabytes(0));
+        assertThat(DataSize.terabytes(-1)).isLessThan(DataSize.terabytes(0));
+
+        // one zero, one positive
+        assertThat(DataSize.bytes(0)).isLessThan(DataSize.bytes(1));
+        assertThat(DataSize.bytes(0)).isLessThan(DataSize.kilobytes(1));
+        assertThat(DataSize.bytes(0)).isLessThan(DataSize.megabytes(1));
+        assertThat(DataSize.bytes(0)).isLessThan(DataSize.gigabytes(1));
+        assertThat(DataSize.bytes(0)).isLessThan(DataSize.terabytes(1));
+
+        assertThat(DataSize.kilobytes(0)).isLessThan(DataSize.bytes(1));
+        assertThat(DataSize.kilobytes(0)).isLessThan(DataSize.kilobytes(1));
+        assertThat(DataSize.kilobytes(0)).isLessThan(DataSize.megabytes(1));
+        assertThat(DataSize.kilobytes(0)).isLessThan(DataSize.gigabytes(1));
+        assertThat(DataSize.kilobytes(0)).isLessThan(DataSize.terabytes(1));
+
+        assertThat(DataSize.megabytes(0)).isLessThan(DataSize.bytes(1));
+        assertThat(DataSize.megabytes(0)).isLessThan(DataSize.kilobytes(1));
+        assertThat(DataSize.megabytes(0)).isLessThan(DataSize.megabytes(1));
+        assertThat(DataSize.megabytes(0)).isLessThan(DataSize.gigabytes(1));
+        assertThat(DataSize.megabytes(0)).isLessThan(DataSize.terabytes(1));
+
+        assertThat(DataSize.gigabytes(0)).isLessThan(DataSize.bytes(1));
+        assertThat(DataSize.gigabytes(0)).isLessThan(DataSize.kilobytes(1));
+        assertThat(DataSize.gigabytes(0)).isLessThan(DataSize.megabytes(1));
+        assertThat(DataSize.gigabytes(0)).isLessThan(DataSize.gigabytes(1));
+        assertThat(DataSize.gigabytes(0)).isLessThan(DataSize.terabytes(1));
+
+        assertThat(DataSize.terabytes(0)).isLessThan(DataSize.bytes(1));
+        assertThat(DataSize.terabytes(0)).isLessThan(DataSize.kilobytes(1));
+        assertThat(DataSize.terabytes(0)).isLessThan(DataSize.megabytes(1));
+        assertThat(DataSize.terabytes(0)).isLessThan(DataSize.gigabytes(1));
+        assertThat(DataSize.terabytes(0)).isLessThan(DataSize.terabytes(1));
+
+        assertThat(DataSize.bytes(1)).isGreaterThan(DataSize.bytes(0));
+        assertThat(DataSize.bytes(1)).isGreaterThan(DataSize.kilobytes(0));
+        assertThat(DataSize.bytes(1)).isGreaterThan(DataSize.megabytes(0));
+        assertThat(DataSize.bytes(1)).isGreaterThan(DataSize.gigabytes(0));
+        assertThat(DataSize.bytes(1)).isGreaterThan(DataSize.terabytes(0));
+
+        assertThat(DataSize.kilobytes(1)).isGreaterThan(DataSize.bytes(0));
+        assertThat(DataSize.kilobytes(1)).isGreaterThan(DataSize.kilobytes(0));
+        assertThat(DataSize.kilobytes(1)).isGreaterThan(DataSize.megabytes(0));
+        assertThat(DataSize.kilobytes(1)).isGreaterThan(DataSize.gigabytes(0));
+        assertThat(DataSize.kilobytes(1)).isGreaterThan(DataSize.terabytes(0));
+
+        assertThat(DataSize.megabytes(1)).isGreaterThan(DataSize.bytes(0));
+        assertThat(DataSize.megabytes(1)).isGreaterThan(DataSize.kilobytes(0));
+        assertThat(DataSize.megabytes(1)).isGreaterThan(DataSize.megabytes(0));
+        assertThat(DataSize.megabytes(1)).isGreaterThan(DataSize.gigabytes(0));
+        assertThat(DataSize.megabytes(1)).isGreaterThan(DataSize.terabytes(0));
+
+        assertThat(DataSize.gigabytes(1)).isGreaterThan(DataSize.bytes(0));
+        assertThat(DataSize.gigabytes(1)).isGreaterThan(DataSize.kilobytes(0));
+        assertThat(DataSize.gigabytes(1)).isGreaterThan(DataSize.megabytes(0));
+        assertThat(DataSize.gigabytes(1)).isGreaterThan(DataSize.gigabytes(0));
+        assertThat(DataSize.gigabytes(1)).isGreaterThan(DataSize.terabytes(0));
+
+        assertThat(DataSize.terabytes(1)).isGreaterThan(DataSize.bytes(0));
+        assertThat(DataSize.terabytes(1)).isGreaterThan(DataSize.kilobytes(0));
+        assertThat(DataSize.terabytes(1)).isGreaterThan(DataSize.megabytes(0));
+        assertThat(DataSize.terabytes(1)).isGreaterThan(DataSize.gigabytes(0));
+        assertThat(DataSize.terabytes(1)).isGreaterThan(DataSize.terabytes(0));
+
+        // both negative
+        assertThat(DataSize.bytes(-2)).isLessThan(DataSize.bytes(-1));
+        assertThat(DataSize.bytes(-2)).isGreaterThan(DataSize.kilobytes(-1));
+        assertThat(DataSize.bytes(-2)).isGreaterThan(DataSize.megabytes(-1));
+        assertThat(DataSize.bytes(-2)).isGreaterThan(DataSize.gigabytes(-1));
+        assertThat(DataSize.bytes(-2)).isGreaterThan(DataSize.terabytes(-1));
+
+        assertThat(DataSize.kilobytes(-2)).isLessThan(DataSize.bytes(-1));
+        assertThat(DataSize.kilobytes(-2)).isLessThan(DataSize.kilobytes(-1));
+        assertThat(DataSize.kilobytes(-2)).isGreaterThan(DataSize.megabytes(-1));
+        assertThat(DataSize.kilobytes(-2)).isGreaterThan(DataSize.gigabytes(-1));
+        assertThat(DataSize.kilobytes(-2)).isGreaterThan(DataSize.terabytes(-1));
+
+        assertThat(DataSize.megabytes(-2)).isLessThan(DataSize.bytes(-1));
+        assertThat(DataSize.megabytes(-2)).isLessThan(DataSize.kilobytes(-1));
+        assertThat(DataSize.megabytes(-2)).isLessThan(DataSize.megabytes(-1));
+        assertThat(DataSize.megabytes(-2)).isGreaterThan(DataSize.gigabytes(-1));
+        assertThat(DataSize.megabytes(-2)).isGreaterThan(DataSize.terabytes(-1));
+
+        assertThat(DataSize.gigabytes(-2)).isLessThan(DataSize.bytes(-1));
+        assertThat(DataSize.gigabytes(-2)).isLessThan(DataSize.kilobytes(-1));
+        assertThat(DataSize.gigabytes(-2)).isLessThan(DataSize.megabytes(-1));
+        assertThat(DataSize.gigabytes(-2)).isLessThan(DataSize.gigabytes(-1));
+        assertThat(DataSize.gigabytes(-2)).isGreaterThan(DataSize.terabytes(-1));
+
+        assertThat(DataSize.terabytes(-2)).isLessThan(DataSize.bytes(-1));
+        assertThat(DataSize.terabytes(-2)).isLessThan(DataSize.kilobytes(-1));
+        assertThat(DataSize.terabytes(-2)).isLessThan(DataSize.megabytes(-1));
+        assertThat(DataSize.terabytes(-2)).isLessThan(DataSize.gigabytes(-1));
+        assertThat(DataSize.terabytes(-2)).isLessThan(DataSize.terabytes(-1));
+
+        assertThat(DataSize.bytes(-1)).isGreaterThan(DataSize.bytes(-2));
+        assertThat(DataSize.bytes(-1)).isGreaterThan(DataSize.kilobytes(-2));
+        assertThat(DataSize.bytes(-1)).isGreaterThan(DataSize.megabytes(-2));
+        assertThat(DataSize.bytes(-1)).isGreaterThan(DataSize.gigabytes(-2));
+        assertThat(DataSize.bytes(-1)).isGreaterThan(DataSize.terabytes(-2));
+
+        assertThat(DataSize.kilobytes(-1)).isLessThan(DataSize.bytes(-2));
+        assertThat(DataSize.kilobytes(-1)).isGreaterThan(DataSize.kilobytes(-2));
+        assertThat(DataSize.kilobytes(-1)).isGreaterThan(DataSize.megabytes(-2));
+        assertThat(DataSize.kilobytes(-1)).isGreaterThan(DataSize.gigabytes(-2));
+        assertThat(DataSize.kilobytes(-1)).isGreaterThan(DataSize.terabytes(-2));
+
+        assertThat(DataSize.megabytes(-1)).isLessThan(DataSize.bytes(-2));
+        assertThat(DataSize.megabytes(-1)).isLessThan(DataSize.kilobytes(-2));
+        assertThat(DataSize.megabytes(-1)).isGreaterThan(DataSize.megabytes(-2));
+        assertThat(DataSize.megabytes(-1)).isGreaterThan(DataSize.gigabytes(-2));
+        assertThat(DataSize.megabytes(-1)).isGreaterThan(DataSize.terabytes(-2));
+
+        assertThat(DataSize.gigabytes(-1)).isLessThan(DataSize.bytes(-2));
+        assertThat(DataSize.gigabytes(-1)).isLessThan(DataSize.kilobytes(-2));
+        assertThat(DataSize.gigabytes(-1)).isLessThan(DataSize.megabytes(-2));
+        assertThat(DataSize.gigabytes(-1)).isGreaterThan(DataSize.gigabytes(-2));
+        assertThat(DataSize.gigabytes(-1)).isGreaterThan(DataSize.terabytes(-2));
+
+        assertThat(DataSize.terabytes(-1)).isLessThan(DataSize.bytes(-2));
+        assertThat(DataSize.terabytes(-1)).isLessThan(DataSize.kilobytes(-2));
+        assertThat(DataSize.terabytes(-1)).isLessThan(DataSize.megabytes(-2));
+        assertThat(DataSize.terabytes(-1)).isLessThan(DataSize.gigabytes(-2));
+        assertThat(DataSize.terabytes(-1)).isGreaterThan(DataSize.terabytes(-2));
+
+        // both positive
+        assertThat(DataSize.bytes(1)).isLessThan(DataSize.bytes(2));
+        assertThat(DataSize.bytes(1)).isLessThan(DataSize.kilobytes(2));
+        assertThat(DataSize.bytes(1)).isLessThan(DataSize.megabytes(2));
+        assertThat(DataSize.bytes(1)).isLessThan(DataSize.gigabytes(2));
+        assertThat(DataSize.bytes(1)).isLessThan(DataSize.terabytes(2));
+
+        assertThat(DataSize.kilobytes(1)).isGreaterThan(DataSize.bytes(2));
+        assertThat(DataSize.kilobytes(1)).isLessThan(DataSize.kilobytes(2));
+        assertThat(DataSize.kilobytes(1)).isLessThan(DataSize.megabytes(2));
+        assertThat(DataSize.kilobytes(1)).isLessThan(DataSize.gigabytes(2));
+        assertThat(DataSize.kilobytes(1)).isLessThan(DataSize.terabytes(2));
+
+        assertThat(DataSize.megabytes(1)).isGreaterThan(DataSize.bytes(2));
+        assertThat(DataSize.megabytes(1)).isGreaterThan(DataSize.kilobytes(2));
+        assertThat(DataSize.megabytes(1)).isLessThan(DataSize.megabytes(2));
+        assertThat(DataSize.megabytes(1)).isLessThan(DataSize.gigabytes(2));
+        assertThat(DataSize.megabytes(1)).isLessThan(DataSize.terabytes(2));
+
+        assertThat(DataSize.gigabytes(1)).isGreaterThan(DataSize.bytes(2));
+        assertThat(DataSize.gigabytes(1)).isGreaterThan(DataSize.kilobytes(2));
+        assertThat(DataSize.gigabytes(1)).isGreaterThan(DataSize.megabytes(2));
+        assertThat(DataSize.gigabytes(1)).isLessThan(DataSize.gigabytes(2));
+        assertThat(DataSize.gigabytes(1)).isLessThan(DataSize.terabytes(2));
+
+        assertThat(DataSize.terabytes(1)).isGreaterThan(DataSize.bytes(2));
+        assertThat(DataSize.terabytes(1)).isGreaterThan(DataSize.kilobytes(2));
+        assertThat(DataSize.terabytes(1)).isGreaterThan(DataSize.megabytes(2));
+        assertThat(DataSize.terabytes(1)).isGreaterThan(DataSize.gigabytes(2));
+        assertThat(DataSize.terabytes(1)).isLessThan(DataSize.terabytes(2));
+
+        assertThat(DataSize.bytes(2)).isGreaterThan(DataSize.bytes(1));
+        assertThat(DataSize.bytes(2)).isLessThan(DataSize.kilobytes(1));
+        assertThat(DataSize.bytes(2)).isLessThan(DataSize.megabytes(1));
+        assertThat(DataSize.bytes(2)).isLessThan(DataSize.gigabytes(1));
+        assertThat(DataSize.bytes(2)).isLessThan(DataSize.terabytes(1));
+
+        assertThat(DataSize.kilobytes(2)).isGreaterThan(DataSize.bytes(1));
+        assertThat(DataSize.kilobytes(2)).isGreaterThan(DataSize.kilobytes(1));
+        assertThat(DataSize.kilobytes(2)).isLessThan(DataSize.megabytes(1));
+        assertThat(DataSize.kilobytes(2)).isLessThan(DataSize.gigabytes(1));
+        assertThat(DataSize.kilobytes(2)).isLessThan(DataSize.terabytes(1));
+
+        assertThat(DataSize.megabytes(2)).isGreaterThan(DataSize.bytes(1));
+        assertThat(DataSize.megabytes(2)).isGreaterThan(DataSize.kilobytes(1));
+        assertThat(DataSize.megabytes(2)).isGreaterThan(DataSize.megabytes(1));
+        assertThat(DataSize.megabytes(2)).isLessThan(DataSize.gigabytes(1));
+        assertThat(DataSize.megabytes(2)).isLessThan(DataSize.terabytes(1));
+
+        assertThat(DataSize.gigabytes(2)).isGreaterThan(DataSize.bytes(1));
+        assertThat(DataSize.gigabytes(2)).isGreaterThan(DataSize.kilobytes(1));
+        assertThat(DataSize.gigabytes(2)).isGreaterThan(DataSize.megabytes(1));
+        assertThat(DataSize.gigabytes(2)).isGreaterThan(DataSize.gigabytes(1));
+        assertThat(DataSize.gigabytes(2)).isLessThan(DataSize.terabytes(1));
+
+        assertThat(DataSize.terabytes(2)).isGreaterThan(DataSize.bytes(1));
+        assertThat(DataSize.terabytes(2)).isGreaterThan(DataSize.kilobytes(1));
+        assertThat(DataSize.terabytes(2)).isGreaterThan(DataSize.megabytes(1));
+        assertThat(DataSize.terabytes(2)).isGreaterThan(DataSize.gigabytes(1));
+        assertThat(DataSize.terabytes(2)).isGreaterThan(DataSize.terabytes(1));
+
+        // one negative, one positive
+        assertThat(DataSize.bytes(-1)).isLessThan(DataSize.bytes(1));
+        assertThat(DataSize.bytes(-1)).isLessThan(DataSize.kilobytes(1));
+        assertThat(DataSize.bytes(-1)).isLessThan(DataSize.megabytes(1));
+        assertThat(DataSize.bytes(-1)).isLessThan(DataSize.gigabytes(1));
+        assertThat(DataSize.bytes(-1)).isLessThan(DataSize.terabytes(1));
+
+        assertThat(DataSize.kilobytes(-1)).isLessThan(DataSize.bytes(1));
+        assertThat(DataSize.kilobytes(-1)).isLessThan(DataSize.kilobytes(1));
+        assertThat(DataSize.kilobytes(-1)).isLessThan(DataSize.megabytes(1));
+        assertThat(DataSize.kilobytes(-1)).isLessThan(DataSize.gigabytes(1));
+        assertThat(DataSize.kilobytes(-1)).isLessThan(DataSize.terabytes(1));
+
+        assertThat(DataSize.megabytes(-1)).isLessThan(DataSize.bytes(1));
+        assertThat(DataSize.megabytes(-1)).isLessThan(DataSize.kilobytes(1));
+        assertThat(DataSize.megabytes(-1)).isLessThan(DataSize.megabytes(1));
+        assertThat(DataSize.megabytes(-1)).isLessThan(DataSize.gigabytes(1));
+        assertThat(DataSize.megabytes(-1)).isLessThan(DataSize.terabytes(1));
+
+        assertThat(DataSize.gigabytes(-1)).isLessThan(DataSize.bytes(1));
+        assertThat(DataSize.gigabytes(-1)).isLessThan(DataSize.kilobytes(1));
+        assertThat(DataSize.gigabytes(-1)).isLessThan(DataSize.megabytes(1));
+        assertThat(DataSize.gigabytes(-1)).isLessThan(DataSize.gigabytes(1));
+        assertThat(DataSize.gigabytes(-1)).isLessThan(DataSize.terabytes(1));
+
+        assertThat(DataSize.terabytes(-1)).isLessThan(DataSize.bytes(1));
+        assertThat(DataSize.terabytes(-1)).isLessThan(DataSize.kilobytes(1));
+        assertThat(DataSize.terabytes(-1)).isLessThan(DataSize.megabytes(1));
+        assertThat(DataSize.terabytes(-1)).isLessThan(DataSize.gigabytes(1));
+        assertThat(DataSize.terabytes(-1)).isLessThan(DataSize.terabytes(1));
+
+        assertThat(DataSize.bytes(1)).isGreaterThan(DataSize.bytes(-1));
+        assertThat(DataSize.bytes(1)).isGreaterThan(DataSize.kilobytes(-1));
+        assertThat(DataSize.bytes(1)).isGreaterThan(DataSize.megabytes(-1));
+        assertThat(DataSize.bytes(1)).isGreaterThan(DataSize.gigabytes(-1));
+        assertThat(DataSize.bytes(1)).isGreaterThan(DataSize.terabytes(-1));
+
+        assertThat(DataSize.kilobytes(1)).isGreaterThan(DataSize.bytes(-1));
+        assertThat(DataSize.kilobytes(1)).isGreaterThan(DataSize.kilobytes(-1));
+        assertThat(DataSize.kilobytes(1)).isGreaterThan(DataSize.megabytes(-1));
+        assertThat(DataSize.kilobytes(1)).isGreaterThan(DataSize.gigabytes(-1));
+        assertThat(DataSize.kilobytes(1)).isGreaterThan(DataSize.terabytes(-1));
+
+        assertThat(DataSize.megabytes(1)).isGreaterThan(DataSize.bytes(-1));
+        assertThat(DataSize.megabytes(1)).isGreaterThan(DataSize.kilobytes(-1));
+        assertThat(DataSize.megabytes(1)).isGreaterThan(DataSize.megabytes(-1));
+        assertThat(DataSize.megabytes(1)).isGreaterThan(DataSize.gigabytes(-1));
+        assertThat(DataSize.megabytes(1)).isGreaterThan(DataSize.terabytes(-1));
+
+        assertThat(DataSize.gigabytes(1)).isGreaterThan(DataSize.bytes(-1));
+        assertThat(DataSize.gigabytes(1)).isGreaterThan(DataSize.kilobytes(-1));
+        assertThat(DataSize.gigabytes(1)).isGreaterThan(DataSize.megabytes(-1));
+        assertThat(DataSize.gigabytes(1)).isGreaterThan(DataSize.gigabytes(-1));
+        assertThat(DataSize.gigabytes(1)).isGreaterThan(DataSize.terabytes(-1));
+
+        assertThat(DataSize.terabytes(1)).isGreaterThan(DataSize.bytes(-1));
+        assertThat(DataSize.terabytes(1)).isGreaterThan(DataSize.kilobytes(-1));
+        assertThat(DataSize.terabytes(1)).isGreaterThan(DataSize.megabytes(-1));
+        assertThat(DataSize.terabytes(1)).isGreaterThan(DataSize.gigabytes(-1));
+        assertThat(DataSize.terabytes(1)).isGreaterThan(DataSize.terabytes(-1));
+    }
+
+    @Test
+    void serializesCorrectlyWithJackson() throws IOException {
+        final ObjectMapper mapper = new ObjectMapper();
+
+        assertThat(mapper.writeValueAsString(DataSize.bytes(0L))).isEqualTo("\"0 bytes\"");
+        assertThat(mapper.writeValueAsString(DataSize.bytes(1L))).isEqualTo("\"1 byte\"");
+        assertThat(mapper.writeValueAsString(DataSize.bytes(2L))).isEqualTo("\"2 bytes\"");
+
+        assertThat(mapper.writeValueAsString(DataSize.kilobytes(0L))).isEqualTo("\"0 kilobytes\"");
+        assertThat(mapper.writeValueAsString(DataSize.kilobytes(1L))).isEqualTo("\"1 kilobyte\"");
+        assertThat(mapper.writeValueAsString(DataSize.kilobytes(2L))).isEqualTo("\"2 kilobytes\"");
+        assertThat(mapper.writeValueAsString(DataSize.megabytes(0L))).isEqualTo("\"0 megabytes\"");
+        assertThat(mapper.writeValueAsString(DataSize.megabytes(1L))).isEqualTo("\"1 megabyte\"");
+        assertThat(mapper.writeValueAsString(DataSize.megabytes(2L))).isEqualTo("\"2 megabytes\"");
+        assertThat(mapper.writeValueAsString(DataSize.gigabytes(0L))).isEqualTo("\"0 gigabytes\"");
+        assertThat(mapper.writeValueAsString(DataSize.gigabytes(1L))).isEqualTo("\"1 gigabyte\"");
+        assertThat(mapper.writeValueAsString(DataSize.gigabytes(2L))).isEqualTo("\"2 gigabytes\"");
+        assertThat(mapper.writeValueAsString(DataSize.terabytes(0L))).isEqualTo("\"0 terabytes\"");
+        assertThat(mapper.writeValueAsString(DataSize.terabytes(1L))).isEqualTo("\"1 terabyte\"");
+        assertThat(mapper.writeValueAsString(DataSize.terabytes(2L))).isEqualTo("\"2 terabytes\"");
+        assertThat(mapper.writeValueAsString(DataSize.petabytes(0L))).isEqualTo("\"0 petabytes\"");
+        assertThat(mapper.writeValueAsString(DataSize.petabytes(1L))).isEqualTo("\"1 petabyte\"");
+        assertThat(mapper.writeValueAsString(DataSize.petabytes(2L))).isEqualTo("\"2 petabytes\"");
+
+        assertThat(mapper.writeValueAsString(DataSize.kibibytes(0L))).isEqualTo("\"0 kibibytes\"");
+        assertThat(mapper.writeValueAsString(DataSize.kibibytes(1L))).isEqualTo("\"1 kibibyte\"");
+        assertThat(mapper.writeValueAsString(DataSize.kibibytes(2L))).isEqualTo("\"2 kibibytes\"");
+        assertThat(mapper.writeValueAsString(DataSize.mebibytes(0L))).isEqualTo("\"0 mebibytes\"");
+        assertThat(mapper.writeValueAsString(DataSize.mebibytes(1L))).isEqualTo("\"1 mebibyte\"");
+        assertThat(mapper.writeValueAsString(DataSize.mebibytes(2L))).isEqualTo("\"2 mebibytes\"");
+        assertThat(mapper.writeValueAsString(DataSize.gibibytes(0L))).isEqualTo("\"0 gibibytes\"");
+        assertThat(mapper.writeValueAsString(DataSize.gibibytes(1L))).isEqualTo("\"1 gibibyte\"");
+        assertThat(mapper.writeValueAsString(DataSize.gibibytes(2L))).isEqualTo("\"2 gibibytes\"");
+        assertThat(mapper.writeValueAsString(DataSize.tebibytes(0L))).isEqualTo("\"0 tebibytes\"");
+        assertThat(mapper.writeValueAsString(DataSize.tebibytes(1L))).isEqualTo("\"1 tebibyte\"");
+        assertThat(mapper.writeValueAsString(DataSize.tebibytes(2L))).isEqualTo("\"2 tebibytes\"");
+        assertThat(mapper.writeValueAsString(DataSize.pebibytes(0L))).isEqualTo("\"0 pebibytes\"");
+        assertThat(mapper.writeValueAsString(DataSize.pebibytes(1L))).isEqualTo("\"1 pebibyte\"");
+        assertThat(mapper.writeValueAsString(DataSize.pebibytes(2L))).isEqualTo("\"2 pebibytes\"");
+    }
+
+    @Test
+    void deserializesCorrectlyWithJackson() throws IOException {
+        final ObjectMapper mapper = new ObjectMapper();
+
+        assertThat(mapper.readValue("\"0 bytes\"", DataSize.class)).isEqualTo(DataSize.bytes(0L));
+        assertThat(mapper.readValue("\"1 byte\"", DataSize.class)).isEqualTo(DataSize.bytes(1L));
+        assertThat(mapper.readValue("\"2 bytes\"", DataSize.class)).isEqualTo(DataSize.bytes(2L));
+        assertThat(mapper.readValue("\"0 kilobytes\"", DataSize.class)).isEqualTo(DataSize.kilobytes(0L));
+        assertThat(mapper.readValue("\"1 kilobyte\"", DataSize.class)).isEqualTo(DataSize.kilobytes(1L));
+        assertThat(mapper.readValue("\"2 kilobytes\"", DataSize.class)).isEqualTo(DataSize.kilobytes(2L));
+        assertThat(mapper.readValue("\"0 megabytes\"", DataSize.class)).isEqualTo(DataSize.megabytes(0L));
+        assertThat(mapper.readValue("\"1 megabyte\"", DataSize.class)).isEqualTo(DataSize.megabytes(1L));
+        assertThat(mapper.readValue("\"2 megabytes\"", DataSize.class)).isEqualTo(DataSize.megabytes(2L));
+        assertThat(mapper.readValue("\"0 gigabytes\"", DataSize.class)).isEqualTo(DataSize.gigabytes(0L));
+        assertThat(mapper.readValue("\"1 gigabyte\"", DataSize.class)).isEqualTo(DataSize.gigabytes(1L));
+        assertThat(mapper.readValue("\"2 gigabytes\"", DataSize.class)).isEqualTo(DataSize.gigabytes(2L));
+        assertThat(mapper.readValue("\"0 terabytes\"", DataSize.class)).isEqualTo(DataSize.terabytes(0L));
+        assertThat(mapper.readValue("\"1 terabytes\"", DataSize.class)).isEqualTo(DataSize.terabytes(1L));
+        assertThat(mapper.readValue("\"2 terabytes\"", DataSize.class)).isEqualTo(DataSize.terabytes(2L));
+        assertThat(mapper.readValue("\"0 petabytes\"", DataSize.class)).isEqualTo(DataSize.petabytes(0L));
+        assertThat(mapper.readValue("\"1 petabytes\"", DataSize.class)).isEqualTo(DataSize.petabytes(1L));
+        assertThat(mapper.readValue("\"2 petabytes\"", DataSize.class)).isEqualTo(DataSize.petabytes(2L));
+    }
+
+    @Test
+    void testParseWithDefaultDataSizeUnit() {
+        assertThat(DataSize.parse("1 MiB", DataSizeUnit.KIBIBYTES)).isEqualTo(DataSize.mebibytes(1L));
+        assertThat(DataSize.parse("128", DataSizeUnit.KIBIBYTES)).isEqualTo(DataSize.kibibytes(128L));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void testToSize() {
+        assertThat(DataSize.bytes(5L).toSize()).isEqualTo(Size.bytes(5L));
+        assertThat(DataSize.kilobytes(5L).toSize()).isEqualTo(Size.bytes(5L * 1000L));
+        assertThat(DataSize.kibibytes(5L).toSize()).isEqualTo(Size.kilobytes(5L));
+        assertThat(DataSize.megabytes(5L).toSize()).isEqualTo(Size.bytes(5L * 1000L * 1000L));
+        assertThat(DataSize.mebibytes(5L).toSize()).isEqualTo(Size.megabytes(5L));
+        assertThat(DataSize.gigabytes(5L).toSize()).isEqualTo(Size.bytes(5L * 1000L * 1000L * 1000L));
+        assertThat(DataSize.gibibytes(5L).toSize()).isEqualTo(Size.gigabytes(5L));
+        assertThat(DataSize.terabytes(5L).toSize()).isEqualTo(Size.bytes(5L * 1000L * 1000L * 1000L * 1000L));
+        assertThat(DataSize.tebibytes(5L).toSize()).isEqualTo(Size.terabytes(5L));
+        assertThat(DataSize.petabytes(5L).toSize()).isEqualTo(Size.bytes(5L * 1000L * 1000L * 1000L * 1000L * 1000L));
+        assertThat(DataSize.pebibytes(5L).toSize()).isEqualTo(Size.terabytes(5L * 1024L));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void testFromSize() {
+        assertThat(DataSize.fromSize(Size.bytes(5L))).isEqualTo(DataSize.bytes(5L));
+        assertThat(DataSize.fromSize(Size.kilobytes(5L))).isEqualTo(DataSize.kibibytes(5L));
+        assertThat(DataSize.fromSize(Size.megabytes(5L))).isEqualTo(DataSize.mebibytes(5L));
+        assertThat(DataSize.fromSize(Size.gigabytes(5L))).isEqualTo(DataSize.gibibytes(5L));
+        assertThat(DataSize.fromSize(Size.terabytes(5L))).isEqualTo(DataSize.tebibytes(5L));
+    }
+}

--- a/dropwizard-util/src/test/java/io/dropwizard/util/DataSizeUnitTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/DataSizeUnitTest.java
@@ -1,0 +1,189 @@
+package io.dropwizard.util;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class DataSizeUnitTest {
+    private static class Converter {
+        private Function<Long, Long> f;
+
+        Converter(Function<Long, Long> f) {
+            this.f = f;
+        }
+
+        long toOneDst() {
+            return f.apply(1L);
+        }
+    }
+
+    static Stream<Arguments> parameters() {
+        return Stream.of(
+                // bytes
+                arguments(DataSizeUnit.BYTES, DataSizeUnit.BYTES, new Converter(DataSizeUnit.BYTES::toBytes), 1L),
+                arguments(DataSizeUnit.BYTES, DataSizeUnit.KILOBYTES, new Converter(DataSizeUnit.BYTES::toKilobytes), 0L),
+                arguments(DataSizeUnit.BYTES, DataSizeUnit.MEGABYTES, new Converter(DataSizeUnit.BYTES::toMegabytes), 0L),
+                arguments(DataSizeUnit.BYTES, DataSizeUnit.GIGABYTES, new Converter(DataSizeUnit.BYTES::toGigabytes), 0L),
+                arguments(DataSizeUnit.BYTES, DataSizeUnit.TERABYTES, new Converter(DataSizeUnit.BYTES::toTerabytes), 0L),
+                arguments(DataSizeUnit.BYTES, DataSizeUnit.PETABYTES, new Converter(DataSizeUnit.BYTES::toPetabytes), 0L),
+
+                arguments(DataSizeUnit.BYTES, DataSizeUnit.KIBIBYTES, new Converter(DataSizeUnit.BYTES::toKibibytes), 0L),
+                arguments(DataSizeUnit.BYTES, DataSizeUnit.MEBIBYTES, new Converter(DataSizeUnit.BYTES::toMebibytes), 0L),
+                arguments(DataSizeUnit.BYTES, DataSizeUnit.GIBIBYTES, new Converter(DataSizeUnit.BYTES::toGibibytes), 0L),
+                arguments(DataSizeUnit.BYTES, DataSizeUnit.TEBIBYTES, new Converter(DataSizeUnit.BYTES::toTebibytes), 0L),
+                arguments(DataSizeUnit.BYTES, DataSizeUnit.PEBIBYTES, new Converter(DataSizeUnit.BYTES::toPebibytes), 0L),
+
+                // kilobytes
+                arguments(DataSizeUnit.KILOBYTES, DataSizeUnit.BYTES, new Converter(DataSizeUnit.KILOBYTES::toBytes), 1000L),
+                arguments(DataSizeUnit.KILOBYTES, DataSizeUnit.KILOBYTES, new Converter(DataSizeUnit.KILOBYTES::toKilobytes), 1L),
+                arguments(DataSizeUnit.KILOBYTES, DataSizeUnit.MEGABYTES, new Converter(DataSizeUnit.KILOBYTES::toMegabytes), 0L),
+                arguments(DataSizeUnit.KILOBYTES, DataSizeUnit.GIGABYTES, new Converter(DataSizeUnit.KILOBYTES::toGigabytes), 0L),
+                arguments(DataSizeUnit.KILOBYTES, DataSizeUnit.TERABYTES, new Converter(DataSizeUnit.KILOBYTES::toTerabytes), 0L),
+                arguments(DataSizeUnit.KILOBYTES, DataSizeUnit.PETABYTES, new Converter(DataSizeUnit.KILOBYTES::toPetabytes), 0L),
+
+                arguments(DataSizeUnit.KILOBYTES, DataSizeUnit.KIBIBYTES, new Converter(DataSizeUnit.KILOBYTES::toKibibytes), 0L),
+                arguments(DataSizeUnit.KILOBYTES, DataSizeUnit.MEBIBYTES, new Converter(DataSizeUnit.KILOBYTES::toMebibytes), 0L),
+                arguments(DataSizeUnit.KILOBYTES, DataSizeUnit.GIBIBYTES, new Converter(DataSizeUnit.KILOBYTES::toGibibytes), 0L),
+                arguments(DataSizeUnit.KILOBYTES, DataSizeUnit.TEBIBYTES, new Converter(DataSizeUnit.KILOBYTES::toTebibytes), 0L),
+                arguments(DataSizeUnit.KILOBYTES, DataSizeUnit.PEBIBYTES, new Converter(DataSizeUnit.KILOBYTES::toPebibytes), 0L),
+
+                // megabytes
+                arguments(DataSizeUnit.MEGABYTES, DataSizeUnit.BYTES, new Converter(DataSizeUnit.MEGABYTES::toBytes), 1000L * 1000L),
+                arguments(DataSizeUnit.MEGABYTES, DataSizeUnit.KILOBYTES, new Converter(DataSizeUnit.MEGABYTES::toKilobytes), 1000L),
+                arguments(DataSizeUnit.MEGABYTES, DataSizeUnit.MEGABYTES, new Converter(DataSizeUnit.MEGABYTES::toMegabytes), 1L),
+                arguments(DataSizeUnit.MEGABYTES, DataSizeUnit.GIGABYTES, new Converter(DataSizeUnit.MEGABYTES::toGigabytes), 0L),
+                arguments(DataSizeUnit.MEGABYTES, DataSizeUnit.TERABYTES, new Converter(DataSizeUnit.MEGABYTES::toTerabytes), 0L),
+                arguments(DataSizeUnit.MEGABYTES, DataSizeUnit.PETABYTES, new Converter(DataSizeUnit.MEGABYTES::toPetabytes), 0L),
+
+                arguments(DataSizeUnit.MEGABYTES, DataSizeUnit.KIBIBYTES, new Converter(DataSizeUnit.MEGABYTES::toKibibytes), 1000L * 1000L / 1024L),
+                arguments(DataSizeUnit.MEGABYTES, DataSizeUnit.MEBIBYTES, new Converter(DataSizeUnit.MEGABYTES::toMebibytes), 0L),
+                arguments(DataSizeUnit.MEGABYTES, DataSizeUnit.GIBIBYTES, new Converter(DataSizeUnit.MEGABYTES::toGibibytes), 0L),
+                arguments(DataSizeUnit.MEGABYTES, DataSizeUnit.TEBIBYTES, new Converter(DataSizeUnit.MEGABYTES::toTebibytes), 0L),
+                arguments(DataSizeUnit.MEGABYTES, DataSizeUnit.PEBIBYTES, new Converter(DataSizeUnit.MEGABYTES::toPebibytes), 0L),
+
+                // gigabytes
+                arguments(DataSizeUnit.GIGABYTES, DataSizeUnit.BYTES, new Converter(DataSizeUnit.GIGABYTES::toBytes), 1000L * 1000L * 1000L),
+                arguments(DataSizeUnit.GIGABYTES, DataSizeUnit.KILOBYTES, new Converter(DataSizeUnit.GIGABYTES::toKilobytes), 1000L * 1000L),
+                arguments(DataSizeUnit.GIGABYTES, DataSizeUnit.MEGABYTES, new Converter(DataSizeUnit.GIGABYTES::toMegabytes), 1000L),
+                arguments(DataSizeUnit.GIGABYTES, DataSizeUnit.GIGABYTES, new Converter(DataSizeUnit.GIGABYTES::toGigabytes), 1L),
+                arguments(DataSizeUnit.GIGABYTES, DataSizeUnit.TERABYTES, new Converter(DataSizeUnit.GIGABYTES::toTerabytes), 0L),
+                arguments(DataSizeUnit.GIGABYTES, DataSizeUnit.PETABYTES, new Converter(DataSizeUnit.GIGABYTES::toPetabytes), 0L),
+
+                arguments(DataSizeUnit.GIGABYTES, DataSizeUnit.KIBIBYTES, new Converter(DataSizeUnit.GIGABYTES::toKibibytes), 1000L * 1000L * 1000L / 1024L),
+                arguments(DataSizeUnit.GIGABYTES, DataSizeUnit.MEBIBYTES, new Converter(DataSizeUnit.GIGABYTES::toMebibytes), 1000L * 1000L * 1000L / (1024L * 1024L)),
+                arguments(DataSizeUnit.GIGABYTES, DataSizeUnit.GIBIBYTES, new Converter(DataSizeUnit.GIGABYTES::toGibibytes), 0L),
+                arguments(DataSizeUnit.GIGABYTES, DataSizeUnit.TEBIBYTES, new Converter(DataSizeUnit.GIGABYTES::toTebibytes), 0L),
+                arguments(DataSizeUnit.GIGABYTES, DataSizeUnit.PEBIBYTES, new Converter(DataSizeUnit.GIGABYTES::toPebibytes), 0L),
+
+                // terabytes
+                arguments(DataSizeUnit.TERABYTES, DataSizeUnit.BYTES, new Converter(DataSizeUnit.TERABYTES::toBytes), 1000L * 1000L * 1000L * 1000L),
+                arguments(DataSizeUnit.TERABYTES, DataSizeUnit.KILOBYTES, new Converter(DataSizeUnit.TERABYTES::toKilobytes), 1000L * 1000L * 1000L),
+                arguments(DataSizeUnit.TERABYTES, DataSizeUnit.MEGABYTES, new Converter(DataSizeUnit.TERABYTES::toMegabytes), 1000L * 1000L),
+                arguments(DataSizeUnit.TERABYTES, DataSizeUnit.GIGABYTES, new Converter(DataSizeUnit.TERABYTES::toGigabytes), 1000L),
+                arguments(DataSizeUnit.TERABYTES, DataSizeUnit.TERABYTES, new Converter(DataSizeUnit.TERABYTES::toTerabytes), 1L),
+                arguments(DataSizeUnit.TERABYTES, DataSizeUnit.PETABYTES, new Converter(DataSizeUnit.TERABYTES::toPetabytes), 0L),
+
+                arguments(DataSizeUnit.TERABYTES, DataSizeUnit.KIBIBYTES, new Converter(DataSizeUnit.TERABYTES::toKibibytes), 1000L * 1000L * 1000L * 1000L / 1024L),
+                arguments(DataSizeUnit.TERABYTES, DataSizeUnit.MEBIBYTES, new Converter(DataSizeUnit.TERABYTES::toMebibytes), 1000L * 1000L * 1000L * 1000L / (1024L * 1024L)),
+                arguments(DataSizeUnit.TERABYTES, DataSizeUnit.GIBIBYTES, new Converter(DataSizeUnit.TERABYTES::toGibibytes), 1000L * 1000L * 1000L * 1000L / (1024L * 1024L * 1024L)),
+                arguments(DataSizeUnit.TERABYTES, DataSizeUnit.TEBIBYTES, new Converter(DataSizeUnit.TERABYTES::toTebibytes), 0L),
+                arguments(DataSizeUnit.TERABYTES, DataSizeUnit.PEBIBYTES, new Converter(DataSizeUnit.TERABYTES::toPebibytes), 0L),
+
+                // petabytes
+                arguments(DataSizeUnit.PETABYTES, DataSizeUnit.BYTES, new Converter(DataSizeUnit.PETABYTES::toBytes), 1000L * 1000L * 1000L * 1000L * 1000L),
+                arguments(DataSizeUnit.PETABYTES, DataSizeUnit.KILOBYTES, new Converter(DataSizeUnit.PETABYTES::toKilobytes), 1000L * 1000L * 1000L * 1000L),
+                arguments(DataSizeUnit.PETABYTES, DataSizeUnit.MEGABYTES, new Converter(DataSizeUnit.PETABYTES::toMegabytes), 1000L * 1000L * 1000L),
+                arguments(DataSizeUnit.PETABYTES, DataSizeUnit.GIGABYTES, new Converter(DataSizeUnit.PETABYTES::toGigabytes), 1000L * 1000L),
+                arguments(DataSizeUnit.PETABYTES, DataSizeUnit.TERABYTES, new Converter(DataSizeUnit.PETABYTES::toTerabytes), 1000L),
+                arguments(DataSizeUnit.PETABYTES, DataSizeUnit.PETABYTES, new Converter(DataSizeUnit.PETABYTES::toPetabytes), 1L),
+
+                arguments(DataSizeUnit.PETABYTES, DataSizeUnit.KIBIBYTES, new Converter(DataSizeUnit.PETABYTES::toKibibytes), 1000L * 1000L * 1000L * 1000L * 1000L / 1024L),
+                arguments(DataSizeUnit.PETABYTES, DataSizeUnit.MEBIBYTES, new Converter(DataSizeUnit.PETABYTES::toMebibytes), 1000L * 1000L * 1000L * 1000L * 1000L / (1024L * 1024L)),
+                arguments(DataSizeUnit.PETABYTES, DataSizeUnit.GIBIBYTES, new Converter(DataSizeUnit.PETABYTES::toGibibytes), 1000L * 1000L * 1000L * 1000L * 1000L / (1024L * 1024L * 1024L)),
+                arguments(DataSizeUnit.PETABYTES, DataSizeUnit.TEBIBYTES, new Converter(DataSizeUnit.PETABYTES::toTebibytes), 1000L * 1000L * 1000L * 1000L * 1000L / (1024L * 1024L * 1024L * 1024L)),
+                arguments(DataSizeUnit.PETABYTES, DataSizeUnit.PEBIBYTES, new Converter(DataSizeUnit.PETABYTES::toPebibytes), 0L),
+
+                // kibibytes
+                arguments(DataSizeUnit.KIBIBYTES, DataSizeUnit.BYTES, new Converter(DataSizeUnit.KIBIBYTES::toBytes), 1024L),
+                arguments(DataSizeUnit.KIBIBYTES, DataSizeUnit.KILOBYTES, new Converter(DataSizeUnit.KIBIBYTES::toKilobytes), 1L),
+                arguments(DataSizeUnit.KIBIBYTES, DataSizeUnit.MEGABYTES, new Converter(DataSizeUnit.KIBIBYTES::toMegabytes), 0L),
+                arguments(DataSizeUnit.KIBIBYTES, DataSizeUnit.GIGABYTES, new Converter(DataSizeUnit.KIBIBYTES::toGigabytes), 0L),
+                arguments(DataSizeUnit.KIBIBYTES, DataSizeUnit.TERABYTES, new Converter(DataSizeUnit.KIBIBYTES::toTerabytes), 0L),
+                arguments(DataSizeUnit.KIBIBYTES, DataSizeUnit.PETABYTES, new Converter(DataSizeUnit.KIBIBYTES::toPetabytes), 0L),
+
+                arguments(DataSizeUnit.KIBIBYTES, DataSizeUnit.KIBIBYTES, new Converter(DataSizeUnit.KIBIBYTES::toKibibytes), 1L),
+                arguments(DataSizeUnit.KIBIBYTES, DataSizeUnit.MEBIBYTES, new Converter(DataSizeUnit.KIBIBYTES::toMebibytes), 0L),
+                arguments(DataSizeUnit.KIBIBYTES, DataSizeUnit.GIBIBYTES, new Converter(DataSizeUnit.KIBIBYTES::toGibibytes), 0L),
+                arguments(DataSizeUnit.KIBIBYTES, DataSizeUnit.TEBIBYTES, new Converter(DataSizeUnit.KIBIBYTES::toTebibytes), 0L),
+                arguments(DataSizeUnit.KIBIBYTES, DataSizeUnit.PEBIBYTES, new Converter(DataSizeUnit.KIBIBYTES::toPebibytes), 0L),
+
+                // mebibytes
+                arguments(DataSizeUnit.MEBIBYTES, DataSizeUnit.BYTES, new Converter(DataSizeUnit.MEBIBYTES::toBytes), 1024L * 1024L),
+                arguments(DataSizeUnit.MEBIBYTES, DataSizeUnit.KILOBYTES, new Converter(DataSizeUnit.MEBIBYTES::toKilobytes), 1024L * 1024L / 1000L),
+                arguments(DataSizeUnit.MEBIBYTES, DataSizeUnit.MEGABYTES, new Converter(DataSizeUnit.MEBIBYTES::toMegabytes), 1L),
+                arguments(DataSizeUnit.MEBIBYTES, DataSizeUnit.GIGABYTES, new Converter(DataSizeUnit.MEBIBYTES::toGigabytes), 0L),
+                arguments(DataSizeUnit.MEBIBYTES, DataSizeUnit.TERABYTES, new Converter(DataSizeUnit.MEBIBYTES::toTerabytes), 0L),
+                arguments(DataSizeUnit.MEBIBYTES, DataSizeUnit.PETABYTES, new Converter(DataSizeUnit.MEBIBYTES::toPetabytes), 0L),
+
+                arguments(DataSizeUnit.MEBIBYTES, DataSizeUnit.KIBIBYTES, new Converter(DataSizeUnit.MEBIBYTES::toKibibytes), 1024L),
+                arguments(DataSizeUnit.MEBIBYTES, DataSizeUnit.MEBIBYTES, new Converter(DataSizeUnit.MEBIBYTES::toMebibytes), 1L),
+                arguments(DataSizeUnit.MEBIBYTES, DataSizeUnit.GIBIBYTES, new Converter(DataSizeUnit.MEBIBYTES::toGibibytes), 0L),
+                arguments(DataSizeUnit.MEBIBYTES, DataSizeUnit.TEBIBYTES, new Converter(DataSizeUnit.MEBIBYTES::toTebibytes), 0L),
+                arguments(DataSizeUnit.MEBIBYTES, DataSizeUnit.PEBIBYTES, new Converter(DataSizeUnit.MEBIBYTES::toPebibytes), 0L),
+
+                // gibibytes
+                arguments(DataSizeUnit.GIBIBYTES, DataSizeUnit.BYTES, new Converter(DataSizeUnit.GIBIBYTES::toBytes), 1024L * 1024L * 1024L),
+                arguments(DataSizeUnit.GIBIBYTES, DataSizeUnit.KILOBYTES, new Converter(DataSizeUnit.GIBIBYTES::toKilobytes), 1024L * 1024L * 1024L / 1000L),
+                arguments(DataSizeUnit.GIBIBYTES, DataSizeUnit.MEGABYTES, new Converter(DataSizeUnit.GIBIBYTES::toMegabytes), 1024L * 1024L * 1024L / (1000L * 1000L)),
+                arguments(DataSizeUnit.GIBIBYTES, DataSizeUnit.GIGABYTES, new Converter(DataSizeUnit.GIBIBYTES::toGigabytes), 1L),
+                arguments(DataSizeUnit.GIBIBYTES, DataSizeUnit.TERABYTES, new Converter(DataSizeUnit.GIBIBYTES::toTerabytes), 0L),
+                arguments(DataSizeUnit.GIBIBYTES, DataSizeUnit.PETABYTES, new Converter(DataSizeUnit.GIBIBYTES::toPetabytes), 0L),
+
+                arguments(DataSizeUnit.GIBIBYTES, DataSizeUnit.KIBIBYTES, new Converter(DataSizeUnit.GIBIBYTES::toKibibytes), 1024L * 1024L),
+                arguments(DataSizeUnit.GIBIBYTES, DataSizeUnit.MEBIBYTES, new Converter(DataSizeUnit.GIBIBYTES::toMebibytes), 1024L),
+                arguments(DataSizeUnit.GIBIBYTES, DataSizeUnit.GIBIBYTES, new Converter(DataSizeUnit.GIBIBYTES::toGibibytes), 1L),
+                arguments(DataSizeUnit.GIBIBYTES, DataSizeUnit.TEBIBYTES, new Converter(DataSizeUnit.GIBIBYTES::toTebibytes), 0L),
+                arguments(DataSizeUnit.GIBIBYTES, DataSizeUnit.PEBIBYTES, new Converter(DataSizeUnit.GIBIBYTES::toPebibytes), 0L),
+
+                // tebibytes
+                arguments(DataSizeUnit.TEBIBYTES, DataSizeUnit.BYTES, new Converter(DataSizeUnit.TEBIBYTES::toBytes), 1024L * 1024L * 1024L * 1024L),
+                arguments(DataSizeUnit.TEBIBYTES, DataSizeUnit.KILOBYTES, new Converter(DataSizeUnit.TEBIBYTES::toKilobytes), 1024L * 1024L * 1024L * 1024L / 1000L),
+                arguments(DataSizeUnit.TEBIBYTES, DataSizeUnit.MEGABYTES, new Converter(DataSizeUnit.TEBIBYTES::toMegabytes), 1024L * 1024L * 1024L * 1024L / (1000L * 1000L)),
+                arguments(DataSizeUnit.TEBIBYTES, DataSizeUnit.GIGABYTES, new Converter(DataSizeUnit.TEBIBYTES::toGigabytes), 1024L * 1024L * 1024L * 1024L / (1000L * 1000L * 1000L)),
+                arguments(DataSizeUnit.TEBIBYTES, DataSizeUnit.TERABYTES, new Converter(DataSizeUnit.TEBIBYTES::toTerabytes), 1L),
+                arguments(DataSizeUnit.TEBIBYTES, DataSizeUnit.PETABYTES, new Converter(DataSizeUnit.TEBIBYTES::toPetabytes), 0L),
+
+                arguments(DataSizeUnit.TEBIBYTES, DataSizeUnit.KIBIBYTES, new Converter(DataSizeUnit.TEBIBYTES::toKibibytes), 1024L * 1024L * 1024L),
+                arguments(DataSizeUnit.TEBIBYTES, DataSizeUnit.MEBIBYTES, new Converter(DataSizeUnit.TEBIBYTES::toMebibytes), 1024L * 1024L),
+                arguments(DataSizeUnit.TEBIBYTES, DataSizeUnit.GIBIBYTES, new Converter(DataSizeUnit.TEBIBYTES::toGibibytes), 1024L),
+                arguments(DataSizeUnit.TEBIBYTES, DataSizeUnit.TEBIBYTES, new Converter(DataSizeUnit.TEBIBYTES::toTebibytes), 1L),
+                arguments(DataSizeUnit.TEBIBYTES, DataSizeUnit.PEBIBYTES, new Converter(DataSizeUnit.TEBIBYTES::toPebibytes), 0L),
+
+                // pebibytes
+                arguments(DataSizeUnit.PEBIBYTES, DataSizeUnit.BYTES, new Converter(DataSizeUnit.PEBIBYTES::toBytes), 1024L * 1024L * 1024L * 1024L * 1024L),
+                arguments(DataSizeUnit.PEBIBYTES, DataSizeUnit.KILOBYTES, new Converter(DataSizeUnit.PEBIBYTES::toKilobytes), 1024L * 1024L * 1024L * 1024L * 1024L / 1000L),
+                arguments(DataSizeUnit.PEBIBYTES, DataSizeUnit.MEGABYTES, new Converter(DataSizeUnit.PEBIBYTES::toMegabytes), 1024L * 1024L * 1024L * 1024L * 1024L / (1000L * 1000L)),
+                arguments(DataSizeUnit.PEBIBYTES, DataSizeUnit.GIGABYTES, new Converter(DataSizeUnit.PEBIBYTES::toGigabytes), 1024L * 1024L * 1024L * 1024L * 1024L / (1000L * 1000L * 1000L)),
+                arguments(DataSizeUnit.PEBIBYTES, DataSizeUnit.TERABYTES, new Converter(DataSizeUnit.PEBIBYTES::toTerabytes), 1024L * 1024L * 1024L * 1024L * 1024L / (1000L * 1000L * 1000L * 1000L)),
+                arguments(DataSizeUnit.PEBIBYTES, DataSizeUnit.PETABYTES, new Converter(DataSizeUnit.PEBIBYTES::toPetabytes), 1L),
+
+                arguments(DataSizeUnit.PEBIBYTES, DataSizeUnit.KIBIBYTES, new Converter(DataSizeUnit.PEBIBYTES::toKibibytes), 1024L * 1024L * 1024L * 1024L),
+                arguments(DataSizeUnit.PEBIBYTES, DataSizeUnit.MEBIBYTES, new Converter(DataSizeUnit.PEBIBYTES::toMebibytes), 1024L * 1024L * 1024L),
+                arguments(DataSizeUnit.PEBIBYTES, DataSizeUnit.GIBIBYTES, new Converter(DataSizeUnit.PEBIBYTES::toGibibytes), 1024L * 1024L),
+                arguments(DataSizeUnit.PEBIBYTES, DataSizeUnit.TEBIBYTES, new Converter(DataSizeUnit.PEBIBYTES::toTebibytes), 1024L),
+                arguments(DataSizeUnit.PEBIBYTES, DataSizeUnit.PEBIBYTES, new Converter(DataSizeUnit.PEBIBYTES::toPebibytes), 1L));
+    }
+
+    @ParameterizedTest(name = "{0} => {1}")
+    @MethodSource("parameters")
+    void oneSrcUnitInDstUnits(DataSizeUnit src, DataSizeUnit dst, Converter c, long value) {
+        assertThat(dst.convert(1, src)).isEqualTo(value);
+        assertThat(c.toOneDst()).isEqualTo(value);
+    }
+}

--- a/dropwizard-util/src/test/java/io/dropwizard/util/SizeTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/SizeTest.java
@@ -8,39 +8,40 @@ import java.io.IOException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
-public class SizeTest {
+@SuppressWarnings("deprecation")
+class SizeTest {
     @Test
-    public void convertsToTerabytes() throws Exception {
+    void convertsToTerabytes() {
         assertThat(Size.terabytes(2).toTerabytes())
                 .isEqualTo(2);
     }
 
     @Test
-    public void convertsToGigabytes() throws Exception {
+    void convertsToGigabytes() {
         assertThat(Size.terabytes(2).toGigabytes())
                 .isEqualTo(2048);
     }
 
     @Test
-    public void convertsToMegabytes() throws Exception {
+    void convertsToMegabytes() {
         assertThat(Size.gigabytes(2).toMegabytes())
                 .isEqualTo(2048);
     }
 
     @Test
-    public void convertsToKilobytes() throws Exception {
+    void convertsToKilobytes() {
         assertThat(Size.megabytes(2).toKilobytes())
                 .isEqualTo(2048);
     }
 
     @Test
-    public void convertsToBytes() throws Exception {
+    void convertsToBytes() {
         assertThat(Size.kilobytes(2).toBytes())
                 .isEqualTo(2048L);
     }
 
     @Test
-    public void parsesTerabytes() throws Exception {
+    void parsesTerabytes() {
         assertThat(Size.parse("2TB"))
                 .isEqualTo(Size.terabytes(2));
 
@@ -55,7 +56,7 @@ public class SizeTest {
     }
 
     @Test
-    public void parsesGigabytes() throws Exception {
+    void parsesGigabytes() {
         assertThat(Size.parse("2GB"))
                 .isEqualTo(Size.gigabytes(2));
 
@@ -70,7 +71,7 @@ public class SizeTest {
     }
 
     @Test
-    public void parsesMegabytes() throws Exception {
+    void parsesMegabytes() {
         assertThat(Size.parse("2MB"))
                 .isEqualTo(Size.megabytes(2));
 
@@ -85,7 +86,7 @@ public class SizeTest {
     }
 
     @Test
-    public void parsesKilobytes() throws Exception {
+    void parsesKilobytes() {
         assertThat(Size.parse("2KB"))
                 .isEqualTo(Size.kilobytes(2));
 
@@ -100,7 +101,7 @@ public class SizeTest {
     }
 
     @Test
-    public void parsesBytes() throws Exception {
+    void parsesBytes() {
         assertThat(Size.parse("2B"))
                 .isEqualTo(Size.bytes(2));
 
@@ -112,18 +113,18 @@ public class SizeTest {
     }
 
     @Test
-    public void parseSizeWithWhiteSpaces() {
+    void parseSizeWithWhiteSpaces() {
         assertThat(Size.parse("64   kilobytes"))
                 .isEqualTo(Size.kilobytes(64));
     }
 
     @Test
-    public void parseCaseInsensitive() {
+    void parseCaseInsensitive() {
         assertThat(Size.parse("1b")).isEqualTo(Size.parse("1B"));
     }
 
     @Test
-    public void parseSingleLetterSuffix() {
+    void parseSingleLetterSuffix() {
         assertThat(Size.parse("1B")).isEqualTo(Size.bytes(1));
         assertThat(Size.parse("1K")).isEqualTo(Size.kilobytes(1));
         assertThat(Size.parse("1M")).isEqualTo(Size.megabytes(1));
@@ -132,22 +133,22 @@ public class SizeTest {
     }
 
     @Test
-    public void unableParseWrongSizeCount() {
+    void unableParseWrongSizeCount() {
         assertThatIllegalArgumentException().isThrownBy(() -> Size.parse("three bytes"));
     }
 
     @Test
-    public void unableParseWrongSizeUnit() {
+    void unableParseWrongSizeUnit() {
         assertThatIllegalArgumentException().isThrownBy(() -> Size.parse("1EB"));
     }
 
     @Test
-    public void unableParseWrongSizeFormat() {
+    void unableParseWrongSizeFormat() {
         assertThatIllegalArgumentException().isThrownBy(() -> Size.parse("1 mega byte"));
     }
 
     @Test
-    public void isHumanReadable() throws Exception {
+    void isHumanReadable() {
         assertThat(Size.gigabytes(3).toString())
                 .isEqualTo("3 gigabytes");
 
@@ -156,19 +157,19 @@ public class SizeTest {
     }
 
     @Test
-    public void hasAQuantity() throws Exception {
+    void hasAQuantity() {
         assertThat(Size.gigabytes(3).getQuantity())
                 .isEqualTo(3);
     }
 
     @Test
-    public void hasAUnit() throws Exception {
+    void hasAUnit() {
         assertThat(Size.gigabytes(3).getUnit())
                 .isEqualTo(SizeUnit.GIGABYTES);
     }
 
     @Test
-    public void isComparable() throws Exception {
+    void isComparable() {
         // both zero
         assertThat(Size.bytes(0).compareTo(Size.bytes(0))).isEqualTo(0);
         assertThat(Size.bytes(0).compareTo(Size.kilobytes(0))).isEqualTo(0);
@@ -507,7 +508,7 @@ public class SizeTest {
     }
 
     @Test
-    public void serializesCorrectlyWithJackson() throws IOException {
+    void serializesCorrectlyWithJackson() throws IOException {
         final ObjectMapper mapper = new ObjectMapper();
 
         assertThat(mapper.writeValueAsString(Size.bytes(0L))).isEqualTo("\"0 bytes\"");
@@ -528,7 +529,7 @@ public class SizeTest {
     }
 
     @Test
-    public void deserializesCorrectlyWithJackson() throws IOException {
+    void deserializesCorrectlyWithJackson() throws IOException {
         final ObjectMapper mapper = new ObjectMapper();
 
         assertThat(mapper.readValue("\"0 bytes\"", Size.class)).isEqualTo(Size.bytes(0L));
@@ -549,7 +550,7 @@ public class SizeTest {
     }
 
     @Test
-    public void verifyComparableContract() {
+    void verifyComparableContract() {
         final Size kb = Size.kilobytes(1024L);
         final Size bytes = Size.bytes(kb.toBytes());
 
@@ -559,5 +560,29 @@ public class SizeTest {
         // If comparator == 0, then the following must be true
         assertThat(bytes.equals(kb)).isTrue();
         assertThat(kb.equals(bytes)).isTrue();
+    }
+
+    @Test
+    void testFromDataSize() {
+        assertThat(Size.fromDataSize(DataSize.bytes(5L))).isEqualTo(Size.bytes(5L));
+        assertThat(Size.fromDataSize(DataSize.kibibytes(5L))).isEqualTo(Size.kilobytes(5L));
+        assertThat(Size.fromDataSize(DataSize.kilobytes(5L))).isEqualTo(Size.bytes(5L * 1000L));
+        assertThat(Size.fromDataSize(DataSize.mebibytes(5L))).isEqualTo(Size.megabytes(5L));
+        assertThat(Size.fromDataSize(DataSize.megabytes(5L))).isEqualTo(Size.bytes(5L * 1000L * 1000L));
+        assertThat(Size.fromDataSize(DataSize.gibibytes(5L))).isEqualTo(Size.gigabytes(5L));
+        assertThat(Size.fromDataSize(DataSize.gigabytes(5L))).isEqualTo(Size.bytes(5L * 1000L * 1000L * 1000L));
+        assertThat(Size.fromDataSize(DataSize.tebibytes(5L))).isEqualTo(Size.terabytes(5L));
+        assertThat(Size.fromDataSize(DataSize.terabytes(5L))).isEqualTo(Size.bytes(5L * 1000L * 1000L * 1000L * 1000L));
+        assertThat(Size.fromDataSize(DataSize.pebibytes(5L))).isEqualTo(Size.terabytes(5L * 1024L * 1024L));
+        assertThat(Size.fromDataSize(DataSize.petabytes(5L))).isEqualTo(Size.bytes(5L * 1000L * 1000L * 1000L * 1000L * 1000L));
+    }
+
+    @Test
+    void testToDataSize() {
+        assertThat(Size.bytes(5L).toDataSize()).isEqualTo(DataSize.bytes(5L));
+        assertThat(Size.kilobytes(5L).toDataSize()).isEqualTo(DataSize.kibibytes(5L));
+        assertThat(Size.megabytes(5L).toDataSize()).isEqualTo(DataSize.mebibytes(5L));
+        assertThat(Size.gigabytes(5L).toDataSize()).isEqualTo(DataSize.gibibytes(5L));
+        assertThat(Size.terabytes(5L).toDataSize()).isEqualTo(DataSize.tebibytes(5L));
     }
 }

--- a/dropwizard-util/src/test/java/io/dropwizard/util/SizeUnitTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/SizeUnitTest.java
@@ -4,11 +4,11 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SizeUnitTest {
+@SuppressWarnings("deprecation")
+class SizeUnitTest {
     // BYTES
-
     @Test
-    public void oneByteInBytes() throws Exception {
+    void oneByteInBytes() {
         assertThat(SizeUnit.BYTES.convert(1, SizeUnit.BYTES))
                 .isEqualTo(1);
 
@@ -16,9 +16,8 @@ public class SizeUnitTest {
                 .isEqualTo(1);
     }
 
-
     @Test
-    public void oneByteInKilobytes() throws Exception {
+    void oneByteInKilobytes() {
         assertThat(SizeUnit.KILOBYTES.convert(1, SizeUnit.BYTES))
                 .isZero();
 
@@ -27,7 +26,7 @@ public class SizeUnitTest {
     }
 
     @Test
-    public void oneByteInMegabytes() throws Exception {
+    void oneByteInMegabytes() {
         assertThat(SizeUnit.MEGABYTES.convert(1, SizeUnit.BYTES))
                 .isZero();
 
@@ -36,7 +35,7 @@ public class SizeUnitTest {
     }
 
     @Test
-    public void oneByteInGigabytes() throws Exception {
+    void oneByteInGigabytes() {
         assertThat(SizeUnit.GIGABYTES.convert(1, SizeUnit.BYTES))
                 .isZero();
 
@@ -45,7 +44,7 @@ public class SizeUnitTest {
     }
 
     @Test
-    public void oneByteInTerabytes() throws Exception {
+    void oneByteInTerabytes() {
         assertThat(SizeUnit.TERABYTES.convert(1, SizeUnit.BYTES))
                 .isZero();
 
@@ -56,7 +55,7 @@ public class SizeUnitTest {
     // KILOBYTES
 
     @Test
-    public void oneKilobyteInBytes() throws Exception {
+    void oneKilobyteInBytes() {
         assertThat(SizeUnit.BYTES.convert(1, SizeUnit.KILOBYTES))
                 .isEqualTo(1024);
 
@@ -65,7 +64,7 @@ public class SizeUnitTest {
     }
 
     @Test
-    public void oneKilobyteInKilobytes() throws Exception {
+    void oneKilobyteInKilobytes() {
         assertThat(SizeUnit.KILOBYTES.convert(1, SizeUnit.KILOBYTES))
                 .isEqualTo(1);
 
@@ -74,7 +73,7 @@ public class SizeUnitTest {
     }
 
     @Test
-    public void oneKilobyteInMegabytes() throws Exception {
+    void oneKilobyteInMegabytes() {
         assertThat(SizeUnit.MEGABYTES.convert(1, SizeUnit.KILOBYTES))
                 .isZero();
 
@@ -83,7 +82,7 @@ public class SizeUnitTest {
     }
 
     @Test
-    public void oneKilobyteInGigabytes() throws Exception {
+    void oneKilobyteInGigabytes() {
         assertThat(SizeUnit.GIGABYTES.convert(1, SizeUnit.KILOBYTES))
                 .isZero();
 
@@ -92,7 +91,7 @@ public class SizeUnitTest {
     }
 
     @Test
-    public void oneKilobyteInTerabytes() throws Exception {
+    void oneKilobyteInTerabytes() {
         assertThat(SizeUnit.TERABYTES.convert(1, SizeUnit.KILOBYTES))
                 .isZero();
 
@@ -103,7 +102,7 @@ public class SizeUnitTest {
     // MEGABYTES
 
     @Test
-    public void oneMegabyteInBytes() throws Exception {
+    void oneMegabyteInBytes() {
         assertThat(SizeUnit.BYTES.convert(1, SizeUnit.MEGABYTES))
                 .isEqualTo(1048576);
 
@@ -112,7 +111,7 @@ public class SizeUnitTest {
     }
 
     @Test
-    public void oneMegabyteInKilobytes() throws Exception {
+    void oneMegabyteInKilobytes() {
         assertThat(SizeUnit.KILOBYTES.convert(1, SizeUnit.MEGABYTES))
                 .isEqualTo(1024);
 
@@ -121,7 +120,7 @@ public class SizeUnitTest {
     }
 
     @Test
-    public void oneMegabyteInMegabytes() throws Exception {
+    void oneMegabyteInMegabytes() {
         assertThat(SizeUnit.MEGABYTES.convert(1, SizeUnit.MEGABYTES))
                 .isEqualTo(1);
 
@@ -130,7 +129,7 @@ public class SizeUnitTest {
     }
 
     @Test
-    public void oneMegabyteInGigabytes() throws Exception {
+    void oneMegabyteInGigabytes() {
         assertThat(SizeUnit.GIGABYTES.convert(1, SizeUnit.MEGABYTES))
                 .isZero();
 
@@ -139,7 +138,7 @@ public class SizeUnitTest {
     }
 
     @Test
-    public void oneMegabyteInTerabytes() throws Exception {
+    void oneMegabyteInTerabytes() {
         assertThat(SizeUnit.TERABYTES.convert(1, SizeUnit.MEGABYTES))
                 .isZero();
 
@@ -150,7 +149,7 @@ public class SizeUnitTest {
     // GIGABYTES
 
     @Test
-    public void oneGigabyteInBytes() throws Exception {
+    void oneGigabyteInBytes() {
         assertThat(SizeUnit.BYTES.convert(1, SizeUnit.GIGABYTES))
                 .isEqualTo(1073741824);
 
@@ -159,7 +158,7 @@ public class SizeUnitTest {
     }
 
     @Test
-    public void oneGigabyteInKilobytes() throws Exception {
+    void oneGigabyteInKilobytes() {
         assertThat(SizeUnit.KILOBYTES.convert(1, SizeUnit.GIGABYTES))
                 .isEqualTo(1048576);
 
@@ -168,7 +167,7 @@ public class SizeUnitTest {
     }
 
     @Test
-    public void oneGigabyteInMegabytes() throws Exception {
+    void oneGigabyteInMegabytes() {
         assertThat(SizeUnit.MEGABYTES.convert(1, SizeUnit.GIGABYTES))
                 .isEqualTo(1024);
 
@@ -177,7 +176,7 @@ public class SizeUnitTest {
     }
 
     @Test
-    public void oneGigabyteInGigabytes() throws Exception {
+    void oneGigabyteInGigabytes() {
         assertThat(SizeUnit.GIGABYTES.convert(1, SizeUnit.GIGABYTES))
                 .isEqualTo(1L);
 
@@ -186,7 +185,7 @@ public class SizeUnitTest {
     }
 
     @Test
-    public void oneGigabyteInTerabytes() throws Exception {
+    void oneGigabyteInTerabytes() {
         assertThat(SizeUnit.TERABYTES.convert(1, SizeUnit.GIGABYTES))
                 .isZero();
 
@@ -197,7 +196,7 @@ public class SizeUnitTest {
     // TERABYTES
 
     @Test
-    public void oneTerabyteInBytes() throws Exception {
+    void oneTerabyteInBytes() {
         assertThat(SizeUnit.BYTES.convert(1, SizeUnit.TERABYTES))
                 .isEqualTo(1099511627776L);
 
@@ -206,7 +205,7 @@ public class SizeUnitTest {
     }
 
     @Test
-    public void oneTerabyteInKilobytes() throws Exception {
+    void oneTerabyteInKilobytes() {
         assertThat(SizeUnit.KILOBYTES.convert(1, SizeUnit.TERABYTES))
                 .isEqualTo(1073741824L);
 
@@ -215,7 +214,7 @@ public class SizeUnitTest {
     }
 
     @Test
-    public void oneTerabyteInMegabytes() throws Exception {
+    void oneTerabyteInMegabytes() {
         assertThat(SizeUnit.MEGABYTES.convert(1, SizeUnit.TERABYTES))
                 .isEqualTo(1048576);
 
@@ -224,7 +223,7 @@ public class SizeUnitTest {
     }
 
     @Test
-    public void oneTerabyteInGigabytes() throws Exception {
+    void oneTerabyteInGigabytes() {
         assertThat(SizeUnit.GIGABYTES.convert(1, SizeUnit.TERABYTES))
                 .isEqualTo(1024);
 
@@ -233,11 +232,20 @@ public class SizeUnitTest {
     }
 
     @Test
-    public void oneTerabyteInTerabytes() throws Exception {
+    void oneTerabyteInTerabytes() {
         assertThat(SizeUnit.TERABYTES.convert(1, SizeUnit.TERABYTES))
                 .isEqualTo(1);
 
         assertThat(SizeUnit.TERABYTES.toTerabytes(1))
                 .isEqualTo(1);
+    }
+
+    @Test
+    void testToDataSizeUnit() {
+        assertThat(SizeUnit.BYTES.toDataSizeUnit()).isEqualTo(DataSizeUnit.BYTES);
+        assertThat(SizeUnit.KILOBYTES.toDataSizeUnit()).isEqualTo(DataSizeUnit.KIBIBYTES);
+        assertThat(SizeUnit.MEGABYTES.toDataSizeUnit()).isEqualTo(DataSizeUnit.MEBIBYTES);
+        assertThat(SizeUnit.GIGABYTES.toDataSizeUnit()).isEqualTo(DataSizeUnit.GIBIBYTES);
+        assertThat(SizeUnit.TERABYTES.toDataSizeUnit()).isEqualTo(DataSizeUnit.TEBIBYTES);
     }
 }

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/DataSizeRange.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/DataSizeRange.java
@@ -1,0 +1,60 @@
+package io.dropwizard.validation;
+
+import io.dropwizard.util.DataSizeUnit;
+
+import javax.validation.Constraint;
+import javax.validation.OverridesAttribute;
+import javax.validation.Payload;
+import javax.validation.ReportAsSingleViolation;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The annotated element has to be in the appropriate range.
+ * Apply on {@link io.dropwizard.util.DataSize} instances.
+ */
+@Documented
+@Constraint(validatedBy = { })
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
+@Retention(RUNTIME)
+@MinDataSize(0)
+@MaxDataSize(value = Long.MAX_VALUE, unit = DataSizeUnit.PEBIBYTES)
+@ReportAsSingleViolation
+public @interface DataSizeRange {
+    @OverridesAttribute(constraint = MinDataSize.class, name = "value")
+    long min() default 0;
+
+    @OverridesAttribute(constraint = MaxDataSize.class, name = "value")
+    long max() default Long.MAX_VALUE;
+
+    @OverridesAttribute.List({
+        @OverridesAttribute(constraint = MinDataSize.class, name = "unit"),
+        @OverridesAttribute(constraint = MaxDataSize.class, name = "unit")
+    })
+    DataSizeUnit unit() default DataSizeUnit.BYTES;
+
+    String message() default "must be between {min} {unit} and {max} {unit}";
+
+    Class<?>[] groups() default { };
+
+    @SuppressWarnings("UnusedDeclaration") Class<? extends Payload>[] payload() default { };
+
+    /**
+     * Defines several {@code @SizeRange} annotations on the same element.
+     */
+    @Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
+    @Retention(RUNTIME)
+    @Documented
+    @interface List {
+        DataSizeRange[] value();
+    }
+}

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/MaxDataSize.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/MaxDataSize.java
@@ -1,0 +1,45 @@
+package io.dropwizard.validation;
+
+import io.dropwizard.util.DataSizeUnit;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The annotated element must be a {@link io.dropwizard.util.DataSize}
+ * whose value must be less than or equal to the specified maximum.
+ * <p/>
+ * <code>null</code> elements are considered valid
+ */
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = MaxDataSizeValidator.class)
+public @interface MaxDataSize {
+    String message() default "must be less than or equal to {value} {unit}";
+
+    Class<?>[] groups() default {};
+
+    @SuppressWarnings("UnusedDeclaration") Class<? extends Payload>[] payload() default {};
+
+    /**
+     * @return value the element must be less than or equal to
+     */
+    long value();
+
+    /**
+     * @return unit of the value the element must be less than or equal to
+     */
+    DataSizeUnit unit() default DataSizeUnit.BYTES;
+}

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/MaxDataSizeValidator.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/MaxDataSizeValidator.java
@@ -1,0 +1,28 @@
+package io.dropwizard.validation;
+
+import io.dropwizard.util.DataSize;
+import io.dropwizard.util.DataSizeUnit;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * Check that a {@link DataSize} being validated is less than or equal to the
+ * minimum value specified.
+ */
+public class MaxDataSizeValidator implements ConstraintValidator<MaxDataSize, DataSize> {
+
+    private long maxQty = 0;
+    private DataSizeUnit maxUnit = DataSizeUnit.BYTES;
+
+    @Override
+    public void initialize(MaxDataSize constraintAnnotation) {
+        this.maxQty = constraintAnnotation.value();
+        this.maxUnit = constraintAnnotation.unit();
+    }
+
+    @Override
+    public boolean isValid(DataSize value, ConstraintValidatorContext context) {
+        return (value == null) || (value.toBytes() <= maxUnit.toBytes(maxQty));
+    }
+}

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/MinDataSize.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/MinDataSize.java
@@ -1,0 +1,45 @@
+package io.dropwizard.validation;
+
+import io.dropwizard.util.DataSizeUnit;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The annotated element must be a {@link io.dropwizard.util.DataSize}
+ * whose value must be higher or equal to the specified minimum.
+ * <p/>
+ * <code>null</code> elements are considered valid
+ */
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = MinDataSizeValidator.class)
+public @interface MinDataSize {
+    String message() default "must be greater than or equal to {value} {unit}";
+
+    Class<?>[] groups() default {};
+
+    @SuppressWarnings("UnusedDeclaration") Class<? extends Payload>[] payload() default {};
+
+    /**
+     * @return value the element must be higher or equal to
+     */
+    long value();
+
+    /**
+     * @return unit of the value the element must be higher or equal to
+     */
+    DataSizeUnit unit() default DataSizeUnit.BYTES;
+}

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/MinDataSizeValidator.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/MinDataSizeValidator.java
@@ -1,0 +1,28 @@
+package io.dropwizard.validation;
+
+import io.dropwizard.util.DataSize;
+import io.dropwizard.util.DataSizeUnit;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * Check that a {@link DataSize} being validated is greater than or equal to the
+ * minimum value specified.
+ */
+public class MinDataSizeValidator implements ConstraintValidator<MinDataSize, DataSize> {
+
+    private long minQty = 0;
+    private DataSizeUnit minUnit = DataSizeUnit.BYTES;
+
+    @Override
+    public void initialize(MinDataSize constraintAnnotation) {
+        this.minQty = constraintAnnotation.value();
+        this.minUnit = constraintAnnotation.unit();
+    }
+
+    @Override
+    public boolean isValid(DataSize value, ConstraintValidatorContext context) {
+        return (value == null) || (value.toBytes() >= minUnit.toBytes(minQty));
+    }
+}

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/DataSizeValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/DataSizeValidatorTest.java
@@ -1,0 +1,91 @@
+package io.dropwizard.validation;
+
+import io.dropwizard.util.DataSize;
+import io.dropwizard.util.DataSizeUnit;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.Valid;
+import javax.validation.Validator;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DataSizeValidatorTest {
+    @SuppressWarnings("unused")
+    public static class Example {
+        @MaxDataSize(value = 30, unit = DataSizeUnit.KILOBYTES)
+        private DataSize tooBig = DataSize.gigabytes(2);
+
+        @MinDataSize(value = 30, unit = DataSizeUnit.KILOBYTES)
+        private DataSize tooSmall = DataSize.bytes(100);
+
+        @DataSizeRange(min = 10, max = 100, unit = DataSizeUnit.KILOBYTES)
+        private DataSize outOfRange = DataSize.megabytes(2);
+
+        @Valid
+        private List<@MaxDataSize(value = 30, unit = DataSizeUnit.KILOBYTES) DataSize> maxDataSize =
+                Collections.singletonList(DataSize.gigabytes(2));
+
+        @Valid
+        private List<@MinDataSize(value = 30, unit = DataSizeUnit.KILOBYTES) DataSize> minDataSize =
+                Collections.singletonList(DataSize.bytes(100));
+
+        @Valid
+        private List<@DataSizeRange(min = 10, max = 100, unit = DataSizeUnit.KILOBYTES) DataSize> rangeDataSize =
+                Collections.singletonList(DataSize.megabytes(2));
+
+        void setTooBig(DataSize tooBig) {
+            this.tooBig = tooBig;
+        }
+
+        void setTooSmall(DataSize tooSmall) {
+            this.tooSmall = tooSmall;
+        }
+
+        void setOutOfRange(DataSize outOfRange) {
+            this.outOfRange = outOfRange;
+        }
+
+        void setMaxDataSize(List<DataSize> maxDataSize) {
+            this.maxDataSize = maxDataSize;
+        }
+
+        void setMinDataSize(List<DataSize> minDataSize) {
+            this.minDataSize = minDataSize;
+        }
+
+        void setRangeDataSize(List<DataSize> rangeDataSize) {
+            this.rangeDataSize = rangeDataSize;
+        }
+    }
+
+    private final Validator validator = BaseValidator.newValidator();
+
+    @Test
+    void returnsASetOfErrorsForAnObject() {
+        if ("en".equals(Locale.getDefault().getLanguage())) {
+            assertThat(ConstraintViolations.format(validator.validate(new Example())))
+                    .containsOnly("outOfRange must be between 10 KILOBYTES and 100 KILOBYTES",
+                            "tooBig must be less than or equal to 30 KILOBYTES",
+                            "tooSmall must be greater than or equal to 30 KILOBYTES",
+                            "maxDataSize[0].<list element> must be less than or equal to 30 KILOBYTES",
+                            "minDataSize[0].<list element> must be greater than or equal to 30 KILOBYTES",
+                            "rangeDataSize[0].<list element> must be between 10 KILOBYTES and 100 KILOBYTES");
+        }
+    }
+
+    @Test
+    void returnsAnEmptySetForAValidObject() {
+        final Example example = new Example();
+        example.setTooBig(DataSize.bytes(10));
+        example.setTooSmall(DataSize.megabytes(10));
+        example.setOutOfRange(DataSize.kilobytes(64));
+        example.setMaxDataSize(Collections.singletonList(DataSize.bytes(10)));
+        example.setMinDataSize(Collections.singletonList(DataSize.megabytes(10)));
+        example.setRangeDataSize(Collections.singletonList(DataSize.kilobytes(64)));
+
+        assertThat(validator.validate(example)).isEmpty();
+    }
+}


### PR DESCRIPTION
The `Size` and `SizeUnit` classes in Dropwizard are using a common but incorrect definition of data size units, in which 1 kilobyte equals 1024 bytes.

The `DataSize` and `DataSizeUnit` classes are using the correct definitions according to SI and IEC, in which 1 kilobyte equals 1000 bytes and 1 kibibytes equals 1024 bytes.

Instead of modifying the existing `Size` and `SizeUnit` classes, this change set introduces a new set of classes, `DataSize` and `DataSizeUnit`, with the possibility to convert the old units into the new, correct units.

Example:
```
assertEquals(Size.parse("128 kb").toDataSize(), DataSize.kibibytes(128L));
```

This is a breaking change and has to be properly documented in the release notes and upgrade notes of Dropwizard.

Closes #2152
Closes #2154