### PR TITLE
Replace global dropwizard.version property

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -20,137 +20,137 @@
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-assets</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-auth</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-client</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-configuration</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-core</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-db</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-forms</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-hibernate</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-jackson</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-jdbi3</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-jersey</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-jetty</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-lifecycle</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-logging</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-metrics</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-metrics-graphite</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-migrations</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-request-logging</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-json-logging</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-servlets</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-testing</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-util</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-validation</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-views</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-views-freemarker</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-views-mustache</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-http2</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/dropwizard-example/pom.xml
+++ b/dropwizard-example/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dropwizard-example</artifactId>
-    <version>2.0.7-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <groupId>io.dropwizard</groupId>
     <name>Dropwizard Example Application</name>
 
@@ -31,7 +31,7 @@
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-dependencies</artifactId>
-                <version>${project.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/dropwizard-parent/pom.xml
+++ b/dropwizard-parent/pom.xml
@@ -244,7 +244,7 @@
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-dependencies</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>2.0.7-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <module>dropwizard-json-logging</module>
 
         <module>dropwizard-archetypes</module>
+        <module>dropwizard-example</module>
     </modules>
 
     <properties>
@@ -57,8 +58,6 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <maven.site.deploy.skip>true</maven.site.deploy.skip>
-
-        <dropwizard.version>2.0.7-SNAPSHOT</dropwizard.version>
 
         <!-- Plugin versions, see also dropwizard-dependencies -->
         <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>


### PR DESCRIPTION
Many Maven plugins and other tools needed to automate releases don't support the Dropwizard version being used from a global property in POM files.