### PR TITLE
Remove Stack Trace Printing In Task Servlet To Remove Potential Security Vulnerability

### DIFF
--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/TaskServlet.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/TaskServlet.java
@@ -129,7 +129,6 @@ public class TaskServlet extends HttpServlet {
                 resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
                 output.println();
                 output.println(e.getMessage());
-                e.printStackTrace(output);
             } finally {
                 output.close();
             }


### PR DESCRIPTION
###### Problem:
Information from a stack trace propagates to an external user. Stack traces can unintentionally reveal implementation details that are useful to an attacker for developing a subsequent exploit.
###### Solution:
Remove printing of stack trace in `TaskServlet`

