### PR TITLE
Add current class loader to javassist ClassPool

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -13,6 +13,7 @@ import io.dropwizard.jersey.validation.FuzzyEnumParamConverterProvider;
 import io.dropwizard.util.Strings;
 import javassist.ClassPool;
 import javassist.CtClass;
+import javassist.LoaderClassPath;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.internal.inject.Binder;
 import org.glassfish.jersey.internal.inject.Providers;
@@ -148,6 +149,7 @@ public class DropwizardResourceConfig extends ResourceConfig {
                 // Need to create a new subclass dynamically here because Jersey
                 // doesn't add new bindings for the same class
                 ClassPool pool = ClassPool.getDefault();
+                pool.insertClassPath(new LoaderClassPath(this.getClass().getClassLoader()));
                 CtClass cc = pool.makeClass(SpecificBinder.class.getName() + UUID.randomUUID());
                 cc.setSuperclass(pool.get(SpecificBinder.class.getName()));
                 Object binderProxy = cc.toClass().getConstructor(Object.class, Class.class).newInstance(object, clazz);


### PR DESCRIPTION
In certain environments (eg AWS Lambda), the default/system
class loader doesn't have dropwizard classes in it.  Use the
current class's class loader to ensure that it does.

###### Problem:
In certain environments (eg AWS Lambda), the default/system
class loader doesn't have dropwizard classes in it, and we see the following:
```
javassist.NotFoundException: io.dropwizard.jersey.DropwizardResourceConfig$SpecificBinder
    at javassist.ClassPool.get(ClassPool.java:422)
    at io.dropwizard.jersey.DropwizardResourceConfig.register(DropwizardResourceConfig.java:152)
```
###### Solution:
Use the current class's class loader to ensure that it does.

###### Result:
Running dropwizard in aws lambda works (with some glue between an aws RequestHandler and the dropwizard application's resourceConfig).  Running as a standard shaded jar also still works.
Note that I don't know a good way to write a test for this, as the failure is dependent on aws lambda's underlying jvm implementation.  
