### PR TITLE
Add support for configuring Jetty cookie compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ nb-configuration.xml
 atlassian-ide-plugin.xml
 
 logs
+
+.DS_Store

--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -39,6 +39,7 @@ v2.0.0: Unreleased
 * Disable using ``X-Forwarded-*`` headers by default (`#2748 <https://github.com/dropwizard/dropwizard/pull/2748>`_)
 * Fix typo by renaming ``ResilentSocketOutputStream`` to ``ResilientSocketOutputStream`` (`#2766 <https://github.com/dropwizard/dropwizard/pull/2766>`_)
 * Adds an opt-in URI request logging filter factory (`UriFilterFactory`)  (`#2794 <https://github.com/dropwizard/dropwizard/pull/2795>`_)`
+* Add support for configuring Jetty's cookie compliance (`#2812 <https://github.com/dropwizard/dropwizard/pull/2812>`_)
 
 .. _rel-1.3.9:
 

--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -368,6 +368,26 @@ httpCompliance           RFC7230             This sets the http compliance level
 
                                              * RFC7230: Disallow header folding.
                                              * RFC2616: Allow header folding.
+requestCookieCompliance  RFC6265             This sets the cookie compliance level used by Jetty when parsing request ``Cookie``
+                                             headers, this can be useful when needing to support Version=1 cookies defined in
+                                             RFC2109 (and continued in RFC2965) which allows for special/reserved characters
+                                             (control, separator, et al) to be enclosed within double quotes when used in a
+                                             cookie value;
+                                             Possible values are set forth in the ``org.eclipse.jetty.http.CookieCompliance``
+                                             enum:
+
+                                             * RFC6265: Special characters in cookie values must be encoded.
+                                             * RFC2965: Allows for special characters enclosed within double quotes.
+responseCookieCompliance RFC6265             This sets the cookie compliance level used by Jetty when generating response
+                                             ``Set-Cookie`` headers, this can be useful when needing to support Version=1 cookies
+                                             defined in RFC2109 (and continued in RFC2965) which allows for special/reserved
+                                             characters (control, separator, et al) to be enclosed within double quotes when used
+                                             in a cookie value;
+                                             Possible values are set forth in the ``org.eclipse.jetty.http.CookieCompliance``
+                                             enum:
+
+                                             * RFC6265: Special characters in cookie values must be encoded.
+                                             * RFC2965: Allows for special characters enclosed within double quotes.
 ======================== ==================  ======================================================================================
 
 .. _`java.net.Socket#setSoTimeout(int)`: https://docs.oracle.com/javase/8/docs/api/java/net/Socket.html#setSoTimeout-int-

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
@@ -9,6 +9,7 @@ import io.dropwizard.util.Duration;
 import io.dropwizard.validation.MinDataSize;
 import io.dropwizard.validation.MinDuration;
 import io.dropwizard.validation.PortRange;
+import org.eclipse.jetty.http.CookieCompliance;
 import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.io.ArrayByteBufferPool;
 import org.eclipse.jetty.io.ByteBufferPool;
@@ -212,6 +213,38 @@ import static com.codahale.metrics.MetricRegistry.name;
  *             </ul>
  *         </td>
  *     </tr>
+ *     <tr>
+ *         <td>{@code requestCookieCompliance}</td>
+ *         <td>RFC6265</td>
+ *         <td>
+ *             This sets the cookie compliance level used by Jetty when parsing request {@code Cookie} headers,
+ *             this can be useful when needing to support Version=1 cookies defined in RFC2109 (and continued in
+ *             RFC2965) which allows for special/reserved characters (control, separator, et al) to be enclosed within
+ *             double quotes when used in a cookie value;
+ *
+ *             Possible values are set forth in the org.eclipse.jetty.http.CookieCompliance enum:
+ *             <ul>
+ *                 <li>RFC6265: Special characters in cookie values must be encoded.</li>
+ *                 <li>RFC2965: Allows for special characters enclosed within double quotes.</li>
+ *             </ul>
+ *         </td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code responseCookieCompliance}</td>
+ *         <td>RFC6265</td>
+ *         <td>
+ *             This sets the cookie compliance level used by Jetty when generating response {@code Set-Cookie} headers,
+ *             this can be useful when needing to support Version=1 cookies defined in RFC2109 (and continued in
+ *             RFC2965) which allows for special/reserved characters (control, separator, et al) to be enclosed within
+ *             double quotes when used in a cookie value;
+ *
+ *             Possible values are set forth in the org.eclipse.jetty.http.CookieCompliance enum:
+ *             <ul>
+ *                 <li>RFC6265: Special characters in cookie values must be encoded.</li>
+ *                 <li>RFC2965: Allows for special characters enclosed within double quotes.</li>
+ *             </ul>
+ *         </td>
+ *     </tr>
  * </table>
  */
 @JsonTypeName("http")
@@ -297,6 +330,8 @@ public class HttpConnectorFactory implements ConnectorFactory {
     private boolean useForwardedHeaders = false;
     private boolean useProxyProtocol = false;
     private HttpCompliance httpCompliance = HttpCompliance.RFC7230;
+    private CookieCompliance requestCookieCompliance = CookieCompliance.RFC6265;
+    private CookieCompliance responseCookieCompliance = CookieCompliance.RFC6265;
 
     @JsonProperty
     public int getPort() {
@@ -530,6 +565,26 @@ public class HttpConnectorFactory implements ConnectorFactory {
         this.httpCompliance = httpCompliance;
     }
 
+    @JsonProperty
+    public CookieCompliance getRequestCookieCompliance() {
+        return requestCookieCompliance;
+    }
+
+    @JsonProperty
+    public void setRequestCookieCompliance(CookieCompliance requestCookieCompliance) {
+        this.requestCookieCompliance = requestCookieCompliance;
+    }
+
+    @JsonProperty
+    public CookieCompliance getResponseCookieCompliance() {
+        return responseCookieCompliance;
+    }
+
+    @JsonProperty
+    public void setResponseCookieCompliance(CookieCompliance responseCookieCompliance) {
+        this.responseCookieCompliance = responseCookieCompliance;
+    }
+
 
     @Override
     public Connector build(Server server,
@@ -610,6 +665,8 @@ public class HttpConnectorFactory implements ConnectorFactory {
         httpConfig.setSendServerVersion(useServerHeader);
         httpConfig.setMinResponseDataRate(minResponseDataPerSecond.toBytes());
         httpConfig.setMinRequestDataRate(minRequestDataPerSecond.toBytes());
+        httpConfig.setRequestCookieCompliance(requestCookieCompliance);
+        httpConfig.setResponseCookieCompliance(responseCookieCompliance);
 
         if (useForwardedHeaders) {
             httpConfig.addCustomizer(new ForwardedRequestCustomizer());

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
@@ -12,6 +12,7 @@ import io.dropwizard.util.DataSize;
 import io.dropwizard.util.Duration;
 import io.dropwizard.util.Resources;
 import io.dropwizard.validation.BaseValidator;
+import org.eclipse.jetty.http.CookieCompliance;
 import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.io.ArrayByteBufferPool;
 import org.eclipse.jetty.io.ByteBufferPool;
@@ -79,6 +80,8 @@ class HttpConnectorFactoryTest {
         assertThat(http.isUseDateHeader()).isTrue();
         assertThat(http.isUseForwardedHeaders()).isFalse();
         assertThat(http.getHttpCompliance()).isEqualTo(HttpCompliance.RFC7230);
+        assertThat(http.getRequestCookieCompliance()).isEqualTo(CookieCompliance.RFC6265);
+        assertThat(http.getResponseCookieCompliance()).isEqualTo(CookieCompliance.RFC6265);
     }
 
     @Test
@@ -111,6 +114,8 @@ class HttpConnectorFactoryTest {
         HttpConfiguration httpConfiguration = http.buildHttpConfiguration();
         assertThat(httpConfiguration.getCustomizers()).hasAtLeastOneElementOfType(ForwardedRequestCustomizer.class);
         assertThat(http.getHttpCompliance()).isEqualTo(HttpCompliance.RFC2616);
+        assertThat(http.getRequestCookieCompliance()).isEqualTo(CookieCompliance.RFC2965);
+        assertThat(http.getResponseCookieCompliance()).isEqualTo(CookieCompliance.RFC6265);
     }
 
     @Test
@@ -122,6 +127,8 @@ class HttpConnectorFactoryTest {
         http.setAcceptQueueSize(1024);
         http.setMinResponseDataPerSecond(DataSize.bytes(200));
         http.setMinRequestDataPerSecond(DataSize.bytes(42));
+        http.setRequestCookieCompliance(CookieCompliance.RFC6265);
+        http.setResponseCookieCompliance(CookieCompliance.RFC6265);
 
         Server server = new Server();
         MetricRegistry metrics = new MetricRegistry();
@@ -170,6 +177,8 @@ class HttpConnectorFactoryTest {
         assertThat(httpConfiguration.getCustomizers()).noneMatch(customizer -> customizer.getClass().equals(ForwardedRequestCustomizer.class));
         assertThat(httpConfiguration.getMinRequestDataRate()).isEqualTo(42);
         assertThat(httpConfiguration.getMinResponseDataRate()).isEqualTo(200);
+        assertThat(httpConfiguration.getRequestCookieCompliance()).isEqualTo(CookieCompliance.RFC6265);
+        assertThat(httpConfiguration.getResponseCookieCompliance()).isEqualTo(CookieCompliance.RFC6265);
 
         connector.stop();
         server.stop();

--- a/dropwizard-jetty/src/test/resources/yaml/http-connector.yml
+++ b/dropwizard-jetty/src/test/resources/yaml/http-connector.yml
@@ -21,3 +21,5 @@ useServerHeader: true
 useDateHeader: false
 useForwardedHeaders: true
 httpCompliance: RFC2616
+requestCookieCompliance: RFC2965
+responseCookieCompliance: RFC6265


### PR DESCRIPTION
###### Problem:
Starting in version 9.4.3, Jetty's default cookie compliance behavior changed to adhere to the more strict RFC6265 standard which no longer allows for special characters to be included in a cookie value if it is enclosed within double quotes (which was allowed under RFC2109 and RFC2965). In some legacy use cases, the old cookie behavior is needed for the application to behave correctly. 

More Context: https://webtide.com/jetty-cookies-and-rfc6265-compliance/

###### Solution:
Jetty allows for the old cookie compliance behavior to be configured for requests or responses via the `HttpConfiguration` object. Dropwizard's `HttpConnectorFactory` can be updated to allow for configuring the legacy cookie compliance behavior.

###### Result:
Dropwizard allows for configuring the request and response cookie compliance behavior for Jetty via the `requestCookieCompliance` and `responseCookieCompliance` fields of the `HttpConnectorFactory`.