### PR TITLE
#2702 allowing validation query to be null

### DIFF
--- a/dropwizard-db/src/main/java/io/dropwizard/db/PooledDataSourceFactory.java
+++ b/dropwizard-db/src/main/java/io/dropwizard/db/PooledDataSourceFactory.java
@@ -50,7 +50,7 @@ public interface PooledDataSourceFactory {
      *
      * @return the SQL query as a string
      */
-    String getValidationQuery();
+    Optional<String> getValidationQuery();
 
     /**
      * Returns the SQL query, which is being used for the database

--- a/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceConfigurationTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceConfigurationTest.java
@@ -24,7 +24,7 @@ public class DataSourceConfigurationTest {
         assertThat(ds.getPassword()).isEqualTo("iAMs00perSecrEET");
         assertThat(ds.getProperties()).containsEntry("charSet", "UTF-8");
         assertThat(ds.getMaxWaitForConnection()).isEqualTo(Duration.seconds(1));
-        assertThat(ds.getValidationQuery()).isEqualTo("/* MyService Health Check */ SELECT 1");
+        assertThat(ds.getValidationQuery()).isEqualTo(Optional.of("/* MyService Health Check */ SELECT 1"));
         assertThat(ds.getMinSize()).isEqualTo(8);
         assertThat(ds.getInitialSize()).isEqualTo(15);
         assertThat(ds.getMaxSize()).isEqualTo(32);
@@ -68,7 +68,7 @@ public class DataSourceConfigurationTest {
         assertThat(ds.getPassword()).isEqualTo("iAMs00perSecrEET");
         assertThat(ds.getProperties()).isEmpty();
         assertThat(ds.getMaxWaitForConnection()).isEqualTo(Duration.seconds(30));
-        assertThat(ds.getValidationQuery()).isEqualTo("/* Health Check */ SELECT 1");
+        assertThat(ds.getValidationQuery()).isEqualTo(Optional.of("/* Health Check */ SELECT 1"));
         assertThat(ds.getMinSize()).isEqualTo(10);
         assertThat(ds.getInitialSize()).isEqualTo(10);
         assertThat(ds.getMaxSize()).isEqualTo(100);

--- a/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceFactoryTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceFactoryTest.java
@@ -138,7 +138,7 @@ public class DataSourceFactoryTest {
         assertThat(factory.getUser()).isEqualTo("pg-user");
         assertThat(factory.getPassword()).isEqualTo("iAMs00perSecrEET");
         assertThat(factory.getUrl()).isEqualTo("jdbc:postgresql://db.example.com/db-prod");
-        assertThat(factory.getValidationQuery()).isEqualTo("/* Health Check */ SELECT 1");
+        assertThat(factory.getValidationQuery()).isEqualTo(Optional.of("/* Health Check */ SELECT 1"));
         assertThat(factory.getValidationQueryTimeout()).isEqualTo(Optional.empty());
     }
 

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/HibernateBundleTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/HibernateBundleTest.java
@@ -17,6 +17,7 @@ import org.mockito.ArgumentCaptor;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
@@ -99,7 +100,7 @@ public class HibernateBundleTest {
 
         assertThat(captor.getValue().getSessionFactory()).isEqualTo(sessionFactory);
 
-        assertThat(captor.getValue().getValidationQuery()).isEqualTo("SELECT something");
+        assertThat(captor.getValue().getValidationQuery()).isEqualTo(Optional.of("SELECT something"));
     }
 
     @Test

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryHealthCheckTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryHealthCheckTest.java
@@ -4,12 +4,17 @@ import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
+import org.hibernate.jdbc.ReturningWork;
 import org.hibernate.query.NativeQuery;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 
+import javax.annotation.Nullable;
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.resource.transaction.spi.TransactionStatus.ACTIVE;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -20,18 +25,17 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("HibernateResourceOpenedButNotSafelyClosed")
 public class SessionFactoryHealthCheckTest {
     private final SessionFactory factory = mock(SessionFactory.class);
-    private final SessionFactoryHealthCheck healthCheck = new SessionFactoryHealthCheck(factory, "SELECT 1");
 
     @Test
     public void hasASessionFactory() throws Exception {
-        assertThat(healthCheck.getSessionFactory())
+        assertThat(healthCheck().getSessionFactory())
                 .isEqualTo(factory);
     }
 
     @Test
     public void hasAValidationQuery() throws Exception {
-        assertThat(healthCheck.getValidationQuery())
-                .isEqualTo("SELECT 1");
+        assertThat(healthCheck("SELECT 1").getValidationQuery())
+                .isEqualTo(Optional.of("SELECT 1"));
     }
 
     @Test
@@ -45,13 +49,33 @@ public class SessionFactoryHealthCheckTest {
         final NativeQuery<?> query = mock(NativeQuery.class);
         when(session.createNativeQuery(anyString())).thenReturn(query);
 
-        assertThat(healthCheck.execute().isHealthy()).isTrue();
+        assertThat(healthCheck("SELECT 1").execute().isHealthy()).isTrue();
 
         final InOrder inOrder = inOrder(factory, session, transaction, query);
         inOrder.verify(factory).openSession();
         inOrder.verify(session).beginTransaction();
         inOrder.verify(session).createNativeQuery("SELECT 1");
         inOrder.verify(query).list();
+        inOrder.verify(transaction).commit();
+        inOrder.verify(session).close();
+    }
+
+    @Test
+    public void isHealthyIfIsValid() {
+        final Session session = mock(Session.class);
+        when(factory.openSession()).thenReturn(session);
+
+        final Transaction transaction = mock(Transaction.class);
+        when(session.beginTransaction()).thenReturn(transaction);
+
+        when(session.doReturningWork(any(ReturningWork.class))).thenReturn(true);
+
+        assertThat(healthCheck().execute().isHealthy()).isTrue();
+
+        final InOrder inOrder = inOrder(factory, session, transaction);
+        inOrder.verify(factory).openSession();
+        inOrder.verify(session).beginTransaction();
+        inOrder.verify(session).doReturningWork(any(ReturningWork.class));
         inOrder.verify(transaction).commit();
         inOrder.verify(session).close();
     }
@@ -69,7 +93,7 @@ public class SessionFactoryHealthCheckTest {
         when(session.createNativeQuery(anyString())).thenReturn(query);
         when(query.list()).thenThrow(new HibernateException("OH NOE"));
 
-        assertThat(healthCheck.execute().isHealthy())
+        assertThat(healthCheck("SELECT 1").execute().isHealthy())
                 .isFalse();
 
         final InOrder inOrder = inOrder(factory, session, transaction, query);
@@ -82,4 +106,33 @@ public class SessionFactoryHealthCheckTest {
 
         verify(transaction, never()).commit();
     }
+
+    @Test
+    public void isUnhealthyIfIsNotValid() {
+        final Session session = mock(Session.class);
+        when(factory.openSession()).thenReturn(session);
+
+        final Transaction transaction = mock(Transaction.class);
+        when(session.beginTransaction()).thenReturn(transaction);
+
+        when(session.doReturningWork(any(ReturningWork.class))).thenReturn(false);
+
+        assertThat(healthCheck().execute().isHealthy()).isFalse();
+
+        final InOrder inOrder = inOrder(factory, session, transaction);
+        inOrder.verify(factory).openSession();
+        inOrder.verify(session).beginTransaction();
+        inOrder.verify(session).doReturningWork(any(ReturningWork.class));
+        inOrder.verify(transaction).commit();
+        inOrder.verify(session).close();
+    }
+
+    private SessionFactoryHealthCheck healthCheck() {
+        return healthCheck(null);
+    }
+
+    private SessionFactoryHealthCheck healthCheck(@Nullable String validationQuery) {
+        return new SessionFactoryHealthCheck(factory, Optional.ofNullable(validationQuery));
+    }
+
 }

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/DBIFactory.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/DBIFactory.java
@@ -5,6 +5,8 @@ import ch.qos.logback.classic.Logger;
 import com.codahale.metrics.jdbi.InstrumentedTimingCollector;
 import com.codahale.metrics.jdbi.strategies.DelegatingStatementNameStrategy;
 import com.codahale.metrics.jdbi.strategies.NameStrategies;
+
+import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.db.ManagedDataSource;
 import io.dropwizard.db.PooledDataSourceFactory;
 import io.dropwizard.jdbi.args.GuavaOptionalArgumentFactory;
@@ -134,7 +136,7 @@ public class DBIFactory {
         environment.lifecycle().manage(dataSource);
 
         // Setup the required health checks.
-        final String validationQuery = configuration.getValidationQuery();
+        final Optional<String> validationQuery = configuration.getValidationQuery();
         environment.healthChecks().register(name, new DBIHealthCheck(
             environment.getHealthCheckExecutorService(),
             configuration.getValidationQueryTimeout().orElseGet(() -> Duration.seconds(5)),

--- a/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/DBIHealthCheck.java
+++ b/dropwizard-jdbi/src/main/java/io/dropwizard/jdbi/DBIHealthCheck.java
@@ -7,20 +7,23 @@ import io.dropwizard.util.Duration;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
 public class DBIHealthCheck extends HealthCheck {
     private final DBI dbi;
-    private final String validationQuery;
+    private final Optional<String> validationQuery;
+    private final int validationQueryTimeout;
     private final TimeBoundHealthCheck timeBoundHealthCheck;
 
-    public DBIHealthCheck(ExecutorService executorService, Duration duration, DBI dbi, String validationQuery) {
+    public DBIHealthCheck(ExecutorService executorService, Duration duration, DBI dbi, Optional<String> validationQuery) {
         this.dbi = dbi;
         this.validationQuery = validationQuery;
+        this.validationQueryTimeout = (int) duration.toSeconds();
         this.timeBoundHealthCheck = new TimeBoundHealthCheck(executorService, duration);
     }
 
-    public DBIHealthCheck(DBI dbi, String validationQuery) {
+    public DBIHealthCheck(DBI dbi, Optional<String> validationQuery) {
         this(new DirectExecutorService(), Duration.seconds(0), dbi, validationQuery);
     }
 
@@ -28,7 +31,12 @@ public class DBIHealthCheck extends HealthCheck {
     protected Result check() throws Exception {
         return timeBoundHealthCheck.check(() -> {
             try (Handle handle = dbi.open()) {
-                handle.execute(validationQuery);
+                if (validationQuery.isPresent()) {
+                    handle.execute(validationQuery.get());
+                } else if (!handle.getConnection().isValid(validationQueryTimeout)) {
+                    return Result.unhealthy("Connection::isValid returned false.");
+                }
+
                 return Result.healthy();
             }
         });

--- a/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/DBIHealthCheckTest.java
+++ b/dropwizard-jdbi/src/test/java/io/dropwizard/jdbi/DBIHealthCheckTest.java
@@ -7,19 +7,23 @@ import org.mockito.Mockito;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 
+import java.sql.Connection;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class DBIHealthCheckTest {
 
     @Test
     public void testItTimesOutProperly() throws Exception {
-        String validationQuery = "select 1";
+        Optional<String> validationQuery = Optional.of("select 1");
         DBI dbi = mock(DBI.class);
         Handle handle = mock(Handle.class);
         when(dbi.open()).thenReturn(handle);
@@ -29,7 +33,7 @@ public class DBIHealthCheckTest {
             } catch (Exception ignored) {
             }
             return null;
-        }).when(handle).execute(validationQuery);
+        }).when(handle).execute(validationQuery.get());
 
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         DBIHealthCheck dbiHealthCheck = new DBIHealthCheck(executorService,
@@ -39,5 +43,25 @@ public class DBIHealthCheckTest {
         HealthCheck.Result result = dbiHealthCheck.check();
         executorService.shutdown();
         assertThat(result.isHealthy()).isFalse();
+    }
+
+    @Test
+    public void testItCallsIsValidWhenValidationQueryIsMissing() throws Exception {
+        DBI dbi = mock(DBI.class);
+        Handle handle = mock(Handle.class);
+        Connection connection = mock(Connection.class);
+        when(dbi.open()).thenReturn(handle);
+        when(handle.getConnection()).thenReturn(connection);
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        DBIHealthCheck dbiHealthCheck = new DBIHealthCheck(executorService,
+            Duration.milliseconds(5),
+            dbi,
+            Optional.empty());
+        HealthCheck.Result result = dbiHealthCheck.check();
+        executorService.shutdown();
+        executorService.awaitTermination(1, TimeUnit.MINUTES);
+        assertThat(result.isHealthy()).isFalse();
+        verify(connection).isValid(anyInt());
     }
 }

--- a/dropwizard-jdbi3/src/main/java/io/dropwizard/jdbi3/JdbiFactory.java
+++ b/dropwizard-jdbi3/src/main/java/io/dropwizard/jdbi3/JdbiFactory.java
@@ -1,5 +1,7 @@
 package io.dropwizard.jdbi3;
 
+import java.util.Optional;
+
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.jdbi3.InstrumentedSqlLogger;
 import com.codahale.metrics.jdbi3.strategies.SmartNameStrategy;
@@ -71,7 +73,7 @@ public class JdbiFactory {
         environment.lifecycle().manage(dataSource);
 
         // Setup the required health checks.
-        final String validationQuery = configuration.getValidationQuery();
+        final Optional<String> validationQuery = configuration.getValidationQuery();
         environment.healthChecks().register(name, new JdbiHealthCheck(
             environment.getHealthCheckExecutorService(),
             configuration.getValidationQueryTimeout().orElseGet(() -> Duration.seconds(5)),

--- a/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/JdbiFactoryTest.java
+++ b/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/JdbiFactoryTest.java
@@ -12,6 +12,7 @@ import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.statement.SqlStatements;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,7 +38,7 @@ public class JdbiFactoryTest {
         when(environment.healthChecks()).thenReturn(healthChecks);
 
         when(configuration.build(metrics, name)).thenReturn(dataSource);
-        when(configuration.getValidationQuery()).thenReturn(validationQuery);
+        when(configuration.getValidationQuery()).thenReturn(Optional.of(validationQuery));
         when(configuration.isAutoCommentsEnabled()).thenReturn(true);
 
         when(jdbi.getConfig(SqlStatements.class)).thenReturn(sqlStatements);

--- a/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/JdbiHealthCheckTest.java
+++ b/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/JdbiHealthCheckTest.java
@@ -1,7 +1,19 @@
 package io.dropwizard.jdbi3;
 
-import com.codahale.metrics.health.HealthCheck;
-import io.dropwizard.util.Duration;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nullable;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.AfterEach;
@@ -9,35 +21,28 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
+import com.codahale.metrics.health.HealthCheck;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import io.dropwizard.util.Duration;
 
 public class JdbiHealthCheckTest {
     private static final String VALIDATION_QUERY = "select 1";
 
     private Jdbi jdbi;
     private Handle handle;
+    private Connection connection;
     private ExecutorService executorService;
-    private JdbiHealthCheck sut;
 
     @BeforeEach
     public void setup() {
         jdbi = mock(Jdbi.class);
         handle = mock(Handle.class);
+        connection = mock(Connection.class);
 
         when(jdbi.open()).thenReturn(handle);
+        when(handle.getConnection()).thenReturn(connection);
 
         executorService = Executors.newSingleThreadExecutor();
-
-        sut = new JdbiHealthCheck(executorService,
-            Duration.milliseconds(100),
-            jdbi,
-            VALIDATION_QUERY);
     }
 
     @AfterEach
@@ -49,9 +54,19 @@ public class JdbiHealthCheckTest {
     public void testNoTimeoutReturnsHealthy() throws Exception {
         when(handle.execute(VALIDATION_QUERY)).thenReturn(0);
 
-        HealthCheck.Result result = sut.check();
+        HealthCheck.Result result = healthCheck(VALIDATION_QUERY).check();
 
         assertThat(result.isHealthy()).isTrue();
+    }
+
+    @Test
+    public void tesHealthyAfterWhenMissingValidationQuery() throws Exception {
+        when(connection.isValid(anyInt())).thenReturn(true);
+
+        HealthCheck.Result result = healthCheck().check();
+
+        assertThat(result.isHealthy()).isTrue();
+        verify(connection).isValid(anyInt());
     }
 
     @Test
@@ -61,8 +76,27 @@ public class JdbiHealthCheckTest {
             return null;
         });
 
-        HealthCheck.Result result = sut.check();
+        HealthCheck.Result result = healthCheck(VALIDATION_QUERY).check();
 
         assertThat(result.isHealthy()).isFalse();
+    }
+
+    @Test
+    public void testUnhealthyWhenMissingValidationQuery() throws Exception {
+        HealthCheck.Result result = healthCheck().check();
+
+        assertThat(result.isHealthy()).isFalse();
+        verify(connection).isValid(anyInt());
+    }
+
+    private JdbiHealthCheck healthCheck() {
+        return healthCheck(null);
+    }
+
+    private JdbiHealthCheck healthCheck(@Nullable String validationQuery) {
+        return new JdbiHealthCheck(executorService,
+            Duration.milliseconds(100),
+            jdbi,
+            Optional.ofNullable(validationQuery));
     }
 }


### PR DESCRIPTION
###### Problem:
tomcat jdbc allows validationQuery to be null, see https://tomcat.apache.org/tomcat-9.0-doc/jdbc-pool.html . In that case it will validate connections by isValid() method on Connection object.

###### Solution:
making validation query Optional. healthchecks calling isValid when validation query is not defined.

