### PR TITLE
Use LinkedHashMap for deterministic iterations

### DIFF
--- a/dropwizard-e2e/src/main/java/com/example/app1/App1Resource.java
+++ b/dropwizard-e2e/src/main/java/com/example/app1/App1Resource.java
@@ -8,6 +8,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import java.util.LinkedHashMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.OptionalInt;
@@ -33,7 +34,7 @@ public class App1Resource {
     @POST
     @Path("mapper")
     public Map<String, String> postMapper(Map<String, String> map) {
-        final Map<String, String> resultMap = new HashMap<>(map);
+        final Map<String, String> resultMap = new LinkedHashMap<>(map);
         resultMap.put("hello", "world");
         return resultMap;
     }


### PR DESCRIPTION
###### Problem:
Test `customJsonProviderRoundtrip` in [App1Test](https://github.com/dropwizard/dropwizard/blob/master/dropwizard-e2e/src/test/java/com/example/app1/App1Test.java) calls`postMapper` in [App1Resource](https://github.com/dropwizard/dropwizard/blob/master/dropwizard-e2e/src/main/java/com/example/app1/App1Resource.java), which returns a HashMap. The test then asserts if the HashMap contains certain entries. However, the test assumes a specific iteration order of the underlying map. But HashMap does not guarantee any specific order of entries. Therefore, the assertions will fail if the iteration order differs

###### Solution:
 This PR proposes to change the HashMap to LinkedHashMap for a deterministic iteration order (same as insertion order). This order is also same as expected by the test assertion: `     assertThat(response).containsExactly(entry("check", "mate"), entry("hello", "world"));`