### PR TITLE
Add missing DAOTest#setPassword() method

### DIFF
--- a/dropwizard-example/pom.xml
+++ b/dropwizard-example/pom.xml
@@ -35,6 +35,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>1.14.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -94,6 +101,22 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.20</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/dropwizard-example/src/test/java/com/example/helloworld/DockerIntegrationTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/DockerIntegrationTest.java
@@ -1,0 +1,104 @@
+package com.example.helloworld;
+
+import com.example.helloworld.api.Saying;
+import com.example.helloworld.core.Person;
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+@ExtendWith(DropwizardExtensionsSupport.class)
+public class DockerIntegrationTest {
+    @Container
+    private static final MySQLContainer<?> MY_SQL_CONTAINER = new MySQLContainer<>();
+
+    private static final String CONFIG_PATH = ResourceHelpers.resourceFilePath("test-docker-example.yml");
+
+    public static final DropwizardAppExtension<HelloWorldConfiguration> APP = new DropwizardAppExtension<>(
+            HelloWorldApplication.class, CONFIG_PATH,
+            ConfigOverride.config("database.url", MY_SQL_CONTAINER::getJdbcUrl),
+            ConfigOverride.config("database.user", MY_SQL_CONTAINER::getUsername),
+            ConfigOverride.config("database.password", MY_SQL_CONTAINER::getPassword)
+            );
+
+    @BeforeAll
+    public static void migrateDb() throws Exception {
+        APP.getApplication().run("db", "migrate", CONFIG_PATH);
+    }
+
+    @Test
+    public void testHelloWorld() throws Exception {
+        final Optional<String> name = Optional.of("Dr. IntegrationTest");
+        final Saying saying = APP.client().target("http://localhost:" + APP.getLocalPort() + "/hello-world")
+                .queryParam("name", name.get())
+                .request()
+                .get(Saying.class);
+        assertThat(saying.getContent()).isEqualTo(APP.getConfiguration().buildTemplate().render(name));
+    }
+
+    @Test
+    public void testPostPerson() throws Exception {
+        final Person person = new Person("Dr. IntegrationTest", "Chief Wizard", 1525);
+        final Person newPerson = postPerson(person);
+        assertThat(newPerson.getId()).isNotNull();
+        assertThat(newPerson.getFullName()).isEqualTo(person.getFullName());
+        assertThat(newPerson.getJobTitle()).isEqualTo(person.getJobTitle());
+    }
+
+    @Test
+    public void testRenderingPersonFreemarker() throws Exception {
+        testRenderingPerson("view_freemarker");
+    }
+
+    @Test
+    public void testRenderingPersonMustache() throws Exception {
+        testRenderingPerson("view_mustache");
+    }
+
+    private void testRenderingPerson(String viewName) throws Exception {
+        final Person person = new Person("Dr. IntegrationTest", "Chief Wizard", 1525);
+        final Person newPerson = postPerson(person);
+        final String url = "http://localhost:" + APP.getLocalPort() + "/people/" + newPerson.getId() + "/" + viewName;
+        Response response = APP.client().target(url).request().get();
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK_200);
+    }
+
+    private Person postPerson(Person person) {
+        return APP.client().target("http://localhost:" + APP.getLocalPort() + "/people")
+                .request()
+                .post(Entity.entity(person, MediaType.APPLICATION_JSON_TYPE))
+                .readEntity(Person.class);
+    }
+
+    @Test
+    public void testLogFileWritten() throws IOException {
+        // The log file is using a size and time based policy, which used to silently
+        // fail (and not write to a log file). This test ensures not only that the
+        // log file exists, but also contains the log line that jetty prints on startup
+        final Path log = Paths.get("./logs/application.log");
+        assertThat(log).exists();
+        final String actual = new String(Files.readAllBytes(log), UTF_8);
+        assertThat(actual).contains("0.0.0.0:" + APP.getLocalPort());
+    }
+}

--- a/dropwizard-example/src/test/java/com/example/helloworld/DockerIntegrationTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/DockerIntegrationTest.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 @ExtendWith(DropwizardExtensionsSupport.class)
 public class DockerIntegrationTest {
     @Container

--- a/dropwizard-example/src/test/java/com/example/helloworld/db/PersonDAOIntegrationTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/db/PersonDAOIntegrationTest.java
@@ -1,0 +1,73 @@
+package com.example.helloworld.db;
+
+import com.example.helloworld.core.Person;
+import io.dropwizard.testing.junit5.DAOTestExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.MySQL57Dialect;
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+@Testcontainers
+@ExtendWith(DropwizardExtensionsSupport.class)
+public class PersonDAOIntegrationTest {
+    @Container
+    private static final MySQLContainer<?> MY_SQL_CONTAINER = new MySQLContainer<>();
+
+    public DAOTestExtension daoTestRule = DAOTestExtension.newBuilder()
+            .customizeConfiguration(c -> c.setProperty(AvailableSettings.DIALECT, MySQL57Dialect.class.getName()))
+            .setDriver(MY_SQL_CONTAINER.getDriverClassName())
+            .setUrl(MY_SQL_CONTAINER.getJdbcUrl())
+            .setUsername(MY_SQL_CONTAINER.getUsername())
+            .setPassword(MY_SQL_CONTAINER.getPassword())
+            .addEntityClass(Person.class)
+            .build();
+
+    private PersonDAO personDAO;
+
+    @BeforeEach
+    public void setUp() {
+        personDAO = new PersonDAO(daoTestRule.getSessionFactory());
+    }
+
+    @Test
+    public void createPerson() {
+        final Person jeff = daoTestRule.inTransaction(() -> personDAO.create(new Person("Jeff", "The plumber", 1995)));
+        assertThat(jeff.getId()).isGreaterThan(0);
+        assertThat(jeff.getFullName()).isEqualTo("Jeff");
+        assertThat(jeff.getJobTitle()).isEqualTo("The plumber");
+        assertThat(jeff.getYearBorn()).isEqualTo(1995);
+        assertThat(personDAO.findById(jeff.getId())).isEqualTo(Optional.of(jeff));
+    }
+
+    @Test
+    public void findAll() {
+        daoTestRule.inTransaction(() -> {
+            personDAO.create(new Person("Jeff", "The plumber", 1975));
+            personDAO.create(new Person("Jim", "The cook", 1985));
+            personDAO.create(new Person("Randy", "The watchman", 1995));
+        });
+
+        final List<Person> persons = personDAO.findAll();
+        assertThat(persons).extracting("fullName").containsOnly("Jeff", "Jim", "Randy");
+        assertThat(persons).extracting("jobTitle").containsOnly("The plumber", "The cook", "The watchman");
+        assertThat(persons).extracting("yearBorn").containsOnly(1975, 1985, 1995);
+    }
+
+    @Test
+    public void handlesNullFullName() {
+        assertThatExceptionOfType(ConstraintViolationException.class).isThrownBy(() ->
+                daoTestRule.inTransaction(() -> personDAO.create(new Person(null, "The null", 0))));
+    }
+}

--- a/dropwizard-example/src/test/java/com/example/helloworld/db/PersonDAOIntegrationTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/db/PersonDAOIntegrationTest.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 @ExtendWith(DropwizardExtensionsSupport.class)
 public class PersonDAOIntegrationTest {
     @Container

--- a/dropwizard-example/src/test/resources/test-docker-example.yml
+++ b/dropwizard-example/src/test/resources/test-docker-example.yml
@@ -1,0 +1,31 @@
+template: Hello, %s!
+defaultName: Stranger
+
+database:
+  driverClass: com.mysql.cj.jdbc.Driver
+  properties:
+    hibernate.dialect: org.hibernate.dialect.MySQL57Dialect
+#  user: sa
+#  password: sa
+#  url: jdbc:h2:./target/test-example
+
+server:
+  applicationConnectors:
+    - type: http
+      port: 0
+  adminConnectors:
+    - type: http
+      port: 0
+
+# Logging settings.
+logging:
+  level: INFO
+  appenders:
+    - type: console
+    - type: file
+      currentLogFilename: './logs/application.log'
+      archivedLogFilenamePattern: './logs/application-%d-%i.log.gz'
+      archive: true
+      archivedFileCount: 7
+      maxFileSize: '1MiB'
+

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/common/DAOTest.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/common/DAOTest.java
@@ -27,8 +27,8 @@ public class DAOTest {
         private boolean showSql = false;
         private boolean useSqlComments = false;
         private boolean bootstrapLogging = true;
-        private Set<Class<?>> entityClasses = new LinkedHashSet<>();
-        private Map<String, String> properties = new HashMap<>();
+        private final Set<Class<?>> entityClasses = new LinkedHashSet<>();
+        private final Map<String, String> properties = new HashMap<>();
         private Consumer<Configuration> configurationCustomizer = c -> {
         };
 
@@ -42,8 +42,18 @@ public class DAOTest {
             return (B) this;
         }
 
+        public B setPassword(String password) {
+            this.password = password;
+            return (B) this;
+        }
+
         public B setDriver(Class<? extends java.sql.Driver> driver) {
             this.driver = driver.getName();
+            return (B) this;
+        }
+
+        public B setDriver(String driver) {
+            this.driver = driver;
             return (B) this;
         }
 


### PR DESCRIPTION
`DAOTest` was missing a method to override the default password.

This PR adds the missing method as well as `DAOTest#setDriver(String)` which works better with external tooling such as Testcontainers.