### PR TITLE
CachingAuthenticator documentation fix

### DIFF
--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/CachingAuthenticator.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/CachingAuthenticator.java
@@ -19,8 +19,8 @@ import java.util.stream.Collectors;
 import static com.codahale.metrics.MetricRegistry.name;
 
 /**
- * An {@link Authenticator} decorator which uses a Guava cache to temporarily cache credentials and
- * their corresponding principals.
+ * An {@link Authenticator} decorator which uses a Caffeine cache to temporarily
+ * cache credentials and their corresponding principals.
  *
  * @param <C> the type of credentials the authenticator can authenticate
  * @param <P> the type of principals the authenticator returns


### PR DESCRIPTION
Updated documentation of CachingAuthenticator to properly reflect the change from Guava to Caffeine

###### Problem:
While reviewing usages of Guava I noticed that the Javadoc for `CachingAuthenticator` was out of date.

###### Solution:
I fixed the documentation.
