### PR TITLE
Application should throw exceptions

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/Application.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/Application.java
@@ -89,11 +89,8 @@ public abstract class Application<T extends Configuration> {
         // Should be called after initialize to give an opportunity to set a custom metric registry
         bootstrap.registerMetrics();
 
-        final Cli cli = new Cli(new JarLocation(getClass()), bootstrap, System.out, System.err);
-        if (!cli.run(arguments)) {
-            // only exit if there's an error running the command
-            onFatalError();
-        }
+        new Cli(new JarLocation(getClass()), bootstrap, System.out, System.err)
+            .run(arguments);
     }
 
     /**
@@ -104,15 +101,5 @@ public abstract class Application<T extends Configuration> {
     protected void addDefaultCommands(Bootstrap<T> bootstrap) {
         bootstrap.addCommand(new ServerCommand<>(this));
         bootstrap.addCommand(new CheckCommand<>(this));
-    }
-
-    /**
-     * Called by {@link #run(String...)} to indicate there was a fatal error running the requested command.
-     *
-     * The default implementation calls {@link System#exit(int)} with a non-zero status code to terminate the
-     * application.
-     */
-    protected void onFatalError() {
-        System.exit(1);
     }
 }

--- a/dropwizard-core/src/main/java/io/dropwizard/cli/Cli.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/Cli.java
@@ -64,7 +64,7 @@ public class Cli {
      * @return whether or not the command successfully executed
      * @throws Exception if something goes wrong
      */
-    public boolean run(String... arguments) throws Exception {
+    public void run(String... arguments) throws Exception {
         try {
             if (isFlag(HELP, arguments)) {
                 parser.printHelp(stdOut);
@@ -80,18 +80,16 @@ public class Cli {
                     // The command failed to run, and the command knows
                     // best how to cleanup / debug exception
                     command.onError(this, namespace, e);
-                    return false;
+                    throw e;
                 }
             }
-            return true;
         } catch (HelpScreenException ignored) {
             // This exception is triggered when the user passes in a help flag.
             // Return true to signal that the process executed normally.
-            return true;
         } catch (ArgumentParserException e) {
             stdErr.println(e.getMessage());
             e.getParser().printHelp(stdErr);
-            return false;
+            throw e;
         }
     }
 

--- a/dropwizard-core/src/test/java/io/dropwizard/ApplicationTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/ApplicationTest.java
@@ -7,24 +7,15 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class ApplicationTest {
     private static class FakeConfiguration extends Configuration {
     }
 
-    private static class FakeApplication extends Application<FakeConfiguration> {
-        boolean fatalError = false;
-
+    private static class PoserApplication extends Application<FakeConfiguration> {
         @Override
         public void run(FakeConfiguration configuration, Environment environment) {}
-
-        @Override
-        protected void onFatalError() {
-            fatalError = true;
-        }
-    }
-
-    private static class PoserApplication extends FakeApplication {
     }
 
     private static class WrapperApplication<C extends FakeConfiguration> extends Application<C> {
@@ -47,7 +38,7 @@ public class ApplicationTest {
 
     @Test
     public void hasAReferenceToItsTypeParameter() throws Exception {
-        assertThat(new FakeApplication().getConfigurationClass())
+        assertThat(new PoserApplication().getConfigurationClass())
                 .isSameAs(FakeConfiguration.class);
     }
 
@@ -68,9 +59,10 @@ public class ApplicationTest {
     public void exitWithFatalErrorWhenCommandFails() throws Exception {
         final File configFile = File.createTempFile("dropwizard-invalid-config", ".yml");
         try {
-            final FakeApplication application = new FakeApplication();
-            application.run("server", configFile.getAbsolutePath());
-            assertThat(application.fatalError).isTrue();
+            final PoserApplication application = new PoserApplication();
+            assertThatThrownBy(() -> {
+                application.run("server", configFile.getAbsolutePath());
+            }).isInstanceOf(Exception.class);
         } finally {
             configFile.delete();
         }

--- a/dropwizard-core/src/test/java/io/dropwizard/cli/CliTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/cli/CliTest.java
@@ -19,6 +19,7 @@ import java.util.Locale;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -116,8 +117,7 @@ public class CliTest {
 
     @Test
     public void handlesShortVersionCommands() throws Exception {
-        assertThat(cli.run("-v"))
-                .isTrue();
+        cli.run("-v");
 
         assertThat(stdOut.toString())
                 .isEqualTo(String.format("1.0.0%n"));
@@ -128,8 +128,7 @@ public class CliTest {
 
     @Test
     public void handlesLongVersionCommands() throws Exception {
-        assertThat(cli.run("--version"))
-                .isTrue();
+        cli.run("--version");
 
         assertThat(stdOut.toString())
                 .isEqualTo(String.format("1.0.0%n"));
@@ -143,8 +142,7 @@ public class CliTest {
         when(location.getVersion()).thenReturn(Optional.empty());
         final Cli newCli = new Cli(location, bootstrap, stdOut, stdErr);
 
-        assertThat(newCli.run("--version"))
-                .isTrue();
+        newCli.run("--version");
 
         assertThat(stdOut.toString())
                 .isEqualTo(String.format("No application version detected. Add a Implementation-Version entry to your JAR's manifest to enable this.%n"));
@@ -155,8 +153,7 @@ public class CliTest {
 
     @Test
     public void handlesZeroArgumentsAsHelpCommand() throws Exception {
-        assertThat(cli.run())
-                .isTrue();
+        cli.run();
 
         assertThat(stdOut.toString())
                 .isEqualTo(String.format(
@@ -176,8 +173,7 @@ public class CliTest {
 
     @Test
     public void handlesShortHelpCommands() throws Exception {
-        assertThat(cli.run("-h"))
-                .isTrue();
+        cli.run("-h");
 
         assertThat(stdOut.toString())
                 .isEqualTo(String.format(
@@ -197,8 +193,7 @@ public class CliTest {
 
     @Test
     public void handlesLongHelpCommands() throws Exception {
-        assertThat(cli.run("--help"))
-                .isTrue();
+        cli.run("--help");
 
         assertThat(stdOut.toString())
                 .isEqualTo(String.format(
@@ -219,8 +214,7 @@ public class CliTest {
     @Test
     @SuppressWarnings("unchecked")
     public void handlesShortHelpSubcommands() throws Exception {
-        assertThat(cli.run("check", "-h"))
-                .isTrue();
+        cli.run("check", "-h");
 
         assertThat(stdOut.toString())
                 .isEqualTo(String.format(
@@ -244,8 +238,7 @@ public class CliTest {
     @Test
     @SuppressWarnings("unchecked")
     public void handlesLongHelpSubcommands() throws Exception {
-        assertThat(cli.run("check", "--help"))
-                .isTrue();
+        cli.run("check", "--help");
 
         assertThat(stdOut.toString())
                 .isEqualTo(String.format(
@@ -268,8 +261,8 @@ public class CliTest {
 
     @Test
     public void rejectsBadCommandFlags() throws Exception {
-        assertThat(cli.run("--yes"))
-                .isFalse();
+        assertThatThrownBy(() -> { cli.run("--yes"); })
+            .isInstanceOf(Exception.class);
 
         assertThat(stdOut.toString())
                 .isEmpty();
@@ -290,8 +283,8 @@ public class CliTest {
 
     @Test
     public void rejectsBadSubcommandFlags() throws Exception {
-        assertThat(cli.run("check", "--yes"))
-                .isFalse();
+        assertThatThrownBy(() -> { cli.run("check", "--yes"); })
+            .isInstanceOf(Exception.class);
 
         assertThat(stdOut.toString())
                 .isEmpty();
@@ -313,8 +306,8 @@ public class CliTest {
 
     @Test
     public void rejectsBadSubcommands() throws Exception {
-        assertThat(cli.run("plop"))
-                .isFalse();
+        assertThatThrownBy(() -> { cli.run("plop"); })
+            .isInstanceOf(Exception.class);
 
         assertThat(stdOut.toString())
                 .isEmpty();
@@ -335,8 +328,7 @@ public class CliTest {
 
     @Test
     public void runsCommands() throws Exception {
-        assertThat(cli.run("check"))
-                .isTrue();
+        cli.run("check");
 
         assertThat(stdOut.toString())
                 .isEmpty();
@@ -352,8 +344,8 @@ public class CliTest {
     public void unhandledExceptionsMessagesArePrintedForCheck() throws Exception {
         doThrow(new BadAppException()).when(command).run(any(Bootstrap.class), any(Namespace.class), any(Configuration.class));
 
-        assertThat(cli.run("check"))
-                .isFalse();
+        assertThatThrownBy(() -> { cli.run("check"); })
+            .isInstanceOf(Exception.class);
 
         assertThat(stdOut.toString())
                 .isEmpty();
@@ -367,8 +359,8 @@ public class CliTest {
     public void unhandledExceptionsCustomCommand() throws Exception {
         doThrow(new BadAppException()).when(command).run(any(Bootstrap.class), any(Namespace.class), any(Configuration.class));
 
-        assertThat(cli.run("custom"))
-            .isFalse();
+        assertThatThrownBy(() -> { cli.run("custom"); })
+            .isInstanceOf(Exception.class);
 
         assertThat(stdOut.toString())
             .isEqualTo(String.format("I did not expect this!%n"));
@@ -382,8 +374,8 @@ public class CliTest {
     public void unhandledExceptionsCustomCommandDebug() throws Exception {
         doThrow(new BadAppException()).when(command).run(any(Bootstrap.class), any(Namespace.class), any(Configuration.class));
 
-        assertThat(cli.run("custom", "--debug"))
-            .isFalse();
+        assertThatThrownBy(() -> { cli.run("custom", "--debug"); })
+            .isInstanceOf(Exception.class);
 
         assertThat(stdOut.toString())
             .isEmpty();

--- a/dropwizard-core/src/test/java/io/dropwizard/cli/CommandTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/cli/CommandTest.java
@@ -57,8 +57,7 @@ public class CommandTest {
 
     @Test
     public void listHelpOnceOnArgumentOmission() throws Exception {
-        assertThat(cli.run("test", "-h"))
-            .isTrue();
+        cli.run("test", "-h");
 
         assertThat(stdOut.toString())
             .isEqualTo(String.format(


### PR DESCRIPTION
This allows exception to be handled and logged.

###### Problem:
`io.dropwizard.Application` doesn't throw exceptions so they can't be caught and logged.

Its very important to know why the app crashed but nothing shows-up in the logs if you call `System.exit()` bypassing all catch blocks.

Overriding `onFatalError()` doesn't work because `onFatalError()` doesn't provide the error message.

###### Solution:
Users can catch and Exceptions and call System.exit() if they like that behavior.

###### Result:
Exceptions can be caught
