### PR TITLE
Upgrade Apache httpclient to 4.5.10 to fix URI rewriting

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -86,7 +86,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.5.7</version>
+                <version>4.5.10</version>
                 <exclusions>
                     <exclusion>
                         <groupId>commons-logging</groupId>


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/HTTPCLIENT-1968 for detailed background.

###### Problem:
4.5.7 introduced a change to normalize URIs by removing repeated forward slashes.  However, this broke encoded reserved characters in the URI, such as the forward slash itself (`%2F`).  I've been running into this while using the latest Dropwizard 1.3 release.

Example URI that fails: `http://localhost/math/1%2F2` (gets converted to `http://localhost/math/1/2` prior to the request being made)

###### Solution:
4.5.8 fixed this issue, but .9 and .10 included good fixes as well, so bump up to 4.5.10.

###### Result:
See the release notes for the list of fixes: https://github.com/apache/httpcomponents-client/blob/4.5.10/RELEASE_NOTES.txt