### PR TITLE
Fix typo for ResilientSocketOutputStream class

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -37,6 +37,7 @@ v2.0.0: Unreleased
 * Added PortDescriptor class and method in ServerLifeCycleListener to provide a list of PortDescriptors, detailing all listening information for the application (`#2711 <https://github.com/dropwizard/dropwizard/pull/2711>`_)
 * Add support for proxy-protocol in http connector configuration (`#2709 <https://github.com/dropwizard/dropwizard/pull/2709>`_)
 * Disable using ``X-Forwarded-*`` headers by default (`#2748 <https://github.com/dropwizard/dropwizard/pull/2748>`_)
+* Fix typo by renaming ``ResilentSocketOutputStream`` to ``ResilientSocketOutputStream`` (`#2766 <https://github.com/dropwizard/dropwizard/pull/2766>`_)
 
 .. _rel-1.3.9:
 

--- a/dropwizard-logging/src/main/java/ch/qos/logback/core/recovery/ResilientSocketOutputStream.java
+++ b/dropwizard-logging/src/main/java/ch/qos/logback/core/recovery/ResilientSocketOutputStream.java
@@ -9,11 +9,11 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 
 /**
- * Represents a resilent persistent connection via TCP as an {@link OutputStream}.
+ * Represents a resilient persistent connection via TCP as an {@link OutputStream}.
  * Automatically tries to reconnect to the server if it encounters errors during writing
  * data via a TCP connection.
  */
-public class ResilentSocketOutputStream extends ResilientOutputStreamBase {
+public class ResilientSocketOutputStream extends ResilientOutputStreamBase {
 
     private final String host;
     private final int port;
@@ -30,8 +30,8 @@ public class ResilentSocketOutputStream extends ResilientOutputStreamBase {
      * @param sendBufferSize      The size of the send buffer of the socket stream in bytes.
      * @param socketFactory       The factory for customizing the client socket.
      */
-    public ResilentSocketOutputStream(String host, int port, int connectionTimeoutMs, int sendBufferSize,
-                                      SocketFactory socketFactory) {
+    public ResilientSocketOutputStream(String host, int port, int connectionTimeoutMs, int sendBufferSize,
+                                       SocketFactory socketFactory) {
         this.host = host;
         this.port = port;
         this.connectionTimeoutMs = connectionTimeoutMs;

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/socket/DropwizardSocketAppender.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/socket/DropwizardSocketAppender.java
@@ -1,14 +1,14 @@
 package io.dropwizard.logging.socket;
 
 import ch.qos.logback.core.OutputStreamAppender;
-import ch.qos.logback.core.recovery.ResilentSocketOutputStream;
+import ch.qos.logback.core.recovery.ResilientSocketOutputStream;
 import ch.qos.logback.core.spi.DeferredProcessingAware;
 
 import javax.net.SocketFactory;
 import java.io.OutputStream;
 
 /**
- * Sends log events to a TCP server, a connection to which is represented as {@link ResilentSocketOutputStream}.
+ * Sends log events to a TCP server, a connection to which is represented as {@link ResilientSocketOutputStream}.
  */
 public class DropwizardSocketAppender<E extends DeferredProcessingAware> extends OutputStreamAppender<E> {
 
@@ -34,7 +34,7 @@ public class DropwizardSocketAppender<E extends DeferredProcessingAware> extends
     }
 
     protected OutputStream socketOutputStream() {
-        final ResilentSocketOutputStream outputStream = new ResilentSocketOutputStream(host, port,
+        final ResilientSocketOutputStream outputStream = new ResilientSocketOutputStream(host, port,
             connectionTimeoutMs, sendBufferSize, socketFactory);
         outputStream.setContext(context);
         return outputStream;

--- a/dropwizard-logging/src/test/java/ch/qos/logback/core/recovery/ResilientSocketOutputStreamTest.java
+++ b/dropwizard-logging/src/test/java/ch/qos/logback/core/recovery/ResilientSocketOutputStreamTest.java
@@ -15,9 +15,9 @@ import java.util.concurrent.TimeUnit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
-public class ResilentSocketOutputStreamTest {
+public class ResilientSocketOutputStreamTest {
 
-    private ResilentSocketOutputStream resilentSocketOutputStream;
+    private ResilientSocketOutputStream resilientSocketOutputStream;
 
     private Thread thread;
     private ServerSocket ss;
@@ -41,7 +41,7 @@ public class ResilentSocketOutputStreamTest {
             }
         });
         thread.start();
-        resilentSocketOutputStream = new ResilentSocketOutputStream("localhost", ss.getLocalPort(),
+        resilientSocketOutputStream = new ResilientSocketOutputStream("localhost", ss.getLocalPort(),
             1024, 500, SocketFactory.getDefault());
     }
 
@@ -49,26 +49,26 @@ public class ResilentSocketOutputStreamTest {
     public void tearDown() throws Exception {
         ss.close();
         thread.interrupt();
-        resilentSocketOutputStream.close();
+        resilientSocketOutputStream.close();
     }
 
     @Test
     public void testCreatesCleanOutputStream() throws Exception {
-        assertThat(resilentSocketOutputStream.presumedClean).isTrue();
-        assertThat(resilentSocketOutputStream.os).isNotNull();
+        assertThat(resilientSocketOutputStream.presumedClean).isTrue();
+        assertThat(resilientSocketOutputStream.os).isNotNull();
     }
 
     @Test
     public void testThrowsExceptionIfCantCreateOutputStream() throws Exception {
-        assertThatIllegalStateException().isThrownBy(() -> new ResilentSocketOutputStream("256.256.256.256", 1024,
+        assertThatIllegalStateException().isThrownBy(() -> new ResilientSocketOutputStream("256.256.256.256", 1024,
             100, 1024, SocketFactory.getDefault()))
             .withMessage("Unable to create a TCP connection to 256.256.256.256:1024");
     }
 
     @Test
     public void testWriteMessage() throws Exception {
-        resilentSocketOutputStream.write("Test message".getBytes(StandardCharsets.UTF_8));
-        resilentSocketOutputStream.flush();
+        resilientSocketOutputStream.write("Test message".getBytes(StandardCharsets.UTF_8));
+        resilientSocketOutputStream.flush();
 
         latch.await(5, TimeUnit.SECONDS);
         assertThat(latch.getCount()).isEqualTo(0);
@@ -76,7 +76,7 @@ public class ResilentSocketOutputStreamTest {
 
     @Test
     public void testGetDescription() {
-        assertThat(resilentSocketOutputStream.getDescription()).isEqualTo(String.format("tcp [localhost:%d]",
+        assertThat(resilientSocketOutputStream.getDescription()).isEqualTo(String.format("tcp [localhost:%d]",
             ss.getLocalPort()));
     }
 }


### PR DESCRIPTION
###### Problem:
As pointed out by @Sounie in https://github.com/dropwizard/dropwizard/commit/04c4563bd5dc6aeb8237ad5349cff05eb91fa5a8#r33455524, `ResilientSocketOutputStream` had a typo in the class name.

###### Solution:
Update class name to remove typo.

###### Result:
Breaking change for any dropwizard user who relied on this class (I suspect the number effected to be small to nil), so it's documented in the release notes just in case.
