### PR TITLE
Fix incorrect docs on registering jersey filters

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -1898,7 +1898,7 @@ You typically register the feature in your Application class, like so:
 
 .. code-block:: java
 
-    environment.jersey().register(DateRequiredFeature.class);
+    environment.jersey().register(new DateRequiredFeature());
 
 
 .. _man-core-servlet-filters:


### PR DESCRIPTION
###### Problem:
Docs on registering jersey filters are wrong.

###### Solution:
`environment.jersey().register(DateRequiredFeature.class);` should be `environment.jersey().register(new DateRequiredFeature());`.

Tested on `1.3.13`.