### PR TITLE
Add automatic module names for all Dropwizard modules

### DIFF
--- a/dropwizard-assets/pom.xml
+++ b/dropwizard-assets/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dropwizard-assets</artifactId>
     <name>Dropwizard Asset Bundle</name>
 
+    <properties>
+        <module.name>io.dropwizard.assets</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/dropwizard-auth/pom.xml
+++ b/dropwizard-auth/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dropwizard-auth</artifactId>
     <name>Dropwizard Authentication</name>
 
+    <properties>
+        <module.name>io.dropwizard.auth</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/dropwizard-client/pom.xml
+++ b/dropwizard-client/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dropwizard-client</artifactId>
     <name>Dropwizard HTTP Client</name>
 
+    <properties>
+        <module.name>io.dropwizard.client</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/dropwizard-configuration/pom.xml
+++ b/dropwizard-configuration/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dropwizard-configuration</artifactId>
     <name>Dropwizard Configuration Support</name>
 
+    <properties>
+        <module.name>io.dropwizard.configuration</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/dropwizard-core/pom.xml
+++ b/dropwizard-core/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dropwizard-core</artifactId>
     <name>Dropwizard</name>
 
+    <properties>
+        <module.name>io.dropwizard.core</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/dropwizard-db/pom.xml
+++ b/dropwizard-db/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dropwizard-db</artifactId>
     <name>Dropwizard Database Support</name>
 
+    <properties>
+        <module.name>io.dropwizard.db</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/dropwizard-forms/pom.xml
+++ b/dropwizard-forms/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dropwizard-forms</artifactId>
     <name>Dropwizard Multipart Form Support</name>
 
+    <properties>
+        <module.name>io.dropwizard.forms</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/dropwizard-health/pom.xml
+++ b/dropwizard-health/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dropwizard-health</artifactId>
     <name>Dropwizard Health Checking Support</name>
 
+    <properties>
+        <module.name>io.dropwizard.health</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/dropwizard-hibernate/pom.xml
+++ b/dropwizard-hibernate/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dropwizard-hibernate</artifactId>
     <name>Dropwizard Hibernate Support</name>
 
+    <properties>
+        <module.name>io.dropwizard.hibernate</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/dropwizard-http2/pom.xml
+++ b/dropwizard-http2/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <argLine>-Duser.language=en -Duser.region=US</argLine>
+        <module.name>io.dropwizard.http2</module.name>
     </properties>
 
     <dependencies>

--- a/dropwizard-jackson/pom.xml
+++ b/dropwizard-jackson/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dropwizard-jackson</artifactId>
     <name>Dropwizard Jackson Support</name>
 
+    <properties>
+        <module.name>io.dropwizard.jackson</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/dropwizard-jdbi3/pom.xml
+++ b/dropwizard-jdbi3/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dropwizard-jdbi3</artifactId>
     <name>Dropwizard JDBI3 Support</name>
 
+    <properties>
+        <module.name>io.dropwizard.jdbi3</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/dropwizard-jersey/pom.xml
+++ b/dropwizard-jersey/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dropwizard-jersey</artifactId>
     <name>Dropwizard Jersey Support</name>
 
+    <properties>
+        <module.name>io.dropwizard.jersey</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/dropwizard-jetty/pom.xml
+++ b/dropwizard-jetty/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dropwizard-jetty</artifactId>
     <name>Dropwizard Jetty Support</name>
 
+    <properties>
+        <module.name>io.dropwizard.jetty</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/dropwizard-json-logging/pom.xml
+++ b/dropwizard-json-logging/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dropwizard-json-logging</artifactId>
     <name>Dropwizard JSON logging</name>
 
+    <properties>
+        <module.name>io.dropwizard.logging.json</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/dropwizard-lifecycle/pom.xml
+++ b/dropwizard-lifecycle/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dropwizard-lifecycle</artifactId>
     <name>Dropwizard Lifecycle Support</name>
 
+    <properties>
+        <module.name>io.dropwizard.lifecycle</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>

--- a/dropwizard-logging/pom.xml
+++ b/dropwizard-logging/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dropwizard-logging</artifactId>
     <name>Dropwizard Logging Support</name>
 
+    <properties>
+        <module.name>io.dropwizard.logging</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/dropwizard-metrics-graphite/pom.xml
+++ b/dropwizard-metrics-graphite/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dropwizard-metrics-graphite</artifactId>
     <name>Dropwizard Metrics Support for Graphite</name>
 
+    <properties>
+        <module.name>io.dropwizard.metrics.graphite</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/dropwizard-metrics/pom.xml
+++ b/dropwizard-metrics/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dropwizard-metrics</artifactId>
     <name>Dropwizard Metrics Support</name>
 
+    <properties>
+        <module.name>io.dropwizard.metrics</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/dropwizard-migrations/pom.xml
+++ b/dropwizard-migrations/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dropwizard-migrations</artifactId>
     <name>Dropwizard Migrations</name>
 
+    <properties>
+        <module.name>io.dropwizard.migrations</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/dropwizard-parent/pom.xml
+++ b/dropwizard-parent/pom.xml
@@ -18,6 +18,7 @@
     </description>
 
     <properties>
+        <module.name>io.dropwizard.parent</module.name>
         <maven.compiler.release>11</maven.compiler.release>
         <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
         <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
@@ -227,6 +228,9 @@
                         <manifest>
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                         </manifest>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${module.name}</Automatic-Module-Name>
+                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>

--- a/dropwizard-request-logging/pom.xml
+++ b/dropwizard-request-logging/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dropwizard-request-logging</artifactId>
     <name>Dropwizard Request Logging Support</name>
 
+    <properties>
+        <module.name>io.dropwizard.request.logging</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/dropwizard-servlets/pom.xml
+++ b/dropwizard-servlets/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dropwizard-servlets</artifactId>
     <name>Dropwizard Servlet Support</name>
 
+    <properties>
+        <module.name>io.dropwizard.servlets</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/dropwizard-testing/pom.xml
+++ b/dropwizard-testing/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dropwizard-testing</artifactId>
     <name>Dropwizard Test Helpers</name>
 
+    <properties>
+        <module.name>io.dropwizard.testing</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/dropwizard-util/pom.xml
+++ b/dropwizard-util/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dropwizard-util</artifactId>
     <name>Dropwizard Utility Classes</name>
 
+    <properties>
+        <module.name>io.dropwizard.util</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/dropwizard-validation/pom.xml
+++ b/dropwizard-validation/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dropwizard-validation</artifactId>
     <name>Dropwizard Validation Support</name>
 
+    <properties>
+        <module.name>io.dropwizard.validation</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/dropwizard-views-freemarker/pom.xml
+++ b/dropwizard-views-freemarker/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dropwizard-views-freemarker</artifactId>
     <name>Dropwizard Freemarker Views</name>
 
+    <properties>
+        <module.name>io.dropwizard.views.freemarker</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/dropwizard-views-mustache/pom.xml
+++ b/dropwizard-views-mustache/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dropwizard-views-mustache</artifactId>
     <name>Dropwizard Mustache Views</name>
 
+    <properties>
+        <module.name>io.dropwizard.views.mustache</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/dropwizard-views/pom.xml
+++ b/dropwizard-views/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>dropwizard-views</artifactId>
     <name>Dropwizard Views</name>
 
+    <properties>
+        <module.name>io.dropwizard.views</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>


### PR DESCRIPTION
This PR adds automatic module names for all Dropwizard modules.

We'll need more tests to see, if everything works with Java 9+ when using the module path.

See also: https://blog.joda.org/2018/03/jpms-negative-benefits.html

Refs https://github.com/dropwizard/dropwizard/pull/3233