### PR TITLE
Fix outdated documentation and method signature

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/cli/Cli.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/Cli.java
@@ -62,10 +62,9 @@ public class Cli {
      * Runs the command line interface given some arguments.
      *
      * @param arguments the command line arguments
-     * @return whether or not the command successfully executed
-     * @throws Exception if something goes wrong
+     * @return the error or an empty optional if command succeeded
      */
-    public Optional<Throwable> run(String... arguments) throws Exception {
+    public Optional<Throwable> run(String... arguments) {
         try {
             if (isFlag(HELP, arguments)) {
                 parser.printHelp(stdOut);


### PR DESCRIPTION
###### Problem:
Documentation and signature are outdated.

###### Solution:
Update them!  
Change to signature should be safe as it does not make the type more restrictive.

###### Result:
Better documentation.

Refs #3020
Refs #3014
Refs #3015