### PR TITLE
Fix regression in OptionalInt/Long/Double handling.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,6 +12,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         java_version: ['openjdk8', 'openjdk11', 'openjdk13']
         os: ['ubuntu-latest', 'windows-latest']

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/DefaultValueUtils.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/DefaultValueUtils.java
@@ -1,0 +1,26 @@
+package io.dropwizard.jersey.optional;
+
+import javax.annotation.Nullable;
+import javax.ws.rs.DefaultValue;
+import java.lang.annotation.Annotation;
+
+final class DefaultValueUtils {
+    private DefaultValueUtils() {}
+
+    /**
+     * Returns the value of the {@link DefaultValue#value()} if found in annotations.
+     * @param annotations Array of annotations (can be null).
+     * @return Value of {@link DefaultValue#value()} if found, otherwise null.
+     */
+    @Nullable
+    static String getDefaultValue(final Annotation[] annotations) {
+        if (annotations != null) {
+            for (Annotation annotation : annotations) {
+                if (DefaultValue.class == annotation.annotationType()) {
+                    return ((DefaultValue) annotation).value();
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalIntParamConverterProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalIntParamConverterProvider.java
@@ -20,16 +20,46 @@ public class OptionalIntParamConverterProvider implements ParamConverterProvider
     @Nullable
     public <T> ParamConverter<T> getConverter(final Class<T> rawType, final Type genericType,
                                               final Annotation[] annotations) {
-        return OptionalInt.class.equals(rawType) ? (ParamConverter<T>) paramConverter : null;
+        if (!OptionalInt.class.equals(rawType)) {
+            return null;
+        }
+        final String defaultValue = DefaultValueUtils.getDefaultValue(annotations);
+        return (ParamConverter<T>) (defaultValue == null ? paramConverter : new OptionalIntParamConverter(defaultValue));
     }
 
     public static class OptionalIntParamConverter implements ParamConverter<OptionalInt> {
+
+        @Nullable
+        private final String defaultValue;
+
+        public OptionalIntParamConverter() {
+            this(null);
+        }
+
+        public OptionalIntParamConverter(@Nullable String defaultValue) {
+            this.defaultValue = defaultValue;
+        }
+
+        @SuppressWarnings("OptionalAssignedToNull")
         @Override
+        @Nullable
         public OptionalInt fromString(final String value) {
             try {
                 final int i = Integer.parseInt(value);
                 return OptionalInt.of(i);
             } catch (NumberFormatException e) {
+                if (defaultValue != null) {
+                    // If an invalid default value is specified, we want to fail fast.
+                    // This is the same behavior as DropWizard 1.3.x and matches Jersey's handling of @DefaultValue for Integer.
+                    if (defaultValue.equals(value)) {
+                        throw e;
+                    }
+                    // In order to fall back to use a default value for an empty query param, we must return null here.
+                    // This preserves backwards compatibility with DropWizard 1.3.x handling of empty query params.
+                    if (value.isEmpty()) {
+                        return null;
+                    }
+                }
                 return OptionalInt.empty();
             }
         }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalDoubleMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalDoubleMessageBodyWriterTest.java
@@ -4,8 +4,10 @@ import io.dropwizard.jersey.AbstractJerseyTest;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import org.junit.jupiter.api.Test;
 
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -17,6 +19,7 @@ import javax.ws.rs.core.Response;
 import java.util.OptionalDouble;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 public class OptionalDoubleMessageBodyWriterTest extends AbstractJerseyTest {
@@ -54,6 +57,35 @@ public class OptionalDoubleMessageBodyWriterTest extends AbstractJerseyTest {
         }
     }
 
+    @Test
+    public void valueSetIgnoresDefault() {
+        assertThat(target("optional-return/default").queryParam("id", "1").request().get(Double.class))
+            .isEqualTo(target("optional-return/double/default").queryParam("id", "1").request().get(Double.class))
+            .isEqualTo(1);
+    }
+
+    @Test
+    public void valueNotSetReturnsDefault() {
+        assertThat(target("optional-return/default").request().get(Double.class))
+            .isEqualTo(target("optional-return/double/default").request().get(Double.class))
+            .isEqualTo(0);
+    }
+
+    @Test
+    public void valueEmptyReturnsDefault() {
+        assertThat(target("optional-return/default").queryParam("id", "").request().get(Double.class))
+            .isEqualTo(target("optional-return/double/default").queryParam("id", "").request().get(Double.class))
+            .isEqualTo(0);
+    }
+
+    @Test
+    public void valueInvalidReturns404() {
+        assertThatThrownBy(() -> target("optional-return/default").queryParam("id", "invalid").request().get(Double.class))
+            .isInstanceOf(NotFoundException.class);
+        assertThatThrownBy(() -> target("optional-return/double/default").queryParam("id", "invalid").request().get(Double.class))
+            .isInstanceOf(NotFoundException.class);
+    }
+
     @Path("optional-return")
     @Produces(MediaType.TEXT_PLAIN)
     public static class OptionalDoubleReturnResource {
@@ -71,6 +103,18 @@ public class OptionalDoubleMessageBodyWriterTest extends AbstractJerseyTest {
         @GET
         public Response showWithQueryParamResponse(@QueryParam("id") OptionalDouble id) {
             return Response.ok(id).build();
+        }
+
+        @Path("default")
+        @GET
+        public OptionalDouble showWithQueryParamAndDefaultValue(@QueryParam("id") @DefaultValue("0") OptionalDouble id) {
+            return id;
+        }
+
+        @Path("double/default")
+        @GET
+        public Double showWithLongQueryParamAndDefaultValue(@QueryParam("id") @DefaultValue("0") Double id) {
+            return id;
         }
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalDoubleParamConverterProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalDoubleParamConverterProviderTest.java
@@ -1,0 +1,19 @@
+package io.dropwizard.jersey.optional;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OptionalDoubleParamConverterProviderTest {
+    @Test
+    public void verifyInvalidDefaultValueFailsFast() {
+        assertThatThrownBy(() -> new OptionalDoubleParamConverterProvider.OptionalDoubleParamConverter("invalid").fromString("invalid"))
+            .isInstanceOf(NumberFormatException.class);
+    }
+
+    @Test
+    public void verifyInvalidValueNoDefaultReturnsNotPresent() {
+        assertThat(new OptionalDoubleParamConverterProvider.OptionalDoubleParamConverter().fromString("invalid")).isNotPresent();
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalIntMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalIntMessageBodyWriterTest.java
@@ -4,8 +4,10 @@ import io.dropwizard.jersey.AbstractJerseyTest;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import org.junit.jupiter.api.Test;
 
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -17,6 +19,7 @@ import javax.ws.rs.core.Response;
 import java.util.OptionalInt;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 public class OptionalIntMessageBodyWriterTest extends AbstractJerseyTest {
@@ -54,6 +57,41 @@ public class OptionalIntMessageBodyWriterTest extends AbstractJerseyTest {
         }
     }
 
+    @Test
+    public void valueSetIgnoresDefault() {
+        assertThat(target("optional-return/default").queryParam("id", "1").request().get(Integer.class))
+            .isEqualTo(target("optional-return/int/default").queryParam("id", "1").request().get(Integer.class))
+            .isEqualTo(1);
+    }
+
+    @Test
+    public void valueNotSetReturnsDefault() {
+        assertThat(target("optional-return/default").request().get(Integer.class))
+            .isEqualTo(target("optional-return/int/default").request().get(Integer.class))
+            .isEqualTo(0);
+    }
+
+    @Test
+    public void valueEmptyReturnsDefault() {
+        assertThat(target("optional-return/default").queryParam("id", "").request().get(Integer.class))
+            .isEqualTo(target("optional-return/int/default").queryParam("id", "").request().get(Integer.class))
+            .isEqualTo(0);
+    }
+
+    @Test
+    public void valueInvalidReturns404() {
+        assertThatThrownBy(() -> target("optional-return/default").queryParam("id", "invalid").request().get(Integer.class))
+            .isInstanceOf(NotFoundException.class);
+        assertThatThrownBy(() -> target("optional-return/int/default").queryParam("id", "invalid").request().get(Integer.class))
+            .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    public void verifyInvalidDefaultValueFailsFast() {
+        assertThatThrownBy(() -> new OptionalIntParamConverterProvider.OptionalIntParamConverter("invalid").fromString("invalid"))
+            .isInstanceOf(NumberFormatException.class);
+    }
+
     @Path("optional-return")
     @Produces(MediaType.TEXT_PLAIN)
     public static class OptionalIntReturnResource {
@@ -71,6 +109,18 @@ public class OptionalIntMessageBodyWriterTest extends AbstractJerseyTest {
         @GET
         public Response showWithQueryParamResponse(@QueryParam("id") OptionalInt id) {
             return Response.ok(id).build();
+        }
+
+        @Path("default")
+        @GET
+        public OptionalInt showWithQueryParamAndDefaultValue(@QueryParam("id") @DefaultValue("0") OptionalInt id) {
+            return id;
+        }
+
+        @Path("int/default")
+        @GET
+        public Integer showWithLongQueryParamAndDefaultValue(@QueryParam("id") @DefaultValue("0") Integer id) {
+            return id;
         }
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalIntParamConverterProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalIntParamConverterProviderTest.java
@@ -1,0 +1,19 @@
+package io.dropwizard.jersey.optional;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OptionalIntParamConverterProviderTest {
+    @Test
+    public void verifyInvalidDefaultValueFailsFast() {
+        assertThatThrownBy(() -> new OptionalIntParamConverterProvider.OptionalIntParamConverter("invalid").fromString("invalid"))
+            .isInstanceOf(NumberFormatException.class);
+    }
+
+    @Test
+    public void verifyInvalidValueNoDefaultReturnsNotPresent() {
+        assertThat(new OptionalIntParamConverterProvider.OptionalIntParamConverter().fromString("invalid")).isNotPresent();
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalLongMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalLongMessageBodyWriterTest.java
@@ -4,8 +4,10 @@ import io.dropwizard.jersey.AbstractJerseyTest;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import org.junit.jupiter.api.Test;
 
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -17,6 +19,7 @@ import javax.ws.rs.core.Response;
 import java.util.OptionalLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 public class OptionalLongMessageBodyWriterTest extends AbstractJerseyTest {
@@ -54,6 +57,35 @@ public class OptionalLongMessageBodyWriterTest extends AbstractJerseyTest {
         }
     }
 
+    @Test
+    public void valueSetIgnoresDefault() {
+        assertThat(target("optional-return/default").queryParam("id", "1").request().get(Long.class))
+            .isEqualTo(target("optional-return/long/default").queryParam("id", "1").request().get(Long.class))
+            .isEqualTo(1L);
+    }
+
+    @Test
+    public void valueNotSetReturnsDefault() {
+        assertThat(target("optional-return/default").request().get(Long.class))
+            .isEqualTo(target("optional-return/long/default").request().get(Long.class))
+            .isEqualTo(0L);
+    }
+
+    @Test
+    public void valueEmptyReturnsDefault() {
+        assertThat(target("optional-return/default").queryParam("id", "").request().get(Long.class))
+            .isEqualTo(target("optional-return/long/default").queryParam("id", "").request().get(Long.class))
+            .isEqualTo(0L);
+    }
+
+    @Test
+    public void valueInvalidReturns404() {
+        assertThatThrownBy(() -> target("optional-return/default").queryParam("id", "invalid").request().get(Long.class))
+            .isInstanceOf(NotFoundException.class);
+        assertThatThrownBy(() -> target("optional-return/long/default").queryParam("id", "invalid").request().get(Long.class))
+            .isInstanceOf(NotFoundException.class);
+    }
+
     @Path("optional-return")
     @Produces(MediaType.TEXT_PLAIN)
     public static class OptionalLongReturnResource {
@@ -71,6 +103,18 @@ public class OptionalLongMessageBodyWriterTest extends AbstractJerseyTest {
         @GET
         public Response showWithQueryParamResponse(@QueryParam("id") OptionalLong id) {
             return Response.ok(id).build();
+        }
+
+        @Path("default")
+        @GET
+        public OptionalLong showWithQueryParamAndDefaultValue(@QueryParam("id") @DefaultValue("0") OptionalLong id) {
+            return id;
+        }
+
+        @Path("long/default")
+        @GET
+        public Long showWithLongQueryParamAndDefaultValue(@QueryParam("id") @DefaultValue("0") Long id) {
+            return id;
         }
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalLongParamConverterProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalLongParamConverterProviderTest.java
@@ -1,0 +1,19 @@
+package io.dropwizard.jersey.optional;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OptionalLongParamConverterProviderTest {
+    @Test
+    public void verifyInvalidDefaultValueFailsFast() {
+        assertThatThrownBy(() -> new OptionalLongParamConverterProvider.OptionalLongParamConverter("invalid").fromString("invalid"))
+            .isInstanceOf(NumberFormatException.class);
+    }
+
+    @Test
+    public void verifyInvalidValueNoDefaultReturnsNotPresent() {
+        assertThat(new OptionalLongParamConverterProvider.OptionalLongParamConverter().fromString("invalid")).isNotPresent();
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
@@ -1030,7 +1030,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
                 .get();
 
         assertThat(response.getStatus()).isEqualTo(200);
-        assertThat(response.readEntity(Integer.class)).isEqualTo(42);
+        assertThat(response.readEntity(Integer.class)).isEqualTo(23);
     }
 
     @Test


### PR DESCRIPTION
DropWizard 2.x changed the behavior of OptionalInt/Long/Double
parameters in two ways. First, empty values used to result in the
`@DefaultValue` of a parameter being used. In DropWizard 2.x, this changed
to return OptionalXYZ.empty() instead.

Additionally, using an invalid value for a `@DefaultValue` parameter used
to fail fast when the Jersey resource was added. This changed with more
lax parsing in DropWizard 2.x.

Update to preserve the previous behavior of empty string parameter
values and invalid `@DefaultValue` values. This should avoid issues with
adoption of DropWizard 2.x.

Fixes #3123.