### PR TITLE
Enable Jackson Afterburner only on Java 8 (backport)

### DIFF
--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import io.dropwizard.util.JavaVersion;
 
 import javax.annotation.Nullable;
 
@@ -56,7 +57,9 @@ public class Jackson {
         mapper.registerModule(new GuavaModule());
         mapper.registerModule(new GuavaExtrasModule());
         mapper.registerModule(new JodaModule());
-        mapper.registerModule(new AfterburnerModule());
+        if (JavaVersion.isJava8()) {
+            mapper.registerModule(new AfterburnerModule());
+        }
         mapper.registerModule(new FuzzyEnumModule());
         mapper.registerModule(new ParameterNamesModule());
         mapper.registerModule(new Jdk8Module());

--- a/dropwizard-util/pom.xml
+++ b/dropwizard-util/pom.xml
@@ -45,5 +45,17 @@
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>RELEASE</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/dropwizard-util/pom.xml
+++ b/dropwizard-util/pom.xml
@@ -45,17 +45,5 @@
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <version>RELEASE</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <version>RELEASE</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/dropwizard-util/src/main/java/io/dropwizard/util/JavaVersion.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/JavaVersion.java
@@ -1,0 +1,22 @@
+package io.dropwizard.util;
+
+import javax.annotation.Nullable;
+
+public class JavaVersion {
+    private JavaVersion() {
+    }
+
+    public static boolean isJava8() {
+        final String specVersion = getJavaSpecVersion();
+        return specVersion != null && specVersion.startsWith("1.8");
+    }
+
+    @Nullable
+    private static String getJavaSpecVersion() {
+        try {
+            return System.getProperty("java.specification.version");
+        } catch (final SecurityException ex) {
+            return null;
+        }
+    }
+}

--- a/dropwizard-util/src/test/java/io/dropwizard/util/JavaVersionTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/JavaVersionTest.java
@@ -1,0 +1,25 @@
+package io.dropwizard.util;
+
+import org.testng.annotations.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class JavaVersionTest {
+    @Test
+    void isJava8_returns_false_if_specVersion_cannot_be_read() {
+        System.clearProperty("java.specification.version");
+        assertThat(JavaVersion.isJava8()).isFalse();
+    }
+
+    @Test
+    void isJava8_returns_true_if_specVersion_is_Java_8() {
+        System.setProperty("java.specification.version", "1.8.0_222");
+        assertThat(JavaVersion.isJava8()).isTrue();
+    }
+
+    @Test
+    void isJava8_returns_true_if_specVersion_is_Java_11() {
+        System.setProperty("java.specification.version", "11");
+        assertThat(JavaVersion.isJava8()).isFalse();
+    }
+}

--- a/dropwizard-util/src/test/java/io/dropwizard/util/JavaVersionTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/JavaVersionTest.java
@@ -6,19 +6,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class JavaVersionTest {
     @Test
-    void isJava8_returns_false_if_specVersion_cannot_be_read() {
+    public void isJava8_returns_false_if_specVersion_cannot_be_read() {
         System.clearProperty("java.specification.version");
         assertThat(JavaVersion.isJava8()).isFalse();
     }
 
     @Test
-    void isJava8_returns_true_if_specVersion_is_Java_8() {
+    public void isJava8_returns_true_if_specVersion_is_Java_8() {
         System.setProperty("java.specification.version", "1.8.0_222");
         assertThat(JavaVersion.isJava8()).isTrue();
     }
 
     @Test
-    void isJava8_returns_true_if_specVersion_is_Java_11() {
+    public void isJava8_returns_true_if_specVersion_is_Java_11() {
         System.setProperty("java.specification.version", "11");
         assertThat(JavaVersion.isJava8()).isFalse();
     }

--- a/dropwizard-util/src/test/java/io/dropwizard/util/JavaVersionTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/JavaVersionTest.java
@@ -1,6 +1,6 @@
 package io.dropwizard.util;
 
-import org.testng.annotations.Test;
+import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 


### PR DESCRIPTION
This MR is to backport the fixes made on b1c39570ef51e0c337f6cacea159fbd80fb598ce to release/1.3.x

###### Problem:
The Jackson Afterburner module is currently not compatible with the JPMS and will lead to illegal reflective access operation warnings:
```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.fasterxml.jackson.module.afterburner.util.MyClassLoader (file:.m2/repository/com/fasterxml/jackson/module/jackson-module-afterburner/2.9.9/jackson-module-afterburner-2.9.9.jar) to method java.lang.ClassLoader.findLoadedClass(java.lang.String)
WARNING: Please consider reporting this to the maintainers of com.fasterxml.jackson.module.afterburner.util.MyClassLoader
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```

Fixes #2909
Refs #2966
Refs FasterXML/jackson-modules-base#37

###### Solution:
Cherry-pick the commit into the release/1.3.x branch to be included on the next release

###### Result:
This will allow the fix to be used on a stable version of dropwizard. As of now, the fix is only available through the 2.0 Release candidate