### PR TITLE
Jackson Afterburner don't use value classloader

### DIFF
--- a/docs/source/manual/upgrade-notes/upgrade-notes-2_0_x.rst
+++ b/docs/source/manual/upgrade-notes/upgrade-notes-2_0_x.rst
@@ -91,3 +91,13 @@ if inclusive is false:
 ::
 
    messageRate must be less than 1 MINUTES
+
+Changed the Jackson's object mapper configuration
+-------------------------------------------------
+
+Note that the Afterburner module is now configured with ``setUseValueClassLoader(false)``
+by default which causes bytecode generation only for public getters/setter and fields to avoid
+Java 9+ complains of ``Illegal reflective access``.
+This might slightly affect performance of your application. See
+` this Jackson issue <https://github.com/FasterXML/jackson-modules-base/issues/37>`_ for more
+information.

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
@@ -60,7 +60,13 @@ public class Jackson {
         mapper.registerModule(new GuavaExtrasModule());
         mapper.registerModule(new CaffeineModule());
         mapper.registerModule(new JodaModule());
-        mapper.registerModule(new AfterburnerModule());
+
+        // make Afterburner generate bytecode only for public getters/setter and fields
+        // without this, Java 9+ complains of "Illegal reflective access"
+        final AfterburnerModule afterburnerModule = new AfterburnerModule();
+        afterburnerModule.setUseValueClassLoader(false);
+        mapper.registerModule(afterburnerModule);
+
         mapper.registerModule(new FuzzyEnumModule());
         mapper.registerModule(new ParameterNamesModule());
         mapper.registerModule(new Jdk8Module());


### PR DESCRIPTION
Make Afterburner generate bytecode only for public getters/setter
and fields to avoid Java 9+ complains of "Illegal reflective access".

Resolves #2909 
