### PR TITLE
Upgrade to Jackson 2.9.10.20200223 to address CVE-2020-8840

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -21,7 +21,7 @@
         <dropwizard.version>${project.version}</dropwizard.version>
         <guava.version>24.1.1-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
-        <jackson.version>2.9.10.20200103</jackson.version>
+        <jackson.version>2.9.10.20200223</jackson.version>
         <jetty.version>9.4.18.v20190429</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.0.5</metrics4.version>


### PR DESCRIPTION
Refs https://github.com/FasterXML/jackson-databind/issues/2620