### PR TITLE
Retrieve Connector Information in ServiceLifecycleListener 1.3.x

### DIFF
--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/PortDescriptor.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/PortDescriptor.java
@@ -5,6 +5,9 @@ import com.google.common.base.MoreObjects;
 public class PortDescriptor {
 
     private static final String UNKNOWN = "UNKNOWN";
+    private static final String DEFAULT_HOST = "0.0.0.0";
+
+    private String host;
 
     private String protocol;
 
@@ -13,15 +16,14 @@ public class PortDescriptor {
     private String connectorType;
 
     public PortDescriptor() {
-        this.protocol = UNKNOWN;
-        this.port = 0;
-        this.connectorType = UNKNOWN;
+        this(UNKNOWN, 0, UNKNOWN, DEFAULT_HOST);
     }
 
-    public PortDescriptor(String protocol, int port, String connectorType) {
+    public PortDescriptor(String protocol, int port, String connectorType, String host) {
         this.protocol = protocol;
         this.port = port;
         this.connectorType = connectorType;
+        this.host = host;
     }
 
     public String getProtocol() {
@@ -48,11 +50,20 @@ public class PortDescriptor {
         this.connectorType = connectorType;
     }
 
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
     public String toString() {
         return MoreObjects.toStringHelper(this)
             .add("port", port)
             .add("protocol", protocol)
             .add("connectorType", connectorType)
+            .add("host", host)
             .toString();
     }
 }

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/PortDescriptor.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/PortDescriptor.java
@@ -4,11 +4,18 @@ import com.google.common.base.MoreObjects;
 
 public class PortDescriptor {
 
+    private static final String UNKNOWN = "UNKNOWN";
+
     private String protocol;
+
     private int port;
+
     private String connectorType;
 
     public PortDescriptor() {
+        this.protocol = UNKNOWN;
+        this.port = 0;
+        this.connectorType = UNKNOWN;
     }
 
     public PortDescriptor(String protocol, int port, String connectorType) {

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/PortDescriptor.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/PortDescriptor.java
@@ -1,0 +1,51 @@
+package io.dropwizard.lifecycle;
+
+import com.google.common.base.MoreObjects;
+
+public class PortDescriptor {
+
+    private String protocol;
+    private int port;
+    private String connectorType;
+
+    public PortDescriptor() {
+    }
+
+    public PortDescriptor(String protocol, int port, String connectorType) {
+        this.protocol = protocol;
+        this.port = port;
+        this.connectorType = connectorType;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public String getConnectorType() {
+        return connectorType;
+    }
+
+    public void setConnectorType(String connectorType) {
+        this.connectorType = connectorType;
+    }
+
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("port", port)
+            .add("protocol", protocol)
+            .add("connectorType", connectorType)
+            .toString();
+    }
+}

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/ServerLifecycleListener.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/ServerLifecycleListener.java
@@ -3,7 +3,11 @@ package io.dropwizard.lifecycle;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+
+import java.util.Arrays;
 import java.util.EventListener;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public interface ServerLifecycleListener extends EventListener {
 
@@ -31,5 +35,23 @@ public interface ServerLifecycleListener extends EventListener {
     default int getAdminPort(Server server) {
         final Connector[] connectors = server.getConnectors();
         return ((ServerConnector) connectors[connectors.length - 1]).getLocalPort();
+    }
+
+    /**
+     * Return the ports mapped to the protocols each the {@link ServerConnector}s in the
+     * provided {@link Server} instance.
+     *
+     * @param server Server instance to use
+     * @return Map of local ports to protocols for the server instance
+     */
+    default List<PortDescriptor> getPortDescriptorList(Server server) {
+        final Connector[] connectors = server.getConnectors();
+        return Arrays.stream(connectors)
+            .map(conn -> conn.getProtocols()
+                .stream()
+                .map(protocol -> new PortDescriptor(protocol, ((ServerConnector) conn).getLocalPort(), conn.getName()))
+                .collect(Collectors.toList()))
+            .flatMap(List::stream)
+            .collect(Collectors.toList());
     }
 }

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/ServerLifecycleListener.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/ServerLifecycleListener.java
@@ -49,7 +49,7 @@ public interface ServerLifecycleListener extends EventListener {
         return Arrays.stream(connectors)
             .map(conn -> conn.getProtocols()
                 .stream()
-                .map(protocol -> new PortDescriptor(protocol, ((ServerConnector) conn).getLocalPort(), conn.getName()))
+                .map(protocol -> new PortDescriptor(protocol, ((ServerConnector) conn).getLocalPort(), conn.getName(), ((ServerConnector) conn).getHost()))
                 .collect(Collectors.toList()))
             .flatMap(List::stream)
             .collect(Collectors.toList());

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/ServerLifecycleListenerTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/ServerLifecycleListenerTest.java
@@ -1,0 +1,109 @@
+package io.dropwizard.lifecycle;
+
+import org.assertj.core.api.Assertions;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ServerLifecycleListenerTest {
+
+    private static final String APPLICATION = "application";
+    private static final String ADMIN = "admin";
+
+    @Test
+    public void getLocalPort() {
+        int localPort = 5673;
+        int adminPort = 12345;
+        Server server = configureAndGetSingleConnectorServer(localPort, adminPort);
+        ServerLifecycleListener listener = (server1) -> {
+        };
+        int retrievedLocalPort = listener.getLocalPort(server);
+        Assertions.assertThat(retrievedLocalPort).isEqualTo(localPort);
+    }
+
+    @Test
+    public void getAdminPort() {
+        int localPort = 5673;
+        int adminPort = 12345;
+        Server server = configureAndGetSingleConnectorServer(localPort, adminPort);
+        ServerLifecycleListener listener = (server1) -> {
+        };
+        int retrievedAdminPort = listener.getAdminPort(server);
+        Assertions.assertThat(retrievedAdminPort).isEqualTo(adminPort);
+    }
+
+    private Server configureAndGetSingleConnectorServer(int applicationPort, int adminPort) {
+        Server server = mock(Server.class);
+        ServerConnector applicationConnector = mock(ServerConnector.class);
+        ServerConnector adminConnector = mock(ServerConnector.class);
+        Connector[] connectors = {applicationConnector, adminConnector};
+        when(server.getConnectors()).thenReturn(connectors);
+        configuredServerConnector(applicationConnector, applicationPort, Arrays.asList("ssl", "http/1.1", "http/2"), APPLICATION);
+        configuredServerConnector(adminConnector, adminPort, Arrays.asList("tls", "http/2"), ADMIN);
+        return server;
+    }
+
+    @Test
+    public void getPortDescriptorList() {
+        Server server = configureMultiProtocolServer();
+        ServerLifecycleListener listener = (server1) -> {
+        };
+        List<PortDescriptor> portDescriptorList = listener.getPortDescriptorList(server);
+        PortDescriptor[] portDescriptors = buildCompletePortDescriptorsArray();
+        Assertions.assertThat(portDescriptorList).usingElementComparator((o1, o2) -> {
+            if (Objects.equals(o1.getConnectorType(), o2.getConnectorType()) &&
+                Objects.equals(o1.getProtocol(), o2.getProtocol()) &&
+                Objects.equals(o1.getPort(), o2.getPort())) {
+                return 0;
+            } else {
+                return -1;
+            }
+        }).contains(portDescriptors);
+    }
+
+    private PortDescriptor[] buildCompletePortDescriptorsArray() {
+        return Stream.of(getPortDescriptors(5673, ADMIN, new String[]{"ssl", "http/1.1", "http/2"}),
+            getPortDescriptors(12345, APPLICATION, new String[]{"tls", "http/2"}),
+            getPortDescriptors(1234, APPLICATION, new String[]{"http/1.1", "http/2", "websocket"}))
+            .flatMap(Arrays::stream)
+            .toArray(PortDescriptor[]::new);
+    }
+
+    private PortDescriptor[] getPortDescriptors(int port, String type, String[] protocols) {
+        return Arrays.stream(protocols)
+            .map(protocol -> getPortDescriptor(protocol, port, type))
+            .toArray(PortDescriptor[]::new);
+    }
+
+    private PortDescriptor getPortDescriptor(String protocol, int port, String type) {
+        return new PortDescriptor(protocol, port, type);
+    }
+
+    private Server configureMultiProtocolServer() {
+        Server server = mock(Server.class);
+        ServerConnector connectorMock1 = mock(ServerConnector.class);
+        ServerConnector connectorMock2 = mock(ServerConnector.class);
+        ServerConnector connectorMock3 = mock(ServerConnector.class);
+        Connector[] connectors = {connectorMock1, connectorMock2, connectorMock3};
+        when(server.getConnectors()).thenReturn(connectors);
+        configuredServerConnector(connectorMock1, 5673, Arrays.asList("ssl", "http/1.1", "http/2"), ADMIN);
+        configuredServerConnector(connectorMock2, 12345, Arrays.asList("tls", "http/2"), APPLICATION);
+        configuredServerConnector(connectorMock3, 1234, Arrays.asList("http/1.1", "http/2", "websocket"), APPLICATION);
+        return server;
+    }
+
+    private void configuredServerConnector(ServerConnector connectorMock1, int localPort, List<String> protocols, String portType) {
+        when(connectorMock1.getLocalPort()).thenReturn(localPort);
+        when(connectorMock1.getProtocols()).thenReturn(protocols);
+        when(connectorMock1.getName()).thenReturn(portType);
+    }
+}

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/ServerLifecycleListenerTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/ServerLifecycleListenerTest.java
@@ -18,6 +18,9 @@ public class ServerLifecycleListenerTest {
 
     private static final String APPLICATION = "application";
     private static final String ADMIN = "admin";
+    private static final String HOST_1 = "192.168.2.5";
+    private static final String HOST_2 = "192.68.4.77";
+    private static final String HOST_3 = "192.168.67.20";
 
     @Test
     public void getLocalPort() {
@@ -47,8 +50,8 @@ public class ServerLifecycleListenerTest {
         ServerConnector adminConnector = mock(ServerConnector.class);
         Connector[] connectors = {applicationConnector, adminConnector};
         when(server.getConnectors()).thenReturn(connectors);
-        configuredServerConnector(applicationConnector, applicationPort, Arrays.asList("ssl", "http/1.1", "http/2"), APPLICATION);
-        configuredServerConnector(adminConnector, adminPort, Arrays.asList("tls", "http/2"), ADMIN);
+        configuredServerConnector(applicationConnector, applicationPort, Arrays.asList("ssl", "http/1.1", "http/2"), APPLICATION, HOST_1);
+        configuredServerConnector(adminConnector, adminPort, Arrays.asList("tls", "http/2"), ADMIN, HOST_2);
         return server;
     }
 
@@ -62,7 +65,8 @@ public class ServerLifecycleListenerTest {
         Assertions.assertThat(portDescriptorList).usingElementComparator((o1, o2) -> {
             if (Objects.equals(o1.getConnectorType(), o2.getConnectorType()) &&
                 Objects.equals(o1.getProtocol(), o2.getProtocol()) &&
-                Objects.equals(o1.getPort(), o2.getPort())) {
+                Objects.equals(o1.getPort(), o2.getPort()) &&
+                Objects.equals(o1.getHost(), o2.getHost())) {
                 return 0;
             } else {
                 return -1;
@@ -71,21 +75,21 @@ public class ServerLifecycleListenerTest {
     }
 
     private PortDescriptor[] buildCompletePortDescriptorsArray() {
-        return Stream.of(getPortDescriptors(5673, ADMIN, new String[]{"ssl", "http/1.1", "http/2"}),
-            getPortDescriptors(12345, APPLICATION, new String[]{"tls", "http/2"}),
-            getPortDescriptors(1234, APPLICATION, new String[]{"http/1.1", "http/2", "websocket"}))
+        return Stream.of(getPortDescriptors(5673, ADMIN, new String[]{"ssl", "http/1.1", "http/2"}, HOST_1),
+            getPortDescriptors(12345, APPLICATION, new String[]{"tls", "http/2"}, HOST_2),
+            getPortDescriptors(1234, APPLICATION, new String[]{"http/1.1", "http/2", "websocket"}, HOST_3))
             .flatMap(Arrays::stream)
             .toArray(PortDescriptor[]::new);
     }
 
-    private PortDescriptor[] getPortDescriptors(int port, String type, String[] protocols) {
+    private PortDescriptor[] getPortDescriptors(int port, String type, String[] protocols, String host) {
         return Arrays.stream(protocols)
-            .map(protocol -> getPortDescriptor(protocol, port, type))
+            .map(protocol -> getPortDescriptor(protocol, port, type, host))
             .toArray(PortDescriptor[]::new);
     }
 
-    private PortDescriptor getPortDescriptor(String protocol, int port, String type) {
-        return new PortDescriptor(protocol, port, type);
+    private PortDescriptor getPortDescriptor(String protocol, int port, String type, String host) {
+        return new PortDescriptor(protocol, port, type, host);
     }
 
     private Server configureMultiProtocolServer() {
@@ -95,15 +99,16 @@ public class ServerLifecycleListenerTest {
         ServerConnector connectorMock3 = mock(ServerConnector.class);
         Connector[] connectors = {connectorMock1, connectorMock2, connectorMock3};
         when(server.getConnectors()).thenReturn(connectors);
-        configuredServerConnector(connectorMock1, 5673, Arrays.asList("ssl", "http/1.1", "http/2"), ADMIN);
-        configuredServerConnector(connectorMock2, 12345, Arrays.asList("tls", "http/2"), APPLICATION);
-        configuredServerConnector(connectorMock3, 1234, Arrays.asList("http/1.1", "http/2", "websocket"), APPLICATION);
+        configuredServerConnector(connectorMock1, 5673, Arrays.asList("ssl", "http/1.1", "http/2"), ADMIN, HOST_1);
+        configuredServerConnector(connectorMock2, 12345, Arrays.asList("tls", "http/2"), APPLICATION, HOST_2);
+        configuredServerConnector(connectorMock3, 1234, Arrays.asList("http/1.1", "http/2", "websocket"), APPLICATION, "192.168.67.20");
         return server;
     }
 
-    private void configuredServerConnector(ServerConnector connectorMock1, int localPort, List<String> protocols, String portType) {
+    private void configuredServerConnector(ServerConnector connectorMock1, int localPort, List<String> protocols, String portType, String host) {
         when(connectorMock1.getLocalPort()).thenReturn(localPort);
         when(connectorMock1.getProtocols()).thenReturn(protocols);
         when(connectorMock1.getName()).thenReturn(portType);
+        when(connectorMock1.getHost()).thenReturn(host);
     }
 }


### PR DESCRIPTION
###### Problem:
In the situation where the server is using dynamic port and the port numbers and protocol are not available to bundles during the initialize method. As such they are picked up during ServerLifecylesListener's ServerStarted method. There are convenience methods for getting the first and last port, but this doesn't address the situation where there are multiple connectors configured with multiple protocols.

###### Solution:
The remedy for the problem is a method that extracts and collects all the connector information to present to the listener in question. As an example, it would provide the port, interface(host/ip), protocols, and connector type(Application/Admin) such that they could be registered as metadata in a service discovery tool such as Consul or Eureka. 

###### Result:
The consolidated information(PortDescriptor) regarding the server's connectors can be presented to the bundle(or other implementors of the LifecycleListener), via the ServiceListener in a convenient manner. 
