### PR TITLE
Upgrade to Jackson 2.9.9.20190807

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -21,8 +21,7 @@
         <dropwizard.version>${project.version}</dropwizard.version>
         <guava.version>28.0-jre</guava.version>
         <jersey.version>2.29</jersey.version>
-        <jackson.version>2.9.9</jackson.version>
-        <jackson-databind.version>2.9.9.1</jackson-databind.version>
+        <jackson.version>2.9.9.20190807</jackson.version>
         <jetty.version>9.4.19.v20190610</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.1.0</metrics4.version>
@@ -41,11 +40,6 @@
                 <version>${jackson.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson-databind.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9#micro-patches