### PR TITLE
Add managed instrumented executors

### DIFF
--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/NamedThreadFactory.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/NamedThreadFactory.java
@@ -1,0 +1,36 @@
+package io.dropwizard.lifecycle.setup;
+
+import java.util.Locale;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class NamedThreadFactory implements ThreadFactory {
+    private static final AtomicInteger poolNumber = new AtomicInteger(1);
+    private final ThreadGroup group;
+    private final AtomicInteger threadNumber = new AtomicInteger(1);
+    private final String namePrefix;
+    private final boolean daemon;
+
+    NamedThreadFactory(String namePrefix) {
+        this(namePrefix, false);
+    }
+
+    NamedThreadFactory(String namePrefix, boolean daemon) {
+        SecurityManager s = System.getSecurityManager();
+        group = (s != null) ? s.getThreadGroup() :
+            Thread.currentThread().getThreadGroup();
+        this.namePrefix = namePrefix;
+        this.daemon = daemon;
+    }
+
+    public Thread newThread(Runnable r) {
+        Thread t = new Thread(group, r,
+            String.format(Locale.ROOT, "%s-pool-%d-thread-%d",
+                namePrefix, poolNumber.getAndIncrement(), threadNumber.getAndIncrement()),
+            0);
+        t.setDaemon(daemon);
+        if (t.getPriority() != Thread.NORM_PRIORITY)
+            t.setPriority(Thread.NORM_PRIORITY);
+        return t;
+    }
+}

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilder.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilder.java
@@ -4,29 +4,25 @@ import com.codahale.metrics.InstrumentedThreadFactory;
 import io.dropwizard.lifecycle.ExecutorServiceManager;
 import io.dropwizard.util.Duration;
 
-import java.util.Locale;
-import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.atomic.AtomicLong;
 
 public class ScheduledExecutorServiceBuilder {
 
-    private static final AtomicLong COUNT = new AtomicLong(0);
     private final LifecycleEnvironment environment;
-    private final String nameFormat;
+    private final String namePrefix;
     private int poolSize;
     private ThreadFactory threadFactory;
     private Duration shutdownTime;
     private RejectedExecutionHandler handler;
     private boolean removeOnCancel;
 
-    public ScheduledExecutorServiceBuilder(LifecycleEnvironment environment, String nameFormat, ThreadFactory factory) {
+    public ScheduledExecutorServiceBuilder(LifecycleEnvironment environment, String namePrefix, ThreadFactory factory) {
         this.environment = environment;
-        this.nameFormat = nameFormat;
+        this.namePrefix = namePrefix;
         this.poolSize = 1;
         this.threadFactory = factory;
         this.shutdownTime = Duration.seconds(5);
@@ -34,20 +30,8 @@ public class ScheduledExecutorServiceBuilder {
         this.removeOnCancel = false;
     }
 
-    public ScheduledExecutorServiceBuilder(LifecycleEnvironment environment, String nameFormat, boolean useDaemonThreads) {
-        this(environment, nameFormat, buildThreadFactory(nameFormat, useDaemonThreads));
-    }
-
-    private static ThreadFactory buildThreadFactory(String nameFormat, boolean daemon) {
-        ThreadFactory defaultThreadFactory = Executors.defaultThreadFactory();
-        return r -> {
-            final Thread thread = defaultThreadFactory.newThread(r);
-            if (nameFormat != null) {
-                thread.setName(String.format(Locale.ROOT, nameFormat, COUNT.incrementAndGet()));
-            }
-            thread.setDaemon(daemon);
-            return thread;
-        };
+    public ScheduledExecutorServiceBuilder(LifecycleEnvironment environment, String namePrefix, boolean useDaemonThreads) {
+        this(environment, namePrefix, new NamedThreadFactory(namePrefix, useDaemonThreads));
     }
 
     public ScheduledExecutorServiceBuilder threads(int threads) {
@@ -77,12 +61,12 @@ public class ScheduledExecutorServiceBuilder {
 
     public ScheduledExecutorService build() {
         final InstrumentedThreadFactory instrumentedThreadFactory = new InstrumentedThreadFactory(threadFactory,
-            environment.getMetricRegistry(), nameFormat);
+            environment.getMetricRegistry(), namePrefix);
 
         final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(poolSize, instrumentedThreadFactory, handler);
         executor.setRemoveOnCancelPolicy(removeOnCancel);
 
-        environment.manage(new ExecutorServiceManager(executor, shutdownTime, nameFormat));
+        environment.manage(new ExecutorServiceManager(executor, shutdownTime, namePrefix));
         return executor;
     }
 }

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
@@ -33,7 +33,7 @@ public class ExecutorServiceBuilderTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        executorServiceBuilder = new ExecutorServiceBuilder(new LifecycleEnvironment(metricRegistry), "test-%d");
+        executorServiceBuilder = new ExecutorServiceBuilder(new LifecycleEnvironment(metricRegistry), "test");
         log = mock(Logger.class);
         ExecutorServiceBuilder.setLog(log);
     }
@@ -125,41 +125,6 @@ public class ExecutorServiceBuilderTest {
         final ThreadPoolExecutor castedExec = (ThreadPoolExecutor) exe;
 
         assertThat(castedExec.getThreadFactory()).isInstanceOf(InstrumentedThreadFactory.class);
-    }
-
-    @Test
-    public void nameWithoutFormat() {
-        final String[][] tests = new String[][] {
-            { "my-client-%d", "my-client" },
-            { "my-client--%d", "my-client-" },
-            { "my-client-%d-abc", "my-client-abc" },
-            { "my-client%d", "my-client" },
-            { "my-client%d-abc", "my-client-abc" },
-            { "my-client%s", "my-client" },
-            { "my-client%sabc", "my-clientabc" },
-            { "my-client%10d", "my-client" },
-            { "my-client%10d0", "my-client0" },
-            { "my-client%-10d", "my-client" },
-            { "my-client%-10d0", "my-client0" },
-            { "my-client-%10d", "my-client" },
-            { "my-client-%10dabc", "my-clientabc" },
-            { "my-client-%1$d", "my-client" },
-            { "my-client-%1$d-abc", "my-client-abc" },
-            { "-%d", "" },
-            { "%d", "" },
-            { "%d-abc", "-abc" },
-            { "%10d", "" },
-            { "%10dabc", "abc" },
-            { "%-10d", "" },
-            { "%-10dabc", "abc" },
-            { "%10s", "" },
-            { "%10sabc", "abc" },
-        };
-        for (String[] t : tests) {
-            assertThat(ExecutorServiceBuilder.getNameWithoutFormat(t[0]))
-                .describedAs("%s -> %s", t[0], t[1])
-                .isEqualTo(t[1]);
-        }
     }
 
     /**

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/LifecycleEnvironmentTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/LifecycleEnvironmentTest.java
@@ -74,7 +74,7 @@ public class LifecycleEnvironmentTest {
         final String expectedName = "DropWizard ThreadFactory Test";
         final String expectedNamePattern = expectedName + "-%d";
 
-        final ThreadFactory tfactory = buildThreadFactory(expectedNamePattern);
+        final ThreadFactory tfactory = new NamedThreadFactory(expectedNamePattern);
 
         final ScheduledExecutorService executorService = environment.scheduledExecutorService("DropWizard Service", tfactory).build();
         final Future<Boolean> isFactoryInUse = executorService.submit(() -> Thread.currentThread().getName().startsWith(expectedName));
@@ -87,24 +87,11 @@ public class LifecycleEnvironmentTest {
         final String expectedName = "DropWizard ThreadFactory Test";
         final String expectedNamePattern = expectedName + "-%d";
 
-        final ThreadFactory tfactory = buildThreadFactory(expectedNamePattern);
+        final ThreadFactory tfactory = new NamedThreadFactory(expectedNamePattern);
 
         final ExecutorService executorService = environment.executorService("Dropwizard Service", tfactory).build();
         final Future<Boolean> isFactoryInUse = executorService.submit(() -> Thread.currentThread().getName().startsWith(expectedName));
 
         assertThat(isFactoryInUse.get()).isTrue();
-    }
-
-    private ThreadFactory buildThreadFactory(String expectedNamePattern) {
-        return new ThreadFactory() {
-            final AtomicLong counter = new AtomicLong(0L);
-            @Override
-            public Thread newThread(Runnable r) {
-                final Thread thread = Executors.defaultThreadFactory().newThread(r);
-                thread.setDaemon(false);
-                thread.setName(String.format(expectedNamePattern, counter.incrementAndGet()));
-                return thread;
-            }
-        };
     }
 }


### PR DESCRIPTION
###### Problem:
1. For threads we have a global counter. Would prefer a counter per executor service (Use a global pool and local thread number similar to DefaultThreadFactory). Can move threadFactory logic to its own class. Would've extended threadFactory but its a private static class.
2. nameFormat seems very unintuitive. It's not clear to users that they have to specify one. Also its usage across classes vary. (ScheduledExecutorServiceBuilder doesn't have that requirement).
3. People who aren't familiar with the ThreadPoolExecutor may run into issues like https://github.com/dropwizard/dropwizard/issues/2553 when using the ExecutorServiceBuilder. 

###### Solution:
1. Use logic used in DefaultThreadFactory with the ability to name threads
2. Avoid nameFormat since the NamedThreadFactory deals with this
3. Create helper methods to managed/instrumented executor services from the Executors class

###### Result:
- User passes a prefix and the threadFactory will add pool/thread number. 
- Whatever the user passes is what is used in the metric name. The methods getNameWithoutFormat in this https://github.com/dropwizard/dropwizard/pull/3142 will return a string appended to itself, so it may have to be reverted. @pkwarren - Any feedback/concerns?
- Includes managed and instrumented executor service factory methods. ThreadPoolExecutor Javadocs urges users to use the Executors factory methods that preconfigure settings for the most common usage scenarios. Also the InstrumentedExecutorService has additional metrics like idle/duration timers which InstrumentedThreadFactory (used in ExecutorServiceBuilder) doesn't have
