### PR TITLE
Add config settings for tasks and health check resources

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -581,6 +581,45 @@ initialStreamRecvWindow   65535     The initial flow control window size for a n
                                     triggered.
 ========================  ========  ===================================================================================
 
+.. _man-configuration-tasks:
+
+Tasks
+=====
+
+.. code-block:: yaml
+
+    admin:
+      tasks:
+        printStackTraceOnError: true
+
+
+====================== ======= ===============================================================
+Name                   Default Description
+====================== ======= ===============================================================
+printStackTraceOnError false   Print the full stack trace when the execution of a task failed.
+====================== ======= ===============================================================
+
+.. _man-configuration-healthchecks:
+
+Health checks
+=============
+
+.. code-block:: yaml
+
+    admin:
+      healthChecks:
+        minThreads: 1
+        maxThreads: 4
+        workQueueSize: 1
+
+
+============= ======= ==========================================================
+Name                   Default Description
+============= ======= ==========================================================
+minThreads    1       The minimum number of threads for executing health checks.
+maxThreads    4       The maximum number of threads for executing health checks.
+workQueueSize 1       The length of the work queue for health check executions.
+============= ======= ==========================================================
 
 .. _man-configuration-logging:
 

--- a/dropwizard-core/src/main/java/io/dropwizard/Configuration.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/Configuration.java
@@ -6,6 +6,7 @@ import io.dropwizard.logging.LoggingFactory;
 import io.dropwizard.metrics.MetricsFactory;
 import io.dropwizard.server.DefaultServerFactory;
 import io.dropwizard.server.ServerFactory;
+import io.dropwizard.setup.AdminFactory;
 
 import javax.annotation.Nullable;
 import javax.validation.Valid;
@@ -72,6 +73,10 @@ public class Configuration {
     @NotNull
     private MetricsFactory metrics = new MetricsFactory();
 
+    @Valid
+    @NotNull
+    private AdminFactory admin = new AdminFactory();
+
     /**
      * Returns the server-specific section of the configuration file.
      *
@@ -122,8 +127,29 @@ public class Configuration {
         this.metrics = metrics;
     }
 
+    /**
+     * Returns the admin interface-specific section of the configuration file.
+     *
+     * @return admin interface-specific configuration parameters
+     * @since 2.0
+     */
+    @JsonProperty("admin")
+    public AdminFactory getAdminFactory() {
+        return admin;
+    }
+
+    /**
+     * Sets the admin interface-specific section of the configuration file.
+     *
+     * @since 2.0
+     */
+    @JsonProperty("admin")
+    public void setAdminFactory(AdminFactory admin) {
+        this.admin = admin;
+    }
+
     @Override
     public String toString() {
-        return "Configuration{server=" + server + ", logging=" + logging + ", metrics=" + metrics + "}";
+        return "Configuration{server=" + server + ", logging=" + logging + ", metrics=" + metrics + ", admin=" + admin + "}";
     }
 }

--- a/dropwizard-core/src/main/java/io/dropwizard/cli/EnvironmentCommand.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/EnvironmentCommand.java
@@ -34,7 +34,8 @@ public abstract class EnvironmentCommand<T extends Configuration> extends Config
                                                         bootstrap.getValidatorFactory(),
                                                         bootstrap.getMetricRegistry(),
                                                         bootstrap.getClassLoader(),
-                                                        bootstrap.getHealthCheckRegistry());
+                                                        bootstrap.getHealthCheckRegistry(),
+                                                        configuration);
         configuration.getMetricsFactory().configure(environment.lifecycle(),
                                                     bootstrap.getMetricRegistry());
         configuration.getServerFactory().configure(environment);

--- a/dropwizard-core/src/main/java/io/dropwizard/setup/AdminEnvironment.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/AdminEnvironment.java
@@ -32,11 +32,13 @@ public class AdminEnvironment extends ServletEnvironment {
      * @param healthChecks a health check registry
      */
     public AdminEnvironment(MutableServletContextHandler handler,
-                            HealthCheckRegistry healthChecks, MetricRegistry metricRegistry) {
+                            HealthCheckRegistry healthChecks,
+                            MetricRegistry metricRegistry,
+                            AdminFactory adminFactory) {
         super(handler);
         this.healthChecks = healthChecks;
         this.healthChecks.register("deadlocks", new ThreadDeadlockHealthCheck());
-        this.tasks = new TaskServlet(metricRegistry);
+        this.tasks = new TaskServlet(metricRegistry, adminFactory.getTasks());
         tasks.add(new GarbageCollectionTask());
         tasks.add(new LogConfigurationTask());
         addServlet("tasks", tasks).addMapping("/tasks/*");

--- a/dropwizard-core/src/main/java/io/dropwizard/setup/AdminFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/AdminFactory.java
@@ -1,0 +1,51 @@
+package io.dropwizard.setup;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.servlets.tasks.TaskConfiguration;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.StringJoiner;
+
+/**
+ * A factory for configuring the admin interface for the environment.
+ *
+ * @since 2.0
+ */
+public class AdminFactory {
+    @Valid
+    @NotNull
+    private HealthCheckConfiguration healthChecks = new HealthCheckConfiguration();
+
+    @Valid
+    @NotNull
+    private TaskConfiguration tasks = new TaskConfiguration();
+
+    @JsonProperty("healthChecks")
+    public HealthCheckConfiguration getHealthChecks() {
+        return healthChecks;
+    }
+
+    @JsonProperty("healthChecks")
+    public void setHealthChecks(HealthCheckConfiguration healthChecks) {
+        this.healthChecks = healthChecks;
+    }
+
+    @JsonProperty("tasks")
+    public TaskConfiguration getTasks() {
+        return tasks;
+    }
+
+    @JsonProperty("tasks")
+    public void setTasks(TaskConfiguration tasks) {
+        this.tasks = tasks;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", AdminFactory.class.getSimpleName() + "[", "]")
+                .add("healthChecks=" + healthChecks)
+                .add("tasks=" + tasks)
+                .toString();
+    }
+}

--- a/dropwizard-core/src/main/java/io/dropwizard/setup/HealthCheckConfiguration.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/HealthCheckConfiguration.java
@@ -1,0 +1,79 @@
+package io.dropwizard.setup;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.StringJoiner;
+
+/**
+ * A factory for configuring the health check sub-system for the environment.
+ * <p/>
+ * <b>Configuration Parameters:</b>
+ * <table>
+ *     <tr>
+ *         <td>Name</td>
+ *         <td>Default</td>
+ *         <td>Description</td>
+ *     </tr>
+ *     <tr>
+ *         <td>minThreads</td>
+ *         <td>1</td>
+ *         <td>The minimum number of threads for executing health checks.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>maxThreads</td>
+ *         <td>4</td>
+ *         <td>The maximum number of threads for executing health checks.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>workQueueSize</td>
+ *         <td>1</td>
+ *         <td>The length of the work queue for health check executions.</td>
+ *     </tr>
+ * </table>
+ *
+ * @since 2.0
+ */
+public class HealthCheckConfiguration {
+    private int minThreads = 1;
+    private int maxThreads = 4;
+    private int workQueueSize = 1;
+
+    @JsonProperty("minThreads")
+    public int getMinThreads() {
+        return minThreads;
+    }
+
+    @JsonProperty("minThreads")
+    public void setMinThreads(int minThreads) {
+        this.minThreads = minThreads;
+    }
+
+    @JsonProperty("maxThreads")
+    public int getMaxThreads() {
+        return maxThreads;
+    }
+
+    @JsonProperty("maxThreads")
+    public void setMaxThreads(int maxThreads) {
+        this.maxThreads = maxThreads;
+    }
+
+    @JsonProperty("workQueueSize")
+    public int getWorkQueueSize() {
+        return workQueueSize;
+    }
+
+    @JsonProperty("workQueueSize")
+    public void setWorkQueueSize(int workQueueSize) {
+        this.workQueueSize = workQueueSize;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", HealthCheckConfiguration.class.getSimpleName() + "[", "]")
+                .add("minThreads=" + minThreads)
+                .add("maxThreads=" + maxThreads)
+                .add("workQueueSize=" + workQueueSize)
+                .toString();
+    }
+}

--- a/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
@@ -1,13 +1,11 @@
 package io.dropwizard.server;
 
-import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
 import io.dropwizard.jackson.Jackson;
-import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.jetty.HttpConnectorFactory;
 import io.dropwizard.jetty.ServerPushFilterFactory;
 import io.dropwizard.logging.ConsoleAppenderFactory;
@@ -44,14 +42,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class DefaultServerFactoryTest {
-    private Environment environment = new Environment("test", Jackson.newObjectMapper(),
-            Validators.newValidator(), new MetricRegistry(),
-            ClassLoader.getSystemClassLoader());
+class DefaultServerFactoryTest {
+    private Environment environment = new Environment("test");
     private DefaultServerFactory http;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
 
         final ObjectMapper objectMapper = Jackson.newObjectMapper();
         objectMapper.getSubtypeResolver().registerSubtypes(ConsoleAppenderFactory.class,
@@ -66,13 +62,13 @@ public class DefaultServerFactoryTest {
     }
 
     @Test
-    public void loadsGzipConfig() throws Exception {
+    void loadsGzipConfig() throws Exception {
         assertThat(http.getGzipFilterFactory().isEnabled())
                 .isFalse();
     }
 
     @Test
-    public void loadsServerPushConfig() throws Exception {
+    void loadsServerPushConfig() throws Exception {
         final ServerPushFilterFactory serverPush = http.getServerPush();
         assertThat(serverPush.isEnabled()).isTrue();
         assertThat(serverPush.getRefererHosts()).contains("dropwizard.io");
@@ -80,35 +76,35 @@ public class DefaultServerFactoryTest {
     }
 
     @Test
-    public void hasAMaximumNumberOfThreads() throws Exception {
+    void hasAMaximumNumberOfThreads() throws Exception {
         assertThat(http.getMaxThreads())
                 .isEqualTo(101);
     }
 
     @Test
-    public void hasAMinimumNumberOfThreads() throws Exception {
+    void hasAMinimumNumberOfThreads() throws Exception {
         assertThat(http.getMinThreads())
                 .isEqualTo(89);
     }
 
     @Test
-    public void hasApplicationContextPath() throws Exception {
+    void hasApplicationContextPath() throws Exception {
         assertThat(http.getApplicationContextPath()).isEqualTo("/app");
     }
 
     @Test
-    public void hasAdminContextPath() throws Exception {
+    void hasAdminContextPath() throws Exception {
         assertThat(http.getAdminContextPath()).isEqualTo("/admin");
     }
 
     @Test
-    public void isDiscoverable() throws Exception {
+    void isDiscoverable() throws Exception {
         assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
                 .contains(DefaultServerFactory.class);
     }
 
     @Test
-    public void registersDefaultExceptionMappers() throws Exception {
+    void registersDefaultExceptionMappers() throws Exception {
         assertThat(http.getRegisterDefaultExceptionMappers()).isTrue();
 
         http.build(environment);
@@ -117,43 +113,41 @@ public class DefaultServerFactoryTest {
     }
 
     @Test
-    public void doesNotDefaultExceptionMappers() throws Exception {
+    void doesNotDefaultExceptionMappers() throws Exception {
         http.setRegisterDefaultExceptionMappers(false);
         assertThat(http.getRegisterDefaultExceptionMappers()).isFalse();
-        Environment environment = new Environment("test", Jackson.newObjectMapper(),
-                Validators.newValidator(), new MetricRegistry(),
-                ClassLoader.getSystemClassLoader());
+        Environment environment = new Environment("test");
         http.build(environment);
         assertThat(environment.jersey().getResourceConfig().getSingletons())
             .filteredOn(x -> x instanceof ExceptionMapperBinder).isEmpty();
     }
 
     @Test
-    public void defaultsDumpAfterStartFalse() throws Exception {
+    void defaultsDumpAfterStartFalse() throws Exception {
         assertThat(http.getDumpAfterStart()).isFalse();
         assertThat(http.build(environment).isDumpAfterStart()).isFalse();
     }
 
     @Test
-    public void defaultsDumpBeforeStopFalse() throws Exception {
+    void defaultsDumpBeforeStopFalse() throws Exception {
         assertThat(http.getDumpBeforeStop()).isFalse();
         assertThat(http.build(environment).isDumpBeforeStop()).isFalse();
     }
 
     @Test
-    public void configuresDumpAfterStart() throws Exception {
+    void configuresDumpAfterStart() throws Exception {
         http.setDumpAfterStart(true);
         assertThat(http.build(environment).isDumpAfterStart()).isTrue();
     }
 
     @Test
-    public void configuresDumpBeforeExit() throws Exception {
+    void configuresDumpBeforeExit() throws Exception {
         http.setDumpBeforeStop(true);
         assertThat(http.build(environment).isDumpBeforeStop()).isTrue();
     }
 
     @Test
-    public void defaultsDetailedJsonProcessingExceptionToFalse() throws Exception {
+    void defaultsDetailedJsonProcessingExceptionToFalse() throws Exception {
         http.build(environment);
         assertThat(environment.jersey().getResourceConfig().getSingletons())
             .filteredOn(x -> x instanceof ExceptionMapperBinder)
@@ -162,7 +156,7 @@ public class DefaultServerFactoryTest {
     }
 
     @Test
-    public void doesNotDefaultDetailedJsonProcessingExceptionToFalse() throws Exception {
+    void doesNotDefaultDetailedJsonProcessingExceptionToFalse() throws Exception {
         http.setDetailedJsonProcessingExceptionMapper(true);
 
         http.build(environment);
@@ -173,7 +167,7 @@ public class DefaultServerFactoryTest {
     }
 
     @Test
-    public void testGracefulShutdown() throws Exception {
+    void testGracefulShutdown() throws Exception {
         CountDownLatch requestReceived = new CountDownLatch(1);
         CountDownLatch shutdownInvoked = new CountDownLatch(1);
 
@@ -239,7 +233,7 @@ public class DefaultServerFactoryTest {
     }
 
     @Test
-    public void testConfiguredEnvironment() {
+    void testConfiguredEnvironment() {
         http.configure(environment);
 
         assertEquals(http.getAdminContextPath(), environment.getAdminContext().getContextPath());
@@ -247,7 +241,7 @@ public class DefaultServerFactoryTest {
     }
 
     @Test
-    public void testDeserializeWithoutJsonAutoDetect() {
+    void testDeserializeWithoutJsonAutoDetect() {
         final ObjectMapper objectMapper = Jackson.newObjectMapper()
             .setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE);
 

--- a/dropwizard-core/src/test/java/io/dropwizard/server/SimpleServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/SimpleServerFactoryTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.server;
 
-import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -43,13 +42,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class SimpleServerFactoryTest {
 
     private SimpleServerFactory http;
-    private final ObjectMapper objectMapper = Jackson.newObjectMapper();
-    private Validator validator = BaseValidator.newValidator();
-    private Environment environment = new Environment("testEnvironment", objectMapper, validator, new MetricRegistry(),
-            ClassLoader.getSystemClassLoader());
+    private Environment environment = new Environment("testEnvironment");
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
+        final ObjectMapper objectMapper = environment.getObjectMapper();
+        final Validator validator = environment.getValidator();
         objectMapper.getSubtypeResolver().registerSubtypes(ConsoleAppenderFactory.class,
                 FileAppenderFactory.class, SyslogAppenderFactory.class, HttpConnectorFactory.class);
         http = (SimpleServerFactory) new YamlConfigurationFactory<>(ServerFactory.class, validator, objectMapper, "dw")
@@ -57,29 +55,29 @@ public class SimpleServerFactoryTest {
     }
 
     @Test
-    public void isDiscoverable() throws Exception {
+    void isDiscoverable() throws Exception {
         assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
                 .contains(SimpleServerFactory.class);
     }
 
     @Test
-    public void testGetAdminContext() {
+    void testGetAdminContext() {
         assertThat(http.getAdminContextPath()).isEqualTo("/secret");
     }
 
     @Test
-    public void testGetApplicationContext() {
+    void testGetApplicationContext() {
         assertThat(http.getApplicationContextPath()).isEqualTo("/service");
     }
 
     @Test
-    public void testGetPort() {
+    void testGetPort() {
         final HttpConnectorFactory connector = (HttpConnectorFactory) http.getConnector();
         assertThat(connector.getPort()).isEqualTo(0);
     }
 
     @Test
-    public void testBuild() throws Exception {
+    void testBuild() throws Exception {
         environment.jersey().register(new TestResource());
         environment.admin().addTask(new TestTask());
 
@@ -96,7 +94,7 @@ public class SimpleServerFactoryTest {
     }
 
     @Test
-    public void testConfiguredEnvironment() {
+    void testConfiguredEnvironment() {
         http.configure(environment);
 
         assertEquals(http.getAdminContextPath(), environment.getAdminContext().getContextPath());
@@ -104,7 +102,7 @@ public class SimpleServerFactoryTest {
     }
 
     @Test
-    public void testDeserializeWithoutJsonAutoDetect() {
+    void testDeserializeWithoutJsonAutoDetect() {
         final ObjectMapper objectMapper = Jackson.newObjectMapper()
             .setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE);
 

--- a/dropwizard-core/src/test/java/io/dropwizard/setup/AdminEnvironmentTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/setup/AdminEnvironmentTest.java
@@ -15,7 +15,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class AdminEnvironmentTest {
+class AdminEnvironmentTest {
     static {
         BootstrapLogging.bootstrap();
     }
@@ -23,10 +23,11 @@ public class AdminEnvironmentTest {
     private final MutableServletContextHandler handler = new MutableServletContextHandler();
     private final HealthCheckRegistry healthCheckRegistry = new HealthCheckRegistry();
     private final MetricRegistry metricRegistry = new MetricRegistry();
-    private final AdminEnvironment env = new AdminEnvironment(handler, healthCheckRegistry, metricRegistry);
+    private final AdminFactory adminFactory = new AdminFactory();
+    private final AdminEnvironment env = new AdminEnvironment(handler, healthCheckRegistry, metricRegistry, adminFactory);
 
     @Test
-    public void addsATaskServlet() throws Exception {
+    void addsATaskServlet() throws Exception {
         final Task task = new Task("thing") {
             @Override
             public void execute(Map<String, List<String>> parameters, PrintWriter output) throws Exception {

--- a/dropwizard-core/src/test/java/io/dropwizard/setup/ExceptionMapperBinderTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/setup/ExceptionMapperBinderTest.java
@@ -1,9 +1,7 @@
 package io.dropwizard.setup;
 
-import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.configuration.YamlConfigurationFactory;
-import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.validation.JerseyViolationException;
 import io.dropwizard.jetty.HttpConnectorFactory;
 import io.dropwizard.logging.ConsoleAppenderFactory;
@@ -12,7 +10,6 @@ import io.dropwizard.logging.SyslogAppenderFactory;
 import io.dropwizard.server.ServerFactory;
 import io.dropwizard.server.SimpleServerFactory;
 import io.dropwizard.util.Resources;
-import io.dropwizard.validation.BaseValidator;
 import org.eclipse.jetty.server.AbstractNetworkConnector;
 import org.eclipse.jetty.server.Server;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,15 +28,14 @@ import java.io.File;
 import static io.dropwizard.server.SimpleServerFactoryTest.httpRequest;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ExceptionMapperBinderTest {
+class ExceptionMapperBinderTest {
     private SimpleServerFactory http;
-    private final ObjectMapper objectMapper = Jackson.newObjectMapper();
-    private Validator validator = BaseValidator.newValidator();
-    private Environment environment = new Environment("testEnvironment", objectMapper, validator, new MetricRegistry(),
-        ClassLoader.getSystemClassLoader());
+    private Environment environment = new Environment("testEnvironment");
 
     @BeforeEach
     public void setUp() throws Exception {
+        final ObjectMapper objectMapper = environment.getObjectMapper();
+        final Validator validator = environment.getValidator();
         objectMapper.getSubtypeResolver().registerSubtypes(ConsoleAppenderFactory.class,
             FileAppenderFactory.class, SyslogAppenderFactory.class, HttpConnectorFactory.class);
         http = (SimpleServerFactory) new YamlConfigurationFactory<>(ServerFactory.class, validator, objectMapper, "dw")

--- a/dropwizard-forms/src/test/java/io/dropwizard/forms/MultiPartBundleTest.java
+++ b/dropwizard-forms/src/test/java/io/dropwizard/forms/MultiPartBundleTest.java
@@ -1,30 +1,21 @@
 package io.dropwizard.forms;
 
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.Configuration;
-import io.dropwizard.jackson.Jackson;
 import io.dropwizard.logging.BootstrapLogging;
 import io.dropwizard.setup.Environment;
-import io.dropwizard.validation.BaseValidator;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MultiPartBundleTest {
+class MultiPartBundleTest {
     static {
         BootstrapLogging.bootstrap();
     }
 
     @Test
-    public void testRun() throws Exception {
-        final Environment environment = new Environment(
-                "multipart-test",
-                Jackson.newObjectMapper(),
-                BaseValidator.newValidator(),
-                new MetricRegistry(),
-                getClass().getClassLoader()
-        );
+    void testRun() {
+        final Environment environment = new Environment("multipart-test");
 
         new MultiPartBundle().run(new Configuration(), environment);
 

--- a/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/JdbiTest.java
+++ b/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/JdbiTest.java
@@ -2,9 +2,7 @@ package io.dropwizard.jdbi3;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.jdbi3.strategies.TimedAnnotationNameStrategy;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.db.DataSourceFactory;
-import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.logging.BootstrapLogging;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Resources;
@@ -22,7 +20,7 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class JdbiTest {
+class JdbiTest {
     static {
         BootstrapLogging.bootstrap();
     }
@@ -31,12 +29,12 @@ public class JdbiTest {
 
     private Jdbi dbi;
     private GameDao dao;
-    private MetricRegistry metricRegistry = new MetricRegistry();
+    private MetricRegistry metricRegistry;
 
     @BeforeEach
-    public void setUp() throws Exception {
-        environment = new Environment("test", new ObjectMapper(), Validators.newValidator(),
-            metricRegistry, ClassLoader.getSystemClassLoader());
+    void setUp() throws Exception {
+        environment = new Environment("test");
+        metricRegistry = environment.metrics();
 
         DataSourceFactory dataSourceFactory = new DataSourceFactory();
         dataSourceFactory.setUrl("jdbc:h2:mem:jdbi3-test");
@@ -56,14 +54,14 @@ public class JdbiTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         for (LifeCycle lc : environment.lifecycle().getManagedObjects()) {
             lc.stop();
         }
     }
 
     @Test
-    public void fluentQueryWorks() {
+    void fluentQueryWorks() {
         dbi.useHandle(h -> assertThat(h.createQuery("SELECT id FROM games " +
             "WHERE home_scored>visitor_scored " +
             "AND played_at > :played_at")
@@ -73,65 +71,65 @@ public class JdbiTest {
     }
 
     @Test
-    public void canAcceptOptionalParams() {
+    void canAcceptOptionalParams() {
         assertThat(dao.findHomeTeamByGameId(Optional.of(4))).contains("Dallas Stars");
         assertThat(metricRegistry.timer("game-dao.findHomeTeamByGameId").getCount()).isEqualTo(1);
     }
 
     @Test
-    public void canAcceptEmptyOptionalParams() {
+    void canAcceptEmptyOptionalParams() {
         assertThat(dao.findHomeTeamByGameId(Optional.empty())).isEmpty();
         assertThat(metricRegistry.timer("game-dao.findHomeTeamByGameId").getCount()).isEqualTo(1);
     }
 
     @Test
-    public void canReturnImmutableLists() {
+    void canReturnImmutableLists() {
         assertThat(dao.findGameIds()).containsExactly(1, 2, 3, 4, 5);
         assertThat(metricRegistry.timer("game-dao.findGameIds").getCount()).isEqualTo(1);
     }
 
     @Test
-    public void canReturnImmutableSets() {
+    void canReturnImmutableSets() {
         assertThat(dao.findAllUniqueHomeTeams()).containsOnly("NY Rangers", "Toronto Maple Leafs", "Dallas Stars");
         assertThat(metricRegistry.timer("game-dao.findAllUniqueHomeTeams").getCount()).isEqualTo(1);
     }
 
     @Test
-    public void canReturnOptional() {
+    void canReturnOptional() {
         assertThat(dao.findIdByTeamsAndDate("NY Rangers", "Vancouver Canucks",
             LocalDate.of(2016, 5, 14))).contains(2);
         assertThat(metricRegistry.timer("game-dao.findIdByTeamsAndDate").getCount()).isEqualTo(1);
     }
 
     @Test
-    public void canReturnEmptyOptional() {
+    void canReturnEmptyOptional() {
         assertThat(dao.findIdByTeamsAndDate("Vancouver Canucks", "NY Rangers",
             LocalDate.of(2016, 5, 14))).isEmpty();
         assertThat(metricRegistry.timer("game-dao.findIdByTeamsAndDate").getCount()).isEqualTo(1);
     }
 
     @Test
-    public void worksWithDates() {
+    void worksWithDates() {
         assertThat(dao.getFirstPlayedSince(LocalDate.of(2016, 3, 1)))
             .isEqualTo(LocalDate.of(2016, 2, 15));
         assertThat(metricRegistry.timer("game-dao.getFirstPlayedSince").getCount()).isEqualTo(1);
     }
 
     @Test
-    public void worksWithOptionalDates() {
+    void worksWithOptionalDates() {
         Optional<LocalDate> date = dao.getLastPlayedDateByTeams("Toronto Maple Leafs", "Anaheim Ducks");
         assertThat(date).contains(LocalDate.of(2016, 2, 11));
         assertThat(metricRegistry.timer("game-dao.last-played-date").getCount()).isEqualTo(1);
     }
 
     @Test
-    public void worksWithAbsentOptionalDates() {
+    void worksWithAbsentOptionalDates() {
         assertThat(dao.getLastPlayedDateByTeams("Vancouver Canucks", "NY Rangers")).isEmpty();
         assertThat(metricRegistry.timer("game-dao.last-played-date").getCount()).isEqualTo(1);
     }
 
     @Test
-    public void testJodaTimeWorksForDateTimes() {
+    void testJodaTimeWorksForDateTimes() {
         dbi.useHandle(h -> assertThat(h.createQuery("SELECT played_at FROM games " +
             "WHERE home_scored > visitor_scored " +
             "AND played_at > :played_at")

--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/TaskConfiguration.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/TaskConfiguration.java
@@ -1,0 +1,45 @@
+package io.dropwizard.servlets.tasks;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.StringJoiner;
+
+/**
+ * A factory for configuring the tasks sub-system for the environment.
+ * <p/>
+ * <b>Configuration Parameters:</b>
+ * <table>
+ *     <tr>
+ *         <td>Name</td>
+ *         <td>Default</td>
+ *         <td>Description</td>
+ *     </tr>
+ *     <tr>
+ *         <td>printStackTraceOnError</td>
+ *         <td>{@code false}</td>
+ *         <td>Print the full stack trace when the execution of a task failed.</td>
+ *     </tr>
+ * </table>
+ *
+ * @since 2.0
+ */
+public class TaskConfiguration {
+    private boolean printStackTraceOnError = false;
+
+    @JsonProperty("printStackTraceOnError")
+    public boolean isPrintStackTraceOnError() {
+        return printStackTraceOnError;
+    }
+
+    @JsonProperty("printStackTraceOnError")
+    public void setPrintStackTraceOnError(boolean printStackTraceOnError) {
+        this.printStackTraceOnError = printStackTraceOnError;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", TaskConfiguration.class.getSimpleName() + "[", "]")
+                .add("printStackTraceOnError=" + printStackTraceOnError)
+                .toString();
+    }
+}

--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/TaskServlet.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/TaskServlet.java
@@ -47,12 +47,23 @@ public class TaskServlet extends HttpServlet {
     private final ConcurrentMap<Task, TaskExecutor> taskExecutors;
 
     private final MetricRegistry metricRegistry;
+    private final TaskConfiguration taskConfiguration;
 
     /**
      * Creates a new TaskServlet.
      */
     public TaskServlet(MetricRegistry metricRegistry) {
+        this(metricRegistry, new TaskConfiguration());
+    }
+
+    /**
+     * Creates a new TaskServlet.
+     *
+     * @since 2.0
+     */
+    public TaskServlet(MetricRegistry metricRegistry, TaskConfiguration taskConfiguration) {
         this.metricRegistry = metricRegistry;
+        this.taskConfiguration = taskConfiguration;
         this.tasks = new ConcurrentHashMap<>();
         this.taskExecutors = new ConcurrentHashMap<>();
     }
@@ -129,7 +140,9 @@ public class TaskServlet extends HttpServlet {
                 resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
                 output.println();
                 output.println(e.getMessage());
-                e.printStackTrace(output);
+                if (taskConfiguration.isPrintStackTraceOnError()) {
+                    e.printStackTrace(output);
+                }
             } finally {
                 output.close();
             }

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/TaskServletTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/TaskServletTest.java
@@ -328,7 +328,7 @@ class TaskServletTest {
 
         servlet.service(request, response);
 
-        assertThat(stringWriter.toString().trim()).startsWith("whoops\njava.lang.RuntimeException: whoops");
+        assertThat(stringWriter.toString().trim()).contains("java.lang.RuntimeException: whoops");
     }
 
     @Test


### PR DESCRIPTION
This change set adds configuration settings for the tasks resource and the health check resources in the Dropwizard admin interface.

The `printStackTraceOnError` (default: false) setting allows to control whether to expose the full exception stack trace of a failing task.

The `minThreads`, `maxThreads`, and `workQueueSize` configuration settings allow to control the thread settings for health checks.

Closes #3036