### PR TITLE
Support comments in DiscoverableSubtypeResolver

### DIFF
--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/DiscoverableSubtypeResolver.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/DiscoverableSubtypeResolver.java
@@ -67,8 +67,6 @@ public class DiscoverableSubtypeResolver extends StdSubtypeResolver {
                             if (loadedClass != null) {
                                 serviceClasses.add(loadedClass);
                             }
-                        } else {
-                            LOGGER.debug("Line began with a comment. Ignoring");
                         }
                     }
                 }

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/DiscoverableSubtypeResolver.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/DiscoverableSubtypeResolver.java
@@ -62,9 +62,13 @@ public class DiscoverableSubtypeResolver extends StdSubtypeResolver {
                      BufferedReader reader = new BufferedReader(streamReader)) {
                     String line;
                     while ((line = reader.readLine()) != null) {
-                        final Class<?> loadedClass = loadClass(line);
-                        if (loadedClass != null) {
-                            serviceClasses.add(loadedClass);
+                        if (!line.startsWith("#")) {
+                            final Class<?> loadedClass = loadClass(line);
+                            if (loadedClass != null) {
+                                serviceClasses.add(loadedClass);
+                            }
+                        } else {
+                            LOGGER.debug("Line began with a comment. Ignoring");
                         }
                     }
                 }


### PR DESCRIPTION
Add the ability to have comments in the DiscoverableSubtypeResolver class resources file

###### Problem:
Currently if you have any other lines in the discoverable resource files you get a bunch of log lines detailing "cannot load this class".  Example:
```
# this is the foo class
org.github.Foo
```

###### Solution:
Add the ability to allow for comments in the resource file.  Comments are lines that start with `#`.

###### Result:
No more log lines for lines that begin with `#` detailing that it's not a class when parsing the class resource files.
