### PR TITLE
Use SynchronousQueue as the default queue

### DIFF
--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilder.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilder.java
@@ -10,8 +10,8 @@ import java.util.Locale;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicLong;
@@ -39,7 +39,7 @@ public class ExecutorServiceBuilder {
         this.allowCoreThreadTimeOut = false;
         this.keepAliveTime = Duration.seconds(60);
         this.shutdownTime = Duration.seconds(5);
-        this.workQueue = new LinkedBlockingQueue<>();
+        this.workQueue = new SynchronousQueue<>();
         this.threadFactory = factory;
         this.handler = new ThreadPoolExecutor.AbortPolicy();
     }

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
@@ -105,8 +105,8 @@ public class ExecutorServiceBuilderTest {
             .maxThreads(Integer.MAX_VALUE)
             .build();
 
-            verify(log, never()).warn(anyString());
-            assertCanExecuteAtLeast2ConcurrentTasks(exe);
+        verify(log, never()).warn(anyString());
+        assertCanExecuteAtLeast2ConcurrentTasks(exe);
     }
 
     @Test

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
@@ -99,22 +99,14 @@ public class ExecutorServiceBuilderTest {
         verify(log, never()).warn(anyString());
     }
 
-    /**
-     * Setting large max threads without large min threads is misleading on the default queue implementation
-     * It should warn or work
-     */
     @Test
-    public void shouldBeAbleToExecute2TasksAtOnceWithLargeMaxThreadsOrBeWarnedOtherwise() {
+    public void shouldBeAbleToExecute2TasksAtOnceWithLargeMaxThreadsAndDefaultMinThreads() {
         ExecutorService exe = executorServiceBuilder
             .maxThreads(Integer.MAX_VALUE)
             .build();
 
-        try {
-            verify(log).warn(anyString());
-        } catch (WantedButNotInvoked error) {
-            // no warning has been given so we should be able to execute at least 2 things at once
+            verify(log, never()).warn(anyString());
             assertCanExecuteAtLeast2ConcurrentTasks(exe);
-        }
     }
 
     @Test

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
@@ -42,6 +42,7 @@ public class ExecutorServiceBuilderTest {
         executorServiceBuilder
             .minThreads(4)
             .maxThreads(8)
+            .workQueue(new LinkedBlockingQueue<>())
             .build();
 
         verify(log).warn(WARNING);


### PR DESCRIPTION
###### Problem:
I'm attempting to address the issue where Environment.lifecycle().executorService(...) might create single-threaded pools - https://github.com/dropwizard/dropwizard/issues/2553 . Since the default queue is unbounded we will end up with single-threaded pools

###### Solution:
I've changed the default queue to ```SynchronousQueue```. I gave this some thought and felt it might be appropriate to use ```SynchronousQueue``` as the default queue, as it just does a direct handoff. Libraries like [Hystrix](https://github.com/Netflix/Hystrix) use ```SynchronousQueue``` as the default queue if [maxQueueSize](https://github.com/Netflix/Hystrix/wiki/Configuration#maxQueueSize) isn't specified. ```SynchronousQueue``` is used in ```Executors.newCachedThreadPool()``` as well.

###### Result:
```ExecutorService``` will use between the specified ```minThreads``` and ```maxThreads``` by default. With this change, the warn message "Parameter 'maximumPoolSize' is conflicting with unbounded work queues" will show up only if an unbounded queue is provided explicitly