### PR TITLE
Fix regression in `AbstractParam` handling

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DefaultValueUtils.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DefaultValueUtils.java
@@ -1,19 +1,22 @@
-package io.dropwizard.jersey.optional;
+package io.dropwizard.jersey;
 
 import javax.annotation.Nullable;
 import javax.ws.rs.DefaultValue;
 import java.lang.annotation.Annotation;
 
-final class DefaultValueUtils {
-    private DefaultValueUtils() {}
+public final class DefaultValueUtils {
+    private DefaultValueUtils() {
+    }
 
     /**
      * Returns the value of the {@link DefaultValue#value()} if found in annotations.
+     *
      * @param annotations Array of annotations (can be null).
      * @return Value of {@link DefaultValue#value()} if found, otherwise null.
+     * @since 2.0
      */
     @Nullable
-    static String getDefaultValue(final Annotation[] annotations) {
+    public static String getDefaultValue(final Annotation[] annotations) {
         if (annotations != null) {
             for (Annotation annotation : annotations) {
                 if (DefaultValue.class == annotation.annotationType()) {

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalDoubleParamConverterProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalDoubleParamConverterProvider.java
@@ -1,5 +1,7 @@
 package io.dropwizard.jersey.optional;
 
+import io.dropwizard.jersey.DefaultValueUtils;
+
 import javax.annotation.Nullable;
 import javax.inject.Singleton;
 import javax.ws.rs.ext.ParamConverter;

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalIntParamConverterProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalIntParamConverterProvider.java
@@ -1,5 +1,7 @@
 package io.dropwizard.jersey.optional;
 
+import io.dropwizard.jersey.DefaultValueUtils;
+
 import javax.annotation.Nullable;
 import javax.inject.Singleton;
 import javax.ws.rs.ext.ParamConverter;

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalLongParamConverterProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalLongParamConverterProvider.java
@@ -1,5 +1,7 @@
 package io.dropwizard.jersey.optional;
 
+import io.dropwizard.jersey.DefaultValueUtils;
+
 import javax.annotation.Nullable;
 import javax.inject.Singleton;
 import javax.ws.rs.ext.ParamConverter;

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/AbstractParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/AbstractParam.java
@@ -20,6 +20,11 @@ public abstract class AbstractParam<T> {
     private final String parameterName;
     private final T value;
 
+    /**
+     * Given an input value from a client, creates a parameter wrapping its parsed value.
+     *
+     * @param input an input value from a client request, might be {@code null}
+     */
     protected AbstractParam(@Nullable String input) {
         this(input, "Parameter");
     }
@@ -27,7 +32,8 @@ public abstract class AbstractParam<T> {
     /**
      * Given an input value from a client, creates a parameter wrapping its parsed value.
      *
-     * @param input an input value from a client request
+     * @param input         an input value from a client request, might be {@code null}
+     * @param parameterName name of the parameter with the provided value
      */
     protected AbstractParam(@Nullable String input, String parameterName) {
         this.parameterName = parameterName;

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/AbstractParamConverter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/AbstractParamConverter.java
@@ -24,9 +24,10 @@ import java.lang.reflect.InvocationTargetException;
 public class AbstractParamConverter<T> implements ParamConverter<T> {
     private final Constructor<T> constructor;
     private final String parameterName;
+    @Nullable
     private final String defaultValue;
 
-    public AbstractParamConverter(Constructor<T> constructor, String parameterName, String defaultValue) {
+    public AbstractParamConverter(Constructor<T> constructor, String parameterName, @Nullable String defaultValue) {
         this.constructor = constructor;
         this.parameterName = parameterName;
         this.defaultValue = defaultValue;

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/AbstractParamConverter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/AbstractParamConverter.java
@@ -1,5 +1,6 @@
 package io.dropwizard.jersey.params;
 
+import io.dropwizard.util.Strings;
 import org.glassfish.jersey.internal.inject.ExtractorException;
 import org.glassfish.jersey.server.internal.LocalizationMessages;
 
@@ -23,17 +24,26 @@ import java.lang.reflect.InvocationTargetException;
 public class AbstractParamConverter<T> implements ParamConverter<T> {
     private final Constructor<T> constructor;
     private final String parameterName;
+    private final String defaultValue;
 
-    public AbstractParamConverter(Constructor<T> constructor, String parameterName) {
+    public AbstractParamConverter(Constructor<T> constructor, String parameterName, String defaultValue) {
         this.constructor = constructor;
         this.parameterName = parameterName;
+        this.defaultValue = defaultValue;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     @Nullable
     public T fromString(String value) {
         try {
-            return _fromString(value);
+            if (Strings.isNullOrEmpty(value) && defaultValue != null && !defaultValue.equals(value)) {
+                return _fromString(defaultValue);
+            } else {
+                return _fromString(value);
+            }
         } catch (InvocationTargetException ex) {
             final Throwable cause = ex.getCause();
             if (cause instanceof WebApplicationException) {
@@ -50,6 +60,9 @@ public class AbstractParamConverter<T> implements ParamConverter<T> {
         return constructor.newInstance(value, parameterName);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String toString(T value) throws IllegalArgumentException {
         if (value == null) {

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/AbstractParamConverterProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/AbstractParamConverterProvider.java
@@ -1,5 +1,6 @@
 package io.dropwizard.jersey.params;
 
+import io.dropwizard.jersey.DefaultValueUtils;
 import io.dropwizard.jersey.validation.JerseyParameterNameProvider;
 
 import javax.annotation.Nullable;
@@ -31,7 +32,8 @@ public class AbstractParamConverterProvider implements ParamConverterProvider {
                 // leaving Jersey to handle these parameters as it normally would.
                 return null;
             }
-            return new AbstractParamConverter<>(constructor, parameterName);
+            final String defaultValue = DefaultValueUtils.getDefaultValue(annotations);
+            return new AbstractParamConverter<>(constructor, parameterName, defaultValue);
         }
         return null;
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
@@ -6,8 +6,8 @@ import io.dropwizard.jersey.jackson.JacksonMessageBodyProviderTest.Example;
 import io.dropwizard.jersey.jackson.JacksonMessageBodyProviderTest.ListExample;
 import io.dropwizard.jersey.jackson.JacksonMessageBodyProviderTest.PartialExample;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.client.Entity;
@@ -345,16 +345,14 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void paramsCanBeValidatedWhenNull() {
-        assertThat(target("/valid/nullable-int-param")
-            .request().get().readEntity(String.class)).isEqualTo("{\"code\":400,\"message\":\"query param num is not a number.\"}");
-    }
-
-    @Test
     public void paramsCanBeUnwrappedAndValidated() {
-        assertThat(target("/valid/nullable-int-param").queryParam("num", 4)
-            .request().get().readEntity(String.class))
-            .containsOnlyOnce("[\"query param num must be less than or equal to 3\"]");
+        final Response response = target("/valid/nullable-int-param")
+                .queryParam("num", 4)
+                .request()
+                .get();
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.readEntity(String.class))
+            .isEqualTo("{\"errors\":[\"query param num must be less than or equal to 3\"]}");
     }
 
     @Test
@@ -722,6 +720,182 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
+    public void longParam_fails_with_null() {
+        final Response response = target("/valid/longParam")
+                .queryParam("num")
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.readEntity(String.class))
+                .isEqualTo("{\"code\":400,\"message\":\"query param num is not a number.\"}");
+    }
+
+    @Test
+    public void longParam_fails_with_emptyString() {
+        final Response response = target("/valid/longParam")
+                .queryParam("num", "")
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.readEntity(String.class))
+                .isEqualTo("{\"code\":400,\"message\":\"query param num is not a number.\"}");
+    }
+
+    @Test
+    public void longParam_fails_with_constraint_violation() {
+        final Response response = target("/valid/longParam")
+                .queryParam("num", 5)
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.readEntity(String.class))
+                .isEqualTo("{\"errors\":[\"query param num must be greater than or equal to 23\"]}");
+    }
+
+    @Test
+    public void longParam_fails_with_string() {
+        final Response response = target("/valid/longParam")
+                .queryParam("num", "string")
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.readEntity(String.class))
+                .isEqualTo("{\"code\":400,\"message\":\"query param num is not a number.\"}");
+    }
+
+
+    @Test
+    public void longParam_succeeds() {
+        final Response response = target("/valid/longParam")
+                .queryParam("num", 42)
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.readEntity(Integer.class)).isEqualTo(42);
+    }
+
+    @Test
+    public void longParamNotNull_fails_with_null() {
+        final Response response = target("/valid/longParamNotNull")
+                .queryParam("num")
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.readEntity(String.class))
+                .isEqualTo("{\"code\":400,\"message\":\"query param num is not a number.\"}");
+    }
+
+    @Test
+    public void longParamNotNull_fails_with_empty_string() {
+        final Response response = target("/valid/longParamNotNull")
+                .queryParam("num", "")
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.readEntity(String.class))
+                .isEqualTo("{\"code\":400,\"message\":\"query param num is not a number.\"}");
+    }
+
+    @Test
+    public void longParamNotNull_fails_with_constraint_violation() {
+        final Response response = target("/valid/longParamNotNull")
+                .queryParam("num", 5)
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.readEntity(String.class))
+                .isEqualTo("{\"errors\":[\"query param num must be greater than or equal to 23\"]}");
+    }
+
+    @Test
+    public void longParamNotNull_fails_with_string() {
+        final Response response = target("/valid/longParamNotNull")
+                .queryParam("num", "test")
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.readEntity(String.class))
+                .isEqualTo("{\"code\":400,\"message\":\"query param num is not a number.\"}");
+    }
+
+    @Test
+    public void longParamNotNull_succeeds() {
+        final Response response = target("/valid/longParamNotNull")
+                .queryParam("num", 42)
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.readEntity(Integer.class)).isEqualTo(42);
+    }
+
+    @Test
+    public void longParamWithDefault_succeeds_with_null() {
+        final Response response = target("/valid/longParamWithDefault")
+                .queryParam("num")
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.readEntity(Integer.class)).isEqualTo(42);
+    }
+
+    @Test
+    public void longParamWithDefault_fails_with_empty_string() {
+        final Response response = target("/valid/longParamWithDefault")
+                .queryParam("num", "")
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.readEntity(Long.class)).isEqualTo(42L);
+    }
+
+    @Test
+    public void longParamWithDefault_fails_with_constraint_violation() {
+        final Response response = target("/valid/longParamWithDefault")
+                .queryParam("num", 5)
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.readEntity(String.class))
+                .isEqualTo("{\"errors\":[\"query param num must be greater than or equal to 23\"]}");
+    }
+
+    @Test
+    public void longParamWithDefault_fails_with_string() {
+        final Response response = target("/valid/longParamWithDefault")
+                .queryParam("num", "test")
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.readEntity(String.class))
+                .isEqualTo("{\"code\":400,\"message\":\"query param num is not a number.\"}");
+    }
+
+    @Test
+    public void longParamWithDefault_succeeds() {
+        final Response response = target("/valid/longParamWithDefault")
+                .queryParam("num", 30)
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.readEntity(Integer.class)).isEqualTo(30);
+    }
+
+    @Test
     public void intParam_fails_with_null() {
         final Response response = target("/valid/intParam")
                 .queryParam("num")
@@ -858,9 +1032,8 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
                 .request()
                 .get();
 
-        assertThat(response.getStatus()).isEqualTo(400);
-        assertThat(response.readEntity(String.class))
-                .isEqualTo("{\"code\":400,\"message\":\"query param num is not a number.\"}");
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.readEntity(Integer.class)).isEqualTo(42);
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ValidatingResource.java
@@ -296,6 +296,25 @@ public class ValidatingResource {
     }
 
     @GET
+    @Path("longParam")
+    public Long longParam(@QueryParam("num") @Min(23) LongParam longParam) {
+        return longParam.get();
+    }
+
+    @GET
+    @Path("longParamNotNull")
+    public Long longParamNotNull(@QueryParam("num")
+                                 @NotNull(payload = Unwrapping.Skip.class) @Min(23) LongParam longParam) {
+        return longParam.get();
+    }
+
+    @GET
+    @Path("longParamWithDefault")
+    public Long longParamWithDefault(@QueryParam("num") @DefaultValue("42") @Min(23) LongParam longParam) {
+        return longParam.get();
+    }
+
+    @GET
     @Path("intParam")
     public Integer intParam(@QueryParam("num") @Min(23) IntParam intParam) {
         return intParam.get();


### PR DESCRIPTION
In Dropwizard 1.3.x and earlier, Jersey interpreted empty strings in parameters (`@CookieParam`, `@QueryParam`, etc.) identical to `null` as missing and used the default value (`@DefaultValue`) as fall-back if it existed.

This change set restores the described behavior in Dropwizard 2.x for the classes inheriting from `AbstractParam`.

Keep in mind that `AbstractParam` and its child classes are deprecated and will be removed in a later Dropwizard version in favor of using `Optional<T>` directly.

Refs #3123
Refs #3134