### PR TITLE
Remove duplicated FilterFactory provider entry

### DIFF
--- a/dropwizard-request-logging/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
+++ b/dropwizard-request-logging/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
@@ -1,2 +1,1 @@
-io.dropwizard.logging.filter.FilterFactory
 io.dropwizard.request.logging.RequestLogFactory


### PR DESCRIPTION
###### Problem:
`dropwizard-request-logging` module specifies a service provider which doesn't exist in the `dropwizard-request-logging.jar` file. This violates the Java Module rule:
When your library's JAR has a META-INF/services directory to specify service providers, then the specified providers must exist in this JAR (as described in the ModuleFinder [spec](https://docs.oracle.com/javase/9/docs/api/java/lang/module/ModuleFinder.html#of-java.nio.file.Path...-))

Due to this issue the `dropwizard-request-logging.jar` cannot be used
in Java modular applications.

If point the Java >=9 launcher to the directory with `dropwizard-request-logging.jar` you will get the following error:
```
$ java -p dropwizard-request-logging/target
Error occurred during initialization of boot layer
java.lang.module.FindException: Unable to derive module descriptor for dropwizard-request-logging/target/dropwizard-request-logging-2.0.0-rc10-SNAPSHOT.jar
Caused by: java.lang.module.InvalidModuleDescriptorException: Provider class io.dropwizard.logging.filter.FilterFactory not in module
```

###### Solution:
Remove `io.dropwizard.logging.filter.FilterFactory` provider entry from the `META_INF/services/io.dropwizard.jackson.Discoverable` in the `dropwizard-request-logging`. It will still be present in the `dropwizard-logging` module where the actually class file is located.

###### Result:
Dropwizard can be used for writing Java modular applications. The Java launcher will not throw any errors.
