### PR TITLE
Added method to report the Dropwizard Build version

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/DropwizardVersion.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/DropwizardVersion.java
@@ -1,0 +1,27 @@
+package io.dropwizard;
+
+/**
+ * Class that exposes the Dropwizard version. Fetches the "Implementation-Version"
+ * manifest attribute from the jar file.
+ * <p>
+ * Note that some ClassLoaders do not expose the package metadata, hence this class might
+ * not be able to determine the Dropwizard version in all environments. Consider using a
+ * reflection-based check instead: For example, checking for the presence of a specific
+ * Dropwizard method that you intend to call.
+ */
+public class DropwizardVersion {
+
+    private DropwizardVersion() {
+    }
+
+    /**
+     * Return the full version string of the present Dropwizard codebase, or {@code null}
+     * if it cannot be determined.
+     * @return the version of Dropwizard or {@code null}
+     * @see Package#getImplementationVersion()
+     */
+    public static String getVersion() {
+        Package pkg = DropwizardVersion.class.getPackage();
+        return (pkg != null) ? pkg.getImplementationVersion() : null;
+    }
+}

--- a/dropwizard-core/src/main/java/io/dropwizard/DropwizardVersion.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/DropwizardVersion.java
@@ -1,5 +1,7 @@
 package io.dropwizard;
 
+import javax.annotation.Nullable;
+
 /**
  * Class that exposes the Dropwizard version. Fetches the "Implementation-Version"
  * manifest attribute from the jar file.
@@ -20,6 +22,7 @@ public class DropwizardVersion {
      * @return the version of Dropwizard or {@code null}
      * @see Package#getImplementationVersion()
      */
+    @Nullable
     public static String getVersion() {
         Package pkg = DropwizardVersion.class.getPackage();
         return (pkg != null) ? pkg.getImplementationVersion() : null;


### PR DESCRIPTION
###### Problem:
Logging Application Build Version during StartUp #3313 

###### Solution:
Retrieved by reading Implementation-Version property from Manifest file

###### Result:
Applications needing the Dropwizard can retrieve it directly