### PR TITLE
Configure metrics event listener to track filters

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -1,5 +1,6 @@
 package io.dropwizard.jersey;
 
+import com.codahale.metrics.Clock;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.jersey2.InstrumentedResourceMethodApplicationListener;
 import com.fasterxml.classmate.ResolvedType;
@@ -68,7 +69,7 @@ public class DropwizardResourceConfig extends ResourceConfig {
         property(ServerProperties.WADL_FEATURE_DISABLE, Boolean.TRUE);
         register(loggingListener);
 
-        register(new InstrumentedResourceMethodApplicationListener(metricRegistry));
+        register(new InstrumentedResourceMethodApplicationListener(metricRegistry, Clock.defaultClock(), true));
         register(CacheControlledResponseFeature.class);
         register(io.dropwizard.jersey.guava.OptionalMessageBodyWriter.class);
         register(new io.dropwizard.jersey.guava.OptionalParamBinder());


### PR DESCRIPTION
###### Problem:

Currently, `@Timed` annotations are not useful for asynchronous resource methods. For example:

`````
@Path("/v1/resource")
public class MyResource {

  @Timed
  @Path("/something")
  @GET 
  public CompletableFuture<Response> myResourceMethod() {
    return someOperationThatRequiresIo().thenApply(entity -> Response.status(200).entity(entity).build());
  }

  private CompletableFuture<String> someOperationThatRequiresIo() {
    ...
  }
}
`````

When deployed, the `com.mypackage.MyResource.myResourceMethod.duration.*` values will not mean much. They will only incorporate the time it took to construct the future object and return, not the time the resource actually took to run and create a response.

The `InstrumentedResourceMethodApplicationListener` actually supports a flag, `trackFilters`, that listens to the correct Jersey events in order to measure the total time for the resource logic to complete, rather than just for the resource method to return. However, there's no way to configure Dropwizard so that this functionality is enabled.

###### Solution:

This is a one-line change that enables `trackFilters`. For every `@Timed` annotation, there would be additional metrics. In this case, in addition to `com.mypackage.MyResource.myResourceMethod`, there would also be `...myResourceMethod.request.filtering`, `...myResourceMethod.response.filtering`, and `...myResourceMethod.total`. The latter of which could be used to determine the actual execution time.

###### Result:

All `@Timed` resource methods would get extra metrics, which could be used to measure execution time for asynchronous resource methods.

To write a test for this change (verify that `trackFilters` is enabled), I'd have to modify "metrics" in order to make that property visible. Not sure how that kind of thing is typically coordinated, or if this even needs a test.

If enabling this for everything isn't something you want to do, I could alternately modify "metrics" such that this is specified in the `@Timed` annotation itself, rather than (or in addition to) being configured globally for all metrics.