### PR TITLE
Bump jetty.version from 9.4.18.v20190429 to 9.4.24.v20191120

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -22,7 +22,7 @@
         <guava.version>24.1.1-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
         <jackson.version>2.9.10.20191020</jackson.version>
-        <jetty.version>9.4.18.v20190429</jetty.version>
+        <jetty.version>9.4.24.v20191120</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.0.5</metrics4.version>
         <slf4j.version>1.7.26</slf4j.version>

--- a/dropwizard-core/src/main/java/io/dropwizard/sslreload/SslReloadTask.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/sslreload/SslReloadTask.java
@@ -21,7 +21,7 @@ public class SslReloadTask extends Task {
     public void execute(ImmutableMultimap<String, String> parameters, PrintWriter output) throws Exception {
         // Iterate through all the reloaders first to ensure valid configuration
         for (SslReload reloader : getReloaders()) {
-            reloader.reload(new SslContextFactory());
+            reloader.reload(new SslContextFactory.Server());
         }
 
         // Now we know that configuration is valid, reload for real

--- a/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2ConnectorFactory.java
+++ b/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2ConnectorFactory.java
@@ -112,7 +112,7 @@ public class Http2ConnectorFactory extends HttpsConnectorFactory {
         final NegotiatingServerConnectionFactory alpn = new ALPNServerConnectionFactory(H2, H2_17);
         alpn.setDefaultProtocol(HTTP_1_1); // Speak HTTP 1.1 over TLS if negotiation fails
 
-        final SslContextFactory sslContextFactory = configureSslContextFactory(new SslContextFactory());
+        final SslContextFactory sslContextFactory = configureSslContextFactory(new SslContextFactory.Server());
         sslContextFactory.addLifeCycleListener(logSslInfoOnStart(sslContextFactory));
         server.addBean(sslContextFactory);
         server.addBean(new SslReload(sslContextFactory, this::configureSslContextFactory));

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
@@ -596,7 +596,7 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
 
         final HttpConnectionFactory httpConnectionFactory = buildHttpConnectionFactory(httpConfig);
 
-        final SslContextFactory sslContextFactory = configureSslContextFactory(new SslContextFactory());
+        final SslContextFactory sslContextFactory = configureSslContextFactory(new SslContextFactory.Server());
         sslContextFactory.addLifeCycleListener(logSslInfoOnStart(sslContextFactory));
 
         server.addBean(sslContextFactory);

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/ContextRoutingHandlerTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/ContextRoutingHandlerTest.java
@@ -66,6 +66,9 @@ public class ContextRoutingHandlerTest {
 
     @Test
     public void startsAndStopsAllHandlers() throws Exception {
+        when(handler1.isStopped()).thenReturn(true);
+        when(handler2.isStopped()).thenReturn(true);
+
         handler.start();
         handler.stop();
 

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
@@ -93,7 +93,7 @@ public class HttpsConnectorFactoryTest {
         factory.setKeyStorePassword("password"); // necessary to avoid a prompt for a password
         factory.setSupportedProtocols(supportedProtocols);
 
-        SslContextFactory sslContextFactory = factory.configureSslContextFactory(new SslContextFactory());
+        SslContextFactory sslContextFactory = factory.configureSslContextFactory(new SslContextFactory.Server());
         assertThat(ImmutableList.copyOf(sslContextFactory.getIncludeProtocols())).isEqualTo(supportedProtocols);
     }
 
@@ -105,7 +105,7 @@ public class HttpsConnectorFactoryTest {
         factory.setKeyStorePassword("password"); // necessary to avoid a prompt for a password
         factory.setExcludedProtocols(excludedProtocols);
 
-        SslContextFactory sslContextFactory = factory.configureSslContextFactory(new SslContextFactory());
+        SslContextFactory sslContextFactory = factory.configureSslContextFactory(new SslContextFactory.Server());
         assertThat(ImmutableList.copyOf(sslContextFactory.getExcludeProtocols())).isEqualTo(excludedProtocols);
     }
 
@@ -134,7 +134,7 @@ public class HttpsConnectorFactoryTest {
         final HttpsConnectorFactory factory = new HttpsConnectorFactory();
         factory.setKeyStoreType(WINDOWS_MY_KEYSTORE_NAME);
 
-        assertNotNull(factory.configureSslContextFactory(new SslContextFactory()));
+        assertNotNull(factory.configureSslContextFactory(new SslContextFactory.Server()));
     }
 
     @Test(expected = IllegalStateException.class)
@@ -143,7 +143,7 @@ public class HttpsConnectorFactoryTest {
 
         final HttpsConnectorFactory factory = new HttpsConnectorFactory();
         factory.setKeyStoreType(WINDOWS_MY_KEYSTORE_NAME);
-        factory.configureSslContextFactory(new SslContextFactory());
+        factory.configureSslContextFactory(new SslContextFactory.Server());
     }
 
     @Test

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/setup/ServletEnvironmentTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/setup/ServletEnvironmentTest.java
@@ -90,8 +90,7 @@ public class ServletEnvironmentTest {
         assertThat(holder.getValue().getName())
                 .isEqualTo("filter");
 
-        assertThat(holder.getValue().getFilter())
-                .isEqualTo(filter);
+        assertThat(holder.getValue()).hasFieldOrPropertyWithValue("_instance", filter);
     }
 
     @Test


### PR DESCRIPTION
Consuming recent Jetty versions with Dropwizard 1.3.x is hindered by https://github.com/eclipse/jetty.project/issues/4385. The changes here update Jetty and in particular change the code to employ `SslContextFactory.Server` as needed for proper HTTPS/SNI support.