### PR TITLE
Changed signature of Task.execute method

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -746,7 +746,7 @@ record runtime information about your tasks. Here's a basic task class:
         }
 
         @Override
-        public void execute(ImmutableMultimap<String, String> parameters, PrintWriter output) throws Exception {
+        public void execute(Map<String,List<String>> parameters, PrintWriter output) throws Exception {
             this.database.truncate();
         }
     }


### PR DESCRIPTION
###### Problem:

Task.execute method parameter has slightly changed between 1.3 and 2.0.

###### Solution:

Corrected the parameter type

###### Result:

Fix for https://github.com/dropwizard/dropwizard/issues/3277
