### PR TITLE
Add slf4j marker to dropwizard-json-logging (backport)

### DIFF
--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/EventAttribute.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/EventAttribute.java
@@ -10,6 +10,7 @@ public enum EventAttribute {
     @JsonProperty("level") LEVEL,
     @JsonProperty("threadName") THREAD_NAME,
     @JsonProperty("mdc") MDC,
+    @JsonProperty("marker") MARKER,
     @JsonProperty("loggerName") LOGGER_NAME,
     @JsonProperty("message") MESSAGE,
     @JsonProperty("exception") EXCEPTION,

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/EventJsonLayoutBaseFactory.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/EventJsonLayoutBaseFactory.java
@@ -42,8 +42,8 @@ import java.util.TimeZone;
 public class EventJsonLayoutBaseFactory extends AbstractJsonLayoutBaseFactory<ILoggingEvent> {
 
     private EnumSet<EventAttribute> includes = EnumSet.of(EventAttribute.LEVEL,
-        EventAttribute.THREAD_NAME, EventAttribute.MDC, EventAttribute.LOGGER_NAME, EventAttribute.MESSAGE,
-        EventAttribute.EXCEPTION, EventAttribute.TIMESTAMP);
+        EventAttribute.THREAD_NAME, EventAttribute.MDC, EventAttribute.MARKER, EventAttribute.LOGGER_NAME,
+        EventAttribute.MESSAGE, EventAttribute.EXCEPTION, EventAttribute.TIMESTAMP);
 
     private Set<String> includesMdcKeys = ImmutableSet.of();
     private boolean flattenMdc = false;

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/EventJsonLayout.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/EventJsonLayout.java
@@ -63,6 +63,7 @@ public class EventJsonLayout extends AbstractJsonLayout<ILoggingEvent> {
             .add("level", isIncluded(EventAttribute.LEVEL), String.valueOf(event.getLevel()))
             .add("thread", isIncluded(EventAttribute.THREAD_NAME), event.getThreadName())
             .add("logger", isIncluded(EventAttribute.LOGGER_NAME), event.getLoggerName())
+            .add("marker", isIncluded(EventAttribute.MARKER) && event.getMarker() != null, () -> event.getMarker().getName())
             .add("message", isIncluded(EventAttribute.MESSAGE), event.getFormattedMessage())
             .add("context", isIncluded(EventAttribute.CONTEXT_NAME), event.getLoggerContextVO().getName())
             .add("version", jsonProtocolVersion != null, jsonProtocolVersion)
@@ -87,8 +88,8 @@ public class EventJsonLayout extends AbstractJsonLayout<ILoggingEvent> {
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
-    private boolean isIncluded(EventAttribute exception) {
-        return includes.contains(exception);
+    private boolean isIncluded(EventAttribute include) {
+        return includes.contains(include);
     }
 
     public ImmutableSet<EventAttribute> getIncludes() {

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/MapBuilder.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/MapBuilder.java
@@ -2,6 +2,7 @@ package io.dropwizard.logging.json.layout;
 
 import com.google.common.collect.Maps;
 
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import java.util.Map;
 
@@ -61,6 +62,20 @@ public class MapBuilder {
     public MapBuilder add(String fieldName, boolean include, @Nullable Map<String, ?> mapValue) {
         if (include && mapValue != null && !mapValue.isEmpty()) {
             map.put(getFieldName(fieldName), mapValue);
+        }
+        return this;
+    }
+
+    /**
+     * Adds the string value to the provided map under the provided field name,
+     * if it should be included. The supplier is only invoked if the field is to be included.
+     */
+    public MapBuilder add(String fieldName, boolean include, Supplier<String> supplier) {
+        if (include) {
+            String value = supplier.get();
+            if (value != null) {
+                map.put(getFieldName(fieldName), value);
+            }
         }
         return this;
     }

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
@@ -30,6 +30,8 @@ import java.io.File;
 import java.io.PrintStream;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
 
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -119,7 +121,8 @@ public class LayoutIntegrationTests {
         try {
             System.setOut(new PrintStream(redirectedStream));
             defaultLoggingFactory.configure(new MetricRegistry(), "json-log-test");
-            LoggerFactory.getLogger("com.example.app").info("Application log");
+            Marker marker = MarkerFactory.getMarker("marker");
+            LoggerFactory.getLogger("com.example.app").info(marker, "Application log");
             Thread.sleep(100); // Need to wait, because the logger is async
 
             JsonNode jsonNode = objectMapper.readTree(redirectedStream.toString());
@@ -127,6 +130,7 @@ public class LayoutIntegrationTests {
             assertThat(jsonNode.get("timestamp").isTextual()).isTrue();
             assertThat(jsonNode.get("level").asText()).isEqualTo("INFO");
             assertThat(jsonNode.get("logger").asText()).isEqualTo("com.example.app");
+            assertThat(jsonNode.get("marker").asText()).isEqualTo("marker");
             assertThat(jsonNode.get("message").asText()).isEqualTo("Application log");
         } finally {
             System.setOut(old);


### PR DESCRIPTION
###### Problem:
Need Slf4j marker in json logs

###### Solution:
Backported changes from #2899 

###### Result:
Marker will be included when present

Fixes: #2960 