### PR TITLE
Update registration of resource instances to call Java 11-friendly javassist library method.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ release.properties
 nb-configuration.xml
 atlassian-ide-plugin.xml
 
+.java-version
+
 logs
 
 .DS_Store

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -153,7 +153,8 @@ public class DropwizardResourceConfig extends ResourceConfig {
                 pool.insertClassPath(new LoaderClassPath(this.getClass().getClassLoader()));
                 CtClass cc = pool.makeClass(SpecificBinder.class.getName() + UUID.randomUUID());
                 cc.setSuperclass(pool.get(SpecificBinder.class.getName()));
-                Object binderProxy = cc.toClass().getConstructor(Object.class, Class.class).newInstance(object, clazz);
+                Object binderProxy = cc.toClass(SpecificBinder.class)
+                    .getConstructor(Object.class, Class.class).newInstance(object, clazz);
                 super.register(binderProxy);
                 return super.register(clazz);
             } catch (Exception e) {


### PR DESCRIPTION
Fixes #2962

###### Problem:
Fix illegal reflective access operation warnings as described in #2962 

###### Solution:
Updated to use a different `CtClass` method (`toClass(Class)`)because the current method used, `toClass()`, will be unavailable in a future release and currently results in illegal reflective access operation warnings. 

###### Result:
Illegal reflective access operation warnings should be gone for this particular use case and the framework will be better prepared for the future when javassist removes the problematic method in the future.
