### PR TITLE
Move ResilientSocketOutputStream into io.dropwizard.logging

### DIFF
--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/ResilientOutputStreamBase.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/ResilientOutputStreamBase.java
@@ -1,0 +1,165 @@
+/*
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2015, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package io.dropwizard.logging;
+
+import ch.qos.logback.core.Context;
+import ch.qos.logback.core.recovery.RecoveryCoordinator;
+import ch.qos.logback.core.status.ErrorStatus;
+import ch.qos.logback.core.status.InfoStatus;
+import ch.qos.logback.core.status.Status;
+import ch.qos.logback.core.status.StatusManager;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+abstract class ResilientOutputStreamBase extends OutputStream {
+
+    private final static int STATUS_COUNT_LIMIT = 2 * 4;
+
+    private int noContextWarning = 0;
+    private int statusCount = 0;
+
+    private Context context;
+    private RecoveryCoordinator recoveryCoordinator;
+
+    protected OutputStream os;
+    boolean presumedClean = true;
+
+    private boolean isPresumedInError() {
+        // existence of recoveryCoordinator indicates failed state
+        return (recoveryCoordinator != null && !presumedClean);
+    }
+
+    public void write(byte[] b, int off, int len) {
+        if (isPresumedInError()) {
+            if (!recoveryCoordinator.isTooSoon()) {
+                attemptRecovery();
+            }
+            return; // return regardless of the success of the recovery attempt
+        }
+
+        try {
+            os.write(b, off, len);
+            postSuccessfulWrite();
+        } catch (IOException e) {
+            postIOFailure(e);
+        }
+    }
+
+    @Override
+    public void write(int b) {
+        if (isPresumedInError()) {
+            if (!recoveryCoordinator.isTooSoon()) {
+                attemptRecovery();
+            }
+            return; // return regardless of the success of the recovery attempt
+        }
+        try {
+            os.write(b);
+            postSuccessfulWrite();
+        } catch (IOException e) {
+            postIOFailure(e);
+        }
+    }
+
+    @Override
+    public void flush() {
+        if (os != null) {
+            try {
+                os.flush();
+                postSuccessfulWrite();
+            } catch (IOException e) {
+                postIOFailure(e);
+            }
+        }
+    }
+
+    abstract String getDescription();
+
+    abstract OutputStream openNewOutputStream() throws IOException;
+
+    private void postSuccessfulWrite() {
+        if (recoveryCoordinator != null) {
+            recoveryCoordinator = null;
+            statusCount = 0;
+            addStatus(new InfoStatus("Recovered from IO failure on " + getDescription(), this));
+        }
+    }
+
+    private void postIOFailure(IOException e) {
+        addStatusIfCountNotOverLimit(new ErrorStatus("IO failure while writing to " + getDescription(), this, e));
+        presumedClean = false;
+        if (recoveryCoordinator == null) {
+            recoveryCoordinator = new RecoveryCoordinator();
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (os != null) {
+            os.close();
+        }
+    }
+
+    private void attemptRecovery() {
+        try {
+            close();
+        } catch (IOException e) {
+            // Ignored
+        }
+
+        addStatusIfCountNotOverLimit(new InfoStatus("Attempting to recover from IO failure on " + getDescription(), this));
+
+        // subsequent writes must always be in append mode
+        try {
+            os = openNewOutputStream();
+            presumedClean = true;
+        } catch (IOException e) {
+            addStatusIfCountNotOverLimit(new ErrorStatus("Failed to open " + getDescription(), this, e));
+        }
+    }
+
+    private void addStatusIfCountNotOverLimit(Status s) {
+        ++statusCount;
+        if (statusCount < STATUS_COUNT_LIMIT) {
+            addStatus(s);
+        }
+
+        if (statusCount == STATUS_COUNT_LIMIT) {
+            addStatus(s);
+            addStatus(new InfoStatus("Will supress future messages regarding " + getDescription(), this));
+        }
+    }
+
+    private void addStatus(Status status) {
+        if (context == null) {
+            if (noContextWarning++ == 0) {
+                System.out.println("LOGBACK: No context given for " + this);
+            }
+            return;
+        }
+        StatusManager sm = context.getStatusManager();
+        if (sm != null) {
+            sm.add(status);
+        }
+    }
+
+    public Context getContext() {
+        return context;
+    }
+
+    public void setContext(Context context) {
+        this.context = context;
+    }
+}

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/ResilientOutputStreamBase.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/ResilientOutputStreamBase.java
@@ -23,6 +23,13 @@ import ch.qos.logback.core.status.StatusManager;
 import java.io.IOException;
 import java.io.OutputStream;
 
+/**
+ * Imported from Logback 1.2.3.
+ *
+ * @see ch.qos.logback.core.recovery.ResilientOutputStreamBase
+ * @see <a href="https://github.com/qos-ch/logback/blob/v_1.2.3/logback-core/src/main/java/ch/qos/logback/core/recovery/ResilientOutputStreamBase.java">ResilientOutputStreamBase</a>
+ */
+@SuppressWarnings("NullAway")
 abstract class ResilientOutputStreamBase extends OutputStream {
 
     private final static int STATUS_COUNT_LIMIT = 2 * 4;

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/ResilientSocketOutputStream.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/ResilientSocketOutputStream.java
@@ -1,4 +1,4 @@
-package ch.qos.logback.core.recovery;
+package io.dropwizard.logging;
 
 import javax.net.SocketFactory;
 import java.io.BufferedOutputStream;

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/socket/DropwizardSocketAppender.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/socket/DropwizardSocketAppender.java
@@ -1,7 +1,7 @@
 package io.dropwizard.logging.socket;
 
 import ch.qos.logback.core.OutputStreamAppender;
-import ch.qos.logback.core.recovery.ResilientSocketOutputStream;
+import io.dropwizard.logging.ResilientSocketOutputStream;
 import ch.qos.logback.core.spi.DeferredProcessingAware;
 
 import javax.net.SocketFactory;

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/ResilientSocketOutputStreamTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/ResilientSocketOutputStreamTest.java
@@ -1,4 +1,4 @@
-package ch.qos.logback.core.recovery;
+package io.dropwizard.logging;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
-public class ResilientSocketOutputStreamTest {
+class ResilientSocketOutputStreamTest {
 
     private ResilientSocketOutputStream resilientSocketOutputStream;
 
@@ -24,7 +24,7 @@ public class ResilientSocketOutputStreamTest {
     private CountDownLatch latch = new CountDownLatch(1);
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         ss = new ServerSocket(0);
         thread = new Thread(() -> {
             while (!Thread.currentThread().isInterrupted()) {
@@ -46,27 +46,27 @@ public class ResilientSocketOutputStreamTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         ss.close();
         thread.interrupt();
         resilientSocketOutputStream.close();
     }
 
     @Test
-    public void testCreatesCleanOutputStream() throws Exception {
+    void testCreatesCleanOutputStream() {
         assertThat(resilientSocketOutputStream.presumedClean).isTrue();
         assertThat(resilientSocketOutputStream.os).isNotNull();
     }
 
     @Test
-    public void testThrowsExceptionIfCantCreateOutputStream() throws Exception {
+    void testThrowsExceptionIfCantCreateOutputStream() {
         assertThatIllegalStateException().isThrownBy(() -> new ResilientSocketOutputStream("256.256.256.256", 1024,
             100, 1024, SocketFactory.getDefault()))
             .withMessage("Unable to create a TCP connection to 256.256.256.256:1024");
     }
 
     @Test
-    public void testWriteMessage() throws Exception {
+    void testWriteMessage() throws Exception {
         resilientSocketOutputStream.write("Test message".getBytes(StandardCharsets.UTF_8));
         resilientSocketOutputStream.flush();
 
@@ -75,7 +75,7 @@ public class ResilientSocketOutputStreamTest {
     }
 
     @Test
-    public void testGetDescription() {
+    void testGetDescription() {
         assertThat(resilientSocketOutputStream.getDescription()).isEqualTo(String.format("tcp [localhost:%d]",
             ss.getLocalPort()));
     }


### PR DESCRIPTION
Using a "reserved" package, such as `ch.qos.logback.core.recovery` from Logback, in an unrelated artifact will cause problems with the Java Platform Module System (JPMS).

In order to prevent a future conflict, the `ResilientSocketOutputStream` and the parent class `ResilientOutputStreamBase` from Logback have been moved into `io.dropwizard.logging`.

While copying code is usually a bad idea, I don't see how we could support Java 9+ with Dropwizard without this change or a change from the Logback project to change the modifier of the required methods in `ResilientOutputStreamBase` to `protected`.