### PR TITLE
Upgrade to Liquibase 4.0.0-beta1

### DIFF
--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -52,7 +52,7 @@
         <jetty.version>9.4.28.v20200408</jetty.version>
         <joda-time.version>2.10.5</joda-time.version>
         <jsr305.version>3.0.2</jsr305.version>
-        <liquibase-core.version>3.8.9</liquibase-core.version>
+        <liquibase-core.version>4.0.0-beta1</liquibase-core.version>
         <liquibase-slf4j.version>2.0.0</liquibase-slf4j.version>
         <logback-throttling-appender.version>1.1.0</logback-throttling-appender.version>
         <logback.version>1.2.3</logback.version>


### PR DESCRIPTION
https://www.liquibase.org/2020/04/liquibase-4.0.0-beta1-released.html