### PR TITLE
allow overriding request executor

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
@@ -44,6 +44,7 @@ import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 import org.apache.http.impl.conn.SystemDefaultDnsResolver;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.protocol.HttpProcessor;
+import org.apache.http.protocol.HttpRequestExecutor;
 
 import javax.annotation.Nullable;
 import javax.net.ssl.HostnameVerifier;
@@ -304,6 +305,19 @@ public class HttpClientBuilder {
     }
 
     /**
+     * Creates a {@link org.apache.http.protocol.HttpRequestExecutor}.
+     *
+     * Intended for use by subclasses to provide a customized request executor.
+     * The default implementation is an {@link com.codahale.metrics.httpclient.InstrumentedHttpRequestExecutor}
+     *
+     * @param name
+     * @return a {@link org.apache.http.protocol.HttpRequestExecutor}
+     */
+    protected HttpRequestExecutor createRequestExecutor(String name) {
+        return new InstrumentedHttpRequestExecutor(metricRegistry, metricNameStrategy, name);
+    }
+
+    /**
      * Creates an Apache {@link org.apache.http.impl.client.HttpClientBuilder}.
      *
      * Intended for use by subclasses to create builder instance from subclass of
@@ -367,7 +381,7 @@ public class HttpClientBuilder {
                 .setSoTimeout(timeout)
                 .build();
 
-        builder.setRequestExecutor(new InstrumentedHttpRequestExecutor(metricRegistry, metricNameStrategy, name))
+        builder.setRequestExecutor(createRequestExecutor(name))
             .setConnectionManager(manager)
             .setDefaultRequestConfig(requestConfig)
             .setDefaultSocketConfig(socketConfig)

--- a/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
@@ -89,8 +89,7 @@ class AnotherHttpClientBuilder extends org.apache.http.impl.client.HttpClientBui
 }
 
 public class HttpClientBuilderTest {
-    class CustomRequestExecutor extends HttpRequestExecutor {
-
+    static class CustomRequestExecutor extends HttpRequestExecutor {
     }
 
     static class CustomBuilder extends HttpClientBuilder {
@@ -113,11 +112,15 @@ public class HttpClientBuilderTest {
         }
 
         @Override
+        protected HttpRequestExecutor createRequestExecutor(String name) {
+            return new CustomRequestExecutor();
+        }
+
+        @Override
         protected org.apache.http.impl.client.HttpClientBuilder customizeBuilder(
             org.apache.http.impl.client.HttpClientBuilder builder
         ) {
             customized = true;
-            builder.setRequestExecutor(mock(CustomRequestExecutor.class));
             return builder;
         }
     }


### PR DESCRIPTION
###### Problem:
Similar to https://github.com/dropwizard/dropwizard/pull/2958, this is a further improvement to allow passing in a customised RequestExecutor so that we can additional metrics regarding cache hit and cache miss.

###### Solution:
Instead of fixed `new InstrumentedHttpRequestExecutor()`, allow the subclasses to provide their own implementation of `HttpRequestExecutor`

###### Result:
N.A.
