### PR TITLE
Enable error-prone on Java 9+ builds.

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
@@ -62,6 +62,7 @@ import java.util.List;
  * </p>
  */
 public class HttpClientBuilder {
+    @SuppressWarnings("UnnecessaryLambda")
     private static final HttpRequestRetryHandler NO_RETRIES = (exception, executionCount, context) -> false;
 
     private final MetricRegistry metricRegistry;

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ConstraintMessage.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ConstraintMessage.java
@@ -17,18 +17,18 @@ import javax.validation.ElementKind;
 import javax.validation.Path;
 import javax.validation.metadata.ConstraintDescriptor;
 import java.lang.reflect.Field;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class ConstraintMessage {
 
     private static final Cache<Pair<Path, ? extends ConstraintDescriptor<?>>, String> PREFIX_CACHE =
             Caffeine.newBuilder()
-            .expireAfterWrite(1, TimeUnit.HOURS)
+            .expireAfterWrite(Duration.ofHours(1))
             .build();
 
     private ConstraintMessage() {

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/ResilientOutputStreamBase.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/ResilientOutputStreamBase.java
@@ -49,6 +49,7 @@ abstract class ResilientOutputStreamBase extends OutputStream {
         return (recoveryCoordinator != null && !presumedClean);
     }
 
+    @Override
     public void write(byte[] b, int off, int len) {
         if (isPresumedInError()) {
             if (!recoveryCoordinator.isTooSoon()) {

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
@@ -190,7 +190,7 @@ class FileAppenderFactoryTest {
 
         final String file = rollingAppender.getFile();
         assertThat(file).contains("test-archived-name-")
-                        .endsWith(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")) + ".log");
+                        .endsWith(LocalDateTime.now(appenderFactory.getTimeZone().toZoneId()).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")) + ".log");
     }
 
     @Test

--- a/dropwizard-metrics/src/main/java/io/dropwizard/metrics/RegexStringMatchingStrategy.java
+++ b/dropwizard-metrics/src/main/java/io/dropwizard/metrics/RegexStringMatchingStrategy.java
@@ -3,8 +3,8 @@ package io.dropwizard.metrics;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 
+import java.time.Duration;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 class RegexStringMatchingStrategy implements StringMatchingStrategy {
@@ -12,7 +12,7 @@ class RegexStringMatchingStrategy implements StringMatchingStrategy {
 
     RegexStringMatchingStrategy() {
         patternCache = Caffeine.newBuilder()
-            .expireAfterWrite(1, TimeUnit.HOURS)
+            .expireAfterWrite(Duration.ofHours(1))
             .build(Pattern::compile);
     }
 

--- a/dropwizard-parent/pom.xml
+++ b/dropwizard-parent/pom.xml
@@ -36,11 +36,43 @@
                 <jdk>[9,)</jdk>
             </activation>
             <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-                <maven.compiler.source>8</maven.compiler.source>
-                <maven.compiler.target>8</maven.compiler.target>
                 <argLine>${surefire.argLine} --illegal-access=deny --add-opens java.base/java.net=ALL-UNNAMED</argLine>
             </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>com.google.errorprone</groupId>
+                                    <artifactId>error_prone_core</artifactId>
+                                    <version>${error_prone.version}</version>
+                                </path>
+                                <!-- enable extended nullability checks -->
+                                <path>
+                                    <groupId>com.uber.nullaway</groupId>
+                                    <artifactId>nullaway</artifactId>
+                                    <version>${nullaway.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                            <compilerArgs>
+                                <arg>-XDcompilePolicy=simple</arg>
+                                <!-- When run as plugin all args must be passed together -->
+                                <arg>-Xplugin:ErrorProne
+                                    -XepDisableWarningsInGeneratedCode
+                                    -Xep:EqualsGetClass:OFF
+                                    -Xep:NullAway:ERROR
+                                    -XepOpt:NullAway:AnnotatedPackages=io.dropwizard
+                                    -XepOpt:NullAway:ExcludedFieldAnnotations=org.mockito.Mock
+                                    -XepOpt:NullAway:UnannotatedSubPackages=io.dropwizard.benchmarks</arg>
+                            </compilerArgs>
+                            <release>8</release>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>release</id>


### PR DESCRIPTION
Newer versions of Java need to run error-prone as a compiler plugin.
Update the profile for Java 9+ builds to run with error-prone plug-in
and same arguments that are used for Java 1.8 build.