### PR TITLE
Support configuration of jetty dump properties

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -63,8 +63,11 @@ rootPath                            ``/*``                                      
 registerDefaultExceptionMappers     true                                             Whether or not the default Jersey ExceptionMappers should be registered.
                                                                                      Set this to false if you want to register your own.
 enableThreadNameFilter              true                                             Whether or not to apply the ``ThreadNameFilter`` that adjusts thread names to include the request method and request URI.
+dumpAfterStart                      false                                            Whether or not to dump `Jetty Diagnostics`_ after start.
+dumpBeforeStop                      false                                            Whether or not to dump `Jetty Diagnostics`_ before stop.
 =================================== ===============================================  =============================================================================
 
+.. _Jetty Diagnostics: https://www.eclipse.org/jetty/documentation/9.4.x/jetty-dump-tool.html
 
 .. _man-configuration-gzip:
 

--- a/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
@@ -204,6 +204,20 @@ import java.util.stream.Collectors;
  *           method and request URI.
  *         </td>
  *     </tr>
+ *     <tr>
+ *         <td>{@code dumpAfterStart}</td>
+ *         <td>true</td>
+ *         <td>
+ *           Whether or not to dump jetty diagnostics after start.
+ *         </td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code dumpBeforeStop}</td>
+ *         <td>true</td>
+ *         <td>
+ *           Whether or not to dump jetty diagnostics before stop.
+ *         </td>
+ *     </tr>
  * </table>
  *
  * @see DefaultServerFactory
@@ -273,6 +287,10 @@ public abstract class AbstractServerFactory implements ServerFactory {
     private Optional<String> jerseyRootPath = Optional.empty();
 
     private boolean enableThreadNameFilter = true;
+
+    private boolean dumpAfterStart = false;
+
+    private boolean dumpBeforeStop = false;
 
     @JsonIgnore
     @ValidationMethod(message = "must have a smaller minThreads than maxThreads")
@@ -500,6 +518,26 @@ public abstract class AbstractServerFactory implements ServerFactory {
         this.enableThreadNameFilter = enableThreadNameFilter;
     }
 
+    @JsonProperty
+    public boolean getDumpAfterStart() {
+        return dumpAfterStart;
+    }
+
+    @JsonProperty
+    public void setDumpAfterStart(boolean dumpAfterStart) {
+        this.dumpAfterStart = dumpAfterStart;
+    }
+
+    @JsonProperty
+    public boolean getDumpBeforeStop() {
+        return dumpBeforeStop;
+    }
+
+    @JsonProperty
+    public void setDumpBeforeStop(boolean dumpBeforeStop) {
+        this.dumpBeforeStop = dumpBeforeStop;
+    }
+
     protected Handler createAdminServlet(Server server,
                                          MutableServletContextHandler handler,
                                          MetricRegistry metrics,
@@ -577,6 +615,8 @@ public abstract class AbstractServerFactory implements ServerFactory {
         server.addBean(errorHandler);
         server.setStopAtShutdown(true);
         server.setStopTimeout(shutdownGracePeriod.toMilliseconds());
+        server.setDumpAfterStart(dumpAfterStart);
+        server.setDumpBeforeStop(dumpBeforeStop);
         return server;
     }
 

--- a/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
@@ -129,6 +129,30 @@ public class DefaultServerFactoryTest {
     }
 
     @Test
+    public void defaultsDumpAfterStartFalse() throws Exception {
+        assertThat(http.getDumpAfterStart()).isFalse();
+        assertThat(http.build(environment).isDumpAfterStart()).isFalse();
+    }
+
+    @Test
+    public void defaultsDumpBeforeStopFalse() throws Exception {
+        assertThat(http.getDumpBeforeStop()).isFalse();
+        assertThat(http.build(environment).isDumpBeforeStop()).isFalse();
+    }
+
+    @Test
+    public void configuresDumpAfterStart() throws Exception {
+        http.setDumpAfterStart(true);
+        assertThat(http.build(environment).isDumpAfterStart()).isTrue();
+    }
+
+    @Test
+    public void configuresDumpBeforeExit() throws Exception {
+        http.setDumpBeforeStop(true);
+        assertThat(http.build(environment).isDumpBeforeStop()).isTrue();
+    }
+
+    @Test
     public void defaultsDetailedJsonProcessingExceptionToFalse() throws Exception {
         http.build(environment);
         assertThat(environment.jersey().getResourceConfig().getSingletons())


### PR DESCRIPTION
###### Problem:
Support configuration of jetty dump properties to assist in troubleshooting and diagnostic investigations.

See also #2742 and https://www.eclipse.org/jetty/documentation/9.4.x/jetty-dump-tool.html

###### Solution:
Add jetty dump properties to the AbstractServerFactory. Properties are defaulted to false and must be opted into.

##### Example configuration:

```yaml
server:
  dumpAfterStart: true
  dumpBeforeStop: true
```

###### Result:
Jetty dump is output when requested.

##### Example output:

dumpAfterStart
```
2019-04-22T21:49:20,585Z INFO  [main] org.eclipse.jetty.server.handler.ContextHandler Started i.d.j.MutableServletContextHandler@476efc81{/,null,AVAILABLE}
2019-04-22T21:49:20,610Z INFO  [main] org.eclipse.jetty.server.AbstractConnector Started application@4913465d{HTTP/1.1,[http/1.1]}{0.0.0.0:8080}
2019-04-22T21:49:20,669Z INFO  [main] org.eclipse.jetty.server.AbstractConnector Started application@4aebd384{SSL,[ssl, http/1.1]}{0.0.0.0:8443}
2019-04-22T21:49:20,679Z INFO  [main] org.eclipse.jetty.server.AbstractConnector Started admin@3b4e0786{HTTP/1.1,[http/1.1]}{0.0.0.0:8081}
2019-04-22T21:49:20,688Z INFO  [main] org.eclipse.jetty.server.AbstractConnector Started admin@66e17bf2{SSL,[ssl, http/1.1]}{0.0.0.0:8444}
Server@71c16f67{STARTING}[9.4.z-SNAPSHOT] - STARTING
+= InstrumentedQueuedThreadPool[dw]@35ff7336{STARTED,8<=13<=1024,i=1,q=0}[ReservedThreadExecutor@2c3c36df{s=0/11,p=0}] - STARTED
|  += ReservedThreadExecutor@2c3c36df{s=0/11,p=0} - STARTED
|  +> threads size=13
<lots of text snipped>
+> AttributesMap@5fd5963d
   +> null
key: +- bean, += managed, +~ unmanaged, +? auto, +: iterable, +] array, +@ map, +> undefined
2019-04-22T21:58:52,936Z INFO  [main] org.eclipse.jetty.server.Server Started @7119ms
```

dumpBeforeExit
```
Server@71c16f67{STOPPING}[9.4.z-SNAPSHOT] - STOPPING
+= InstrumentedQueuedThreadPool[dw]@35ff7336{STARTED,8<=18<=1024,i=3,q=0}[ReservedThreadExecutor@2c3c36df{s=3/11,p=0}] - STARTED
|  += ReservedThreadExecutor@2c3c36df{s=3/11,p=0} - STARTED
<lots of text snipped>
key: +- bean, += managed, +~ unmanaged, +? auto, +: iterable, +] array, +@ map, +> undefined
2019-04-22T22:00:27,406Z INFO  [Thread-11] org.eclipse.jetty.server.AbstractConnector Stopped application@4913465d{HTTP/1.1,[http/1.1]}{0.0.0.0:8080}
2019-04-22T22:00:27,412Z INFO  [Thread-11] org.eclipse.jetty.server.AbstractConnector Stopped application@4aebd384{SSL,[ssl, http/1.1]}{0.0.0.0:8443}
2019-04-22T22:00:27,415Z INFO  [Thread-11] org.eclipse.jetty.server.AbstractConnector Stopped admin@3b4e0786{HTTP/1.1,[http/1.1]}{0.0.0.0:8081}
2019-04-22T22:00:27,425Z INFO  [Thread-11] org.eclipse.jetty.server.AbstractConnector Stopped admin@66e17bf2{SSL,[ssl, http/1.1]}{0.0.0.0:8444}
2019-04-22T22:00:27,427Z INFO  [Thread-11] org.eclipse.jetty.server.handler.ContextHandler Stopped i.d.j.MutableServletContextHandler@476efc81{/,null,UNAVAILABLE}
```
