### PR TITLE
Remove alpn-boot dependency in dropwizard-http2 for Java 8u252

### DIFF
--- a/dropwizard-http2/pom.xml
+++ b/dropwizard-http2/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -13,10 +14,7 @@
     <name>Dropwizard HTTP/2 Support</name>
 
     <properties>
-        <!-- Default alpn-boot version. See <profiles> for specific profiles. -->
-        <!-- See also: https://github.com/jetty-project/jetty-alpn/blob/99b59b42ce87c74606749eb8d6593d0ecd7ada72/docs/version_mapping.properties -->
-        <alpn-boot.version>8.1.13.v20181017</alpn-boot.version>
-        <argLine>"-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar" -Duser.language=en -Duser.region=US</argLine>
+        <argLine>-Duser.language=en -Duser.region=US</argLine>
     </properties>
 
     <dependencies>
@@ -143,12 +141,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-alpn-openjdk8-client</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>
             <scope>test</scope>
@@ -160,22 +152,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-alpn-openjdk8-server</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <!-- This needs to be on your JVM's bootpath for HTTP2 to work with ALPN protocol
-            -Xbootclasspath/p:/<path_to_alpn_boot_jar>/alpn-boot-${alpn-boot.version}.jar
-             The correct version depends on the specific JVM version.
-             Consult http://www.eclipse.org/jetty/documentation/current/alpn-chapter.html for the reference -->
-        <dependency>
-            <groupId>org.mortbay.jetty.alpn</groupId>
-            <artifactId>alpn-boot</artifactId>
-            <version>${alpn-boot.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <!-- Profiles for selecting the correct version of alpn-boot for each JDK.
@@ -203,6 +179,26 @@
             </dependencies>
         </profile>
         <profile>
+            <id>jdk8</id>
+            <activation>
+                <jdk>[1.8.0,9)</jdk>
+            </activation>
+            <properties>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-alpn-openjdk8-client</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-alpn-openjdk8-server</artifactId>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>jdk-1.8.0</id>
             <activation>
                 <property>
@@ -212,7 +208,20 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.0.v20141016</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_05</id>
@@ -224,7 +233,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.0.v20141016</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_11</id>
@@ -236,7 +257,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.0.v20141016</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_20</id>
@@ -248,7 +281,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.0.v20141016</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_25</id>
@@ -260,7 +305,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.2.v20141202</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_31</id>
@@ -272,7 +329,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.3.v20150130</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_40</id>
@@ -284,7 +353,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.3.v20150130</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_45</id>
@@ -296,7 +377,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.3.v20150130</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_51</id>
@@ -308,7 +401,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.4.v20150727</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_60</id>
@@ -320,7 +425,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.5.v20150921</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_65</id>
@@ -332,7 +449,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.6.v20151105</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_66</id>
@@ -344,7 +473,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.6.v20151105</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_71</id>
@@ -356,7 +497,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.7.v20160121</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_72</id>
@@ -368,7 +521,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.7.v20160121</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_73</id>
@@ -380,7 +545,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.7.v20160121</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_74</id>
@@ -392,7 +569,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.7.v20160121</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_77</id>
@@ -404,7 +593,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.7.v20160121</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_91</id>
@@ -416,7 +617,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.7.v20160121</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_92</id>
@@ -428,7 +641,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.8.v20160420</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_101</id>
@@ -440,7 +665,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.9.v20160720</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_102</id>
@@ -452,7 +689,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.9.v20160720</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_111</id>
@@ -464,7 +713,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.9.v20160720</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_112</id>
@@ -476,7 +737,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.10.v20161026</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_121</id>
@@ -488,7 +761,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.11.v20170118</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_131</id>
@@ -500,7 +785,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.11.v20170118</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_141</id>
@@ -512,7 +809,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.11.v20170118</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_144</id>
@@ -524,7 +833,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.11.v20170118</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_151</id>
@@ -536,7 +857,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.11.v20170118</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_152</id>
@@ -548,7 +881,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.11.v20170118</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_161</id>
@@ -560,7 +905,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.12.v20180117</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_162</id>
@@ -572,7 +929,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.12.v20180117</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_171</id>
@@ -584,7 +953,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.12.v20180117</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_172</id>
@@ -596,7 +977,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.12.v20180117</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_181</id>
@@ -608,7 +1001,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.12.v20180117</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_191</id>
@@ -620,7 +1025,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.13.v20181017</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_192</id>
@@ -632,7 +1049,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.13.v20181017</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_201</id>
@@ -644,7 +1073,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.13.v20181017</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_202</id>
@@ -656,7 +1097,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.13.v20181017</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_211</id>
@@ -668,7 +1121,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.13.v20181017</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_212</id>
@@ -680,7 +1145,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.13.v20181017</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_221</id>
@@ -692,7 +1169,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.13.v20181017</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_222</id>
@@ -704,7 +1193,115 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.13.v20181017</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_231</id>
+            <activation>
+                <property>
+                    <name>java.version</name>
+                    <value>1.8.0_231</value>
+                </property>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.13.v20181017</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_232</id>
+            <activation>
+                <property>
+                    <name>java.version</name>
+                    <value>1.8.0_232</value>
+                </property>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.13.v20181017</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_241</id>
+            <activation>
+                <property>
+                    <name>java.version</name>
+                    <value>1.8.0_241</value>
+                </property>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.13.v20181017</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_242</id>
+            <activation>
+                <property>
+                    <name>java.version</name>
+                    <value>1.8.0_242</value>
+                </property>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.13.v20181017</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
The alpn-boot dependency is not required anymore starting with Java 8u251/8u252:
https://github.com/jetty-project/jetty-alpn#jetty-alpn

> The ALPN APIs have been backported from Java 9 to OpenJDK 8u251/8u252. Therefore, since OpenJDK 8u251/8u252 there is no more need for the Jetty ALPN boot jar provided by this project.