### PR TITLE
Update jackson version to 2.9.10

### DIFF
--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -32,7 +32,7 @@
         <hibernate-core.version>5.4.4.Final</hibernate-core.version>
         <hibernate-validator.version>6.0.17.Final</hibernate-validator.version>
         <httpclient.version>4.5.10</httpclient.version>
-        <jackson.version>2.9.9.20190807</jackson.version>
+        <jackson.version>2.9.10</jackson.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
         <jakarta.el.version>3.0.3</jakarta.el.version>
         <javassist.version>3.25.0-GA</javassist.version>


### PR DESCRIPTION
###### Problem:
As per #2938, jackson 2.9.9.20190807 has two newly-discovered threats: CVE-2019-14540 and CVE-2019-16335

###### Solution:
Bump jackson.version to 2.9.10 in master branch (currently 2.0.0-rc11-SNAPSHOT)