### PR TITLE
Fix random port assignment in Resource

### DIFF
--- a/dropwizard-testing/pom.xml
+++ b/dropwizard-testing/pom.xml
@@ -133,6 +133,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
@@ -180,6 +185,11 @@
         <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>
             <artifactId>jersey-test-framework-provider-grizzly2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
+            <artifactId>jersey-test-framework-provider-jetty</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/common/DropwizardTestResourceConfig.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/common/DropwizardTestResourceConfig.java
@@ -5,7 +5,6 @@ import io.dropwizard.jersey.jackson.JacksonFeature;
 import io.dropwizard.jersey.validation.HibernateValidationBinder;
 import io.dropwizard.setup.ExceptionMapperBinder;
 import org.glassfish.jersey.server.ServerProperties;
-import org.glassfish.jersey.test.TestProperties;
 
 import javax.servlet.ServletConfig;
 import javax.ws.rs.core.Context;
@@ -32,7 +31,6 @@ class DropwizardTestResourceConfig extends DropwizardResourceConfig {
     DropwizardTestResourceConfig(ResourceTestJerseyConfiguration configuration) {
         super();
 
-        property(TestProperties.CONTAINER_PORT, "0");
         if (configuration.registerDefaultExceptionMappers) {
             register(new ExceptionMapperBinder(false));
         }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/PersonResourceTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/PersonResourceTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 /**
  * Tests {@link ResourceTestRule}.
@@ -38,17 +39,18 @@ public class PersonResourceTest {
     private static final ObjectMapper OBJECT_MAPPER = Jackson.newObjectMapper()
         .registerModule(new GuavaModule());
 
-    private PeopleStore peopleStore = mock(PeopleStore.class);
-    private ResourceExtension resources = ResourceExtension.builder()
+    private final PeopleStore peopleStore = mock(PeopleStore.class);
+    private final ResourceExtension resources = ResourceExtension.builder()
         .addResource(new PersonResource(peopleStore))
         .setMapper(OBJECT_MAPPER)
         .setClientConfigurator(clientConfig -> clientConfig.register(DummyExceptionMapper.class))
         .build();
 
-    private Person person = new Person("blah", "blah@example.com");
+    private final Person person = new Person("blah", "blah@example.com");
 
     @BeforeEach
     public void setup() {
+        initMocks(peopleStore);
         when(peopleStore.fetchPerson("blah")).thenReturn(person);
     }
 

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/ResourceExtensionMocksTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/ResourceExtensionMocksTest.java
@@ -1,0 +1,55 @@
+package io.dropwizard.testing.junit5;
+
+import io.dropwizard.testing.app.Person;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(DropwizardExtensionsSupport.class)
+class ResourceExtensionMocksTest {
+    @Mock
+    private Person mockPerson;
+
+    private final ResourceExtension resources = ResourceExtension.builder()
+            .addProvider(this::createResource)
+            .build();
+
+    private TestResource createResource() {
+        return new TestResource(mockPerson);
+    }
+
+    @Test
+    public void accessingMockPersonSucceeds() {
+        when(mockPerson.getName()).thenReturn("Person-Name");
+
+        final String resp = resources.target("test/name").request().get(String.class);
+
+        assertThat(resp).isEqualTo("Person-Name");
+    }
+
+    @Path("/test")
+    @Produces(MediaType.TEXT_PLAIN)
+    public static class TestResource {
+        private final Person person;
+
+        public TestResource(Person person) {
+            this.person = person;
+        }
+
+        @GET
+        @Path("/name")
+        public String getPersonName() {
+            return person.getName();
+        }
+    }
+}

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/ResourceExtensionRandomPortsTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/ResourceExtensionRandomPortsTest.java
@@ -1,0 +1,28 @@
+package io.dropwizard.testing.junit5;
+
+import org.glassfish.jersey.test.grizzly.GrizzlyTestContainerFactory;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.ConcurrentSkipListSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DropwizardExtensionsSupport.class)
+class ResourceExtensionRandomPortsTest {
+    private final ResourceExtension resources = ResourceExtension.builder()
+            .setTestContainerFactory(new GrizzlyTestContainerFactory())
+            .build();
+
+    ConcurrentSkipListSet<Integer> usedPorts = new ConcurrentSkipListSet<>();
+
+    @RepeatedTest(10)
+    public void eachTestShouldUseANewPort() {
+        final int port = resources.target("/").getUri().getPort();
+        assertThat(usedPorts).doesNotContain(port);
+
+        usedPorts.add(port);
+    }
+}

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/ResourceExtensionWithJettyTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/ResourceExtensionWithJettyTest.java
@@ -1,0 +1,43 @@
+package io.dropwizard.testing.junit5;
+
+import io.dropwizard.testing.app.ContextInjectionResource;
+import org.glassfish.jersey.test.jetty.JettyTestContainerFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+class ResourceExtensionWithJettyTest {
+
+    private final ResourceExtension resources = ResourceExtension.builder()
+            .addResource(ContextInjectionResource::new)
+            .setTestContainerFactory(new JettyTestContainerFactory())
+            .setClientConfigurator(clientConfig -> clientConfig.register(DummyExceptionMapper.class))
+            .build();
+
+    @Test
+    public void testClientSupportsPatchMethod() {
+        final String resp = resources.target("test")
+                .request()
+                .method("PATCH", Entity.text("Patch is working"), String.class);
+        assertThat(resp).isEqualTo("Patch is working");
+    }
+
+    @Test
+    void testCustomClientConfiguration() {
+        assertThat(resources.client().getConfiguration().isRegistered(DummyExceptionMapper.class)).isTrue();
+    }
+
+    private static class DummyExceptionMapper implements ExceptionMapper<WebApplicationException> {
+        @Override
+        public Response toResponse(WebApplicationException e) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}


### PR DESCRIPTION
The `JerseyTest` instance used by `Resource` didn't set `TestProperties.CONTAINER_PORT` properly so that the tests weren't run with a random port which caused problems when trying to run tests in parallel.