### PR TITLE
Update to Jackson 2.9.10.20191020

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -21,7 +21,7 @@
         <dropwizard.version>${project.version}</dropwizard.version>
         <guava.version>24.1.1-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
-        <jackson.version>2.9.10</jackson.version>
+        <jackson.version>2.9.10.20191020</jackson.version>
         <jetty.version>9.4.18.v20190429</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.0.5</metrics4.version>


### PR DESCRIPTION
###### Problem:
As per #2987, jackson 2.910 has three newly-discovered threats: CVE-2019-16942, CVE-2019-16943, CVE-2019-17531.  Each has a CVSS v3.1 score of 9.8

###### Solution:
Bump `jackson.version` to 2.9.10.20191020.  This updates `jackson-databind` to 2.9.10.1 but does not change anything else.

