### PR TITLE
Add a JSONUnauthorizedHandler

### DIFF
--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/JSONUnauthorizedHandler.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/JSONUnauthorizedHandler.java
@@ -1,0 +1,24 @@
+package io.dropwizard.auth;
+
+import io.dropwizard.jersey.errors.ErrorMessage;
+
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+public class JSONUnauthorizedHandler implements UnauthorizedHandler {
+    private static final String CHALLENGE_FORMAT = "%s realm=\"%s\"";
+
+    @Override
+    public Response buildResponse(String prefix, String realm) {
+        ErrorMessage errorMessage = new ErrorMessage(
+            Response.Status.UNAUTHORIZED.getStatusCode(),
+            "Credentials are required to access this resource."
+        );
+        return Response.status(errorMessage.getCode())
+            .header(HttpHeaders.WWW_AUTHENTICATE, String.format(CHALLENGE_FORMAT, prefix, realm))
+            .type(MediaType.APPLICATION_JSON_TYPE)
+            .entity(errorMessage)
+            .build();
+    }
+}


### PR DESCRIPTION
###### Problem:

Dropwizard provides a `DefaultUnauthorizedHandler` that will returns an HTML error message. A lot of end user seems to need return JSON error message back, which they have to implement themselves, in a more or less consistent fashion with dropwizard error handling.

###### Solution:

This provides a `JSONUnauthorizedHandler` that match dropwizard JSON error message handling, and prevent every end user to reimplement one.

###### References:

- https://github.com/stardogventures/starwizard/blob/master/starwizard-core/src/main/java/io/stardog/starwizard/handlers/JsonUnauthorizedHandler.java
- https://github.com/dropwizard/dropwizard/pull/1863#issuecomment-269090433
