### PR TITLE
Replacing ResourceTestRule with ResourceExtension in documentation

### DIFF
--- a/docs/source/manual/auth.rst
+++ b/docs/source/manual/auth.rst
@@ -280,12 +280,12 @@ Add this dependency into your ``pom.xml`` file:
 OAuth Example
 -------------
 
-When you build your ``ResourceTestRule``, add the ``GrizzlyWebTestContainerFactory`` line.
+When you build your ``ResourceExtension``, add the ``GrizzlyWebTestContainerFactory`` line.
 
 .. code-block:: java
 
     @Rule
-    public ResourceTestRule rule = ResourceTestRule
+    public ResourceExtension rule = ResourceExtension
             .builder()
             .setTestContainerFactory(new GrizzlyWebTestContainerFactory())
             .addProvider(new AuthDynamicFeature(new OAuthCredentialAuthFilter.Builder<User>()
@@ -316,12 +316,12 @@ Note that you need to set the token header manually.
 BasicAuth Example
 -----------------
 
-When you build your ``ResourceTestRule``, add the ``GrizzlyWebTestContainerFactory`` line.
+When you build your ``ResourceExtension``, add the ``GrizzlyWebTestContainerFactory`` line.
 
 .. code-block:: java
 
     @Rule
-    public ResourceTestRule resources = ResourceTestRule
+    public ResourceExtension resources = ResourceExtension
             .builder()
             .setTestContainerFactory(new GrizzlyWebTestContainerFactory())
             .addProvider(new AuthDynamicFeature(new BasicCredentialAuthFilter.Builder<User>()

--- a/docs/source/manual/auth.rst
+++ b/docs/source/manual/auth.rst
@@ -284,20 +284,22 @@ When you build your ``ResourceExtension``, add the ``GrizzlyWebTestContainerFact
 
 .. code-block:: java
 
-    @Rule
-    public ResourceExtension resourceExtension = ResourceExtension
-            .builder()
-            .setTestContainerFactory(new GrizzlyWebTestContainerFactory())
-            .addProvider(new AuthDynamicFeature(new OAuthCredentialAuthFilter.Builder<User>()
-                    .setAuthenticator(new MyOAuthAuthenticator())
-                    .setAuthorizer(new MyAuthorizer())
-                    .setRealm("SUPER SECRET STUFF")
-                    .setPrefix("Bearer")
-                    .buildAuthFilter()))
-            .addProvider(RolesAllowedDynamicFeature.class)
-            .addProvider(new AuthValueFactoryProvider.Binder<>(User.class))
-            .addResource(new ProtectedResource())
-            .build();
+    @ExtendWith(DropwizardExtensionsSupport.class)
+    public class OAuthResourceTest {
+
+        public ResourceExtension resourceExtension = ResourceExtension
+                .builder()
+                .setTestContainerFactory(new GrizzlyWebTestContainerFactory())
+                .addProvider(new AuthDynamicFeature(new OAuthCredentialAuthFilter.Builder<User>()
+                        .setAuthenticator(new MyOAuthAuthenticator())
+                        .setAuthorizer(new MyAuthorizer())
+                        .setRealm("SUPER SECRET STUFF")
+                        .setPrefix("Bearer")
+                        .buildAuthFilter()))
+                .addProvider(RolesAllowedDynamicFeature.class)
+                .addProvider(new AuthValueFactoryProvider.Binder<>(User.class))
+                .addResource(new ProtectedResource())
+                .build();
 
 Note that you need to set the token header manually.
 
@@ -320,18 +322,19 @@ When you build your ``ResourceExtension``, add the ``GrizzlyWebTestContainerFact
 
 .. code-block:: java
 
-    @Rule
-    public ResourceExtension resourceExtension = ResourceExtension
-            .builder()
-            .setTestContainerFactory(new GrizzlyWebTestContainerFactory())
-            .addProvider(new AuthDynamicFeature(new BasicCredentialAuthFilter.Builder<User>()
-                    .setAuthenticator(new MyBasicAuthenticator())
-                    .setAuthorizer(new MyBasicAuthorizer())
-                    .buildAuthFilter()))
-            .addProvider(RolesAllowedDynamicFeature.class)
-            .addProvider(new AuthValueFactoryProvider.Binder<>(User.class))
-    		.addResource(new ProtectedResource())
-            .build()
+    @ExtendWith(DropwizardExtensionsSupport.class)
+    public class OAuthResourceTest {
+        public ResourceExtension resourceExtension = ResourceExtension
+                .builder()
+                .setTestContainerFactory(new GrizzlyWebTestContainerFactory())
+                .addProvider(new AuthDynamicFeature(new BasicCredentialAuthFilter.Builder<User>()
+                        .setAuthenticator(new MyBasicAuthenticator())
+                        .setAuthorizer(new MyBasicAuthorizer())
+                        .buildAuthFilter()))
+                .addProvider(RolesAllowedDynamicFeature.class)
+                .addProvider(new AuthValueFactoryProvider.Binder<>(User.class))
+                .addResource(new ProtectedResource())
+                .build()
 
 Note that you need to set the authorization header manually.
 

--- a/docs/source/manual/auth.rst
+++ b/docs/source/manual/auth.rst
@@ -300,6 +300,7 @@ When you build your ``ResourceExtension``, add the ``GrizzlyWebTestContainerFact
                 .addProvider(new AuthValueFactoryProvider.Binder<>(User.class))
                 .addResource(new ProtectedResource())
                 .build();
+    }
 
 Note that you need to set the token header manually.
 
@@ -335,6 +336,7 @@ When you build your ``ResourceExtension``, add the ``GrizzlyWebTestContainerFact
                 .addProvider(new AuthValueFactoryProvider.Binder<>(User.class))
                 .addResource(new ProtectedResource())
                 .build()
+    }
 
 Note that you need to set the authorization header manually.
 

--- a/docs/source/manual/auth.rst
+++ b/docs/source/manual/auth.rst
@@ -285,7 +285,7 @@ When you build your ``ResourceExtension``, add the ``GrizzlyWebTestContainerFact
 .. code-block:: java
 
     @Rule
-    public ResourceExtension rule = ResourceExtension
+    public ResourceExtension resourceExtension = ResourceExtension
             .builder()
             .setTestContainerFactory(new GrizzlyWebTestContainerFactory())
             .addProvider(new AuthDynamicFeature(new OAuthCredentialAuthFilter.Builder<User>()
@@ -305,7 +305,7 @@ Note that you need to set the token header manually.
 
     @Test
     public void testProtected() throws Exception {
-        final Response response = rule.target("/protected")
+        final Response response = resourceExtension.target("/protected")
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .header("Authorization", "Bearer TOKEN")
                 .get();
@@ -321,7 +321,7 @@ When you build your ``ResourceExtension``, add the ``GrizzlyWebTestContainerFact
 .. code-block:: java
 
     @Rule
-    public ResourceExtension resources = ResourceExtension
+    public ResourceExtension resourceExtension = ResourceExtension
             .builder()
             .setTestContainerFactory(new GrizzlyWebTestContainerFactory())
             .addProvider(new AuthDynamicFeature(new BasicCredentialAuthFilter.Builder<User>()
@@ -342,7 +342,7 @@ Note that you need to set the authorization header manually.
 
         String credential = "Basic " + Base64.getEncoder().encodeToString("test@gmail.com:secret".getBytes())
 
-        Response response = resources
+        Response response = resourceExtension
                 .target("/protected")
                 .request()
                 .header(HttpHeaders.AUTHORIZATION, credential)

--- a/docs/source/manual/forms.rst
+++ b/docs/source/manual/forms.rst
@@ -29,13 +29,13 @@ Testing
 =======
 
 To test resources that utilize multi-part form features, one must add ``MultiPartFeature.class`` to
-the ``ResourceTestRule`` as a provider, and register it on the client like the following:
+the ``ResourceExtension`` as a provider, and register it on the client like the following:
 
 .. code-block:: java
 
     public class MultiPartTest {
         @ClassRule
-        public static final ResourceTestRule resource = ResourceTestRule.builder()
+        public static final ResourceExtension resource = ResourceExtension.builder()
                 .addProvider(MultiPartFeature.class)
                 .addResource(new TestResource())
                 .build();

--- a/docs/source/manual/forms.rst
+++ b/docs/source/manual/forms.rst
@@ -35,7 +35,7 @@ the ``ResourceExtension`` as a provider, and register it on the client like the 
 
     public class MultiPartTest {
         @ClassRule
-        public static final ResourceExtension resource = ResourceExtension.builder()
+        public static final ResourceExtension resourceExtension = ResourceExtension.builder()
                 .addProvider(MultiPartFeature.class)
                 .addResource(new TestResource())
                 .build();
@@ -44,7 +44,7 @@ the ``ResourceExtension`` as a provider, and register it on the client like the 
         public void testClientMultipart() {
             final FormDataMultiPart multiPart = new FormDataMultiPart()
                     .field("test-data", "Hello Multipart");
-            final String response = resource.target("/test")
+            final String response = resourceExtension.target("/test")
                     .register(MultiPartFeature.class)
                     .request()
                     .post(Entity.entity(multiPart, multiPart.getMediaType()), String.class);

--- a/docs/source/manual/forms.rst
+++ b/docs/source/manual/forms.rst
@@ -33,8 +33,9 @@ the ``ResourceExtension`` as a provider, and register it on the client like the 
 
 .. code-block:: java
 
+    @ExtendWith(DropwizardExtensionsSupport.class)
     public class MultiPartTest {
-        @ClassRule
+
         public static final ResourceExtension resourceExtension = ResourceExtension.builder()
                 .addProvider(MultiPartFeature.class)
                 .addResource(new TestResource())


### PR DESCRIPTION
###### Problem:
Dropwizard 2.0 deprecated ResourceTestRule in favor of ResourceExtension. The documentation providing examples of testing resources was not updated to reflect this.

###### Solution:
ResourceTestRule has been removed from the documentation in favor of ResourceExtension.

This work was completed in `auth.rst` and `forms.rst` but not `testing.rst` as that will be handled in #3062 

###### Result:
Documentation is now more up-to-date with reality. :)