### PR TITLE
Upgrade jackson-databind to 2.9.9.1 (1.3 releases)

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -22,6 +23,7 @@
         <guava.version>24.1.1-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
         <jackson.version>2.9.9</jackson.version>
+        <jackson-databind.version>2.9.9.1</jackson-databind.version>
         <jetty.version>9.4.18.v20190429</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.0.5</metrics4.version>
@@ -340,6 +342,11 @@
                 <version>${jackson.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson-databind.version}</version>
             </dependency>
 
             <!-- Jersey -->


### PR DESCRIPTION
Due to a vulnerability in jackson-databind 2.9.9 it is being upgraded to 2.9.9.1

Closes #2783 
