### PR TITLE
Prefer jakarta apis over older javax apis.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - checkout
       - restore_cache:
           key: dropwizard-{{ checksum "pom.xml" }}
-      - run: ./mvnw -V -B -ff install
+      - run: ./mvnw -Pjakarta-apis -V -B -ff install
       - save_cache:
           paths:
             - ~/.m2

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -38,6 +38,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Build with Maven
-      run: ./mvnw -V -B -ff -s .github/settings.xml install '-Dmaven.test.skip=true' '-Dmaven.javadoc.skip=true'
+      run: ./mvnw -Pjakarta-apis -V -B -ff -s .github/settings.xml install '-Dmaven.test.skip=true' '-Dmaven.javadoc.skip=true'
     - name: Run tests
-      run: ./mvnw -V -B -ff -s .github/settings.xml verify
+      run: ./mvnw -Pjakarta-apis -V -B -ff -s .github/settings.xml verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ before_install:
   - rm ~/.m2/settings.xml || true
   - ulimit -c unlimited -S
 script:
-  - ./mvnw -V -B -ff verify
-  - ./mvnw -V -B -ff -q -pl docs site
+  - ./mvnw -Pjakarta-apis -V -B -ff verify
+  - ./mvnw -Pjakarta-apis -V -B -ff -q -pl docs site
 after_success:
   - bash ci/after_success.sh
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,8 +17,8 @@ cache:
 install:
 - cmd: 'java -version'
 build_script:
-- mvnw.cmd -V -B -ff install -Dmaven.test.skip=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Dmaven.deploy.skip=true
+- mvnw.cmd -Pjakarta-apis -V -B -ff install -Dmaven.test.skip=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Dmaven.deploy.skip=true
 test_script:
-- mvnw.cmd -V -B -ff verify -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Dmaven.deploy.skip=true
+- mvnw.cmd -Pjakarta-apis -V -B -ff verify -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Dmaven.deploy.skip=true
 matrix:
   fast_finish: true

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthorizationContext.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthorizationContext.java
@@ -1,0 +1,47 @@
+package io.dropwizard.auth;
+
+import java.security.Principal;
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+import javax.ws.rs.container.ContainerRequestContext;
+
+class AuthorizationContext<P extends Principal> {
+    private final P principal;
+    private final String role;
+    private final @Nullable
+    ContainerRequestContext requestContext;
+
+    AuthorizationContext(P principal, String role, @Nullable ContainerRequestContext requestContext) {
+        this.principal = principal;
+        this.role = role;
+        this.requestContext = requestContext;
+    }
+
+    P getPrincipal() {
+        return principal;
+    }
+
+    String getRole() {
+        return role;
+    }
+
+    @Nullable ContainerRequestContext getRequestContext() {
+        return requestContext;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AuthorizationContext<?> that = (AuthorizationContext<?>) o;
+        return Objects.equals(principal, that.principal) &&
+            Objects.equals(role, that.role) &&
+            Objects.equals(requestContext, that.requestContext);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(principal, role, requestContext);
+    }
+}

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/CachingAuthorizer.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/CachingAuthorizer.java
@@ -21,45 +21,6 @@ import java.util.stream.Collectors;
 
 import static com.codahale.metrics.MetricRegistry.name;
 
-class AuthorizationContext<P extends Principal> {
-    private final P principal;
-    private final String role;
-    private final @Nullable ContainerRequestContext requestContext;
-
-    AuthorizationContext(P principal, String role, @Nullable ContainerRequestContext requestContext) {
-        this.principal = principal;
-        this.role = role;
-        this.requestContext = requestContext;
-    }
-
-    P getPrincipal() {
-        return principal;
-    }
-
-    String getRole() {
-        return role;
-    }
-
-    @Nullable ContainerRequestContext getRequestContext() {
-        return requestContext;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        AuthorizationContext<?> that = (AuthorizationContext<?>) o;
-        return Objects.equals(principal, that.principal) &&
-            Objects.equals(role, that.role) &&
-            Objects.equals(requestContext, that.requestContext);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(principal, role, requestContext);
-    }
-}
-
 /**
  * An {@link Authorizer} decorator which uses a {@link Caffeine} cache to
  * temporarily cache principals' role associations.

--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -18,6 +18,7 @@
 
     <properties>
         <!-- External dependencies -->
+        <activation-api.version>1.2.1</activation-api.version>
         <argparse4j.version>0.8.1</argparse4j.version>
         <byte-buddy.version>1.10.6</byte-buddy.version>
         <caffeine.version>2.8.0</caffeine.version>
@@ -35,9 +36,9 @@
         <jackson.version>2.10.1</jackson.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
         <jakarta.el.version>3.0.3</jakarta.el.version>
+        <jakarta.servlet-api.version>4.0.3</jakarta.servlet-api.version>
         <javassist.version>3.26.0-GA</javassist.version>
-        <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
-        <jaxb-api.version>2.3.1</jaxb-api.version>
+        <jaxb-api.version>2.3.2</jaxb-api.version>
         <jcip-annotations.version>1.0</jcip-annotations.version>
         <jdbi3.version>3.12.0</jdbi3.version>
         <jersey.version>2.29.1</jersey.version>
@@ -53,7 +54,6 @@
         <mustache-compiler.version>0.9.6</mustache-compiler.version>
         <nullaway.version>0.7.8</nullaway.version>
         <objenesis.version>3.1</objenesis.version>
-        <servlet.version>3.0.0.v201112011016</servlet.version>
         <slf4j.version>1.7.30</slf4j.version>
         <tomcat-jdbc.version>9.0.30</tomcat-jdbc.version>
         <usertype.core.version>7.0.0.CR1</usertype.core.version>
@@ -155,26 +155,26 @@
                 <version>${jakarta.el.version}</version>
             </dependency>
             <dependency>
+                <groupId>jakarta.activation</groupId>
+                <artifactId>jakarta.activation-api</artifactId>
+                <version>${activation-api.version}</version>
+                <scope>runtime</scope>
+            </dependency>
+            <dependency>
                 <groupId>jakarta.annotation</groupId>
                 <artifactId>jakarta.annotation-api</artifactId>
                 <version>${jakarta.annotation-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>javax.servlet-api</artifactId>
-                <version>${javax.servlet-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.xml.bind</groupId>
-                <artifactId>jaxb-api</artifactId>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
                 <version>${jaxb-api.version}</version>
                 <scope>runtime</scope>
             </dependency>
             <dependency>
-                <groupId>javax.activation</groupId>
-                <artifactId>javax.activation-api</artifactId>
-                <version>1.2.0</version>
-                <scope>runtime</scope>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>${jakarta.servlet-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>

--- a/dropwizard-e2e/src/test/java/com/example/app1/App1Test.java
+++ b/dropwizard-e2e/src/test/java/com/example/app1/App1Test.java
@@ -2,10 +2,13 @@ package com.example.app1;
 
 import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import io.dropwizard.util.Duration;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,8 +36,12 @@ public class App1Test {
 
     @BeforeAll
     public static void setup() {
+        final JerseyClientConfiguration config = new JerseyClientConfiguration();
+        // Avoid flakiness with default timeouts in CI builds
+        config.setTimeout(Duration.seconds(5));
         client = new JerseyClientBuilder(RULE.getEnvironment())
             .withProvider(new CustomJsonProvider(Jackson.newObjectMapper()))
+            .using(config)
             .build("test client");
     }
 

--- a/dropwizard-hibernate/pom.xml
+++ b/dropwizard-hibernate/pom.xml
@@ -34,6 +34,24 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>javax.activation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
 
         <dependency>

--- a/dropwizard-jersey/pom.xml
+++ b/dropwizard-jersey/pom.xml
@@ -100,6 +100,16 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
@@ -118,12 +128,12 @@
             <artifactId>caffeine</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/dropwizard-jetty/pom.xml
+++ b/dropwizard-jetty/pom.xml
@@ -18,22 +18,22 @@
             <artifactId>dropwizard-logging</artifactId>
         </dependency>
         <dependency>
-            <!-- this is required because jetty-server pom
-            put servlet-api into default scope when it should
-            always be provided scope so it doesn't get compiled.
-            without this there are security exceptions because
-            javax.servlet-api jar is not signed -->
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-jetty9</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/dropwizard-lifecycle/pom.xml
+++ b/dropwizard-lifecycle/pom.xml
@@ -24,6 +24,17 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/dropwizard-migrations/pom.xml
+++ b/dropwizard-migrations/pom.xml
@@ -20,10 +20,22 @@
         <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.mattbertolini</groupId>
             <artifactId>liquibase-slf4j</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/dropwizard-servlets/pom.xml
+++ b/dropwizard-servlets/pom.xml
@@ -34,14 +34,8 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
         <dependency>
-            <!-- this is required because jetty-server pom
-            put servlet-api into default scope when it should
-            always be provided scope so it doesn't get compiled.
-            without this there are security exceptions because
-            javax.servlet-api jar is not signed -->
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>
@@ -63,6 +57,12 @@
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/dropwizard-testing/pom.xml
+++ b/dropwizard-testing/pom.xml
@@ -58,6 +58,24 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>javax.activation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,42 @@
             </modules>
         </profile>
         <profile>
+            <id>jakarta-apis</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <version>1.4.1</version>
+                        <executions>
+                            <execution>
+                                <id>enforce-jakarta-apis</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <bannedDependencies>
+                                            <excludes>
+                                                <!-- Replaced with jakarta.activation:jakarta.activation-api -->
+                                                <exclude>javax.activation:javax.activation-api</exclude>
+                                                <!-- Replaced with jakarta.servlet:jakarta.servlet-api -->
+                                                <exclude>javax.servlet:javax.servlet-api</exclude>
+                                                <!-- Replaced with jakarta.validation:jakarta.validation-api -->
+                                                <exclude>javax.validation:validation-api</exclude>
+                                                <!-- Replaced with jakarta.xml.bind:jakarta.xml.bind-api -->
+                                                <exclude>javax.xml.bind:jaxb-api</exclude>
+                                            </excludes>
+                                        </bannedDependencies>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>release</id>
             <activation>
                 <property>


### PR DESCRIPTION
###### Problem:
When creating a shaded jar based on dropwizard APIs, warnings are shown
during shading about duplicate classes on the classpath.

This occurs because there is a mix of javax.* and jakarta.* modules on the
runtime classpath which ship the same (but conflicting) versions of classes.

###### Solution:
Update to use the latest jakarta apis in all dropwizard modules instead
of a mix of jakarta and javax.* ones (which ship the same classes). This
should make the APIs on the classpath consistent when creating a shaded
application jar and also avoid warnings about duplicate classes during
shading.

To validate that jakarta apis are used, a Maven profile `jakarta-apis` has
been added to the build. To verify jakarta APIs are used, run the build 
with the argument `-P jakarta-apis`.

###### Result:
Should have no impact to downstream applications and avoid shading
warnings about duplicate classes.