### PR TITLE
Add ProxyConectionFactory for enabling the proxy protocol.

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -34,6 +34,7 @@ v2.0.0: Unreleased
 * Upgrade to Jersey 2.28 (`#2613 <https://github.com/dropwizard/dropwizard/pull/2613>`_)
 * Deprecate ``*Param`` classes and will be removed in 3.0.0 (`#2637 <https://github.com/dropwizard/dropwizard/pull/2637>`_)
 * Add data size class adhering to the correct SI and IEC prefixes (`#2686 <https://github.com/dropwizard/dropwizard/pull/2686>`_)
+* Add support for proxy-protocol in http connector configuration (`#2709 <https://github.com/dropwizard/dropwizard/pull/2709>`_)
 
 .. _rel-1.3.9:
 

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
@@ -17,6 +17,7 @@ import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.ForwardedRequestCustomizer;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.ProxyConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
@@ -524,7 +525,7 @@ public class HttpConnectorFactory implements ConnectorFactory {
 
         final ByteBufferPool bufferPool = buildBufferPool();
 
-        return buildConnector(server, scheduler, bufferPool, name, threadPool,
+        return buildConnector(server, scheduler, bufferPool, name, threadPool, new ProxyConnectionFactory(),
                               new Jetty93InstrumentedConnectionFactory(httpConnectionFactory,
                                                                 metrics.timer(httpConnections())));
     }

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
@@ -194,7 +194,7 @@ import static com.codahale.metrics.MetricRegistry.name;
  *         <td>{@code useProxyProtocol}</td>
  *         <td>false</td>
  *         <td>
- *             Enable jetty proxy protocol header support for all application exposed ports.
+ *             Enable jetty proxy protocol header support.
  *         </td>
  *     </tr>
  *     <tr>
@@ -563,7 +563,7 @@ public class HttpConnectorFactory implements ConnectorFactory {
                                              @Nullable ThreadPool threadPool,
                                              ConnectionFactory... factories) {
         if (useProxyProtocol) {
-            factories = ArrayUtil.addToArray(factories, new ProxyConnectionFactory(), ConnectorFactory.class);
+            factories = ArrayUtil.prependToArray(new ProxyConnectionFactory(), factories, ConnectorFactory.class);
         }
 
         final ServerConnector connector = new ServerConnector(server,

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
@@ -18,6 +18,7 @@ import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.server.ForwardedRequestCustomizer;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.ProxyConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
@@ -168,6 +169,23 @@ class HttpConnectorFactoryTest {
         assertThat(httpConfiguration.getMinRequestDataRate()).isEqualTo(42);
         assertThat(httpConfiguration.getMinResponseDataRate()).isEqualTo(200);
 
+        connector.stop();
+        server.stop();
+    }
+
+    @Test
+    void testBuildConnectorWithProxyProtocol() throws Exception {
+        HttpConnectorFactory http = new HttpConnectorFactory();
+        http.setBindHost("127.0.0.1");
+        http.setUseProxyProtocol(true);
+
+        Server server = new Server();
+        MetricRegistry metrics = new MetricRegistry();
+        ThreadPool threadPool = new QueuedThreadPool();
+
+        ServerConnector connector = (ServerConnector) http.build(server, metrics, "test-http-connector-with-proxy-protcol", threadPool);
+
+        assertThat(connector.getConnectionFactories().toArray()[0]).isInstanceOf(ProxyConnectionFactory.class);
         connector.stop();
         server.stop();
     }

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
@@ -183,7 +183,7 @@ class HttpConnectorFactoryTest {
         MetricRegistry metrics = new MetricRegistry();
         ThreadPool threadPool = new QueuedThreadPool();
 
-        ServerConnector connector = (ServerConnector) http.build(server, metrics, "test-http-connector-with-proxy-protcol", threadPool);
+        ServerConnector connector = (ServerConnector) http.build(server, metrics, "test-http-connector-with-proxy-protocol", threadPool);
 
         assertThat(connector.getConnectionFactories().toArray()[0]).isInstanceOf(ProxyConnectionFactory.class);
         connector.stop();


### PR DESCRIPTION
###### Problem:
A DW service running behind a proxy/LB need to know the real source of the request. Attempt to solve #1176 

###### Solution:
[Proxy-Protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) is one the solution for this. Jetty has inbuilt support for it. We just need to utilize that.

###### Result:
request.getRemoteAddr() and request.getRemoteHost() shall give you information about the client that is making the request to proxy not of proxy itself (which is the case as of today without this feature).