### PR TITLE
Updated Documentation to Reflect Deprecation of ResourceTestRule

### DIFF
--- a/docs/source/manual/auth.rst
+++ b/docs/source/manual/auth.rst
@@ -280,12 +280,12 @@ Add this dependency into your ``pom.xml`` file:
 OAuth Example
 -------------
 
-When you build your ``ResourceTestRule``, add the ``GrizzlyWebTestContainerFactory`` line.
+When you build your ``ResourceExtension``, add the ``GrizzlyWebTestContainerFactory`` line.
 
 .. code-block:: java
 
     @Rule
-    public ResourceTestRule rule = ResourceTestRule
+    public ResourceExtension rule = ResourceExtension
             .builder()
             .setTestContainerFactory(new GrizzlyWebTestContainerFactory())
             .addProvider(new AuthDynamicFeature(new OAuthCredentialAuthFilter.Builder<User>()
@@ -316,12 +316,12 @@ Note that you need to set the token header manually.
 BasicAuth Example
 -----------------
 
-When you build your ``ResourceTestRule``, add the ``GrizzlyWebTestContainerFactory`` line.
+When you build your ``ResourceExtension``, add the ``GrizzlyWebTestContainerFactory`` line.
 
 .. code-block:: java
 
     @Rule
-    public ResourceTestRule resources = ResourceTestRule
+    public ResourceExtension resources = ResourceExtension
             .builder()
             .setTestContainerFactory(new GrizzlyWebTestContainerFactory())
             .addProvider(new AuthDynamicFeature(new BasicCredentialAuthFilter.Builder<User>()

--- a/docs/source/manual/forms.rst
+++ b/docs/source/manual/forms.rst
@@ -29,13 +29,13 @@ Testing
 =======
 
 To test resources that utilize multi-part form features, one must add ``MultiPartFeature.class`` to
-the ``ResourceTestRule`` as a provider, and register it on the client like the following:
+the ``ResourceExtension`` as a provider, and register it on the client like the following:
 
 .. code-block:: java
 
     public class MultiPartTest {
         @ClassRule
-        public static final ResourceTestRule resource = ResourceTestRule.builder()
+        public static final ResourceExtension resource = ResourceExtension.builder()
                 .addProvider(MultiPartFeature.class)
                 .addResource(new TestResource())
                 .build();


### PR DESCRIPTION
###### Problem:
Dropwizard 2.0 deprecated `ResourceTestRule` in favor of `ResourceExtension`.  The documentation providing examples of testing resources was not updated to reflect this.

###### Solution:
`ResourceTestRule` has been removed from the documentation in favor of `ResourceExtension`

###### Result:
Documentation is now more up-to-date with reality. :)
