### PR TITLE
Upgrade to Jackson 2.10.5

### DIFF
--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -36,7 +36,7 @@
         <hk2.version>2.6.1</hk2.version>
         <httpclient.version>4.5.12</httpclient.version>
         <httpcore.version>4.4.13</httpcore.version>
-        <jackson.version>2.10.4</jackson.version>
+        <jackson.version>2.10.5</jackson.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
         <jakarta.el.version>3.0.3</jakarta.el.version>
         <jakarta.servlet-api.version>4.0.3</jakarta.servlet-api.version>


### PR DESCRIPTION
This addresses various security fixes:

* CVE-2020-14062: https://github.com/advisories/GHSA-c265-37vj-cwcc
* CVE-2020-14195: https://github.com/advisories/GHSA-mc6h-4qgp-37qh
* CVE-2020-14060: https://github.com/advisories/GHSA-j823-4qch-3rgm
* CVE-2020-14061: https://github.com/advisories/GHSA-c2q3-4qrh-fm48