### PR TITLE
Allow response content type to be specified for a Task

### DIFF
--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/PostBodyTask.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/PostBodyTask.java
@@ -21,6 +21,16 @@ public abstract class PostBodyTask extends Task {
     }
 
     /**
+     * Create a new task with the given name and response content type
+     *
+     * @param name the task's name
+     * @param responseContentType the task's response content type
+     */
+    protected PostBodyTask(String name, String responseContentType) {
+        super(name, responseContentType);
+    }
+
+    /**
      * @param parameters the query string parameters
      * @param body       the plain text request body
      * @param output     a {@link PrintWriter} wrapping the output stream of the task

--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/Task.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/Task.java
@@ -3,6 +3,7 @@ package io.dropwizard.servlets.tasks;
 import java.io.PrintWriter;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * An arbitrary administrative task which can be performed via the admin interface.
@@ -11,6 +12,7 @@ import java.util.Map;
  */
 public abstract class Task {
     private final String name;
+    private final Optional<String> responseContentType;
 
     /**
      * Create a new task with the given name.
@@ -19,6 +21,18 @@ public abstract class Task {
      */
     protected Task(String name) {
         this.name = name;
+        this.responseContentType = Optional.empty();
+    }
+
+    /**
+     * Create a new task with the given name and response content type
+     *
+     * @param name the task's name
+     * @param responseContentType the task's response content type
+     */
+    protected Task(String name, String responseContentType) {
+        this.name = name;
+        this.responseContentType = Optional.ofNullable(responseContentType);
     }
 
     /**
@@ -28,6 +42,15 @@ public abstract class Task {
      */
     public String getName() {
         return name;
+    }
+
+    /**
+     * Returns the task's response content type,
+     *
+     * @return the task's response content type
+     */
+    public Optional<String> getResponseContentType() {
+        return responseContentType;
     }
 
     /**

--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/TaskServlet.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/TaskServlet.java
@@ -42,7 +42,7 @@ import static java.util.Objects.requireNonNull;
 public class TaskServlet extends HttpServlet {
     private static final long serialVersionUID = 7404713218661358124L;
     private static final Logger LOGGER = LoggerFactory.getLogger(TaskServlet.class);
-    private static final String CONTENT_TYPE = "text/plain;charset=UTF-8";
+    private static final String DEFAULT_CONTENT_TYPE = "text/plain;charset=UTF-8";
     private final ConcurrentMap<String, Task> tasks;
     private final ConcurrentMap<Task, TaskExecutor> taskExecutors;
 
@@ -100,7 +100,7 @@ public class TaskServlet extends HttpServlet {
                          HttpServletResponse resp) throws ServletException, IOException {
         if (Strings.isNullOrEmpty(req.getPathInfo())) {
             try (final PrintWriter output = resp.getWriter()) {
-                resp.setContentType(CONTENT_TYPE);
+                resp.setContentType(DEFAULT_CONTENT_TYPE);
                 getTasks().stream()
                     .map(Task::getName)
                     .sorted()
@@ -119,7 +119,7 @@ public class TaskServlet extends HttpServlet {
         final String pathInfo = req.getPathInfo();
         final Task task = pathInfo != null ? tasks.get(pathInfo) : null;
         if (task != null) {
-            resp.setContentType(CONTENT_TYPE);
+            resp.setContentType(task.getResponseContentType().orElse(DEFAULT_CONTENT_TYPE));
             final PrintWriter output = resp.getWriter();
             try {
                 final TaskExecutor taskExecutor = taskExecutors.get(task);

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/TaskServletTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/TaskServletTest.java
@@ -21,6 +21,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.codahale.metrics.MetricRegistry.name;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -72,6 +73,32 @@ public class TaskServletTest {
         servlet.service(request, response);
 
         verify(gc).execute(Collections.emptyMap(), output);
+    }
+
+    @Test
+    public void responseHasSpecifiedContentType() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/gc");
+        when(request.getParameterNames()).thenReturn(Collections.enumeration(Collections.emptyList()));
+        when(response.getWriter()).thenReturn(mock(PrintWriter.class));
+
+        when(gc.getResponseContentType()).thenReturn(Optional.of("application/json"));
+
+        servlet.service(request, response);
+
+        verify(response).setContentType("application/json");
+    }
+
+    @Test
+    public void responseHasDefaultContentTypeWhenNoneSpecified() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getPathInfo()).thenReturn("/gc");
+        when(request.getParameterNames()).thenReturn(Collections.enumeration(Collections.emptyList()));
+        when(response.getWriter()).thenReturn(mock(PrintWriter.class));
+
+        servlet.service(request, response);
+
+        verify(response).setContentType("text/plain;charset=UTF-8");
     }
 
     @Test


### PR DESCRIPTION
###### Problem:
I sometimes want to return data in JSON format in the response from a Task, and it's inconvenient that the response content type is hardcoded as `text/plain;charset=UTF-8`, because some client libraries expect JSON with an `application/json` content type and it means I have to do an extra translation step.

It would be really helpful if, when implementing actions, I had the option of specifying the response type to override the default `text/plain;charset=UTF-8`.

###### Solution:
I added an Optional<String> responseContentType field to Task. 

I kept the existing constructor the same, and added a new one where you can pass a `String contentResponseType`. If the original constructor is used, or if `null` is passed as `contentResponseType` in the new one, then the `contentResponseType` field will be empty.

I added a corresponding constructor to `PostBodyTask` as well, to specify `contentResponseType` - it just passes it through to the super Task.

In `TaskServlet`, I just check if a `contentResponseType` exists for the Task, and set that as the response content type if so, and use the default `text/plain;charset=UTF-8` if not.

Also added tests for both cases - when the response content type is specified, and when it's not and defaults to `text/plain;charset=UTF-8`.

###### Result:
The existing API and behaviour for Tasks remains the same, but you now have the option of specifying a custom response content type for your own custom Tasks, if you need.