### PR TITLE
use JsonUnit to ignore the order of fields in expected JSON string

### DIFF
--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -73,6 +73,7 @@
         <junit.version>4.13</junit.version>
         <junit5.version>5.6.2</junit5.version>
         <mockito.version>3.3.3</mockito.version>
+        <jsonunit.version>2.17.0</jsonunit.version>
 
         <!-- Plugin versions -->
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -507,6 +508,12 @@
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk15on</artifactId>
                 <version>${bcprov-jdk15on.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>net.javacrumbs.json-unit</groupId>
+                <artifactId>json-unit-assertj</artifactId>
+                <version>${jsonunit.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/dropwizard-jackson/pom.xml
+++ b/dropwizard-jackson/pom.xml
@@ -89,6 +89,11 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit-assertj</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonTest.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 
@@ -44,7 +45,7 @@ public class JacksonTest {
         final Issue1627 pojo = new Issue1627(null, null);
         final String json = "{\"string\":null,\"uuid\":null}";
 
-        assertThat(mapper.writeValueAsString(pojo)).isEqualTo(json);
+        assertThatJson(mapper.writeValueAsString(pojo)).isEqualTo(json);
     }
 
     @Test

--- a/dropwizard-json-logging/pom.xml
+++ b/dropwizard-json-logging/pom.xml
@@ -116,6 +116,11 @@
             <artifactId>dropwizard-configuration</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit-assertj</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/JsonFormatterTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/JsonFormatterTest.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class JsonFormatterTest {
@@ -43,7 +44,7 @@ public class JsonFormatterTest {
     @Test
     public void testPrettyPrintWithLineSeparator() {
         JsonFormatter formatter = new JsonFormatter(objectMapper, true, true);
-        assertThat(formatter.toJson(map)).isEqualTo(String.format("{%n" +
+        assertThatJson(formatter.toJson(map)).isEqualTo(String.format("{%n" +
                 "  \"hobbies\" : [ \"Reading\", \"Biking\", \"Snorkeling\" ],%n" +
                 "  \"name\" : \"Jim\"%n" +
                 "}%n"));
@@ -52,7 +53,7 @@ public class JsonFormatterTest {
     @Test
     public void testPrettyPrintNoLineSeparator() {
         JsonFormatter formatter = new JsonFormatter(objectMapper, true, false);
-        assertThat(formatter.toJson(map)).isEqualTo(String.format("{%n" +
+        assertThatJson(formatter.toJson(map)).isEqualTo(String.format("{%n" +
                 "  \"hobbies\" : [ \"Reading\", \"Biking\", \"Snorkeling\" ],%n" +
                 "  \"name\" : \"Jim\"%n" +
                 "}"));


### PR DESCRIPTION
###### Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->
Test `io.dropwizard.jackson.JacksonTest#objectMapperSerializesNullValues` uses `Jackson` to serialize object `pojo`. However, `Jackson` uses reflection API `getDeclaredFields` (https://github.com/FasterXML/jackson-databind/blob/3c67dc5bd9714635f6999bcb401b132791e9d7d0/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedFieldCollector.java#L70) to get the field names, values, and etc. However, API `getDeclaredFields` does not guarantee any specific order of fields. So the serialized result (in this case, a JSON string) can be different depending on the returned result. 

Test `io.dropwizard.jackson.JacksonTest#objectMapperSerializesNullValues` will fail if the serialized string is not in the format as expected. 

An example error message:
```
Expecting:
 <"{"uuid":null,"string":null}">
to be equal to:
 <"{"string":null,"uuid":null}">
but was not.
```

###### Solution:
<!-- Describe the modifications you've done. -->

The test is actually coded with `assertJ`. I found a good test plugin (https://github.com/lukas-krecan/JsonUnit) that integrates well with `assertJ` to compare JSON string without taking the order into consideration.

###### Result:
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->
Test will generate deterministic result (always pass in this case.)
