### PR TITLE
Support for requestAttributes in Json access log

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -951,6 +951,8 @@ JSON access log layout
         - X-Request-Id
       responseHeaders:
         - X-Request-Id
+      requestAttributes:
+        - SomeAttributeName
       customFieldNames:
         timestamp: "@timestamp"
       additionalFields:
@@ -989,6 +991,7 @@ includes                 (timestamp, remoteAddress,
                                                       - ``serverName``        *false*    Whether to include the name of the server to which the request was sent as the ``serverName`` field.
 requestHeaders           (empty)                      Set of request headers included in the JSON map as the ``headers`` field.
 responseHeaders          (empty)                      Set of response headers included in the JSON map as the ``responseHeaders`` field.
+requestAttributes        (empty)                      Set of ServletRequest attributes included in the JSON map as the ``requestAttributes`` field.
 customFieldNames         (empty)                      Map of field name replacements in the JSON map. For example ``requestTime:request_time, userAgent:user_agent)``.
 additionalFields         (empty)                      Map of fields to add in the JSON map.
 =======================  ===========================  ================

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/AccessJsonLayoutBaseFactory.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/AccessJsonLayoutBaseFactory.java
@@ -52,6 +52,7 @@ public class AccessJsonLayoutBaseFactory extends AbstractJsonLayoutBaseFactory<I
 
     private Set<String> responseHeaders = Collections.emptySet();
     private Set<String> requestHeaders = Collections.emptySet();
+    private Set<String> requestAttributes = Collections.emptySet();
 
     @JsonProperty
     public Set<String> getResponseHeaders() {
@@ -71,6 +72,16 @@ public class AccessJsonLayoutBaseFactory extends AbstractJsonLayoutBaseFactory<I
     @JsonProperty
     public void setRequestHeaders(Set<String> requestHeaders) {
         this.requestHeaders = requestHeaders;
+    }
+
+    @JsonProperty
+    public Set<String> getRequestAttributes() {
+        return requestAttributes;
+    }
+
+    @JsonProperty
+    public void setRequestAttributes(Set<String> requestAttributes) {
+        this.requestAttributes = requestAttributes;
     }
 
     @JsonProperty
@@ -94,6 +105,7 @@ public class AccessJsonLayoutBaseFactory extends AbstractJsonLayoutBaseFactory<I
         jsonLayout.setContext(context);
         jsonLayout.setRequestHeaders(requestHeaders);
         jsonLayout.setResponseHeaders(responseHeaders);
+        jsonLayout.setRequestAttributes(requestAttributes);
         return jsonLayout;
     }
 }

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/AccessJsonLayoutTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/AccessJsonLayoutTest.java
@@ -19,6 +19,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 public class AccessJsonLayoutTest {
@@ -192,6 +193,49 @@ public class AccessJsonLayoutTest {
             entry("protocol", "HTTP/1.1"), entry("status", 200),
             entry("request_time", 100L), entry("content_length", 78L),
             entry("user_agent", userAgent), entry("remote_address", remoteAddress));
+    }
+
+    @Test
+    public void testRequestAttributes() {
+        final String attribute1 = "attribute1";
+        final String attribute2 = "attribute2";
+        final String attribute3 = "attribute3";
+
+        final Map<String, String> attributes =
+            Maps.of(
+                attribute1, "value1",
+                attribute2, "value2",
+                attribute3, "value3");
+
+        when(event.getAttribute(eq(attribute1))).thenReturn(attributes.get(attribute1));
+        when(event.getAttribute(eq(attribute2))).thenReturn(attributes.get(attribute2));
+        when(event.getAttribute(eq(attribute3))).thenReturn(attributes.get(attribute3));
+
+        accessJsonLayout.setRequestAttributes(attributes.keySet());
+        assertThat(accessJsonLayout.toJsonMap(event))
+            .containsEntry("requestAttributes", attributes);
+
+    }
+
+    @Test
+    public void testRequestAttributesWithNull() {
+        final String attribute1 = "attribute1";
+        final String attribute2 = "attribute2";
+        final String attribute3 = "attribute3";
+
+        final Map<String, String> attributes =
+            Maps.of(
+                attribute1, "value1",
+                attribute2, "value2");
+
+        when(event.getAttribute(eq(attribute1))).thenReturn(attributes.get(attribute1));
+        when(event.getAttribute(eq(attribute2))).thenReturn(attributes.get(attribute2));
+        when(event.getAttribute(eq(attribute3))).thenReturn(null);
+
+        accessJsonLayout.setRequestAttributes(Sets.of(attribute1, attribute2, attribute3));
+        assertThat(accessJsonLayout.toJsonMap(event))
+            .containsEntry("requestAttributes", Maps.of(attribute1, "value1", attribute2, "value2"));
+
     }
 
     @Test


### PR DESCRIPTION
Summary
=======
Support for requestAttributes similar to LogbackAccessLayout.
When specified, all non-null values will be included in logs

###### Problem:
We were using servletFilters to populate certain application specific contextual information and pass them along as request attributes, which are in turn used for central logging of access logs. Lack of way to specify request Attributes in json log layout is hindering us to move to json logging instead of file logging. 

###### Solution:
* Added configuration support to specify requestAttribute names to be logged. 
* Retrieving the attribute from `IAccessEvent#getAttribute()` api to add them to json log

