### PR TITLE
Remove restrictions on generic type for ConfiguredBundle

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/ConfiguredBundle.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/ConfiguredBundle.java
@@ -9,7 +9,7 @@ import io.dropwizard.setup.Environment;
  *
  * @param <T>    the required configuration interface
  */
-public interface ConfiguredBundle<T extends Configuration> {
+public interface ConfiguredBundle<T> {
     /**
      * Initializes the environment.
      *

--- a/dropwizard-db/src/main/java/io/dropwizard/db/DatabaseConfiguration.java
+++ b/dropwizard-db/src/main/java/io/dropwizard/db/DatabaseConfiguration.java
@@ -1,7 +1,5 @@
 package io.dropwizard.db;
 
-import io.dropwizard.Configuration;
-
-public interface DatabaseConfiguration<T extends Configuration> {
+public interface DatabaseConfiguration<T> {
     PooledDataSourceFactory getDataSourceFactory(T configuration);
 }

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/HibernateBundle.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/HibernateBundle.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
-public abstract class HibernateBundle<T extends Configuration> implements ConfiguredBundle<T>, DatabaseConfiguration<T> {
+public abstract class HibernateBundle<T> implements ConfiguredBundle<T>, DatabaseConfiguration<T> {
     public static final String DEFAULT_NAME = "hibernate";
 
     @Nullable

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/ScanningHibernateBundle.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/ScanningHibernateBundle.java
@@ -1,6 +1,5 @@
 package io.dropwizard.hibernate;
 
-import io.dropwizard.Configuration;
 import org.glassfish.jersey.server.internal.scanning.AnnotationAcceptingListener;
 import org.glassfish.jersey.server.internal.scanning.PackageNamesScanner;
 
@@ -13,7 +12,7 @@ import java.util.List;
 /**
  * Extension of HibernateBundle that scans given package for entities instead of giving them by hand.
  */
-public abstract class ScanningHibernateBundle<T extends Configuration> extends HibernateBundle<T> {
+public abstract class ScanningHibernateBundle<T> extends HibernateBundle<T> {
     /**
      * @param pckg string with package containing Hibernate entities (classes annotated with Hibernate {@code @Entity}
      *             annotation) e. g. {@code com.codahale.fake.db.directory.entities}

--- a/dropwizard-views/src/main/java/io/dropwizard/views/ViewBundle.java
+++ b/dropwizard-views/src/main/java/io/dropwizard/views/ViewBundle.java
@@ -1,6 +1,5 @@
 package io.dropwizard.views;
 
-import io.dropwizard.Configuration;
 import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Sets;
@@ -37,7 +36,7 @@ import java.util.ServiceLoader;
  * }
  * </code></pre>
  *
- *<p>The {@code "profile.ftl[hx]"} or {@code "profile.mustache"} is the path of the template relative to the class name. If
+ * <p>The {@code "profile.ftl[hx]"} or {@code "profile.mustache"} is the path of the template relative to the class name. If
  * this class was {@code com.example.application.PersonView}, Freemarker or Mustache would then look for the file
  * {@code src/main/resources/com/example/application/profile.ftl} or {@code
  * src/main/resources/com/example/application/profile.mustache} respectively. If the template path
@@ -85,7 +84,7 @@ import java.util.ServiceLoader;
  *
  * See Also: <a href="http://mustache.github.io/mustache.5.html">Mustache Manual</a>
  */
-public class ViewBundle<T extends Configuration> implements ConfiguredBundle<T>, ViewConfigurable<T> {
+public class ViewBundle<T> implements ConfiguredBundle<T>, ViewConfigurable<T> {
     private final Iterable<ViewRenderer> viewRenderers;
 
     public ViewBundle() {

--- a/dropwizard-views/src/main/java/io/dropwizard/views/ViewConfigurable.java
+++ b/dropwizard-views/src/main/java/io/dropwizard/views/ViewConfigurable.java
@@ -1,9 +1,7 @@
 package io.dropwizard.views;
 
-import io.dropwizard.Configuration;
-
 import java.util.Map;
 
-public interface ViewConfigurable<T extends Configuration> {
+public interface ViewConfigurable<T> {
     Map<String, Map<String, String>> getViewConfiguration(T configuration);
 }


### PR DESCRIPTION
The restriction of `T extends Configuration` on `ConfiguredBundle<T>` was accidentally added in #2516 and can be removed again.

Refs #2516
Closes #2759