### PR TITLE
Pass request UriInfo to Authorizer.authorize

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -40,6 +40,7 @@ v2.0.0: Unreleased
 * Fix typo by renaming ``ResilentSocketOutputStream`` to ``ResilientSocketOutputStream`` (`#2766 <https://github.com/dropwizard/dropwizard/pull/2766>`_)
 * Adds an opt-in URI request logging filter factory (`UriFilterFactory`)  (`#2794 <https://github.com/dropwizard/dropwizard/pull/2795>`_)`
 * Add support for configuring Jetty's cookie compliance (`#2812 <https://github.com/dropwizard/dropwizard/pull/2812>`_)
+* Deprecate ``Authorizer.authorize(principal, role)`` in favor of ``Authorizer.authorize(principal, role, context)`` (`#2837 <https://github.com/dropwizard/dropwizard/pull/2837>`_)
 
 .. _rel-1.3.9:
 

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthFilter.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthFilter.java
@@ -152,7 +152,7 @@ public abstract class AuthFilter<C, P extends Principal> implements ContainerReq
 
                 @Override
                 public boolean isUserInRole(String role) {
-                    return authorizer.authorize(prince, role, requestContext.getUriInfo());
+                    return authorizer.authorize(prince, role, requestContext);
                 }
 
                 @Override

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthFilter.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthFilter.java
@@ -152,7 +152,7 @@ public abstract class AuthFilter<C, P extends Principal> implements ContainerReq
 
                 @Override
                 public boolean isUserInRole(String role) {
-                    return authorizer.authorize(prince, role);
+                    return authorizer.authorize(prince, role, requestContext.getUriInfo());
                 }
 
                 @Override

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/Authorizer.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/Authorizer.java
@@ -1,7 +1,7 @@
 package io.dropwizard.auth;
 
 import javax.annotation.Nullable;
-import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.container.ContainerRequestContext;
 import java.security.Principal;
 
 /**
@@ -24,10 +24,10 @@ public interface Authorizer<P extends Principal> {
      *
      * @param principal a {@link Principal} object, representing a user
      * @param role a user role
-     * @param uriInfo a request URI information
+     * @param requestContext a request context.
      * @return {@code true}, if the access is granted, {@code false otherwise}
      */
-    default boolean authorize(P principal, String role, @Nullable UriInfo uriInfo) {
+    default boolean authorize(P principal, String role, @Nullable ContainerRequestContext requestContext) {
         return authorize(principal, role);
     }
 }

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/Authorizer.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/Authorizer.java
@@ -1,5 +1,6 @@
 package io.dropwizard.auth;
 
+import javax.ws.rs.core.UriInfo;
 import java.security.Principal;
 
 /**
@@ -8,7 +9,6 @@ import java.security.Principal;
  * @param <P> the type of principals
  */
 public interface Authorizer<P extends Principal> {
-
     /**
      * Decides if access is granted for the given principal in the given role.
      *
@@ -17,4 +17,16 @@ public interface Authorizer<P extends Principal> {
      * @return {@code true}, if the access is granted, {@code false otherwise}
      */
     boolean authorize(P principal, String role);
+
+    /**
+     * Decides if access is granted for the given principal in the given role.
+     *
+     * @param principal a {@link Principal} object, representing a user
+     * @param role a user role
+     * @param uriInfo a request URI information
+     * @return {@code true}, if the access is granted, {@code false otherwise}
+     */
+    default boolean authorize(P principal, String role, UriInfo uriInfo) {
+        return authorize(principal, role);
+    }
 }

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/Authorizer.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/Authorizer.java
@@ -1,5 +1,6 @@
 package io.dropwizard.auth;
 
+import javax.annotation.Nullable;
 import javax.ws.rs.core.UriInfo;
 import java.security.Principal;
 
@@ -26,7 +27,7 @@ public interface Authorizer<P extends Principal> {
      * @param uriInfo a request URI information
      * @return {@code true}, if the access is granted, {@code false otherwise}
      */
-    default boolean authorize(P principal, String role, UriInfo uriInfo) {
+    default boolean authorize(P principal, String role, @Nullable UriInfo uriInfo) {
         return authorize(principal, role);
     }
 }

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/Authorizer.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/Authorizer.java
@@ -17,6 +17,7 @@ public interface Authorizer<P extends Principal> {
      * @param role a user role
      * @return {@code true}, if the access is granted, {@code false otherwise}
      */
+    @Deprecated
     boolean authorize(P principal, String role);
 
     /**
@@ -27,6 +28,7 @@ public interface Authorizer<P extends Principal> {
      * @param requestContext a request context.
      * @return {@code true}, if the access is granted, {@code false otherwise}
      */
+    @SuppressWarnings("deprecation")
     default boolean authorize(P principal, String role, @Nullable ContainerRequestContext requestContext) {
         return authorize(principal, role);
     }

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/CachingAuthorizer.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/CachingAuthorizer.java
@@ -9,17 +9,56 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.util.Sets;
-import org.apache.commons.lang3.tuple.ImmutableTriple;
 
 import javax.annotation.Nullable;
 import javax.ws.rs.core.UriInfo;
 import java.security.Principal;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static com.codahale.metrics.MetricRegistry.name;
+
+class AuthorizationContext<P extends Principal> {
+    private final P principal;
+    private final String role;
+    private final @Nullable UriInfo uriInfo;
+
+    AuthorizationContext(P principal, String role, @Nullable UriInfo uriInfo) {
+        this.principal = principal;
+        this.role = role;
+        this.uriInfo = uriInfo;
+    }
+
+    P getPrincipal() {
+        return principal;
+    }
+
+    String getRole() {
+        return role;
+    }
+
+    @Nullable UriInfo getUriInfo() {
+        return uriInfo;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AuthorizationContext<?> that = (AuthorizationContext<?>) o;
+        return Objects.equals(principal, that.principal) &&
+            Objects.equals(role, that.role) &&
+            Objects.equals(uriInfo, that.uriInfo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(principal, role, uriInfo);
+    }
+}
 
 /**
  * An {@link Authorizer} decorator which uses a {@link Caffeine} cache to
@@ -35,7 +74,7 @@ public class CachingAuthorizer<P extends Principal> implements Authorizer<P> {
     private final Meter cacheMisses;
     private final Timer getsTimer;
 
-    // A cache which maps (principal, role) tuples to boolean
+    // A cache which maps (principal, role, uriInfo) to boolean
     // authorization states.
     //
     // A cached value of `true` indicates that the key's principal is
@@ -47,7 +86,7 @@ public class CachingAuthorizer<P extends Principal> implements Authorizer<P> {
     //
     // Field is package-private to be visible for unit tests
     @VisibleForTesting
-    final LoadingCache<ImmutableTriple<P, String, UriInfo>, Boolean> cache;
+    final LoadingCache<AuthorizationContext<P>, Boolean> cache;
 
     /**
      * Creates a new cached authorizer.
@@ -79,7 +118,7 @@ public class CachingAuthorizer<P extends Principal> implements Authorizer<P> {
         this.getsTimer = metricRegistry.timer(name(authorizer.getClass(), "gets"));
         this.cache = builder.recordStats().build(key -> {
             cacheMisses.mark();
-            return underlying.authorize(key.left, key.middle, key.right);
+            return underlying.authorize(key.getPrincipal(), key.getRole(), key.getUriInfo());
         });
     }
 
@@ -91,7 +130,7 @@ public class CachingAuthorizer<P extends Principal> implements Authorizer<P> {
     @Override
     public boolean authorize(P principal, String role, @Nullable UriInfo uriInfo) {
         try (Timer.Context context = getsTimer.time()) {
-            final ImmutableTriple<P, String, UriInfo> cacheKey = ImmutableTriple.of(principal, role, uriInfo);
+            final AuthorizationContext<P> cacheKey = new AuthorizationContext<>(principal, role, uriInfo);
             final Boolean result = cache.get(cacheKey);
             return result == null ? false : result;
         } catch (CompletionException e) {
@@ -114,7 +153,7 @@ public class CachingAuthorizer<P extends Principal> implements Authorizer<P> {
      * @param uriInfo
      */
     public void invalidate(P principal, String role, UriInfo uriInfo) {
-        cache.invalidate(ImmutableTriple.of(principal, role, uriInfo));
+        cache.invalidate(new AuthorizationContext<>(principal, role, uriInfo));
     }
 
     /**
@@ -123,8 +162,8 @@ public class CachingAuthorizer<P extends Principal> implements Authorizer<P> {
      * @param principal
      */
     public void invalidate(P principal) {
-        final Set<ImmutableTriple<P, String, UriInfo>> keys = cache.asMap().keySet().stream()
-                .filter(cacheKey -> cacheKey.getLeft().equals(principal))
+        final Set<AuthorizationContext<P>> keys = cache.asMap().keySet().stream()
+                .filter(cacheKey -> cacheKey.getPrincipal().equals(principal))
                 .collect(Collectors.toSet());
         cache.invalidateAll(keys);
     }
@@ -137,8 +176,8 @@ public class CachingAuthorizer<P extends Principal> implements Authorizer<P> {
      */
     public void invalidateAll(Iterable<P> principals) {
         final Set<P> principalSet = Sets.of(principals);
-        final Set<ImmutableTriple<P, String, UriInfo>> keys = cache.asMap().keySet().stream()
-                .filter(cacheKey -> principalSet.contains(cacheKey.getLeft()))
+        final Set<AuthorizationContext<P>> keys = cache.asMap().keySet().stream()
+                .filter(cacheKey -> principalSet.contains(cacheKey.getPrincipal()))
                 .collect(Collectors.toSet());
         cache.invalidateAll(keys);
     }
@@ -150,8 +189,8 @@ public class CachingAuthorizer<P extends Principal> implements Authorizer<P> {
      * @param predicate a predicate to filter credentials
      */
     public void invalidateAll(Predicate<? super P> predicate) {
-        final Set<ImmutableTriple<P, String, UriInfo>> keys = cache.asMap().keySet().stream()
-                .filter(cacheKey -> predicate.test(cacheKey.getLeft()))
+        final Set<AuthorizationContext<P>> keys = cache.asMap().keySet().stream()
+                .filter(cacheKey -> predicate.test(cacheKey.getPrincipal()))
                 .collect(Collectors.toSet());
 
         cache.invalidateAll(keys);

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/CachingAuthorizerTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/CachingAuthorizerTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 
+import javax.ws.rs.core.UriInfo;
 import java.security.Principal;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,90 +32,91 @@ public class CachingAuthorizerTest {
     private final Principal principal = new PrincipalImpl("principal");
     private final Principal principal2 = new PrincipalImpl("principal2");
     private final String role = "popular_kids";
+    private final UriInfo uriInfo = mock(UriInfo.class);
 
     @BeforeEach
     public void setUp() throws Exception {
-        when(underlying.authorize(any(), anyString())).thenReturn(true);
+        when(underlying.authorize(any(), anyString(), any())).thenReturn(true);
     }
 
     @Test
     public void cachesTheFirstReturnedPrincipal() throws Exception {
-        assertThat(cached.authorize(principal, role)).isTrue();
-        assertThat(cached.authorize(principal, role)).isTrue();
+        assertThat(cached.authorize(principal, role, uriInfo)).isTrue();
+        assertThat(cached.authorize(principal, role, uriInfo)).isTrue();
 
-        verify(underlying, times(1)).authorize(principal, role);
+        verify(underlying, times(1)).authorize(principal, role, uriInfo);
     }
 
     @Test
     public void respectsTheCacheConfiguration() throws Exception {
-        cached.authorize(principal, role);
+        cached.authorize(principal, role, uriInfo);
         // We need to make sure that background cache invalidation is done before other requests
         cached.cache.cleanUp();
-        cached.authorize(principal2, role);
+        cached.authorize(principal2, role, uriInfo);
         cached.cache.cleanUp();
-        cached.authorize(principal, role);
+        cached.authorize(principal, role, uriInfo);
 
         final InOrder inOrder = inOrder(underlying);
-        inOrder.verify(underlying, times(1)).authorize(principal, role);
-        inOrder.verify(underlying, times(1)).authorize(principal2, role);
-        inOrder.verify(underlying, times(1)).authorize(principal, role);
+        inOrder.verify(underlying, times(1)).authorize(principal, role, uriInfo);
+        inOrder.verify(underlying, times(1)).authorize(principal2, role, uriInfo);
+        inOrder.verify(underlying, times(1)).authorize(principal, role, uriInfo);
     }
 
     @Test
     public void invalidatesPrincipalAndRole() throws Exception {
-        cached.authorize(principal, role);
-        cached.invalidate(principal, role);
-        cached.authorize(principal, role);
+        cached.authorize(principal, role, uriInfo);
+        cached.invalidate(principal, role, uriInfo);
+        cached.authorize(principal, role, uriInfo);
 
-        verify(underlying, times(2)).authorize(principal, role);
+        verify(underlying, times(2)).authorize(principal, role, uriInfo);
     }
 
     @Test
     public void invalidatesSinglePrincipal() throws Exception {
-        cached.authorize(principal, role);
+        cached.authorize(principal, role, uriInfo);
         cached.invalidate(principal);
-        cached.authorize(principal, role);
+        cached.authorize(principal, role, uriInfo);
 
-        verify(underlying, times(2)).authorize(principal, role);
+        verify(underlying, times(2)).authorize(principal, role, uriInfo);
     }
 
     @Test
     public void invalidatesSetsofPrincipals() throws Exception {
-        cached.authorize(principal, role);
-        cached.authorize(principal2, role);
+        cached.authorize(principal, role, uriInfo);
+        cached.authorize(principal2, role, uriInfo);
         cached.invalidateAll(Sets.of(principal, principal2));
-        cached.authorize(principal, role);
-        cached.authorize(principal2, role);
+        cached.authorize(principal, role, uriInfo);
+        cached.authorize(principal2, role, uriInfo);
 
-        verify(underlying, times(2)).authorize(principal, role);
-        verify(underlying, times(2)).authorize(principal2, role);
+        verify(underlying, times(2)).authorize(principal, role, uriInfo);
+        verify(underlying, times(2)).authorize(principal2, role, uriInfo);
     }
 
     @Test
     public void invalidatesPrincipalsMatchingGivenPredicate() throws Exception {
-        cached.authorize(principal, role);
+        cached.authorize(principal, role, uriInfo);
         cached.invalidateAll(principal::equals);
-        cached.authorize(principal, role);
+        cached.authorize(principal, role, uriInfo);
 
-        verify(underlying, times(2)).authorize(principal, role);
+        verify(underlying, times(2)).authorize(principal, role, uriInfo);
     }
 
     @Test
     public void invalidatesAllPrincipals() throws Exception {
-        cached.authorize(principal, role);
-        cached.authorize(principal2, role);
+        cached.authorize(principal, role, uriInfo);
+        cached.authorize(principal2, role, uriInfo);
         cached.invalidateAll();
-        cached.authorize(principal, role);
-        cached.authorize(principal2, role);
+        cached.authorize(principal, role, uriInfo);
+        cached.authorize(principal2, role, uriInfo);
 
-        verify(underlying, times(2)).authorize(principal, role);
-        verify(underlying, times(2)).authorize(principal2, role);
+        verify(underlying, times(2)).authorize(principal, role, uriInfo);
+        verify(underlying, times(2)).authorize(principal2, role, uriInfo);
     }
 
     @Test
     public void calculatesTheSizeOfTheCache() throws Exception {
         assertThat(cached.size()).isEqualTo(0);
-        cached.authorize(principal, role);
+        cached.authorize(principal, role, uriInfo);
         assertThat(cached.size()).isEqualTo(1);
         cached.invalidateAll();
         assertThat(cached.size()).isEqualTo(0);
@@ -123,7 +125,7 @@ public class CachingAuthorizerTest {
     @Test
     public void calculatesCacheStats() throws Exception {
         assertThat(cached.stats().loadCount()).isEqualTo(0);
-        cached.authorize(principal, role);
+        cached.authorize(principal, role, uriInfo);
         assertThat(cached.stats().loadCount()).isEqualTo(1);
         assertThat(cached.size()).isEqualTo(1);
     }
@@ -131,9 +133,9 @@ public class CachingAuthorizerTest {
     @Test
     public void shouldPropagateRuntimeException() throws AuthenticationException {
         final RuntimeException e = new NullPointerException();
-        when(underlying.authorize(principal, role)).thenThrow(e);
+        when(underlying.authorize(principal, role, uriInfo)).thenThrow(e);
         assertThatNullPointerException()
-            .isThrownBy(() -> cached.authorize(principal, role))
+            .isThrownBy(() -> cached.authorize(principal, role, uriInfo))
             .isSameAs(e);
     }
 }

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/CachingAuthorizerTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/CachingAuthorizerTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 
+import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.UriInfo;
 import java.security.Principal;
 
@@ -32,7 +33,7 @@ public class CachingAuthorizerTest {
     private final Principal principal = new PrincipalImpl("principal");
     private final Principal principal2 = new PrincipalImpl("principal2");
     private final String role = "popular_kids";
-    private final UriInfo uriInfo = mock(UriInfo.class);
+    private final ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -41,82 +42,82 @@ public class CachingAuthorizerTest {
 
     @Test
     public void cachesTheFirstReturnedPrincipal() throws Exception {
-        assertThat(cached.authorize(principal, role, uriInfo)).isTrue();
-        assertThat(cached.authorize(principal, role, uriInfo)).isTrue();
+        assertThat(cached.authorize(principal, role, requestContext)).isTrue();
+        assertThat(cached.authorize(principal, role, requestContext)).isTrue();
 
-        verify(underlying, times(1)).authorize(principal, role, uriInfo);
+        verify(underlying, times(1)).authorize(principal, role, requestContext);
     }
 
     @Test
     public void respectsTheCacheConfiguration() throws Exception {
-        cached.authorize(principal, role, uriInfo);
+        cached.authorize(principal, role, requestContext);
         // We need to make sure that background cache invalidation is done before other requests
         cached.cache.cleanUp();
-        cached.authorize(principal2, role, uriInfo);
+        cached.authorize(principal2, role, requestContext);
         cached.cache.cleanUp();
-        cached.authorize(principal, role, uriInfo);
+        cached.authorize(principal, role, requestContext);
 
         final InOrder inOrder = inOrder(underlying);
-        inOrder.verify(underlying, times(1)).authorize(principal, role, uriInfo);
-        inOrder.verify(underlying, times(1)).authorize(principal2, role, uriInfo);
-        inOrder.verify(underlying, times(1)).authorize(principal, role, uriInfo);
+        inOrder.verify(underlying, times(1)).authorize(principal, role, requestContext);
+        inOrder.verify(underlying, times(1)).authorize(principal2, role, requestContext);
+        inOrder.verify(underlying, times(1)).authorize(principal, role, requestContext);
     }
 
     @Test
     public void invalidatesPrincipalAndRole() throws Exception {
-        cached.authorize(principal, role, uriInfo);
-        cached.invalidate(principal, role, uriInfo);
-        cached.authorize(principal, role, uriInfo);
+        cached.authorize(principal, role, requestContext);
+        cached.invalidate(principal, role, requestContext);
+        cached.authorize(principal, role, requestContext);
 
-        verify(underlying, times(2)).authorize(principal, role, uriInfo);
+        verify(underlying, times(2)).authorize(principal, role, requestContext);
     }
 
     @Test
     public void invalidatesSinglePrincipal() throws Exception {
-        cached.authorize(principal, role, uriInfo);
+        cached.authorize(principal, role, requestContext);
         cached.invalidate(principal);
-        cached.authorize(principal, role, uriInfo);
+        cached.authorize(principal, role, requestContext);
 
-        verify(underlying, times(2)).authorize(principal, role, uriInfo);
+        verify(underlying, times(2)).authorize(principal, role, requestContext);
     }
 
     @Test
     public void invalidatesSetsofPrincipals() throws Exception {
-        cached.authorize(principal, role, uriInfo);
-        cached.authorize(principal2, role, uriInfo);
+        cached.authorize(principal, role, requestContext);
+        cached.authorize(principal2, role, requestContext);
         cached.invalidateAll(Sets.of(principal, principal2));
-        cached.authorize(principal, role, uriInfo);
-        cached.authorize(principal2, role, uriInfo);
+        cached.authorize(principal, role, requestContext);
+        cached.authorize(principal2, role, requestContext);
 
-        verify(underlying, times(2)).authorize(principal, role, uriInfo);
-        verify(underlying, times(2)).authorize(principal2, role, uriInfo);
+        verify(underlying, times(2)).authorize(principal, role, requestContext);
+        verify(underlying, times(2)).authorize(principal2, role, requestContext);
     }
 
     @Test
     public void invalidatesPrincipalsMatchingGivenPredicate() throws Exception {
-        cached.authorize(principal, role, uriInfo);
+        cached.authorize(principal, role, requestContext);
         cached.invalidateAll(principal::equals);
-        cached.authorize(principal, role, uriInfo);
+        cached.authorize(principal, role, requestContext);
 
-        verify(underlying, times(2)).authorize(principal, role, uriInfo);
+        verify(underlying, times(2)).authorize(principal, role, requestContext);
     }
 
     @Test
     public void invalidatesAllPrincipals() throws Exception {
-        cached.authorize(principal, role, uriInfo);
-        cached.authorize(principal2, role, uriInfo);
+        cached.authorize(principal, role, requestContext);
+        cached.authorize(principal2, role, requestContext);
         cached.invalidateAll();
-        cached.authorize(principal, role, uriInfo);
-        cached.authorize(principal2, role, uriInfo);
+        cached.authorize(principal, role, requestContext);
+        cached.authorize(principal2, role, requestContext);
 
-        verify(underlying, times(2)).authorize(principal, role, uriInfo);
-        verify(underlying, times(2)).authorize(principal2, role, uriInfo);
+        verify(underlying, times(2)).authorize(principal, role, requestContext);
+        verify(underlying, times(2)).authorize(principal2, role, requestContext);
     }
 
     @Test
     public void calculatesTheSizeOfTheCache() throws Exception {
         assertThat(cached.size()).isEqualTo(0);
-        cached.authorize(principal, role, uriInfo);
+        cached.authorize(principal, role, requestContext);
         assertThat(cached.size()).isEqualTo(1);
         cached.invalidateAll();
         assertThat(cached.size()).isEqualTo(0);
@@ -125,7 +126,7 @@ public class CachingAuthorizerTest {
     @Test
     public void calculatesCacheStats() throws Exception {
         assertThat(cached.stats().loadCount()).isEqualTo(0);
-        cached.authorize(principal, role, uriInfo);
+        cached.authorize(principal, role, requestContext);
         assertThat(cached.stats().loadCount()).isEqualTo(1);
         assertThat(cached.size()).isEqualTo(1);
     }
@@ -133,9 +134,9 @@ public class CachingAuthorizerTest {
     @Test
     public void shouldPropagateRuntimeException() throws AuthenticationException {
         final RuntimeException e = new NullPointerException();
-        when(underlying.authorize(principal, role, uriInfo)).thenThrow(e);
+        when(underlying.authorize(principal, role, requestContext)).thenThrow(e);
         assertThatNullPointerException()
-            .isThrownBy(() -> cached.authorize(principal, role, uriInfo))
+            .isThrownBy(() -> cached.authorize(principal, role, requestContext))
             .isSameAs(e);
     }
 }


### PR DESCRIPTION
###### Problem:

I was looking for a way to authorize a request based on both the `Principal` and path parameters, without having to rewrite an `AuthFilter` or more.

This comes up if you have a `Principal` that has different permissions or roles depending on the object it's accessing, for example: 

A user can access its `Company`, can create a `Case`, but cannot read somebody else `Case`:
```java
@RolesAllowed({"read", "write"})
@GET
public Case getPlan(@Auth User user, @PathParam("company") String company, @PathParam("case") String case) {
    return dao.findCase(user, company, case);
}

@RolesAllowed({"write"})
@POST
public Case getPlan(@Auth User user, @PathParam("company") String company) {
    return dao.createCase(user, company);
}
```

There is currently no real way to authorize this kind of logic using the existing`Authorizer`, since it only aware of `User`/`Principal`.

I've seen a few mention of this problem on the mailing list and it's also related to issue #2534.

###### Solution:

This pass the `UriInfo` from each request to `Authorizer.authorize`, so that you can access path or query parameters to decide if a request is authorized or not. The new signature default to calling `authorize(User principal, String role)`, so it should be backward compatible.

But otherwise the change would look like this:

```java
public class Authorizer implements Authorizer<User> {
    @Override
    public boolean authorize(User principal, String role) {
        return authorize(principal, role, null);
    }

    @Override
    public boolean authorize(User principal, String role, UriInfo uriInfo) {
        return uriInfo.getUriInfo().getPathParameters().getFirst("company").equals("dropwizard");
    }
}
```

It does seems strange that I would be the first one to encounter this use case, with both dropwizard and/or Jersey. So I'm sort of expecting that someone has a much better solution that does not involve rewriting the whole authentication/authorization stack, but if not, this seems like a decent compromise.
