### PR TITLE
Upgrade jackson to 2.9.9

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -21,7 +22,7 @@
         <dropwizard.version>${project.version}</dropwizard.version>
         <guava.version>24.1.1-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
-        <jackson.version>2.9.8</jackson.version>
+        <jackson.version>2.9.9</jackson.version>
         <jetty.version>9.4.18.v20190429</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.0.5</metrics4.version>


### PR DESCRIPTION
###### Problem:
Due to a vulnerability in Jackson 2.9.8 it should be upgraded

###### Solution:
Jackson is being upgraded to 2.9.9

###### Result:
Closes #2779
