### PR TITLE
Update dead link to jersey documentation on filters and interceptors

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -1855,7 +1855,7 @@ has a rich api for `filters and interceptors`_ that can be used directly in Drop
 You can stop the request from reaching your resources by throwing a ``WebApplicationException``. Alternatively,
 you can use filters to modify inbound requests or outbound responses.
 
-.. _filters and interceptors: http://jersey.github.io/documentation/latest/filters-and-interceptors.html
+.. _filters and interceptors: https://eclipse-ee4j.github.io/jersey.github.io/documentation/latest/filters-and-interceptors.html
 
 .. code-block:: java
 


### PR DESCRIPTION
##### Problem:
There was a dead link for jersey filters and interceptors. Instead of leading you to the documentation it would just redirect you to the main jersey page.

###### Solution:
 I have updated this link to be https://eclipse-ee4j.github.io/jersey.github.io/documentation/latest/filters-and-interceptors.html.

###### Result:
The docs will have the proper link to jersey filters.
