### PR TITLE
Exclude javax.el and jakarta.el-api, using glassfish jakarta.el instead

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -96,8 +96,8 @@
             </dependency>
             <dependency>
                 <groupId>org.glassfish</groupId>
-                <artifactId>javax.el</artifactId>
-                <version>3.0.0</version>
+                <artifactId>jakarta.el</artifactId>
+                <version>3.0.2</version>
             </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>

--- a/dropwizard-jersey/pom.xml
+++ b/dropwizard-jersey/pom.xml
@@ -57,6 +57,14 @@
             		<groupId>javax.el</groupId>
             		<artifactId>javax.el-api</artifactId>
             	</exclusion>
+            	<exclusion>
+            		<groupId>org.glassfish</groupId>
+            		<artifactId>javax.el</artifactId>
+            	</exclusion>
+            	<exclusion>
+            		<groupId>jakarta.el</groupId>
+            		<artifactId>jakarta.el-api</artifactId>
+            	</exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/dropwizard-validation/pom.xml
+++ b/dropwizard-validation/pom.xml
@@ -34,7 +34,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
+            <artifactId>jakarta.el</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Fixes duplicate classes between the 3 jars
Fixes #2739

###### Problem:
jakarta jars are replacing javax jars, so should depend on that instead of javax.  Furthermore, the glassfish jakarta.el implementation jar includes all the classes from the jakarta.el-api jar (see https://github.com/eclipse-ee4j/el-ri/issues/32), so should only depend on the implementation jar.

###### Solution:
depend on org.glassfish:jakarta-el, and exclude the other 2 jars
