### PR TITLE
Test can fail if map iterates in a different order

### DIFF
--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/LoggingExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/LoggingExceptionMapperTest.java
@@ -62,7 +62,7 @@ public class LoggingExceptionMapperTest extends AbstractJerseyTest {
         assertThat(thrown).isInstanceOf(WebApplicationException.class);
         final Response resp = ((WebApplicationException) thrown).getResponse();
         assertThat(resp.getStatus()).isEqualTo(405);
-        assertThat(resp.getHeaders()).contains(entry("Allow", Collections.singletonList("GET,OPTIONS")));
+        assertThat(resp.getHeaders()).containsAnyOf(entry("Allow", Collections.singletonList("GET,OPTIONS")), entry("Allow", Collections.singletonList("OPTIONS,GET")));
         assertThat(resp.readEntity(String.class)).isEqualTo("{\"code\":405,\"message\":\"HTTP 405 Method Not Allowed\"}");
     }
 


### PR DESCRIPTION
###### Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->
Test `handlesMethodNotAllowedWithHeaders` in `LoggingExceptionMapperTest.java`  depends on the iteration order of  `Response.getHeaders`, and its return type is `MultivaluedMap`. However, it does not guarantee any specific order of entries. Therefore, the assertion in that test cases will fail if the order is different.
###### Solution:
<!-- Describe the modifications you've done. -->
This PR proposes to use `containsAnyOf` instead of `contains`, which verifies that the actual map contains the given entries in any order.
###### Result:
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->
The test becomes no longer flaky.