### PR TITLE
Fix test that binds to 8080

### DIFF
--- a/dropwizard-core/src/test/java/io/dropwizard/BundleTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/BundleTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.nio.file.Files;
-import java.util.Collections;
+import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -20,7 +20,17 @@ public class BundleTest {
 
         final File configFile = File.createTempFile("bundle-test", ".yml");
         try {
-            Files.write(configFile.toPath(), Collections.singleton("text: Test"));
+            Files.write(configFile.toPath(), Arrays.asList(
+                "text: Test",
+                "server:",
+                "  applicationConnectors:",
+                "    - type: http",
+                "      port: 0",
+                "  adminConnectors:",
+                "    - type: http",
+                "      port: 0"
+            ));
+
             final TestApplication application = new TestApplication(deprecatedBundle);
             application.run("server", configFile.getAbsolutePath());
         } finally {


### PR DESCRIPTION
###### Problem:
Running the `BundleTest` tests while another service is running on the box will fail the test as this test uses the default server configuration binding to port 8080.

###### Solution:
Force the test to use an available port.

###### Result:
Test passed on a machine where 8080 was not available.
