### PR TITLE
Allow overriding ViewMessageBodyWriter#detectLocale()

### DIFF
--- a/dropwizard-views/src/main/java/io/dropwizard/views/ViewMessageBodyWriter.java
+++ b/dropwizard-views/src/main/java/io/dropwizard/views/ViewMessageBodyWriter.java
@@ -88,7 +88,7 @@ public class ViewMessageBodyWriter implements MessageBodyWriter<View> {
         }
     }
 
-    Locale detectLocale(HttpHeaders headers) {
+    protected Locale detectLocale(HttpHeaders headers) {
         final List<Locale> languages;
         try {
             languages = headers.getAcceptableLanguages();


### PR DESCRIPTION
### Problem:
In our application we want to have a custom application specific locale
detection procedure based on query parameters of the HTTP request.
Currently, the `ViewMessageBodyWriter.detectLocale` method is package
private which makes it quite cumbersome to override.

### Solution:
Make `ViewMessageBodyWriter.detectLocale` protected

### Result:
We will be able to register our own ViewMessageBodyWriter implementation
which overrides the `detectLocale` method in a nice way.
