### PR TITLE
Move upgrade notes from GitHub wiki into documentation

### DIFF
--- a/docs/source/manual/index.rst
+++ b/docs/source/manual/index.rst
@@ -23,6 +23,7 @@ User Manual
     views
     scala
     testing
+    upgrade-notes
     example
     configuration
     internals

--- a/docs/source/manual/upgrade-notes.rst
+++ b/docs/source/manual/upgrade-notes.rst
@@ -1,0 +1,15 @@
+.. _upgrade-notes:
+
+#############
+Upgrade Notes
+#############
+
+.. toctree::
+   :titlesonly:
+
+   upgrade-notes/upgrade-notes-0_7_x.rst
+   upgrade-notes/upgrade-notes-0_8_x.rst
+   upgrade-notes/upgrade-notes-0_9_x.rst
+   upgrade-notes/upgrade-notes-1_0_x.rst
+   upgrade-notes/upgrade-notes-1_1_x.rst
+   upgrade-notes/upgrade-notes-2_0_x.rst

--- a/docs/source/manual/upgrade-notes/upgrade-notes-0_7_x.rst
+++ b/docs/source/manual/upgrade-notes/upgrade-notes-0_7_x.rst
@@ -1,0 +1,19 @@
+.. _upgrade-notes-dropwizard-0_7_x:
+
+##################################
+Upgrade Notes for Dropwizard 0.7.x
+##################################
+
+-  Update Java source and target versions in ``maven-compiler-plugin`` to *1.7* (most applications should be already on 1.7);
+-  Replace Maven dependencies from ``com.yammer.dropwizard`` to ``io.dropwizard``;
+-  Replace package statements from ``com.yammer.dropwizard`` to ``io.dropwizard`` throughout the codebase;
+-  If you use ``dropwizard-db``, update configuration class to use ``DataSourceFactory``;
+-  If you use ``dropwizard-hibernate``, update Hibernate bundle by overriding ``getDataSourceFactory``;
+-  If you use ``dropwizard-migrations``, update Migrations bundle by overriding ``getDataSourceFactory﻿``;
+-  If you serve static files, add ``dropwizard-assets`` to dependencies;
+-  If you use templating, add ``dropwizard-views-freemaker`` or ``dropwizard-views-mustache`` accordingly;
+-  Update the application to override ``getName()`` instead of providing the bundle with the name;
+-  Change how resources are added from ``environment.addResource(resource)`` to ``environment.jersey().register(resource)``;
+-  Once everything is compiling, rename ``*Service`` class to ``*Application``;
+-  Change test classes extending ``ResourceTest`` to use ``ResourceTestRule``;
+-  Convert ``app.yml`` to the new server layout (see ``ServerFactory`` and ``ConnectorFactory``);

--- a/docs/source/manual/upgrade-notes/upgrade-notes-0_8_x.rst
+++ b/docs/source/manual/upgrade-notes/upgrade-notes-0_8_x.rst
@@ -1,0 +1,149 @@
+.. _upgrade-notes-dropwizard-0_8_x:
+
+##################################
+Upgrade Notes for Dropwizard 0.8.x
+##################################
+
+First
+=====
+
+Check out `Migration discussion 0.7.1 to 0.8.0 <https://groups.google.com/forum/#!topic/dropwizard-dev/VInOW_ebiAc>`__
+at the ``dropwizard-dev`` mailing list.
+
+Migration of Apache Commons Lang
+================================
+
+The classes were moved to a new package. You have to update the corresponding imports:
+
+| search for: ``org.apache.commons.lang.``
+| replace with: ``org.apache.commons.lang3.``
+
+Use assertions from AssertJ
+===========================
+
+Instead of the FEST assertions you should use the AssertJ assertions:
+
+| search for: ``org.fest.assertions.api.Assertions.``
+| replace with: ``org.assertj.core.api.Assertions.``
+
+Migration of custom URL pattern
+===============================
+
+If you set a custom URL pattern in your application ``run`` method you should move the definition to your configuration file:
+
+Remove from Java code (example):
+
+.. code-block:: java
+
+   environment.jersey().setUrlPattern("/api/*");
+
+Add to configuration file (example):
+
+.. code-block:: yaml
+
+   server:
+     rootPath: '/api/*'
+
+Migration of Jersey
+===================
+
+This is not a simple *search and replace* migration, so I show you a few
+examples of often used code snippets for integration testing:
+
+Dropwizard Class Rule
+---------------------
+
+The class rule was not modified. It is shown here because it is used in
+the examples below.
+
+.. code-block:: java
+
+   @ClassRule
+   public static final DropwizardAppRule<SportChefConfiguration> RULE = 
+                       new DropwizardAppRule<>(App.class, "config.yaml");
+
+Executing a GET request
+-----------------------
+
+.. code-block:: java
+
+   final WebTarget target = ClientBuilder.newClient().target(
+           String.format("http://localhost:%d/api/user/1", RULE.getLocalPort()));
+
+   final Response response = target
+           .request(MediaType.APPLICATION_JSON_TYPE)
+           .accept(MediaType.APPLICATION_JSON_TYPE)
+           .get();
+
+   assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+
+   final User user = response.readEntity(User.class);
+   assertThat(user.getId()).isEqualTo(1L);
+   assertThat(user.getFirstName()).isEqualTo("John");
+   assertThat(user.getLastName()).isEqualTo("Doe");
+
+Executing a POST request
+------------------------
+
+.. code-block:: java
+
+   final WebTarget target = ClientBuilder.newClient().target(
+           String.format("http://localhost:%d/api/user", RULE.getLocalPort()));
+
+   final User user = new User(0L, "John", "Doe");
+
+   final Response response = target
+           .request(MediaType.APPLICATION_JSON_TYPE)
+           .accept(MediaType.APPLICATION_JSON_TYPE)
+           .post(Entity.json(user));
+
+   assertThat(response.getStatus()).isEqualTo(Response.Status.CREATED.getStatusCode());
+
+   final URI location = response.getLocation();
+   assertThat(location).isNotNull();
+
+   final String path = location.getPath();
+   final long newId = Long.parseLong(path.substring(path.lastIndexOf("/") + 1));
+   assertThat(newId).isGreaterThan(0);
+
+Executing a empty PUT request
+-----------------------------
+
+Jersey 2 does not by default allow empty PUT or DELETE requests.
+If you want to enable this, you have to add a configuration parameter
+
+.. code-block:: java
+
+   Client client = ClientBuilder.newClient();
+   client.property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true);
+   WebTarget target = client.target(
+           String.format("http://localhost:%d/api/user", RULE.getLocalPort()));
+
+   Response response = target
+           .request()
+           .put(null);
+
+   assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+
+Request/response filters
+------------------------
+
+If you previously used jersey container filters in your Dropwizard app,
+``getContainerRequestFilters()`` will now fail to resolve:
+
+.. code-block:: java
+
+   env.jersey()
+   .getResourceConfig()
+   .getContainerRequestFilters()
+   .add(new AuthorizedFilter());
+
+You might need to rewrite the filter to JAX-RS 2.0 and then you may use
+the one and only ``.register()`` instead.
+
+My filters used imports from ``jersey.spi.container`` and needed to be rewritten for Jersey 2.x.
+See also: `Jersey 1.x to 2.x migration guide <https://jersey.github.io/documentation/2.16/user-guide.html#mig-1.x>`_.
+
+.. code-block:: java
+
+   env.jersey().register(new AuthorizationFilter());

--- a/docs/source/manual/upgrade-notes/upgrade-notes-0_9_x.rst
+++ b/docs/source/manual/upgrade-notes/upgrade-notes-0_9_x.rst
@@ -1,0 +1,92 @@
+.. _upgrade-notes-dropwizard-0_9_x:
+
+##################################
+Upgrade Notes for Dropwizard 0.9.x
+##################################
+
+Migrating Auth
+==============
+
+1. Any custom types representing a user need to implement the
+   ``Principal`` interface
+
+2. In your ``Application#run`` add
+
+   .. code-block:: java
+
+      environment.jersey().register(RolesAllowedDynamicFeature.class);
+
+3. Create an Authorizer
+
+   .. code-block:: java
+
+      public class ExampleAuthorizer implements Authorizer<User> {
+        @Override
+        public boolean authorize(User user, String role) {
+          return user.getName().equals("good-guy") && role.equals("ADMIN");
+        }
+      }
+
+4. Create an ``AuthFilter`` using your ``Authenticator`` and ``Authorizer``
+
+   .. code-block:: java
+
+      final BasicCredentialAuthFilter<User> userBasicCredentialAuthFilter =
+              new BasicCredentialAuthFilter.Builder<User>()
+                      .setAuthenticator(new ExampleAuthenticator())
+                      .setRealm("SUPER SECRET STUFF")
+                      .setAuthorizer(new ExampleAuthorizer())
+                      .buildAuthFilter();
+
+5. Register ``AuthDynamicFeature`` with your ``AuthFilter``
+
+   .. code-block:: java
+
+      environment.jersey().register(new AuthDynamicFeature(userBasicCredentialAuthFilter));
+
+6. Register the ``AuthValueFactoryProvider.Binder`` so with your custom user type if you have one
+
+   .. code-block:: java
+
+      environment.jersey().register(new AuthValueFactoryProvider.Binder(User.class));
+
+7. Annotate resources methods that already have ``@Auth`` with ``@RolesAllowed("admin")`` where admin is a role
+
+   .. code-block:: shell
+
+      $ curl 'testUser:secret@localhost:8080/protected'
+      Hey there, testUser. You know the secret!
+
+UnwrapValidatedValue Changes
+============================
+
+With the upgrade to Hibernate Validator 5.2.1.Final, the behavior of ``@UnwrapValidatedValue`` has slightly changed.
+In some situations, the annotation is now unnecessary.
+However, when inference is not possible and is ambiguous where the constraint annotation applies, a runtime exception is thrown.
+This is only a problem when dealing with constraints that can apply to both the wrapper and inner type like ``@NotNull``.
+The fix is to explicitly set ``false`` or ``true`` for ``@UnwrapValidatedValue``
+
+For instance if you previously had code like:
+
+.. code-block:: java
+
+   @GET
+   public String heads(@QueryParam("cheese") @NotNull IntParam secretSauce) {
+
+Where ``@NotNull`` is meant to apply to wrapper type of ``IntParam`` and not the inner type of
+``Integer`` (as ``IntParam`` will never yield a ``null`` integer).
+Hibernate Validator doesn't know this, but it does know that ``@NotNull`` can be applied to both ``IntParam`` and ``Integer``,
+so in Dropwizard 0.9.x the previous code will now fail and must be changed to
+
+.. code-block:: java
+
+   @GET
+   public String heads(@QueryParam("cheese") @NotNull @UnwrapValidatedValue(false) IntParam secretSauce) {
+
+For more information on the behavior changes, see `accompanying table for automatic value unwrapping <https://hibernate.atlassian.net/browse/HV-925>`__
+
+Logging bootstrap
+=================
+
+If you configured console logging in your tests with a utility method shipped with Dropwizard,
+you should replace calls of ``LoggingFactory.bootstrap`` to ``BootstrapLogging.bootstrap``.

--- a/docs/source/manual/upgrade-notes/upgrade-notes-1_0_x.rst
+++ b/docs/source/manual/upgrade-notes/upgrade-notes-1_0_x.rst
@@ -1,0 +1,48 @@
+.. _upgrade-notes-dropwizard-1_0_x:
+
+##################################
+Upgrade Notes for Dropwizard 1.0.x
+##################################
+
+Change the project compile and target level to 1.8
+==================================================
+
+Dropwizard 1.0.0 is compiled against JDK 1.8 uses its features extensively.
+So, to use this version of Dropwizard your project should be compiled and targeted to run on JDK 1.8.
+
+Remove the ``dropwizard-java8`` module
+======================================
+
+Support for Java 8 features is now provided out of the box.
+
+Migrate ``dropwizard-spdy`` to ``dropwizard-http2``
+===================================================
+
+If you used the SPDY connector, you should use the HTTP/2 integration now.
+
+.. code-block:: yaml
+
+   # - type: spdy3
+   - type: h2
+     port: 8445
+     keyStorePath: example.keystore
+     keyStorePassword: example
+
+Replace Guava’s ``Optional`` by ``java.util.Optional`` in Dropwizard public API
+===============================================================================
+
+Although Guava’s ``Optional`` should be still supported in your Jersey and JDBI resources,
+Dropwizard API now exposes optional results as ``java.util.Optional``.
+
+For example, in authenticators you should change ``Optional.absent`` to ``Optional.empty``.
+
+Migrate your Hibernate resources to Hibernate 5
+===============================================
+
+Checkout the `Hibernate 5.0 migration guide <https://github.com/hibernate/hibernate-orm/blob/5.0/migration-guide.adoc>`__
+
+Add missing ``@Valid`` annotations
+==================================
+
+In 0.9.x, ``@Validated`` was sufficient to enable validation.
+In 1.0.x, it is `necessary <https://github.com/dropwizard/dropwizard/pull/1251#issuecomment-142645734>`__ to include ``@Valid`` as well.

--- a/docs/source/manual/upgrade-notes/upgrade-notes-1_1_x.rst
+++ b/docs/source/manual/upgrade-notes/upgrade-notes-1_1_x.rst
@@ -1,0 +1,33 @@
+.. _upgrade-notes-dropwizard-1_1_x:
+
+##################################
+Upgrade Notes for Dropwizard 1.1.x
+##################################
+
+Due to :pr:`1851`, users must now add mockito as a test dependency
+
+.. code-block:: xml
+
+   <dependency>
+       <groupId>org.mockito</groupId>
+       <artifactId>mockito-core</artifactId>
+       <version>2.7.6</version>
+       <scope>test</scope>
+   </dependency>
+
+Else become susceptible to the following error:
+
+::
+
+   java.lang.NoClassDefFoundError: org/mockito/Mockito
+
+--------------
+
+Due to :pr:`1695`, ``Cli`` no longer allows exceptions to propagate, (which is a net positive),
+but I did have to rewrite my tests to no longer trap for exceptions but examine stderr.
+
+--------------
+
+If you used the Hibernate integration, you need to upgrade your data access code to Hibernate 5.2.7 from 5.1.0.
+Please see the discussion of the change in :pr:`1871`.
+Please also check out the `Hibernate 5.2 Migration Guide <https://github.com/hibernate/hibernate-orm/wiki/Migration-Guide---5.2>`__.

--- a/docs/source/manual/upgrade-notes/upgrade-notes-2_0_x.rst
+++ b/docs/source/manual/upgrade-notes/upgrade-notes-2_0_x.rst
@@ -1,0 +1,89 @@
+.. _upgrade-notes-dropwizard-2_0_x:
+
+##################################
+Upgrade Notes for Dropwizard 2.0.x
+##################################
+
+Removed Configuration Options
+=============================
+
+The following configuration options have been removed, so Dropwizard configuration files should no longer use these options
+
+-  ``soLingerTime``: the configuration option would have become a noop
+   anyways. See :pr:`2490` for more info
+-  ``blockingTimeout``: was previously used as an internal Jetty failsafe mechanism,
+   `and that use case was no longer deemed necessary <https://github.com/eclipse/jetty.project/issues/2525>`__.
+   If one had previously used ``blockingTimeout`` to discard slow clients, please use the new configuration options
+   ``minRequestDataPerSecond`` and ``minResponseDataPerSecond``
+-  ``minRequestDataRate``: has been renamed to ``minRequestDataPerSecond`` and changed from a number to a size like "100 bytes"
+
+Jersey changes
+==============
+
+Dropwizard has upgraded to the latest and greatest Jersey, but it has come at some migration cost:
+
+If one created a custom provider (eg: parse / write JSON differently, so a custom ``JacksonJaxbJsonProvider`` is written),
+you must annotate the class with the appropriate ``@Consumes`` and ``@Produces`` and register it with a Jersey ``Feature``
+instead of an ``AbstractBinder`` if it been so previously.
+
+HK2 internal API has been updated, so if you previously had a ``AbstractValueFactoryProvider``,
+that will need to migrate to a ``AbstractValueParamProvider``
+
+Jersey Reactive Client API was updated to remove ``RxClient``, as reactive capabilities are built into the client.
+You only need to use Dropwizard’s ``buildRx`` for client when you want a switch the default to something like RxJava 2’s ``Flowable``.
+
+More Secure TLS
+===============
+
+Dropwizard 2.0, by default, only allows cipher suites that support forward secrecy.
+The only cipher suites newly disabled are those under the ``TLS_RSA_*`` family.
+Clients which don’t support forward secrecy (expected to be a small amount)
+may now find that they can’t communicate with a Dropwizard 2.0 server.
+If necessary one can override what cipher suites are blacklisted using the ``excludedCipherSuites`` configuration option.
+
+Dropwizard 2.0, by default, only supports TLS 1.2. While Dropwizard 1.x effectively only supported TLS 1.2,
+due to the supported cipher suites, one could still conceivably configure their server or receive a client
+that could negotiate a TLS 1.0 or 1.1 connection.
+One can still decide what TLS protocols are on the blacklist by configuring ``excludedProtocols``.
+
+We also hope that in 2.0 it is more clear what protocols and cipher suites are enabled / disabled,
+as previously one would see the following statement logged on startup:
+
+::
+
+   Supported protocols: [SSLv2Hello, SSLv3, TLSv1, TLSv1.1, TLSv1.2]
+
+While not technically wrong, displaying the protocols that *could* be enabled is misleading
+as it makes one believe that Dropwizard employs extremely unsafe defaults.
+We’ve reworked what is logged to only the protocols and cipher suites that Dropwizard *will* expose.
+And log the protocols and cipher suites that Dropwizard will reject,
+and thus could expose them if configured to do so.
+So now you’ll see the following in the logs:
+
+::
+
+   Enabled protocols: [TLSv1.2]
+   Disabled protocols: [SSLv2Hello, SSLv3, TLSv1, TLSv1.1]
+
+Miscellaneous
+=============
+
+Improved validation message for min/max duration
+------------------------------------------------
+
+``@MinDuration`` / ``@MaxDuration`` have had their validation messages improved, so instead of
+
+   messageRate must be less than (or equal to, if in ‘inclusive’ mode) 1
+   MINUTES
+
+one will see if inclusive is true
+
+::
+
+   messageRate must be less than or equal to 1 MINUTES
+
+if inclusive is false:
+
+::
+
+   messageRate must be less than 1 MINUTES


### PR DESCRIPTION
Instead of maintaining multiple places where users have to check for information, let's move the upgrade notes for Dropwizard into the documentation.