### PR TITLE
Disable errorprone: EqualsGetClass check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -400,6 +400,8 @@
                             </annotationProcessorPaths>
                             <compilerArgs>
                                 <arg>-XepDisableWarningsInGeneratedCode</arg>
+                                <!-- Disable EqualsGetClass. Further discussion: https://github.com/dropwizard/dropwizard/pull/2647 -->
+                                <arg>-Xep:EqualsGetClass:OFF</arg>
                                 <arg>-Xep:NullAway:ERROR</arg>
                                 <arg>-XepOpt:NullAway:AnnotatedPackages=io.dropwizard</arg>
                                 <arg>-XepOpt:NullAway:ExcludedFieldAnnotations=org.mockito.Mock</arg>


### PR DESCRIPTION
###### Problem:
Preferring [`instanceof` instead of `getClass` in `Object#equals`](https://errorprone.info/bugpattern/EqualsGetClass) may be polarizing (https://github.com/dropwizard/dropwizard/pull/2647). So instead leaving the PR stagnated and warning to pollute the console output -- suppress them

###### Solution:
Warnings suppressed in pom.

###### Result:
Closes #2647
