### PR TITLE
reset the client

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardAppExtension.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardAppExtension.java
@@ -216,6 +216,7 @@ public class DropwizardAppExtension<C extends Configuration> implements Dropwiza
             synchronized (this) {
                 if (client != null) {
                     client.close();
+                    client = null;
                 }
             }
         }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/ReuseDropwizardAppExtensionTestSuite.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/ReuseDropwizardAppExtensionTestSuite.java
@@ -1,0 +1,49 @@
+package io.dropwizard.testing.junit5;
+
+import io.dropwizard.testing.app.DropwizardTestApplication;
+import io.dropwizard.testing.app.TestConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReuseDropwizardAppExtensionTestSuite {
+    public static final DropwizardAppExtension<TestConfiguration> EXTENSION =
+        new DropwizardAppExtension<>(DropwizardTestApplication.class, resourceFilePath("test-config.yaml"));
+
+}
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+class DropwizardAppExtensionTestSuiteFoo {
+    public static final DropwizardAppExtension<TestConfiguration> EXTENSION = ReuseDropwizardAppExtensionTestSuite.EXTENSION;
+
+    @Test
+    public void clientHasNotBeenClosed() {
+        final String response = EXTENSION.client()
+                .target("http://localhost:" + EXTENSION.getAdminPort() + "/tasks/echo")
+                .request()
+                .post(Entity.entity("Custom message", MediaType.TEXT_PLAIN), String.class);
+
+        assertThat(response).isEqualTo("Custom message");
+    }
+}
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+class DropwizardAppExtensionTestSuiteBar {
+    public static final DropwizardAppExtension<TestConfiguration> EXTENSION = ReuseDropwizardAppExtensionTestSuite.EXTENSION;
+
+    @Test
+    public void clientHasNotBeenClosed() {
+        final String response = EXTENSION.client()
+                .target("http://localhost:" + EXTENSION.getAdminPort() + "/tasks/echo")
+                .request()
+                .post(Entity.entity("Custom message", MediaType.TEXT_PLAIN), String.class);
+
+        assertThat(response).isEqualTo("Custom message");
+    }
+}
+


### PR DESCRIPTION
###### Problem:
If a DropwizardAppExtension instance is reused in multiple classes (as described in its JavaDoc), the client returned by the client() method is closed after the first class.

###### Solution:
Set the client to null after closing it.

###### Result:
Tests reusing DropwizardAppExtension as described in its JavaDoc can successfully use the client returned from client(). The example still won't be accurate as the application is not really being reused as DropwizardExtensionsSupport can't tell the difference between this and any other static field implementing DropwizardExtension and closes it after each class. Here is the related issue:
https://github.com/dropwizard/dropwizard/issues/2763