### PR TITLE
Allow simple logger level config to support "OFF"

### DIFF
--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/DefaultLoggingFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/DefaultLoggingFactory.java
@@ -291,9 +291,9 @@ public class DefaultLoggingFactory implements LoggingFactory {
         for (Map.Entry<String, JsonNode> entry : loggers.entrySet()) {
             final Logger logger = loggerContext.getLogger(entry.getKey());
             final JsonNode jsonNode = entry.getValue();
-            if (jsonNode.isTextual()) {
+            if (jsonNode.isTextual() || jsonNode.isBoolean()) {
                 // Just a level as a string
-                logger.setLevel(Level.valueOf(jsonNode.asText()));
+                logger.setLevel(toLevel(jsonNode.asText()));
             } else if (jsonNode.isObject()) {
                 // A level and an appender
                 final LoggerConfiguration configuration;
@@ -317,7 +317,6 @@ public class DefaultLoggingFactory implements LoggingFactory {
     }
 
     static Level toLevel(@Nullable String text) {
-        // required because YAML maps "off" to a boolean false
         if ("false".equalsIgnoreCase(text)) {
             // required because YAML maps "off" to a boolean false
             return Level.OFF;

--- a/dropwizard-logging/src/test/resources/yaml/logging_level_off.yml
+++ b/dropwizard-logging/src/test/resources/yaml/logging_level_off.yml
@@ -1,0 +1,11 @@
+level: OFF
+loggers:
+  "com.example.app": OFF
+  "com.example.newApp":
+    level: OFF
+    appenders:
+      - type: console
+  "com.example.legacyApp":
+    level: OFF
+appenders:
+  - type: console


### PR DESCRIPTION
Fixes #2818

###### Problem:
`DefaultLoggingFactory` doesn't allow for `OFF` to be configured as a logger level in the simple config case. Example: 
```
logging:
  loggers:
    "com.example.my.logger": OFF
```
results in "Unsupported format of logger".

###### Solution:
Updated the if check to accept boolean values since `OFF` is translated to `false` in YAML and use existing `toLevel` method that properly handles boolean as `Level.OFF`.

###### Result:
`OFF` will be allowed as a logger level in the simple case without requiring it to be quoted.
