### PR TITLE
Support customizing BootstrapServiceRegistryBuilder

### DIFF
--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryFactory.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryFactory.java
@@ -16,7 +16,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 public class SessionFactoryFactory {
     private static final Logger LOGGER = LoggerFactory.getLogger(SessionFactoryFactory.class);

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryFactory.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryFactory.java
@@ -68,11 +68,9 @@ public class SessionFactoryFactory {
                                                ConnectionProvider connectionProvider,
                                                Map<String, String> properties,
                                                List<Class<?>> entities) {
-        BootstrapServiceRegistryBuilder builder =
-            configureBootstrapServiceRegistryBuilder(new BootstrapServiceRegistryBuilder());
 
         final BootstrapServiceRegistry bootstrapServiceRegistry =
-            Objects.requireNonNull(builder, "builder can not be null").build();
+            configureBootstrapServiceRegistryBuilder(new BootstrapServiceRegistryBuilder()).build();
 
         final Configuration configuration = new Configuration(bootstrapServiceRegistry);
         configuration.setProperty(AvailableSettings.CURRENT_SESSION_CONTEXT_CLASS, "managed");

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryFactoryTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryFactoryTest.java
@@ -27,8 +27,10 @@ import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class SessionFactoryFactoryTest {
     static {

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryFactoryTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryFactoryTest.java
@@ -163,22 +163,6 @@ public class SessionFactoryFactoryTest {
         assertThat(sessionFactory.getSessionFactoryOptions().getInterceptor()).isSameAs(EmptyInterceptor.INSTANCE);
     }
 
-    @Test
-    public void buildBootstrapServiceRegistryRequireNonNull() {
-        final SessionFactoryFactory customFactory = new SessionFactoryFactory() {
-            @Override
-            protected BootstrapServiceRegistryBuilder configureBootstrapServiceRegistryBuilder(BootstrapServiceRegistryBuilder bootstrapServiceRegistryBuilder) {
-                return null;
-            }
-        };
-
-        assertThrows(NullPointerException.class, () ->
-            sessionFactory = customFactory.build(bundle,
-                environment,
-                config,
-                Collections.singletonList(Person.class)));
-    }
-
     private void build() {
         this.sessionFactory = factory.build(bundle,
             environment,


### PR DESCRIPTION
###### Problem:
Allows to add [Integrators](https://docs.jboss.org/hibernate/orm/5.2/javadocs/org/hibernate/integrator/spi/class-use/Integrator.html) to Hibernate

###### Solution:
Add a protected method to SessionFactoryFactory that allow the configuration of BootstrapServiceRegistryBuilder