### PR TITLE
Fix FreeMarker "incompatible improvements" error logs

### DIFF
--- a/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/FreemarkerViewRendererTest.java
+++ b/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/FreemarkerViewRendererTest.java
@@ -1,6 +1,8 @@
 package io.dropwizard.views.freemarker;
 
 import com.codahale.metrics.MetricRegistry;
+
+import freemarker.template.Configuration;
 import io.dropwizard.logging.BootstrapLogging;
 import io.dropwizard.views.ViewMessageBodyWriter;
 import io.dropwizard.views.ViewRenderExceptionMapper;
@@ -82,7 +84,7 @@ public class FreemarkerViewRendererTest extends JerseyTest {
     @Override
     protected Application configure() {
         ResourceConfig config = new ResourceConfig();
-        final ViewRenderer renderer = new FreemarkerViewRenderer();
+        final ViewRenderer renderer = new FreemarkerViewRenderer(Configuration.VERSION_2_3_30);
         config.register(new ViewMessageBodyWriter(new MetricRegistry(), Collections.singletonList(renderer)));
         config.register(new ExampleResource());
         config.register(new ViewRenderExceptionMapper());


### PR DESCRIPTION
###### Problem:
This addresses https://github.com/dropwizard/dropwizard/issues/3195

[FreemarkerViewRenderer](https://github.com/dropwizard/dropwizard/blob/master/dropwizard-views-freemarker/src/main/java/io/dropwizard/views/freemarker/FreemarkerViewRenderer.java) uses `freemarker.template.Configuration` in a way that is not recommended by using `Configuration.getVersion()` as the "incompatible improvements" setting.

###### Solution:
In this PR a new constructor is defined that lets the user set the version to use for the freemarker configuration and deprecates the old constructor.

###### Result:
The following error messages aren't logged anymore:
```
[2020-03-16T16:42:03,118Z](dw-admin-47)([]) ERROR - configuration - DefaultObjectWrapper.incompatibleImprovements was set to the object returned by Configuration.getVersion(). That defeats the purpose of incompatibleImprovements, and makes upgrading FreeMarker a potentially breaking change. Also, this probably won't be allowed starting from 2.4.0. Instead, set incompatibleImprovements to the highest concrete version that's known to be compatible with your application.
[2020-03-16T16:42:03,119Z](dw-admin-47)([]) ERROR - configuration - Configuration.incompatibleImprovements was set to the object returned by Configuration.getVersion(). That defeats the purpose of incompatibleImprovements, and makes upgrading FreeMarker a potentially breaking change. Also, this probably won't be allowed starting from 2.4.0. Instead, set incompatibleImprovements to the highest concrete version that's known to be compatible with your application.
[2020-03-16T16:42:03,119Z](dw-admin-47)([]) ERROR - configuration - DefaultObjectWrapper.incompatibleImprovements was set to the object returned by Configuration.getVersion(). That defeats the purpose of incompatibleImprovements, and makes upgrading FreeMarker a potentially breaking change. Also, this probably won't be allowed starting from 2.4.0. Instead, set incompatibleImprovements to the highest concrete version that's known to be compatible with your application.

```
