### PR TITLE
Allow overriding default media type in AssetServlet/AssetBundle

### DIFF
--- a/dropwizard-assets/src/main/java/io/dropwizard/assets/AssetsBundle.java
+++ b/dropwizard-assets/src/main/java/io/dropwizard/assets/AssetsBundle.java
@@ -18,11 +18,13 @@ public class AssetsBundle implements ConfiguredBundle<Configuration> {
     private static final String DEFAULT_ASSETS_NAME = "assets";
     private static final String DEFAULT_INDEX_FILE = "index.htm";
     private static final String DEFAULT_PATH = "/assets";
+    private static final String DEFAULT_MEDIA_TYPE = "text/html";
 
     private final String resourcePath;
     private final String uriPath;
     private final String indexFile;
     private final String assetsName;
+    private final String defaultMediaType;
 
     /**
      * Creates a new AssetsBundle which serves up static assets from
@@ -31,7 +33,7 @@ public class AssetsBundle implements ConfiguredBundle<Configuration> {
      * @see AssetsBundle#AssetsBundle(String, String, String)
      */
     public AssetsBundle() {
-        this(DEFAULT_PATH, DEFAULT_PATH, DEFAULT_INDEX_FILE, DEFAULT_ASSETS_NAME);
+        this(DEFAULT_PATH, DEFAULT_PATH, DEFAULT_INDEX_FILE, DEFAULT_ASSETS_NAME, DEFAULT_MEDIA_TYPE);
     }
 
     /**
@@ -40,11 +42,11 @@ public class AssetsBundle implements ConfiguredBundle<Configuration> {
      * {@code path} of {@code "/assets"}, {@code src/main/resources/assets/example.js} would be
      * served up from {@code /assets/example.js}.
      *
-     * @param path    the classpath and URI root of the static asset files
+     * @param path the classpath and URI root of the static asset files
      * @see AssetsBundle#AssetsBundle(String, String, String)
      */
     public AssetsBundle(String path) {
-        this(path, path, DEFAULT_INDEX_FILE, DEFAULT_ASSETS_NAME);
+        this(path, path, DEFAULT_INDEX_FILE, DEFAULT_ASSETS_NAME, DEFAULT_MEDIA_TYPE);
     }
 
     /**
@@ -53,12 +55,12 @@ public class AssetsBundle implements ConfiguredBundle<Configuration> {
      * {@code resourcePath} of {@code "/assets"} and a uriPath of {@code "/js"},
      * {@code src/main/resources/assets/example.js} would be served up from {@code /js/example.js}.
      *
-     * @param resourcePath    the resource path (in the classpath) of the static asset files
-     * @param uriPath    the uri path for the static asset files
+     * @param resourcePath the resource path (in the classpath) of the static asset files
+     * @param uriPath      the uri path for the static asset files
      * @see AssetsBundle#AssetsBundle(String, String, String)
      */
     public AssetsBundle(String resourcePath, String uriPath) {
-        this(resourcePath, uriPath, DEFAULT_INDEX_FILE, DEFAULT_ASSETS_NAME);
+        this(resourcePath, uriPath, DEFAULT_INDEX_FILE, DEFAULT_ASSETS_NAME, DEFAULT_MEDIA_TYPE);
     }
 
     /**
@@ -68,12 +70,12 @@ public class AssetsBundle implements ConfiguredBundle<Configuration> {
      * {@code resourcePath} of {@code "/assets"} and a uriPath of {@code "/js"},
      * {@code src/main/resources/assets/example.js} would be served up from {@code /js/example.js}.
      *
-     * @param resourcePath        the resource path (in the classpath) of the static asset files
-     * @param uriPath             the uri path for the static asset files
-     * @param indexFile           the name of the index file to use
+     * @param resourcePath the resource path (in the classpath) of the static asset files
+     * @param uriPath      the uri path for the static asset files
+     * @param indexFile    the name of the index file to use
      */
     public AssetsBundle(String resourcePath, String uriPath, String indexFile) {
-        this(resourcePath, uriPath, indexFile, DEFAULT_ASSETS_NAME);
+        this(resourcePath, uriPath, indexFile, DEFAULT_ASSETS_NAME, DEFAULT_MEDIA_TYPE);
     }
 
     /**
@@ -83,12 +85,31 @@ public class AssetsBundle implements ConfiguredBundle<Configuration> {
      * {@code resourcePath} of {@code "/assets"} and a uriPath of {@code "/js"},
      * {@code src/main/resources/assets/example.js} would be served up from {@code /js/example.js}.
      *
-     * @param resourcePath        the resource path (in the classpath) of the static asset files
-     * @param uriPath             the uri path for the static asset files
-     * @param indexFile           the name of the index file to use
-     * @param assetsName          the name of servlet mapping used for this assets bundle
+     * @param resourcePath the resource path (in the classpath) of the static asset files
+     * @param uriPath      the uri path for the static asset files
+     * @param indexFile    the name of the index file to use
+     * @param assetsName   the name of servlet mapping used for this assets bundle
      */
     public AssetsBundle(String resourcePath, String uriPath, String indexFile, String assetsName) {
+        this(resourcePath, uriPath, indexFile, assetsName, DEFAULT_MEDIA_TYPE);
+    }
+
+    /**
+     * Creates a new AssetsBundle which will configure the application to serve the static files
+     * located in {@code src/main/resources/${resourcePath}} as {@code /${uriPath}}. If no file name is
+     * in ${uriPath}, ${indexFile} is appended before serving. For example, given a
+     * {@code resourcePath} of {@code "/assets"} and a uriPath of {@code "/js"},
+     * {@code src/main/resources/assets/example.js} would be served up from {@code /js/example.js}.
+     *
+     * @param resourcePath     the resource path (in the classpath) of the static asset files
+     * @param uriPath          the uri path for the static asset files
+     * @param indexFile        the name of the index file to use
+     * @param assetsName       the name of servlet mapping used for this assets bundle
+     * @param defaultMediaType the default media type for unknown file extensions
+     * @since 2.0
+     */
+    public AssetsBundle(String resourcePath, String uriPath, String indexFile, String assetsName,
+                        String defaultMediaType) {
         if (!resourcePath.startsWith("/")) {
             throw new IllegalArgumentException(resourcePath + " is not an absolute path");
         }
@@ -101,6 +122,7 @@ public class AssetsBundle implements ConfiguredBundle<Configuration> {
         this.uriPath = uriPath.endsWith("/") ? uriPath : (uriPath + '/');
         this.indexFile = indexFile;
         this.assetsName = assetsName;
+        this.defaultMediaType = defaultMediaType;
     }
 
     @Override
@@ -121,7 +143,14 @@ public class AssetsBundle implements ConfiguredBundle<Configuration> {
         return indexFile;
     }
 
+    /**
+     * @since 2.0
+     */
+    public String getDefaultMediaType() {
+        return defaultMediaType;
+    }
+
     protected AssetServlet createServlet() {
-        return new AssetServlet(resourcePath, uriPath, indexFile, StandardCharsets.UTF_8);
+        return new AssetServlet(resourcePath, uriPath, indexFile, defaultMediaType, StandardCharsets.UTF_8);
     }
 }

--- a/dropwizard-assets/src/test/java/io/dropwizard/assets/AssetsBundleTest.java
+++ b/dropwizard-assets/src/test/java/io/dropwizard/assets/AssetsBundleTest.java
@@ -25,16 +25,16 @@ public class AssetsBundleTest {
     private final ServletEnvironment servletEnvironment = mock(ServletEnvironment.class);
     private final Environment environment = mock(Environment.class);
 
-    private AssetServlet servlet = new AssetServlet("/", "/", null, null);
+    private AssetServlet servlet = new AssetServlet("/", "/", null, null, null);
     private String servletPath = "";
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         when(environment.servlets()).thenReturn(servletEnvironment);
     }
 
     @Test
-    public void hasADefaultPath() throws Exception {
+    public void hasADefaultPath() {
         runBundle(new AssetsBundle());
 
         assertThat(servletPath)
@@ -51,7 +51,7 @@ public class AssetsBundleTest {
     }
 
     @Test
-    public void canHaveCustomPaths() throws Exception {
+    public void canHaveCustomPaths() {
         runBundle(new AssetsBundle("/json"));
 
         assertThat(servletPath)
@@ -68,7 +68,7 @@ public class AssetsBundleTest {
     }
 
     @Test
-    public void canHaveDifferentUriAndResourcePaths() throws Exception {
+    public void canHaveDifferentUriAndResourcePaths() {
         runBundle(new AssetsBundle("/json", "/what"));
 
         assertThat(servletPath)
@@ -85,7 +85,7 @@ public class AssetsBundleTest {
     }
 
     @Test
-    public void canSupportDiffrentAssetsBundleName() throws Exception {
+    public void canSupportDifferentAssetsBundleName() {
         runBundle(new AssetsBundle("/json", "/what/new", "index.txt", "customAsset1"), "customAsset1");
 
         assertThat(servletPath)
@@ -115,7 +115,7 @@ public class AssetsBundleTest {
     }
 
     @Test
-    public void canHaveDifferentUriAndResourcePathsAndIndexFilename() throws Exception {
+    public void canHaveDifferentUriAndResourcePathsAndIndexFilename() {
         runBundle(new AssetsBundle("/json", "/what", "index.txt"));
 
         assertThat(servletPath)
@@ -129,6 +129,17 @@ public class AssetsBundleTest {
 
         assertThat(servlet.getUriPath())
                 .isEqualTo("/what");
+    }
+
+    @Test
+    public void canHaveDifferentDefaultMediaType() {
+        runBundle(new AssetsBundle("/assets", "/assets", "index.html", "assets", "text/plain"));
+
+        assertThat(servletPath).isEqualTo("/assets/*");
+        assertThat(servlet.getIndexFile()).isEqualTo("index.html");
+        assertThat(servlet.getResourceURL()).isEqualTo(normalize("assets"));
+        assertThat(servlet.getUriPath()).isEqualTo("/assets");
+        assertThat(servlet.getDefaultMediaType()).isEqualTo("text/plain");
     }
 
     private URL normalize(String path) {

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/assets/AssetServletTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/assets/AssetServletTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
-
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -28,6 +27,8 @@ public class AssetServletTest {
     private static final String DUMMY_SERVLET = "/dummy_servlet/";
     private static final String NOINDEX_SERVLET = "/noindex_servlet/";
     private static final String NOCHARSET_SERVLET = "/nocharset_servlet/";
+    private static final String NOMEDIATYPE_SERVLET = "/nomediatype_servlet/";
+    private static final String MEDIATYPE_SERVLET = "/mediatype_servlet/";
     private static final String ROOT_SERVLET = "/";
     private static final String RESOURCE_PATH = "/assets";
 
@@ -65,6 +66,22 @@ public class AssetServletTest {
         }
     }
 
+    public static class NoDefaultMediaTypeAssetServlet extends AssetServlet {
+        private static final long serialVersionUID = 1L;
+
+        public NoDefaultMediaTypeAssetServlet() {
+            super(RESOURCE_PATH, NOMEDIATYPE_SERVLET, null, null, StandardCharsets.UTF_8);
+        }
+    }
+
+    public static class DefaultMediaTypeAssetServlet extends AssetServlet {
+        private static final long serialVersionUID = 1L;
+
+        public DefaultMediaTypeAssetServlet() {
+            super(RESOURCE_PATH, MEDIATYPE_SERVLET, null, "text/plain", StandardCharsets.UTF_8);
+        }
+    }
+
     private static final ServletTester SERVLET_TESTER = new ServletTester();
     private final HttpTester.Request request = HttpTester.newRequest();
     @Nullable
@@ -75,6 +92,8 @@ public class AssetServletTest {
         SERVLET_TESTER.addServlet(DummyAssetServlet.class, DUMMY_SERVLET + '*');
         SERVLET_TESTER.addServlet(NoIndexAssetServlet.class, NOINDEX_SERVLET + '*');
         SERVLET_TESTER.addServlet(NoCharsetAssetServlet.class, NOCHARSET_SERVLET + '*');
+        SERVLET_TESTER.addServlet(NoDefaultMediaTypeAssetServlet.class, NOMEDIATYPE_SERVLET + '*');
+        SERVLET_TESTER.addServlet(DefaultMediaTypeAssetServlet.class, MEDIATYPE_SERVLET + '*');
         SERVLET_TESTER.addServlet(RootAssetServlet.class, ROOT_SERVLET + '*');
         SERVLET_TESTER.start();
 
@@ -171,11 +190,11 @@ public class AssetServletTest {
             eTags.add(future.get());
         }
         assertThat(eTags)
-            .describedAs("eTag generation should be consistent with concurrent requests")
-            .hasSize(1);
+                .describedAs("eTag generation should be consistent with concurrent requests")
+                .hasSize(1);
         assertThat(firstEtag)
-            .isEqualTo("\"e7bd7e8e\"")
-            .isEqualTo(eTags.iterator().next());
+                .isEqualTo("\"e7bd7e8e\"")
+                .isEqualTo(eTags.iterator().next());
     }
 
     @Test
@@ -370,12 +389,12 @@ public class AssetServletTest {
         final int statusWithMatchingLastModifiedTime = response.getStatus();
 
         request.putDateField(HttpHeader.IF_MODIFIED_SINCE,
-                          lastModifiedTime - 100);
+                lastModifiedTime - 100);
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request.generate()));
         final int statusWithStaleLastModifiedTime = response.getStatus();
 
         request.putDateField(HttpHeader.IF_MODIFIED_SINCE,
-                          lastModifiedTime + 100);
+                lastModifiedTime + 100);
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request.generate()));
         final int statusWithRecentLastModifiedTime = response.getStatus();
 
@@ -404,6 +423,26 @@ public class AssetServletTest {
                 .isEqualTo(200);
         assertThat(MimeTypes.CACHE.get(response.get(HttpHeader.CONTENT_TYPE)))
                 .isEqualTo(MimeTypes.Type.TEXT_HTML_UTF_8);
+    }
+
+    @Test
+    public void defaultsToHtmlIfNotOverridden() throws Exception {
+        request.setURI(NOMEDIATYPE_SERVLET + "foo.bar");
+        response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request.generate()));
+        assertThat(response.getStatus())
+                .isEqualTo(200);
+        assertThat(MimeTypes.CACHE.get(response.get(HttpHeader.CONTENT_TYPE)))
+                .isEqualTo(MimeTypes.Type.TEXT_HTML_UTF_8);
+    }
+
+    @Test
+    public void servesWithDefaultMediaType() throws Exception {
+        request.setURI(MEDIATYPE_SERVLET + "foo.bar");
+        response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request.generate()));
+        assertThat(response.getStatus())
+                .isEqualTo(200);
+        assertThat(MimeTypes.CACHE.get(response.get(HttpHeader.CONTENT_TYPE)))
+                .isEqualTo(MimeTypes.Type.TEXT_PLAIN_UTF_8);
     }
 
     @Test


### PR DESCRIPTION
Sometimes the default media type of `text/html` in the `AssetServlet` and `AssetBundle` might not be the best fit for every use case.

This PR exposes a setting to specify the default media type for `AssetBundle` and `AssetServlet` and override the default of `text/html`.