### PR TITLE
Add slf4j marker to dropwizard-json-logging.

### DIFF
--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/EventAttribute.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/EventAttribute.java
@@ -9,6 +9,7 @@ public enum EventAttribute {
     @JsonProperty("level") LEVEL,
     @JsonProperty("threadName") THREAD_NAME,
     @JsonProperty("mdc") MDC,
+    @JsonProperty("marker") MARKER,
     @JsonProperty("loggerName") LOGGER_NAME,
     @JsonProperty("message") MESSAGE,
     @JsonProperty("exception") EXCEPTION,

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/EventJsonLayoutBaseFactory.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/EventJsonLayoutBaseFactory.java
@@ -47,8 +47,8 @@ import javax.annotation.Nullable;
 public class EventJsonLayoutBaseFactory extends AbstractJsonLayoutBaseFactory<ILoggingEvent> {
 
     private EnumSet<EventAttribute> includes = EnumSet.of(EventAttribute.LEVEL,
-        EventAttribute.THREAD_NAME, EventAttribute.MDC, EventAttribute.LOGGER_NAME, EventAttribute.MESSAGE,
-        EventAttribute.EXCEPTION, EventAttribute.TIMESTAMP);
+        EventAttribute.THREAD_NAME, EventAttribute.MDC, EventAttribute.MARKER, EventAttribute.LOGGER_NAME,
+        EventAttribute.MESSAGE, EventAttribute.EXCEPTION, EventAttribute.TIMESTAMP);
 
     private Set<String> includesMdcKeys = Collections.emptySet();
     private boolean flattenMdc = false;

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/EventJsonLayout.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/EventJsonLayout.java
@@ -62,6 +62,7 @@ public class EventJsonLayout extends AbstractJsonLayout<ILoggingEvent> {
             .addTimestamp("timestamp", isIncluded(EventAttribute.TIMESTAMP), event.getTimeStamp())
             .add("level", isIncluded(EventAttribute.LEVEL), () -> String.valueOf(event.getLevel()))
             .add("thread", isIncluded(EventAttribute.THREAD_NAME), event::getThreadName)
+            .add("marker", isIncluded(EventAttribute.MARKER) && event.getMarker() != null, () -> event.getMarker().getName())
             .add("logger", isIncluded(EventAttribute.LOGGER_NAME), event::getLoggerName)
             .add("message", isIncluded(EventAttribute.MESSAGE), event::getFormattedMessage)
             .add("context", isIncluded(EventAttribute.CONTEXT_NAME), () -> event.getLoggerContextVO().getName())
@@ -99,8 +100,8 @@ public class EventJsonLayout extends AbstractJsonLayout<ILoggingEvent> {
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
-    private boolean isIncluded(EventAttribute exception) {
-        return includes.contains(exception);
+    private boolean isIncluded(EventAttribute include) {
+        return includes.contains(include);
     }
 
     public Set<EventAttribute> getIncludes() {

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
@@ -24,6 +24,8 @@ import org.eclipse.jetty.server.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -131,6 +133,7 @@ public class LayoutIntegrationTests {
         assertThat(factory.getIncludes()).contains(EventAttribute.LEVEL,
             EventAttribute.THREAD_NAME,
             EventAttribute.MDC,
+            EventAttribute.MARKER,
             EventAttribute.LOGGER_NAME,
             EventAttribute.MESSAGE,
             EventAttribute.EXCEPTION,
@@ -144,7 +147,8 @@ public class LayoutIntegrationTests {
         try {
             System.setOut(new PrintStream(redirectedStream));
             defaultLoggingFactory.configure(new MetricRegistry(), "json-log-test");
-            LoggerFactory.getLogger("com.example.app").info("Application log");
+            Marker marker = MarkerFactory.getMarker("marker");
+            LoggerFactory.getLogger("com.example.app").info(marker, "Application log");
             Thread.sleep(100); // Need to wait, because the logger is async
 
             JsonNode jsonNode = objectMapper.readTree(redirectedStream.toString());
@@ -152,6 +156,7 @@ public class LayoutIntegrationTests {
             assertThat(jsonNode.get("timestamp").isTextual()).isTrue();
             assertThat(jsonNode.get("level").asText()).isEqualTo("INFO");
             assertThat(jsonNode.get("logger").asText()).isEqualTo("com.example.app");
+            assertThat(jsonNode.get("marker").asText()).isEqualTo("marker");
             assertThat(jsonNode.get("message").asText()).isEqualTo("Application log");
         } finally {
             System.setOut(old);

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/EventJsonLayoutTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/EventJsonLayoutTest.java
@@ -13,6 +13,7 @@ import io.dropwizard.util.Sets;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.slf4j.Marker;
 
 import java.time.ZoneId;
 import java.util.Collections;
@@ -38,6 +39,7 @@ public class EventJsonLayoutTest {
             EventAttribute.LEVEL,
             EventAttribute.THREAD_NAME,
             EventAttribute.MDC,
+            EventAttribute.MARKER,
             EventAttribute.LOGGER_NAME,
             EventAttribute.MESSAGE,
             EventAttribute.EXCEPTION,
@@ -48,6 +50,7 @@ public class EventJsonLayoutTest {
     private final JsonFormatter jsonFormatter = new JsonFormatter(Jackson.newObjectMapper(), false, true);
     private ThrowableProxyConverter throwableProxyConverter = Mockito.mock(ThrowableProxyConverter.class);
     private ILoggingEvent event = Mockito.mock(ILoggingEvent.class);
+    private Marker marker = Mockito.mock(Marker.class);
     private Map<String, Object> defaultExpectedFields;
 
     private EventJsonLayout eventJsonLayout;
@@ -58,6 +61,7 @@ public class EventJsonLayoutTest {
         when(event.getLevel()).thenReturn(Level.INFO);
         when(event.getThreadName()).thenReturn("main");
         when(event.getMDCPropertyMap()).thenReturn(mdc);
+        when(event.getMarker()).thenReturn(marker);
         when(event.getLoggerName()).thenReturn(logger);
         when(event.getFormattedMessage()).thenReturn(message);
         when(event.getLoggerContextVO()).thenReturn(new LoggerContextVO("test", Collections.emptyMap(), 0));
@@ -65,12 +69,15 @@ public class EventJsonLayoutTest {
                 new StackTraceElement("declaringClass", "methodName", "fileName", 42)
         });
 
+        when(marker.getName()).thenReturn("marker");
+
         eventJsonLayout = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter,
                 DEFAULT_EVENT_ATTRIBUTES, Collections.emptyMap(), Collections.emptyMap(), Collections.emptySet(), false);
 
         defaultExpectedFields = new HashMap<>();
         defaultExpectedFields.put("timestamp", timestamp);
         defaultExpectedFields.put("logger", logger);
+        defaultExpectedFields.put("marker", "marker");
         defaultExpectedFields.put("message", message);
         defaultExpectedFields.put("thread", "main");
         defaultExpectedFields.put("level", "INFO");


### PR DESCRIPTION
###### Problem:
json-log-format does not include slf4j marker information in the output.

###### Solution:
Added EventAttribute.MARKER and included it if present in EventJsonLayout.