### PR TITLE
Fix links to Jersey Client API

### DIFF
--- a/docs/source/manual/client.rst
+++ b/docs/source/manual/client.rst
@@ -124,7 +124,7 @@ If HttpClient_ is too low-level for you, Dropwizard also supports Jersey's `Clie
 Jersey's ``Client`` allows you to use all of the server-side media type support that your service
 uses to, for example, deserialize ``application/json`` request entities as POJOs.
 
-.. _Client API: https://jersey.github.io/documentation/2.24/client.html
+.. _Client API: https://eclipse-ee4j.github.io/jersey.github.io/documentation/2.29.1/client.html
 
 To create a :ref:`managed <man-core-managed>`, instrumented ``JerseyClient`` instance, your
 :ref:`configuration class <man-core-configuration>` needs an :ref:`jersey client configuration <man-configuration-clients-jersey>` instance:
@@ -182,8 +182,8 @@ the `Jersey Client Properties`_ can be used.
     method on the ``JerseyClientBuilder``, because by default it's configured by Dropwizard's
     ``HttpClientBuilder``, so the Jersey properties are ignored.
 
-.. _Jersey Client Configuration: https://jersey.github.io/documentation/latest/appendix-properties.html#appendix-properties-client
-.. _Jersey Client Properties: https://jersey.github.io/apidocs/2.24/jersey/org/glassfish/jersey/client/ClientProperties.html
+.. _Jersey Client Configuration: https://eclipse-ee4j.github.io/jersey.github.io/documentation/2.29.1/appendix-properties.html#appendix-properties-client
+.. _Jersey Client Properties: https://eclipse-ee4j.github.io/jersey.github.io/apidocs/2.29.1/jersey/org/glassfish/jersey/client/ClientProperties.html
 
 .. _man-client-jersey-rx-usage:
 
@@ -220,7 +220,7 @@ Alternatively, there are RxJava, Guava, and JSR-166e implementations.
 By allowing Dropwizard to create the rx-client, the same thread pool that is utilized by traditional
 synchronous and asynchronous requests, is used for rx requests.
 
-.. _rx-clients: https://jersey.github.io/documentation/2.24/rx-client.html
+.. _rx-clients: https://eclipse-ee4j.github.io/jersey.github.io/documentation/2.29.1/rx-client.html
 
 Proxy Authentication
 --------------------


### PR DESCRIPTION
There are still old URLs in [other files](https://github.com/dropwizard/dropwizard/search?q=%22jersey.github.io%22). I don’t know whether they should point to the latest Jersey version or the one Dropwizard actually uses (which would take some effort to keep in sync).