### PR TITLE
Add CachingAuthenticator option to enable negative caches

### DIFF
--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/CachingAuthenticatorTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/CachingAuthenticatorTest.java
@@ -119,4 +119,14 @@ class CachingAuthenticatorTest {
                 .isThrownBy(() -> cached.authenticate("credentials"))
                 .isEqualTo(e);
     }
+
+    @Test
+    void cachesTheNegativeResultIfSpecified() throws Exception {
+        when(underlying.authenticate(anyString())).thenReturn(Optional.empty());
+        Caffeine<Object, Object> caffeine = Caffeine.newBuilder().maximumSize(1L).executor(Runnable::run);
+        cached = new CachingAuthenticator<>(new MetricRegistry(), underlying, caffeine, true);
+        assertThat(cached.authenticate("credentials")).isEqualTo(Optional.empty());
+        verify(underlying).authenticate("credentials");
+        assertThat(cached.size()).isEqualTo(1);
+    }
 }


### PR DESCRIPTION
###### Problem:

`CachingAuthenticator` isn't caching negative results (`Optional.absent()`) because of #947.

But in other cases, not having a negative cache causes a kind of DoS.
If the underlying authenticator requires a little high cost to verify authentication request and the failure will not be cached, many invalid auth requests will cause resource shortage very easily.

In our case, client agents may send so many requests (possibly with invalid auth token by misconfiguration). If we authenticate those requests without negative caches, our underlying authentication endpoint will meet the unexpected number of requests.

###### Solution:

The change of this pull-requests introduces optional negative caches. CachingAuthenticator will enable negative caches only when it's specified so.
