### PR TITLE
Make tests more stable by using JSONAssert equals

### DIFF
--- a/dropwizard-views-freemarker/pom.xml
+++ b/dropwizard-views-freemarker/pom.xml
@@ -40,5 +40,11 @@
             <artifactId>jersey-test-framework-provider-inmemory</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/MultipleContentTypeTest.java
+++ b/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/MultipleContentTypeTest.java
@@ -8,9 +8,11 @@ import io.dropwizard.views.View;
 import io.dropwizard.views.ViewMessageBodyWriter;
 import io.dropwizard.views.ViewRenderer;
 import org.glassfish.jersey.test.JerseyTest;
+import org.json.JSONException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -56,12 +58,20 @@ public class MultipleContentTypeTest extends JerseyTest {
                 .register(new ExampleResource());
     }
 
+    public void assertJsonEqualsNonStrict(String json1, String json2) {
+        try {
+            JSONAssert.assertEquals(json1, json2, false);
+        } catch (JSONException jse) {
+            throw new IllegalArgumentException(jse.getMessage());
+        }
+    }
+
     @Test
     public void testJsonContentType() {
         final Response response = target("/").request().accept(MediaType.APPLICATION_JSON_TYPE).get();
 
         assertThat(response.getStatus()).isEqualTo(200);
-        assertThat(response.readEntity(String.class)).isEqualTo("{\"title\":\"Title#TEST\",\"content\":\"Content#TEST\"}");
+        assertJsonEqualsNonStrict(response.readEntity(String.class), "{\"title\":\"Title#TEST\",\"content\":\"Content#TEST\"}");
     }
 
     @Test
@@ -80,7 +90,7 @@ public class MultipleContentTypeTest extends JerseyTest {
         final Response response = target("/json").request().accept(MediaType.APPLICATION_JSON_TYPE).get();
 
         assertThat(response.getStatus()).isEqualTo(200);
-        assertThat(response.readEntity(String.class)).isEqualTo("{\"title\":\"Title#TEST\",\"content\":\"Content#TEST\"}");
+        assertJsonEqualsNonStrict(response.readEntity(String.class), "{\"title\":\"Title#TEST\",\"content\":\"Content#TEST\"}");
     }
 
     @Test


### PR DESCRIPTION
###### Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->
Tests in `io/dropwizard/views/freemarker/MultipleContentTypeTest.java` uses `jackson` to serialize objects into json and assert the serialized results with several hard-coded strings. However, the order of serialized json is not guaranteed so tests may fail if the order is different. So tests may fail or pass without any changes made to the source code and cannot serve as good regression tests.

###### Solution:
<!-- Describe the modifications you've done. -->
This PR proposes to use `JSONAssert` and modify the corresponding json test assertions
###### Result:
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->
Tests become no longer flaky.