### PR TITLE
Reuse DefaultThreadFactory

### DIFF
--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilder.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilder.java
@@ -52,9 +52,10 @@ public class ExecutorServiceBuilder {
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
     private static ThreadFactory buildThreadFactory(String nameFormat) {
+        ThreadFactory defaultThreadFactory = Executors.defaultThreadFactory();
         String.format(Locale.ROOT, nameFormat, 0); // Fail fast on invalid name format
         return r -> {
-            final Thread thread = Executors.defaultThreadFactory().newThread(r);
+            final Thread thread = defaultThreadFactory.newThread(r);
             thread.setName(String.format(Locale.ROOT, nameFormat, COUNT.incrementAndGet()));
             return thread;
         };

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilder.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilder.java
@@ -39,8 +39,9 @@ public class ScheduledExecutorServiceBuilder {
     }
 
     private static ThreadFactory buildThreadFactory(String nameFormat, boolean daemon) {
+        ThreadFactory defaultThreadFactory = Executors.defaultThreadFactory();
         return r -> {
-            final Thread thread = Executors.defaultThreadFactory().newThread(r);
+            final Thread thread = defaultThreadFactory.newThread(r);
             if (nameFormat != null) {
                 thread.setName(String.format(Locale.ROOT, nameFormat, COUNT.incrementAndGet()));
             }


### PR DESCRIPTION
###### Problem:
The current default thread factory creates a new DefaultThreadFactory instance whenever a new thread is constructed

###### Solution:
Just reusing the same threadFactory per executorService

###### Result:
Will reduce object creation when requesting new threads
