### PR TITLE
DropwizardTestSupport should only override the app's ConfigurationSou…

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
@@ -6,7 +6,6 @@ import io.dropwizard.Configuration;
 import io.dropwizard.cli.Command;
 import io.dropwizard.cli.ServerCommand;
 import io.dropwizard.configuration.ConfigurationSourceProvider;
-import io.dropwizard.configuration.FileConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.setup.Bootstrap;
@@ -46,6 +45,7 @@ public class DropwizardTestSupport<C extends Configuration> {
 
     @Nullable
     protected final String configPath;
+    @Nullable
     protected final ConfigurationSourceProvider configSourceProvider;
     protected final Set<ConfigOverride> configOverrides;
     @Nullable
@@ -80,7 +80,7 @@ public class DropwizardTestSupport<C extends Configuration> {
 
     public DropwizardTestSupport(Class<? extends Application<C>> applicationClass,
                                  @Nullable String configPath,
-                                 ConfigurationSourceProvider configSourceProvider,
+                                 @Nullable ConfigurationSourceProvider configSourceProvider,
                                  ConfigOverride... configOverrides) {
         this(applicationClass, configPath, configSourceProvider, null, configOverrides);
     }
@@ -98,7 +98,7 @@ public class DropwizardTestSupport<C extends Configuration> {
 
     public DropwizardTestSupport(Class<? extends Application<C>> applicationClass,
                                  @Nullable String configPath,
-                                 ConfigurationSourceProvider configSourceProvider,
+                                 @Nullable ConfigurationSourceProvider configSourceProvider,
                                  @Nullable String customPropertyPrefix,
                                  ConfigOverride... configOverrides) {
         this(applicationClass, configPath, configSourceProvider, customPropertyPrefix, ServerCommand::new, configOverrides);
@@ -128,12 +128,12 @@ public class DropwizardTestSupport<C extends Configuration> {
                                  @Nullable String customPropertyPrefix,
                                  Function<Application<C>, Command> commandInstantiator,
                                  ConfigOverride... configOverrides) {
-        this(applicationClass, configPath, new FileConfigurationSourceProvider(), customPropertyPrefix, commandInstantiator, configOverrides);
+        this(applicationClass, configPath, null, customPropertyPrefix, commandInstantiator, configOverrides);
     }
 
     public DropwizardTestSupport(Class<? extends Application<C>> applicationClass,
                                  @Nullable String configPath,
-                                 ConfigurationSourceProvider configSourceProvider,
+                                 @Nullable ConfigurationSourceProvider configSourceProvider,
                                  @Nullable String customPropertyPrefix,
                                  Function<Application<C>, Command> commandInstantiator,
                                  ConfigOverride... configOverrides) {
@@ -180,7 +180,7 @@ public class DropwizardTestSupport<C extends Configuration> {
         }
         this.applicationClass = applicationClass;
         this.configPath = "";
-        this.configSourceProvider = new FileConfigurationSourceProvider();
+        this.configSourceProvider = null;
         this.configOverrides = Collections.emptySet();
         this.customPropertyPrefix = null;
         this.configuration = configuration;
@@ -288,7 +288,9 @@ public class DropwizardTestSupport<C extends Configuration> {
         };
 
         getApplication().initialize(bootstrap);
-        bootstrap.setConfigurationSourceProvider(configSourceProvider);
+        if (configSourceProvider != null) {
+            bootstrap.setConfigurationSourceProvider(configSourceProvider);
+        }
 
         if (explicitConfig) {
             bootstrap.setConfigurationFactoryFactory((klass, validator, objectMapper, propertyPrefix) ->

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportWithResourceConfigProviderTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportWithResourceConfigProviderTest.java
@@ -1,16 +1,21 @@
 package io.dropwizard.testing;
 
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
+import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
-import io.dropwizard.testing.app.TestApplication;
 import io.dropwizard.testing.app.TestConfiguration;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.io.InputStream;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class DropwizardTestSupportWithResourceConfigProviderTest {
+    private static final TestResourceConfigurationSourceProvider TEST_CONFIG_SOURCE_PROVIDER =
+            new TestResourceConfigurationSourceProvider();
     private static final DropwizardTestSupport<TestConfiguration> TEST_SUPPORT = new DropwizardTestSupport<>(
             TestApplication.class, "test-config.yaml", new ResourceConfigurationSourceProvider());
 
@@ -40,5 +45,34 @@ class DropwizardTestSupportWithResourceConfigProviderTest {
     void returnsEnvironment() {
         final Environment environment = TEST_SUPPORT.getEnvironment();
         assertThat(environment.getName()).isEqualTo("TestApplication");
+    }
+
+    @Test
+    void doesNotOverwriteConfigSourceProviderIfNotProvidedInConstructor() throws Exception {
+        DropwizardTestSupport<TestConfiguration> support = new DropwizardTestSupport<>(
+                TestApplication.class, "test-config.yaml");
+        try {
+            support.before();
+            assertThat(TEST_CONFIG_SOURCE_PROVIDER.openCalled).isTrue();
+        } finally {
+            support.after();
+        }
+    }
+
+    public static class TestResourceConfigurationSourceProvider extends ResourceConfigurationSourceProvider {
+        volatile boolean openCalled = false;
+
+        @Override
+        public InputStream open(String path) throws IOException {
+            openCalled = true;
+            return super.open(path);
+        }
+    }
+
+    public static class TestApplication extends io.dropwizard.testing.app.TestApplication {
+        @Override
+        public void initialize(Bootstrap<TestConfiguration> bootstrap) {
+            bootstrap.setConfigurationSourceProvider(TEST_CONFIG_SOURCE_PROVIDER);
+        }
     }
 }


### PR DESCRIPTION
…rceProvider if one is explicitly provided in a constructor (#2719)

###### Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->
See #2719 

###### Solution:
<!-- Describe the modifications you've done. -->
Made `DropwizardTestSupport`s `ConfigurationSourceProvider` override nullable, and only override the app's `ConfigurationSourceProvider` if one is explicitly provided via a constructor.

###### Result:
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->
This will fix the behavior of `DropwizardTestSupport` in tests when the app sets a different `ConfigurationSourceProvider`.