### PR TITLE
Remove mention of junit5 suite level extension

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardAppExtension.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardAppExtension.java
@@ -30,42 +30,6 @@ import java.util.function.Function;
  * override the {@link #newApplication()} method to provide your application instance(s).
  * </p>
  *
- * <p>
- * Using DropwizardAppExtension at the suite level can speed up test runs, as the application is only started and stopped
- * once for the entire suite:
- * </p>
- *
- * <pre>
- * public class MySuite {
- *   public static final DropwizardAppExtension&lt;MyConfig> DROPWIZARD = new DropwizardAppExtension&lt;>(...);
- * }
- * </pre>
- *
- * <p>
- * If the same instance of DropwizardAppExtension is reused at the suite- and class-level, then the application will be
- * started and stopped once, regardless of whether the entire suite or a single test is executed.
- * </p>
- *
- * <pre>
- * &#064;ExtendWith(DropwizardExtensionsSupport.class)
- * public class FooTest {
- *   public static final DropwizardAppExtension&lt;MyConfig> DROPWIZARD = MySuite.DROPWIZARD;
- *
- *   public void testFoo() { ... }
- * }
- *
- * &#064;ExtendWith(DropwizardExtensionsSupport.class)
- * public class BarTest {
- *   public static final DropwizardAppExtension&lt;MyConfig> DROPWIZARD = MySuite.DROPWIZARD;
- *
- *   public void testBar() { ... }
- * }
- * </pre>
- *
- * <p>
- *
- * </p>
- *
  * @param <C> the configuration type
  */
 //@formatter:on


### PR DESCRIPTION
###### Problem:
Junit5 does not contain the same suite level resource as junit4 ([based on stackoverflow answer][stack] and [open issue][issue]). `DropwizardAppExtension` doesn't advertises code that for suite level testing, but it is a lie and thus misleading.

###### Solution:
Remove documentation involving suite level testing from `DropwizardAppExtension` from the javadocs to avoid any confusion.

###### Result:
Closes #2763

[stack]: https://stackoverflow.com/a/50678092/433785
[issue]: https://github.com/junit-team/junit5/issues/456