### PR TITLE
Support nested JUnit 5 tests with `DropwizardExtension`

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardExtensionsSupport.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardExtensionsSupport.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.util.ReflectionUtils;
 
+import javax.annotation.Nullable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
@@ -20,9 +21,9 @@ public class DropwizardExtensionsSupport implements BeforeAllCallback, BeforeEac
 
     private static Set<Field> findAnnotatedFields(Class<?> testClass, boolean isStaticMember) {
         final Set<Field> set = Arrays.stream(testClass.getDeclaredFields()).
-            filter(m -> isStaticMember == Modifier.isStatic(m.getModifiers())).
-            filter(m -> DropwizardExtension.class.isAssignableFrom(m.getType())).
-            collect(Collectors.toSet());
+                filter(m -> isStaticMember == Modifier.isStatic(m.getModifiers())).
+                filter(m -> DropwizardExtension.class.isAssignableFrom(m.getType())).
+                collect(Collectors.toSet());
         if (!testClass.getSuperclass().equals(Object.class)) {
             set.addAll(findAnnotatedFields(testClass.getSuperclass(), isStaticMember));
         }
@@ -32,48 +33,119 @@ public class DropwizardExtensionsSupport implements BeforeAllCallback, BeforeEac
     @Override
     public void afterAll(ExtensionContext extensionContext) throws Exception {
         try {
-            for (Field member : findAnnotatedFields(extensionContext.getRequiredTestClass(), true)) {
-                ((DropwizardExtension) ReflectionUtils.makeAccessible(member).get(null)).after();
-            }
+            afterAll(extensionContext.getRequiredTestClass());
+        } catch (Exception e) {
+            throw e;
         } catch (Throwable e) {
-            throw new RuntimeException(e);
+            throw new Exception(e);
+        }
+    }
+
+    private void afterAll(Class<?> cls) throws Throwable {
+        final Class<?> enclosingClass = cls.getEnclosingClass();
+        if (enclosingClass != null) {
+            afterAll(enclosingClass);
+        }
+        for (Field member : findAnnotatedFields(cls, true)) {
+            getDropwizardExtension(member, null).after();
         }
     }
 
     @Override
     public void afterEach(ExtensionContext extensionContext) throws Exception {
         final Object testInstance = extensionContext.getTestInstance()
-            .orElseThrow(() -> new IllegalStateException("Unable to get the current test instance"));
+                .orElseThrow(() -> new IllegalStateException("Unable to get the current test instance"));
         try {
-            for (Field member : findAnnotatedFields(testInstance.getClass(), false)) {
-                ((DropwizardExtension) ReflectionUtils.makeAccessible(member).get(testInstance)).after();
-            }
+            afterEach(testInstance, testInstance.getClass());
+        } catch (Exception e) {
+            throw e;
         } catch (Throwable e) {
-            throw new RuntimeException(e);
+            throw new Exception(e);
+        }
+    }
+
+    private void afterEach(Object testInstance, Class<?> cls) throws Throwable {
+        final Class<?> enclosingClass = testInstance.getClass().getEnclosingClass();
+        if (enclosingClass != null) {
+            final Object enclosing = getEnclosingInstance(testInstance);
+            if (enclosing != null) {
+                afterEach(enclosing, enclosingClass);
+            }
+        }
+        for (Field member : findAnnotatedFields(cls, false)) {
+            getDropwizardExtension(member, testInstance).after();
         }
     }
 
     @Override
     public void beforeAll(ExtensionContext extensionContext) throws Exception {
         try {
-            for (Field member : findAnnotatedFields(extensionContext.getRequiredTestClass(), true)) {
-                ((DropwizardExtension) ReflectionUtils.makeAccessible(member).get(null)).before();
-            }
+            beforeAll(extensionContext.getRequiredTestClass());
+        } catch (Exception e) {
+            throw e;
         } catch (Throwable e) {
-            throw new RuntimeException(e);
+            throw new Exception(e);
+        }
+    }
+
+    private void beforeAll(Class<?> cls) throws Throwable {
+        final Class<?> enclosingClass = cls.getEnclosingClass();
+        if (enclosingClass != null) {
+            beforeAll(enclosingClass);
+        }
+        for (Field member : findAnnotatedFields(cls, true)) {
+            getDropwizardExtension(member, null).before();
         }
     }
 
     @Override
     public void beforeEach(ExtensionContext extensionContext) throws Exception {
         final Object testInstance = extensionContext.getTestInstance()
-            .orElseThrow(() -> new IllegalStateException("Unable to get the current test instance"));
+                .orElseThrow(() -> new IllegalStateException("Unable to get the current test instance"));
         try {
-            for (Field member : findAnnotatedFields(testInstance.getClass(), false)) {
-                ((DropwizardExtension) ReflectionUtils.makeAccessible(member).get(testInstance)).before();
-            }
+            beforeEach(testInstance, testInstance.getClass());
+        } catch (Exception e) {
+            throw e;
         } catch (Throwable e) {
-            throw new RuntimeException(e);
+            throw new Exception(e);
         }
+    }
+
+    private void beforeEach(Object testInstance, Class<?> cls) throws Throwable {
+        final Class<?> enclosingClass = cls.getEnclosingClass();
+        if (enclosingClass != null) {
+            final Object enclosing = getEnclosingInstance(testInstance);
+            if (enclosing != null) {
+                beforeEach(enclosing, cls);
+            }
+        }
+        for (Field member : findAnnotatedFields(testInstance.getClass(), false)) {
+            getDropwizardExtension(member, testInstance).before();
+        }
+    }
+
+    @Nullable
+    private Object getEnclosingInstance(Object o) throws IllegalAccessException {
+        final Class<?> innerClass = o.getClass();
+        if (innerClass.getEnclosingClass() == null) {
+            return null;
+        }
+
+        // https://stackoverflow.com/a/15265900
+        // 10 levels of nested classes should be enough for everyone
+        for (int i = 0; i < 10; i++) {
+            try {
+                final Field field = innerClass.getDeclaredField("this$" + i);
+                field.setAccessible(true);
+                return field.get(o);
+            } catch (NoSuchFieldException e) {
+                // NOP
+            }
+        }
+        return null;
+    }
+
+    private DropwizardExtension getDropwizardExtension(Field member, @Nullable Object o) throws IllegalAccessException {
+        return (DropwizardExtension) ReflectionUtils.makeAccessible(member).get(o);
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/NestedResourceTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/NestedResourceTest.java
@@ -1,0 +1,151 @@
+package io.dropwizard.testing.junit5;
+
+import io.dropwizard.testing.app.TestApplication;
+import io.dropwizard.testing.app.TestConfiguration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+class NestedResourceTest {
+    private static DropwizardAppExtension<TestConfiguration> staticApp = new DropwizardAppExtension<>(
+            TestApplication.class, resourceFilePath("test-config.yaml"));
+    private static DropwizardClientExtension staticClient = new DropwizardClientExtension();
+    private static DAOTestExtension staticDao = DAOTestExtension.newBuilder().build();
+    private static ResourceExtension staticResources = ResourceExtension.builder().build();
+
+    private DropwizardAppExtension<TestConfiguration> app = new DropwizardAppExtension<>(
+            TestApplication.class, resourceFilePath("test-config.yaml"));
+    private DropwizardClientExtension client = new DropwizardClientExtension();
+    private DAOTestExtension dao = DAOTestExtension.newBuilder().build();
+    private ResourceExtension resources = ResourceExtension.builder().build();
+
+    @Test
+    void staticApp() {
+        assertThat(staticApp.getEnvironment()).isNotNull();
+    }
+
+    @Test
+    void staticClient() {
+        assertThat(staticClient.baseUri()).isNotNull();
+    }
+
+    @Test
+    void staticDao() {
+        assertThat(staticDao.getSessionFactory()).isNotNull();
+    }
+
+    @Test
+    void staticResources() {
+        assertThat(staticResources.target("")).isNotNull();
+    }
+
+    @Test
+    void app() {
+        assertThat(app.getEnvironment()).isNotNull();
+    }
+
+    @Test
+    void client() {
+        assertThat(client.baseUri()).isNotNull();
+    }
+
+    @Test
+    void dao() {
+        assertThat(dao.getSessionFactory()).isNotNull();
+    }
+
+    @Test
+    void resources() {
+        assertThat(resources.target("")).isNotNull();
+    }
+
+    @Nested
+    class InnerTest {
+        @Test
+        void staticApp() {
+            assertThat(staticApp.getEnvironment()).isNotNull();
+        }
+
+        @Test
+        void staticClient() {
+            assertThat(staticClient.baseUri()).isNotNull();
+        }
+
+        @Test
+        void staticDao() {
+            assertThat(staticDao.getSessionFactory()).isNotNull();
+        }
+
+        @Test
+        void staticResources() {
+            assertThat(staticResources.target("")).isNotNull();
+        }
+
+        @Test
+        void app() {
+            assertThat(app.getEnvironment()).isNotNull();
+        }
+
+        @Test
+        void client() {
+            assertThat(client.baseUri()).isNotNull();
+        }
+
+        @Test
+        void dao() {
+            assertThat(dao.getSessionFactory()).isNotNull();
+        }
+
+        @Test
+        void resources() {
+            assertThat(resources.target("")).isNotNull();
+        }
+
+        @Nested
+        class InnerInnerTest {
+            @Test
+            void staticApp() {
+                assertThat(staticApp.getEnvironment()).isNotNull();
+            }
+
+            @Test
+            void staticClient() {
+                assertThat(staticClient.baseUri()).isNotNull();
+            }
+
+            @Test
+            void staticDao() {
+                assertThat(staticDao.getSessionFactory()).isNotNull();
+            }
+
+            @Test
+            void staticResources() {
+                assertThat(staticResources.target("")).isNotNull();
+            }
+
+            @Test
+            void app() {
+                assertThat(app.getEnvironment()).isNotNull();
+            }
+
+            @Test
+            void client() {
+                assertThat(client.baseUri()).isNotNull();
+            }
+
+            @Test
+            void dao() {
+                assertThat(dao.getSessionFactory()).isNotNull();
+            }
+
+            @Test
+            void resources() {
+                assertThat(resources.target("")).isNotNull();
+            }
+        }
+    }
+}


### PR DESCRIPTION
`DropwizardExtensionsSupport` didn't initialize the extension fields of enclosing classes, so that nested tests using fields of the enclosing class wouldn't work.

Fixes #2906