### PR TITLE
Add quotes to Maven commands in GitHub actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,6 +24,6 @@ jobs:
       with:
         java-version: ${{ matrix.java_version }}
     - name: Build with Maven
-      run: ./mvnw -V -B -ff -s .github/settings.xml install -Dmaven.test.skip=true -Dmaven.javadoc.skip=true
+      run: ./mvnw -V -B -ff -s .github/settings.xml install '-Dmaven.test.skip=true' '-Dmaven.javadoc.skip=true'
     - name: Run tests
       run: ./mvnw -V -B -ff -s .github/settings.xml verify


### PR DESCRIPTION
```
[ERROR] Unknown lifecycle phase ".test.skip=true". You must specify a valid lifecycle phase or a goal in the format <plugin-prefix>:<goal> or <plugin-group-id>:<plugin-artifact-id>[:<plugin-version>]:<goal>.
```

Refs https://stackoverflow.com/questions/6347985/cannot-run-maven-using-mvn-d-argument-within-microsoft-powershell-but-works