### PR TITLE
Upgrade jackson-databind to 2.9.9.1

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -22,6 +22,7 @@
         <guava.version>28.0-jre</guava.version>
         <jersey.version>2.29</jersey.version>
         <jackson.version>2.9.9</jackson.version>
+        <jackson-databind.version>2.9.9.1</jackson-databind.version>
         <jetty.version>9.4.19.v20190610</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.1.0</metrics4.version>
@@ -41,7 +42,12 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson-databind.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.objenesis</groupId>
                 <artifactId>objenesis</artifactId>


### PR DESCRIPTION
Due to a vulnerability in jackson-databind 2.9.9.1 it is being upgraded to 2.9.9.1

Closes #2783
