### PR TITLE
Upgrade to SnakeYAML to address CVE-2017-18640

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -341,6 +341,12 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- CVE-2017-18640: https://nvd.nist.gov/vuln/detail/CVE-2017-18640 -->
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>1.26</version>
+            </dependency>
 
             <!-- Jersey -->
             <dependency>


### PR DESCRIPTION
SnakeYAML < 1.26 is vulnerable to a Billion Laughs attack (denial of service).

* https://nvd.nist.gov/vuln/detail/CVE-2017-18640
* https://bitbucket.org/asomov/snakeyaml/issues/377

Refs FasterXML/jackson-dataformats-text#187
Refs #3223