### PR TITLE
Move to joschi/setup-jdk for GitHub Actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -4,6 +4,10 @@ on:
     branches:
     - master
     - release/*
+  pull_request:
+    branches:
+    - master
+    - release/*
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java_version: [1.8, 11, 13]
+        java_version: ['openjdk8', 'openjdk11', 'openjdk13']
         os: [ubuntu-latest, macOS-latest]
     steps:
     - uses: actions/checkout@v1
     - name: Set up JDK
-      uses: actions/setup-java@v1
+      uses: joschi/setup-jdk@v1
       with:
         java-version: ${{ matrix.java_version }}
     - name: Print Java and Maven versions


### PR DESCRIPTION
The [joschi/setup-jdk](https://github.com/marketplace/actions/setup-java-environment-based-on-adoptopenjdk) action supports the OpenJDK distributions from AdoptOpenJDK.

https://github.com/marketplace/actions/setup-java-environment-based-on-adoptopenjdk