### PR TITLE
Add GitHub workflow to close stale issues and PRs

### DIFF
--- a/.github/workflows/close_stale.yml
+++ b/.github/workflows/close_stale.yml
@@ -1,0 +1,15 @@
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "0 * * * *"
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 14 days'
+        stale-pr-message: 'This pull request is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 14 days'
+        days-before-stale: 90
+        days-before-close: 14


### PR DESCRIPTION
Issues and PRs will be marked as stale after 90 days and removed if there wasn't any activity 14 days after that.