### PR TITLE
Update jackson version to 2.9.10.20200103 in 1.3.x branch

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -21,7 +21,7 @@
         <dropwizard.version>${project.version}</dropwizard.version>
         <guava.version>24.1.1-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
-        <jackson.version>2.9.10.20191020</jackson.version>
+        <jackson.version>2.9.10.20200103</jackson.version>
         <jetty.version>9.4.18.v20190429</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.0.5</metrics4.version>


### PR DESCRIPTION
Update `jackson.version` from 2.9.10.20191020 to 2.9.10.20200103
This has effect of updating `jackson-databind` from 2.9.10.1 to 2.9.10.2 and addresses [CVE-2019-20330](https://nvd.nist.gov/vuln/detail/CVE-2019-20330)

###### Problem:
Dropwizard 1.3.17 uses `jackson-databind` 2.9.10.1.  This is vulnerable to CVE-2019-20330

###### Solution:
Update `jackson.version` in `dropwizard-bom` from 2.9.10.20191020 to 2.9.10.20200103.

###### Result:
Updating `jackson.version` results in update to `jackson-bom` that is imported by Dropwizard 1.3.x., thus updating `jackson-databind` from 2.9.10.1 to 2.9.10.2. From [jackson release notes](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9):

> jackson-databind 2.9.10.2 (03-Jan-2020)
> 2526: Block two more gadget types (ehcache/JNDI -CVE-2019-20330)
> 2544: java.lang.NoClassDefFoundError Thrown for compact profile1

Note that PR is only necessary for Dropwizard 1.3.x branch.  Dropwizard 2.x uses jackson 2.10.x and is not vulnerable to the CVE.



