### PR TITLE
Executor metrics shouldn't contain fmt string.

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -6,6 +6,12 @@ Release Notes
 
 Please refer to `GitHub releases <https://github.com/dropwizard/dropwizard/releases>`__ for the most up-to-date release notes.
 
+.. _rel-2.1.0:
+
+v2.1.0: TBD
+====================
+
+* :ref:`upgrade-notes-dropwizard-2_1_x`
 
 .. _rel-2.0.0:
 

--- a/docs/source/manual/upgrade-notes.rst
+++ b/docs/source/manual/upgrade-notes.rst
@@ -13,3 +13,4 @@ Upgrade Notes
    upgrade-notes/upgrade-notes-1_0_x.rst
    upgrade-notes/upgrade-notes-1_1_x.rst
    upgrade-notes/upgrade-notes-2_0_x.rst
+   upgrade-notes/upgrade-notes-2_1_x.rst

--- a/docs/source/manual/upgrade-notes/upgrade-notes-2_1_x.rst
+++ b/docs/source/manual/upgrade-notes/upgrade-notes-2_1_x.rst
@@ -1,0 +1,19 @@
+.. _upgrade-notes-dropwizard-2_1_x:
+
+##################################
+Upgrade Notes for Dropwizard 2.1.x
+##################################
+
+Executor Service Metrics
+========================
+
+In Dropwizard 2.0.x, metric names for an instrumented ExecutorService
+created by ``Environment.executorService(String)`` contained a format
+string (i.e. ``-%d``). In DropWizard 2.1.x this has been fixed so
+metric names contain the portion of the nameFormat without the
+format string. Additionally, nameFormat must contain a format
+String, returning to the behavior from pre-2.0.x releases which
+used Guava's ThreadFactoryBuilder.
+
+See https://github.com/dropwizard/dropwizard/issues/3139 for more
+details on the issue and the fix.

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilder.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilder.java
@@ -121,32 +121,32 @@ public class ExecutorServiceBuilder {
 
     static String getNameWithoutFormat(String nameFormat) {
         final String name = String.format(Locale.ROOT, nameFormat, 0);
-        final StringBuilder nameWithoutFormat = new StringBuilder(nameFormat.length());
-        int mismatchIdx = -1;
-        for (int i = 0; i < name.length(); i++) {
-            final char nameFormatCh = nameFormat.charAt(i);
-            final char nameCh = name.charAt(i);
-            if (nameFormatCh != nameCh) {
-                if (nameWithoutFormat.length() > 0 && nameWithoutFormat.charAt(i - 1) == '-') {
-                    // Remove dash before %d if it exists
-                    nameWithoutFormat.setLength(i - 1);
-                }
-                mismatchIdx = i;
+        return commonPrefixWithoutHyphen(name, nameFormat) + commonSuffix(name, nameFormat);
+    }
+
+    static String commonPrefixWithoutHyphen(String name, String nameFormat) {
+        final int minLength = Math.min(name.length(), nameFormat.length());
+        int diffIndex;
+        for (diffIndex = 0; diffIndex < minLength; diffIndex++) {
+            if (name.charAt(diffIndex) != nameFormat.charAt(diffIndex)) {
                 break;
             }
-            nameWithoutFormat.append(nameCh);
         }
-        int commonSuffixNameFormatIdx = nameFormat.length();
-        for (int nameFormatIdx = nameFormat.length() - 1, nameIdx = name.length() - 1; nameFormatIdx > mismatchIdx && nameIdx > mismatchIdx; nameFormatIdx--, nameIdx--) {
-            final char nameFormatCh = nameFormat.charAt(nameFormatIdx);
-            final char nameCh = name.charAt(nameIdx);
-            if (nameFormatCh != nameCh) {
+        if (diffIndex > 0 && name.charAt(diffIndex - 1) == '-') {
+            diffIndex--;
+        }
+        return name.substring(0, diffIndex);
+    }
+
+    static String commonSuffix(String name, String nameFormat) {
+        int nameIndex = name.length();
+        int nameFormatIndex = nameFormat.length();
+        while (--nameIndex >= 0 && --nameFormatIndex >= 0) {
+            if (name.charAt(nameIndex) != nameFormat.charAt(nameFormatIndex)) {
                 break;
             }
-            commonSuffixNameFormatIdx = nameFormatIdx;
         }
-        nameWithoutFormat.append(nameFormat.substring(commonSuffixNameFormatIdx));
-        return nameWithoutFormat.toString();
+        return name.substring(nameIndex + 1);
     }
 
     private boolean isBoundedQueue() {


### PR DESCRIPTION
Update ExecutorServiceBuilder to remove the format string from the
metric name. Currently, a thread pool named 'jersey-client-foo-%d' will
have metrics 'jersey-client-foo-%d.created',
'jersey-client-foo-%d.terminated', and 'jersey-client-foo-%d.running'
added to the metrics registry. The '-%d' format string is only meant to
ensure that threads are uniquely named and shouldn't be included in the
name of the metric.

Update ExecutorServiceBuilder to strip the format portion of the
nameFormat from the metric name.

Fixes #3139.