### PR TITLE
Adds a request logging uri filter 

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -38,6 +38,7 @@ v2.0.0: Unreleased
 * Add support for proxy-protocol in http connector configuration (`#2709 <https://github.com/dropwizard/dropwizard/pull/2709>`_)
 * Disable using ``X-Forwarded-*`` headers by default (`#2748 <https://github.com/dropwizard/dropwizard/pull/2748>`_)
 * Fix typo by renaming ``ResilentSocketOutputStream`` to ``ResilientSocketOutputStream`` (`#2766 <https://github.com/dropwizard/dropwizard/pull/2766>`_)
+* Adds an opt-in URI request logging filter factory (`UriFilterFactory`)  (`#2794 <https://github.com/dropwizard/dropwizard/pull/2795>`_)`
 
 .. _rel-1.3.9:
 

--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -1178,6 +1178,24 @@ Reference ``SecretFilterFactory`` type in our configuration.
 
 The last step is to add our class (in this case ``com.example.SecretFilterFactory``) to ``META-INF/services/io.dropwizard.logging.filter.FilterFactory`` in our resources folder.
 
+.. _man-core-request-log-url-filtering:
+
+Filtering Request Logs for a Specific URI
+-----------------------------------------
+
+Reference ``UriFilterFactory`` type in your configuration.
+
+.. code-block:: yaml
+
+    server:
+      requestLog:
+        appenders:
+          - type: console
+            filterFactories:
+              - type: uri
+                uris:
+                  - "/health-check"
+
 .. _man-core-testing-applications:
 
 Testing Applications

--- a/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/filter/UriFilterFactory.java
+++ b/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/filter/UriFilterFactory.java
@@ -1,0 +1,43 @@
+package io.dropwizard.request.logging.filter;
+
+import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.core.spi.FilterReply;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.dropwizard.logging.filter.FilterFactory;
+
+import java.util.Collections;
+import java.util.Set;
+
+import javax.validation.constraints.NotNull;
+
+@JsonTypeName("uri")
+public class UriFilterFactory implements FilterFactory<IAccessEvent> {
+    @NotNull
+    private Set<String> uris = Collections.emptySet();
+
+    @JsonProperty
+    public Set<String> getUris() {
+        return uris;
+    }
+
+    @JsonProperty
+    public void setUris(final Set<String> uris) {
+        this.uris = uris;
+    }
+
+    @Override
+    public Filter<IAccessEvent> build() {
+        return new Filter<IAccessEvent>() {
+            @Override
+            public FilterReply decide(final IAccessEvent event) {
+                if (uris.contains(event.getRequestURI())) {
+                    return FilterReply.DENY;
+                }
+
+                return FilterReply.NEUTRAL;
+            }
+        };
+    }
+}

--- a/dropwizard-request-logging/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
+++ b/dropwizard-request-logging/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
@@ -1,1 +1,2 @@
+io.dropwizard.logging.filter.FilterFactory
 io.dropwizard.request.logging.RequestLogFactory

--- a/dropwizard-request-logging/src/main/resources/META-INF/services/io.dropwizard.logging.filter.FilterFactory
+++ b/dropwizard-request-logging/src/main/resources/META-INF/services/io.dropwizard.logging.filter.FilterFactory
@@ -1,0 +1,1 @@
+io.dropwizard.request.logging.filter.UriFilterFactory

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/filter/UriFilterFactoryTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/filter/UriFilterFactoryTest.java
@@ -1,0 +1,73 @@
+package io.dropwizard.request.logging.filter;
+
+import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.core.spi.FilterReply;
+import io.dropwizard.jackson.DiscoverableSubtypeResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+public class UriFilterFactoryTest {
+    private final IAccessEvent accessEvent = mock(IAccessEvent.class);
+    private final UriFilterFactory filterFactory = new UriFilterFactory();
+
+    @BeforeEach
+    void setUp() {
+        reset(accessEvent);
+    }
+
+    @Test
+    public void shouldDenyLogsForConfiguredUri() {
+        final String path = "/health-check";
+        filterFactory.setUris(Collections.singleton(path));
+        final Filter filter = filterFactory.build();
+
+        when(accessEvent.getRequestURI()).thenReturn(path);
+
+        final FilterReply reply = filter.decide(accessEvent);
+
+        assertThat(reply).isEqualTo(FilterReply.DENY);
+    }
+
+    @Test
+    public void shouldNotDenyUnconfiguredUriLogs() {
+        filterFactory.setUris(Collections.emptySet());
+        final Filter filter = filterFactory.build();
+
+        when(accessEvent.getRequestURI()).thenReturn("/foo");
+
+        final FilterReply reply = filter.decide(accessEvent);
+
+        assertThat(reply).isEqualTo(FilterReply.NEUTRAL);
+    }
+
+    @Test
+    public void shouldDenyLogsForAdditionalConfiguredUris() {
+        final Set<String> paths = new HashSet<>();
+        paths.add("/health-check");
+        paths.add("/sys/health");
+        filterFactory.setUris(paths);
+
+        final Filter filter = filterFactory.build();
+
+        when(accessEvent.getRequestURI()).thenReturn("/sys/health");
+
+        final FilterReply reply = filter.decide(accessEvent);
+
+        assertThat(reply).isEqualTo(FilterReply.DENY);
+    }
+
+    @Test
+    public void isDiscoverable() {
+        assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes()).contains(UriFilterFactory.class);
+    }
+}


### PR DESCRIPTION
###### Problem:
#2794 
 
###### Solution:
Adds a `UriFilterFactory` class to the `dropwizard-request-logging` module, so that users of Dropwizard can add this in without pulling in any other dependencies if they find it useful.

###### Result:
If this factory is used and configured, any specified paths (only fully qualified paths, regexes don't work in this implementation) will be filtered out of request logs. 

If a user wanted to filter out their request logs for the `/health-check` path (if they were using https://github.com/dropwizard/dropwizard-health :) ), their request logs would only contain logs for requests to paths that are not equal to `/health-check`.