### PR TITLE
Allow to setNormalizeUri on HTTP client

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
@@ -333,6 +333,7 @@ public class HttpClientBuilder {
         final Integer timeout = (int) configuration.getTimeout().toMilliseconds();
         final Integer connectionTimeout = (int) configuration.getConnectionTimeout().toMilliseconds();
         final Integer connectionRequestTimeout = (int) configuration.getConnectionRequestTimeout().toMilliseconds();
+        final boolean normalizeUri = configuration.isNormalizeUriEnabled();
         final long keepAlive = configuration.getKeepAlive().toMilliseconds();
         final ConnectionReuseStrategy reuseStrategy = keepAlive == 0
                 ? new NoConnectionReuseStrategy()
@@ -347,6 +348,7 @@ public class HttpClientBuilder {
                 .setSocketTimeout(timeout)
                 .setConnectTimeout(connectionTimeout)
                 .setConnectionRequestTimeout(connectionRequestTimeout)
+                .setNormalizeUri(normalizeUri)
                 .build();
         final SocketConfig socketConfig = SocketConfig.custom()
                 .setTcpNoDelay(true)

--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientConfiguration.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientConfiguration.java
@@ -32,6 +32,8 @@ public class HttpClientConfiguration {
 
     private boolean cookiesEnabled = false;
 
+    private boolean normalizeUriEnabled = true;
+
     @Min(1)
     @Max(Integer.MAX_VALUE)
     private int maxConnections = 1024;
@@ -128,6 +130,16 @@ public class HttpClientConfiguration {
     @JsonProperty
     public void setCookiesEnabled(boolean enabled) {
         this.cookiesEnabled = enabled;
+    }
+
+    @JsonProperty
+    public boolean isNormalizeUriEnabled() {
+        return normalizeUriEnabled;
+    }
+
+    @JsonProperty
+    public void setNormalizeUriEnabled(final boolean normalizeUriEnabled) {
+        this.normalizeUriEnabled = normalizeUriEnabled;
     }
 
     @JsonProperty

--- a/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
@@ -340,6 +340,23 @@ public class HttpClientBuilderTest {
     }
 
     @Test
+    public void normalizeUriByDefault() throws Exception {
+        assertThat(builder.using(configuration).createClient(apacheBuilder, connectionManager, "test")).isNotNull();
+
+        assertThat(((RequestConfig) spyHttpClientBuilderField("defaultRequestConfig", apacheBuilder)).isNormalizeUri())
+            .isEqualTo(true);
+    }
+
+    @Test
+    public void disableNormalizeUriWhenDisabled() throws Exception {
+        configuration.setNormalizeUriEnabled(false);
+        assertThat(builder.using(configuration).createClient(apacheBuilder, connectionManager, "test")).isNotNull();
+
+        assertThat(((RequestConfig) spyHttpClientBuilderField("defaultRequestConfig", apacheBuilder)).isNormalizeUri())
+            .isEqualTo(false);
+    }
+
+    @Test
     public void setsTheSocketTimeout() throws Exception {
         configuration.setTimeout(Duration.milliseconds(500));
         assertThat(builder.using(configuration).createClient(apacheBuilder, connectionManager, "test")).isNotNull();


### PR DESCRIPTION
###### Problem:

Recent versions (>=4.5.8) of HTTPClient introduced a normalizeUri
settings that prevent URL rewrites introduce in earlier versions.

Being able to disable said settings is sometimes useful when dealing
with legacy systems.

See: https://issues.apache.org/jira/browse/HTTPCLIENT-1968

###### Solution:

This allow to enable or disable `normalizeUri` settings, the default is still true, therefore the existing behaviour is unchanged.

