### PR TITLE
Fix typo in `flattenMdc` field name

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -910,7 +910,7 @@ JSON layout
       additionalFields:
         service-name: "user-service"
       includesMdcKeys: [userId]
-      flattenMDC: true
+      flattenMdc: true
       exception:
         rootFirst: true
         depth: full


### PR DESCRIPTION
###### Problem:
There is a typo in the code example.  The example as-is doesn't work with Dropwizard
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->

###### Solution:
Corrected the typo
<!-- Describe the modifications you've done. -->

###### Result:
Code example works with Dropwizard
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->
