### PR TITLE
feat: Introducing severity as a additional field for EventJsonLayout

### DIFF
--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/EventJsonLayout.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/EventJsonLayout.java
@@ -61,6 +61,7 @@ public class EventJsonLayout extends AbstractJsonLayout<ILoggingEvent> {
         final MapBuilder mapBuilder = new MapBuilder(timestampFormatter, customFieldNames, additionalFields, includes.size())
             .addTimestamp("timestamp", isIncluded(EventAttribute.TIMESTAMP), event.getTimeStamp())
             .add("level", isIncluded(EventAttribute.LEVEL), () -> String.valueOf(event.getLevel()))
+            .add("severity", isIncluded(EventAttribute.LEVEL), () -> String.valueOf(event.getLevel()))
             .add("thread", isIncluded(EventAttribute.THREAD_NAME), event::getThreadName)
             .add("marker", isIncluded(EventAttribute.MARKER) && event.getMarker() != null, () -> event.getMarker().getName())
             .add("logger", isIncluded(EventAttribute.LOGGER_NAME), event::getLoggerName)

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/EventJsonLayoutTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/EventJsonLayoutTest.java
@@ -5,7 +5,6 @@ import ch.qos.logback.classic.pattern.ThrowableProxyConverter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggerContextVO;
 import ch.qos.logback.classic.spi.ThrowableProxyVO;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.logging.json.EventAttribute;
 import io.dropwizard.util.Maps;
@@ -81,6 +80,7 @@ public class EventJsonLayoutTest {
         defaultExpectedFields.put("message", message);
         defaultExpectedFields.put("thread", "main");
         defaultExpectedFields.put("level", "INFO");
+        defaultExpectedFields.put("severity", "INFO");
         defaultExpectedFields.put("mdc", mdc);
         defaultExpectedFields.put("caller_class_name", "declaringClass");
         defaultExpectedFields.put("caller_file_name", "fileName");


### PR DESCRIPTION

###### Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->
As of now, we only have "level" when sometimes the logger is parsed
based on "severity" label.

###### Solution:
<!-- Describe the modifications you've done. -->
Adding a new field in EventJsonLayout

###### Result:
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->
