### PR TITLE
Upgrade to Jackson 2.9.10.20200411

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -21,7 +21,7 @@
         <dropwizard.version>${project.version}</dropwizard.version>
         <guava.version>24.1.1-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
-        <jackson.version>2.9.10.20200223</jackson.version>
+        <jackson.version>2.9.10.20200411</jackson.version>
         <jetty.version>9.4.18.v20190429</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.0.5</metrics4.version>


### PR DESCRIPTION
Update jackson-bom from  2.9.10.20200223 to 2.9.10.20200411.  This addresses issue #3245 and updates `jackson-databind` from 2.9.10.3 to 2.9.10.4 thus fixing 12 CVE by blocking multiple gadget types (including shiro-core, for which there is no CVE):
* CVE-2020-9546
* CVE-2020-9547
* CVE-2020-9548
* CVE-2020-10969
* CVE-2020-10650
* CVE-2020-10672
* CVE-2020-10673
* CVE-2020-10968
* CVE-2020-11111
* CVE-2020-11112
* CVE-2020-11113
* CVE-2020-11619
* CVE-2020-11620

###### Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->

###### Solution:
<!-- Describe the modifications you've done. -->

###### Result:
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->
