### PR TITLE
Make it easier to inherit from dropwizard-parent

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -15,10 +15,6 @@
         Bill of materials to make sure a consistent set of versions is used for Dropwizard modules.
     </description>
 
-    <properties>
-        <dropwizard.version>2.0.5-SNAPSHOT</dropwizard.version>
-    </properties>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/dropwizard-parent/pom.xml
+++ b/dropwizard-parent/pom.xml
@@ -242,7 +242,7 @@
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-dependencies</artifactId>
-                <version>${project.version}</version>
+                <version>${dropwizard.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,8 @@
 
         <maven.site.deploy.skip>true</maven.site.deploy.skip>
 
+        <dropwizard.version>2.0.5-SNAPSHOT</dropwizard.version>
+
         <!-- Plugin versions, see also dropwizard-dependencies -->
         <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
         <maven-archetype-plugin.version>3.1.2</maven-archetype-plugin.version>


### PR DESCRIPTION
The dropwizard-parent POM was using `${project.version}` for specifying the version of dropwizard-dependencies.

This prevented using it in projects in which the version is not a valid (and not the desired) Dropwizard version.

Refs #2897