### PR TITLE
make it possible to created subclass of apache http builder

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
@@ -299,12 +299,24 @@ public class HttpClientBuilder {
      * @return an {@link io.dropwizard.client.ConfiguredCloseableHttpClient}
      */
     ConfiguredCloseableHttpClient buildWithDefaultRequestConfiguration(String name) {
-        return createClient(org.apache.http.impl.client.HttpClientBuilder.create(),
+        return createClient(createBuilder(),
                 createConnectionManager(createConfiguredRegistry(), name), name);
     }
 
     /**
-     * Configures an Apache {@link org.apache.http.impl.client.HttpClientBuilder HttpClientBuilder}.
+     * Creates an Apache {@link org.apache.http.impl.client.HttpClientBuilder}.
+     *
+     * Intended for use by subclasses to create builder instance from subclass of
+     * {@link org.apache.http.impl.client.HttpClientBuilder}
+     *
+     * @return an {@link org.apache.http.impl.client.HttpClientBuilder}
+     */
+    protected org.apache.http.impl.client.HttpClientBuilder createBuilder() {
+        return org.apache.http.impl.client.HttpClientBuilder.create();
+    }
+
+    /**
+     * Configures an Apache {@link org.apache.http.impl.client.HttpClientBuilder}.
      *
      * Intended for use by subclasses to inject HttpClientBuilder
      * configuration. The default implementation is an identity

--- a/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
@@ -95,6 +95,7 @@ public class HttpClientBuilderTest {
 
     static class CustomBuilder extends HttpClientBuilder {
         public boolean customized;
+        @Nullable
         public org.apache.http.impl.client.HttpClientBuilder builder;
 
         public CustomBuilder(MetricRegistry metricRegistry) {

--- a/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
@@ -95,11 +95,10 @@ public class HttpClientBuilderTest {
 
     static class CustomBuilder extends HttpClientBuilder {
         public boolean customized;
-        @Nullable
         public org.apache.http.impl.client.HttpClientBuilder builder;
 
         public CustomBuilder(MetricRegistry metricRegistry) {
-            this(metricRegistry, null);
+            this(metricRegistry, org.apache.http.impl.client.HttpClientBuilder.create());
         }
 
         public CustomBuilder(MetricRegistry metricRegistry, org.apache.http.impl.client.HttpClientBuilder builder) {


### PR DESCRIPTION
###### Problem:
This PR is to support [CachingHttpClientBuilder](https://github.com/apache/httpcomponents-client/blob/4.5.x/httpclient-cache/src/main/java/org/apache/http/impl/client/cache/CachingHttpClientBuilder.java)

The `HttpClientBuilder` always creates an `org.apache.http.impl.client.HttpClientBuilder`, which is not possible to take in another builder.

This change together with `customizeBuiler()`, we will be able to create a `CachingHttpClient`.

###### Solution:
Instead of hardcoded `org.apache.http.impl.client.HttpClientBuilder.create()`, move it to a method so the subclass can override it and provide other builders.

###### Result:
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->
