### PR TITLE
Upgrade to Jackson 2.9.10.20200621

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -21,7 +21,7 @@
         <dropwizard.version>${project.version}</dropwizard.version>
         <guava.version>24.1.1-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
-        <jackson.version>2.9.10.20200411</jackson.version>
+        <jackson.version>2.9.10.20200621</jackson.version>
         <jetty.version>9.4.18.v20190429</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.0.5</metrics4.version>


### PR DESCRIPTION
This addresses various security fixes:

* CVE-2020-14062: https://github.com/advisories/GHSA-c265-37vj-cwcc
* CVE-2020-14195: https://github.com/advisories/GHSA-mc6h-4qgp-37qh
* CVE-2020-14060: https://github.com/advisories/GHSA-j823-4qch-3rgm
* CVE-2020-14061: https://github.com/advisories/GHSA-c2q3-4qrh-fm48