### PR TITLE
Upgrade to Jackson 2.9.9.20190807

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -21,8 +21,7 @@
         <dropwizard.version>${project.version}</dropwizard.version>
         <guava.version>24.1.1-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
-        <jackson.version>2.9.9</jackson.version>
-        <jackson-databind.version>2.9.9.1</jackson-databind.version>
+        <jackson.version>2.9.9.20190807</jackson.version>
         <jetty.version>9.4.18.v20190429</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.0.5</metrics4.version>
@@ -341,11 +340,6 @@
                 <version>${jackson.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson-databind.version}</version>
             </dependency>
 
             <!-- Jersey -->


### PR DESCRIPTION
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9#micro-patches