### PR TITLE
Register HK2 AbstractBinder with Jersey

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -142,7 +142,7 @@ public class DropwizardResourceConfig extends ResourceConfig {
         // If a class gets passed through as an object, cast to Class and register directly
         if (component instanceof Class<?>) {
             return super.register((Class<?>) component);
-        } else if (Providers.isProvider(clazz) || Binder.class.isAssignableFrom(clazz)) {
+        } else if (Providers.isProvider(clazz) || org.glassfish.hk2.utilities.Binder.class.isAssignableFrom(clazz)) {
             // If Jersey supports this component's class (including Binders), register directly
             return super.register(object);
         } else {

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -14,7 +14,6 @@ import javassist.ClassPool;
 import javassist.CtClass;
 import javassist.LoaderClassPath;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
-import org.glassfish.jersey.internal.inject.Binder;
 import org.glassfish.jersey.internal.inject.Providers;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.ServerProperties;

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
@@ -6,6 +6,7 @@ import org.glassfish.jersey.server.model.Resource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import javax.inject.Inject;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -216,6 +217,23 @@ public class DropwizardResourceConfigTest {
     }
 
     @Test
+    void logResourceWithHK2Binder() {
+        rc.register(ResourceWithInjectedDependency.class);
+        rc.register(new org.glassfish.hk2.utilities.binding.AbstractBinder() {
+            @Override
+            protected void configure() {
+                bindAsContract(Dependency.class);
+            }
+        });
+
+        runJersey();
+        final String expectedLog = String.format("The following paths were found for the configured resources:%n" + "%n"
+            + "    GET     /another (io.dropwizard.jersey.DropwizardResourceConfigTest.ResourceWithInjectedDependency)");
+
+        assertThat(rc.getEndpointsInfo()).contains(expectedLog);
+    }
+
+    @Test
     void logsEndpointsContextPathUrlPattern() {
         rc.setContextPath("/context");
         rc.setUrlPattern("/pattern");
@@ -416,5 +434,22 @@ public class DropwizardResourceConfigTest {
         @Path("/address")
         public String getAddress() {return "B";}
 
+    }
+
+    public static class ResourceWithInjectedDependency implements ResourceInterface {
+        private Dependency dependency;
+
+        @Inject
+        public ResourceWithInjectedDependency(Dependency dependency) {
+            this.dependency = dependency;
+        }
+
+        public String bar() {
+            return dependency.get();
+        }
+    }
+
+    public static class Dependency {
+        public String get() {return "A";}
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/ProvidersBinderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/ProvidersBinderTest.java
@@ -1,0 +1,35 @@
+package io.dropwizard.jersey;
+
+import org.glassfish.jersey.internal.inject.Providers;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Demonstrates that DropwizardResourceConfig.register needs to include an extra condition for hk2 binder, but not for
+ * jersey Binder as it will be picked up as a Provider
+ */
+public class ProvidersBinderTest {
+
+    @Test
+    public void demonstrateThatHk2BinderIsNotPickedUpAsProvider() {
+        org.glassfish.hk2.utilities.Binder binder = new org.glassfish.hk2.utilities.binding.AbstractBinder() {
+            @Override
+            protected void configure() {
+
+            }
+        };
+        assertThat(Providers.isProvider(binder.getClass())).isFalse();
+    }
+
+    @Test
+    public void demonstrateThatJerseyBinderIsPickedUpAsProvider() {
+        org.glassfish.jersey.internal.inject.Binder binder = new org.glassfish.jersey.internal.inject.AbstractBinder() {
+            @Override
+            protected void configure() {
+
+            }
+        };
+        assertThat(Providers.isProvider(binder.getClass())).isTrue();
+    }
+}


### PR DESCRIPTION
###### Problem:
Before 2.0.0 version, dropwizard and jeresey allowed to register org.glassfish.hk2.utilities.binding.AbstractBinder. This got broken by jersey and then fixed in 2.29. However dropwizard does not pass hk2 Abstract binder directly to jersey, resulting in a failure.

###### Solution:
This pull request modifies DropwizardResourceConfig, so that instances of org.glassfish.hk2.utilities.binding.AbstractBinder are passed directly to jersey.

###### Result:
As a result of this pull request, 2.0.0 will behave exactly the same as 1.x.x for configuring hk2 dependency injection.

Fixes #2999