### PR TITLE
Support handling failed commands via `Application#onFatalError(…

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/Application.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/Application.java
@@ -113,7 +113,6 @@ public abstract class Application<T extends Configuration> {
      * @param t The {@link Throwable} instance which caused the command to fail.
      * @since 2.0
      */
-    @SuppressWarnings("deprecated")
     protected void onFatalError(Throwable t) {
         onFatalError();
     }

--- a/dropwizard-core/src/main/java/io/dropwizard/Application.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/Application.java
@@ -90,10 +90,8 @@ public abstract class Application<T extends Configuration> {
         bootstrap.registerMetrics();
 
         final Cli cli = new Cli(new JarLocation(getClass()), bootstrap, System.out, System.err);
-        if (!cli.run(arguments)) {
-            // only exit if there's an error running the command
-            onFatalError();
-        }
+        // only exit if there's an error running the command
+        cli.run(arguments).ifPresent(this::onFatalError);
     }
 
     /**
@@ -111,7 +109,24 @@ public abstract class Application<T extends Configuration> {
      *
      * The default implementation calls {@link System#exit(int)} with a non-zero status code to terminate the
      * application.
+     *
+     * @param t The {@link Throwable} instance which caused the command to fail.
+     * @since 2.0
      */
+    @SuppressWarnings("deprecated")
+    protected void onFatalError(Throwable t) {
+        onFatalError();
+    }
+
+    /**
+     * Called by {@link #run(String...)} to indicate there was a fatal error running the requested command.
+     *
+     * The default implementation calls {@link System#exit(int)} with a non-zero status code to terminate the
+     * application.
+     *
+     * @deprecated Use #onFatalError(Throwable) instead.
+     */
+    @Deprecated
     protected void onFatalError() {
         System.exit(1);
     }

--- a/dropwizard-core/src/main/java/io/dropwizard/cli/Cli.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/Cli.java
@@ -18,6 +18,7 @@ import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -64,7 +65,7 @@ public class Cli {
      * @return whether or not the command successfully executed
      * @throws Exception if something goes wrong
      */
-    public boolean run(String... arguments) throws Exception {
+    public Optional<Throwable> run(String... arguments) throws Exception {
         try {
             if (isFlag(HELP, arguments)) {
                 parser.printHelp(stdOut);
@@ -80,18 +81,18 @@ public class Cli {
                     // The command failed to run, and the command knows
                     // best how to cleanup / debug exception
                     command.onError(this, namespace, e);
-                    return false;
+                    return Optional.of(e);
                 }
             }
-            return true;
+            return Optional.empty();
         } catch (HelpScreenException ignored) {
             // This exception is triggered when the user passes in a help flag.
             // Return true to signal that the process executed normally.
-            return true;
+            return Optional.empty();
         } catch (ArgumentParserException e) {
             stdErr.println(e.getMessage());
             e.getParser().printHelp(stdErr);
-            return false;
+            return Optional.of(e);
         }
     }
 

--- a/dropwizard-core/src/test/java/io/dropwizard/cli/CommandTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/cli/CommandTest.java
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class CommandTest {
+class CommandTest {
     private static class TestCommand extends Command {
         protected TestCommand() {
             super("test", "test");
@@ -45,7 +45,7 @@ public class CommandTest {
     private Cli cli;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() {
         final JarLocation location = mock(JarLocation.class);
         final Bootstrap<Configuration> bootstrap = new Bootstrap<>(app);
         when(location.toString()).thenReturn("dw-thing.jar");
@@ -56,9 +56,9 @@ public class CommandTest {
     }
 
     @Test
-    public void listHelpOnceOnArgumentOmission() throws Exception {
+    void listHelpOnceOnArgumentOmission() throws Exception {
         assertThat(cli.run("test", "-h"))
-            .isTrue();
+            .isEmpty();
 
         assertThat(stdOut.toString())
             .isEqualTo(String.format(


### PR DESCRIPTION
Instead of just exiting the application by default (`Application#onFatalError()`) in case a command failed,
the `Application#onFatalError(Throwable)` method allows reacting to different causes of the failure.

Closes #3014
Closes #3015