### PR TITLE
Add details on how to configure filterFactories

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -876,6 +876,14 @@ port                         514            The port on which the UDP server is 
 FilterFactories
 ---------------
 
+
+A factory used for request loging appenders should implement ``io.dropwizard.logging.filter.FilterFactory<IAccessEvent>``
+while one used for regular logging should implement ``io.dropwizard.logging.filter.FilterFactory<ILoggingEvent>``.
+To register a factory, its fully qualified classname must be listed in
+``META-INF/services/io.dropwizard.logging.filter.FilterFactory``. The factory then can be referenced in the configuration 
+either via its simple calssname or via type name, if factory class annotated with ``@JsonTypeName``.
+
+
 .. code-block:: yaml
 
     logging:
@@ -886,11 +894,11 @@ FilterFactories
             - type: URI
 
 
-====================== ===========  ================
+====================== ===========  =====================
 Name                   Default      Description
-====================== ===========  ================
-type                   REQUIRED     The filter type.
-====================== ===========  ================
+====================== ===========  =====================
+type                   REQUIRED     The filter type name.
+====================== ===========  =====================
 
 .. _man-configuration-json-layout:
 


### PR DESCRIPTION
###### Problem:
Docs on filter factories could be improved. Only after studying this PR https://github.com/dropwizard/dropwizard/pull/1435 it becomes clear how to register them. The fact that logging event has different type for request logger was another conundrum.

###### Solution:
Explicitly specify steps to register filter factory and the type to use for which logger (request logging vs generic logging)
