### PR TITLE
Update Jetty to the latest secure version, 9.4.30.v20200611

### DIFF
--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -22,7 +22,7 @@
         <guava.version>24.1.1-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
         <jackson.version>2.9.10.20200621</jackson.version>
-        <jetty.version>9.4.24.v20191120</jetty.version>
+        <jetty.version>9.4.25.v20191220</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.0.5</metrics4.version>
         <slf4j.version>1.7.26</slf4j.version>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -22,7 +22,7 @@
         <guava.version>24.1.1-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
         <jackson.version>2.9.10.20200621</jackson.version>
-        <jetty.version>9.4.22.v20191022</jetty.version>
+        <jetty.version>9.4.23.v20191118</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.0.5</metrics4.version>
         <slf4j.version>1.7.26</slf4j.version>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -22,7 +22,7 @@
         <guava.version>24.1.1-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
         <jackson.version>2.9.10.20200621</jackson.version>
-        <jetty.version>9.4.28.v20200408</jetty.version>
+        <jetty.version>9.4.29.v20200521</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.0.5</metrics4.version>
         <slf4j.version>1.7.26</slf4j.version>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -22,7 +22,7 @@
         <guava.version>24.1.1-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
         <jackson.version>2.9.10.20200621</jackson.version>
-        <jetty.version>9.4.20.v20190813</jetty.version>
+        <jetty.version>9.4.21.v20190926</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.0.5</metrics4.version>
         <slf4j.version>1.7.26</slf4j.version>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -22,7 +22,7 @@
         <guava.version>24.1.1-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
         <jackson.version>2.9.10.20200621</jackson.version>
-        <jetty.version>9.4.25.v20191220</jetty.version>
+        <jetty.version>9.4.26.v20200117</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.0.5</metrics4.version>
         <slf4j.version>1.7.26</slf4j.version>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -22,7 +22,7 @@
         <guava.version>24.1.1-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
         <jackson.version>2.9.10.20200621</jackson.version>
-        <jetty.version>9.4.26.v20200117</jetty.version>
+        <jetty.version>9.4.27.v20200227</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.0.5</metrics4.version>
         <slf4j.version>1.7.26</slf4j.version>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -22,7 +22,7 @@
         <guava.version>24.1.1-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
         <jackson.version>2.9.10.20200621</jackson.version>
-        <jetty.version>9.4.27.v20200227</jetty.version>
+        <jetty.version>9.4.28.v20200408</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.0.5</metrics4.version>
         <slf4j.version>1.7.26</slf4j.version>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -22,7 +22,7 @@
         <guava.version>24.1.1-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
         <jackson.version>2.9.10.20200621</jackson.version>
-        <jetty.version>9.4.21.v20190926</jetty.version>
+        <jetty.version>9.4.22.v20191022</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.0.5</metrics4.version>
         <slf4j.version>1.7.26</slf4j.version>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -22,7 +22,7 @@
         <guava.version>24.1.1-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
         <jackson.version>2.9.10.20200621</jackson.version>
-        <jetty.version>9.4.19.v20190610</jetty.version>
+        <jetty.version>9.4.20.v20190813</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.0.5</metrics4.version>
         <slf4j.version>1.7.26</slf4j.version>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -22,7 +22,7 @@
         <guava.version>24.1.1-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
         <jackson.version>2.9.10.20200621</jackson.version>
-        <jetty.version>9.4.18.v20190429</jetty.version>
+        <jetty.version>9.4.19.v20190610</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.0.5</metrics4.version>
         <slf4j.version>1.7.26</slf4j.version>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -22,7 +22,7 @@
         <guava.version>24.1.1-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
         <jackson.version>2.9.10.20200621</jackson.version>
-        <jetty.version>9.4.29.v20200521</jetty.version>
+        <jetty.version>9.4.30.v20200611</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.0.5</metrics4.version>
         <slf4j.version>1.7.26</slf4j.version>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -22,7 +22,7 @@
         <guava.version>24.1.1-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
         <jackson.version>2.9.10.20200621</jackson.version>
-        <jetty.version>9.4.23.v20191118</jetty.version>
+        <jetty.version>9.4.24.v20191120</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.0.5</metrics4.version>
         <slf4j.version>1.7.26</slf4j.version>

--- a/dropwizard-core/src/main/java/io/dropwizard/sslreload/SslReloadTask.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/sslreload/SslReloadTask.java
@@ -21,7 +21,7 @@ public class SslReloadTask extends Task {
     public void execute(ImmutableMultimap<String, String> parameters, PrintWriter output) throws Exception {
         // Iterate through all the reloaders first to ensure valid configuration
         for (SslReload reloader : getReloaders()) {
-            reloader.reload(new SslContextFactory());
+            reloader.reload(new SslContextFactory.Server());
         }
 
         // Now we know that configuration is valid, reload for real

--- a/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2ConnectorFactory.java
+++ b/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2ConnectorFactory.java
@@ -112,7 +112,7 @@ public class Http2ConnectorFactory extends HttpsConnectorFactory {
         final NegotiatingServerConnectionFactory alpn = new ALPNServerConnectionFactory(H2, H2_17);
         alpn.setDefaultProtocol(HTTP_1_1); // Speak HTTP 1.1 over TLS if negotiation fails
 
-        final SslContextFactory sslContextFactory = configureSslContextFactory(new SslContextFactory());
+        final SslContextFactory sslContextFactory = configureSslContextFactory(new SslContextFactory.Server());
         sslContextFactory.addLifeCycleListener(logSslInfoOnStart(sslContextFactory));
         server.addBean(sslContextFactory);
         server.addBean(new SslReload(sslContextFactory, this::configureSslContextFactory));

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/AbstractHttp2Test.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/AbstractHttp2Test.java
@@ -28,7 +28,7 @@ public class AbstractHttp2Test {
         BootstrapLogging.bootstrap();
     }
 
-    final SslContextFactory sslContextFactory = new SslContextFactory();
+    final SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
     HttpClient client;
 
     @Before

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
@@ -596,7 +596,7 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
 
         final HttpConnectionFactory httpConnectionFactory = buildHttpConnectionFactory(httpConfig);
 
-        final SslContextFactory sslContextFactory = configureSslContextFactory(new SslContextFactory());
+        final SslContextFactory sslContextFactory = configureSslContextFactory(new SslContextFactory.Server());
         sslContextFactory.addLifeCycleListener(logSslInfoOnStart(sslContextFactory));
 
         server.addBean(sslContextFactory);

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/ContextRoutingHandlerTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/ContextRoutingHandlerTest.java
@@ -67,10 +67,11 @@ public class ContextRoutingHandlerTest {
     @Test
     public void startsAndStopsAllHandlers() throws Exception {
         handler.start();
-        handler.stop();
+        verify(handler1).start();
+        verify(handler2).start();
 
-        final InOrder inOrder = inOrder(handler1, handler2);
-        inOrder.verify(handler1).start();
-        inOrder.verify(handler2).start();
+        handler.stop();
+        verify(handler1).stop();
+        verify(handler2).stop();
     }
 }

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/ContextRoutingHandlerTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/ContextRoutingHandlerTest.java
@@ -5,12 +5,10 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.InOrder;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
@@ -141,6 +141,14 @@ public class HttpConnectorFactoryTest {
         assertThat(connector.getScheduler()).isInstanceOf(ScheduledExecutorScheduler.class);
         assertThat(connector.getExecutor()).isSameAs(threadPool);
 
+        // That's gross, but unfortunately ArrayByteBufferPool doesn't have API for configuration
+        ByteBufferPool byteBufferPool = connector.getByteBufferPool();
+        assertThat(byteBufferPool).isInstanceOf(ArrayByteBufferPool.class);
+        assertThat(getField(ArrayByteBufferPool.class, "_minCapacity", true).get(byteBufferPool)).isEqualTo(64);
+        assertThat(getField(ArrayByteBufferPool.class, "_factor", true).get(byteBufferPool)).isEqualTo(1024);
+        assertThat(((Object[]) getField(ArrayByteBufferPool.class, "_direct", true)
+                .get(byteBufferPool)).length).isEqualTo(64);
+
         assertThat(connector.getAcceptors()).isEqualTo(1);
         assertThat(connector.getSelectorManager().getSelectorCount()).isEqualTo(2);
 

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
@@ -9,8 +9,8 @@ import io.dropwizard.jackson.DiscoverableSubtypeResolver;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.validation.BaseValidator;
 import org.apache.commons.lang3.SystemUtils;
-import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.ConnectionFactory;
+import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.SecureRequestCustomizer;
@@ -30,6 +30,7 @@ import java.io.File;
 import java.net.URI;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -93,8 +94,8 @@ public class HttpsConnectorFactoryTest {
         factory.setKeyStorePassword("password"); // necessary to avoid a prompt for a password
         factory.setSupportedProtocols(supportedProtocols);
 
-        SslContextFactory sslContextFactory = factory.configureSslContextFactory(new SslContextFactory());
-        assertThat(ImmutableList.copyOf(sslContextFactory.getIncludeProtocols())).isEqualTo(supportedProtocols);
+        SslContextFactory sslContextFactory = factory.configureSslContextFactory(new SslContextFactory.Server());
+        assertThat(Arrays.asList(sslContextFactory.getIncludeProtocols())).isEqualTo(supportedProtocols);
     }
 
     @Test
@@ -105,8 +106,8 @@ public class HttpsConnectorFactoryTest {
         factory.setKeyStorePassword("password"); // necessary to avoid a prompt for a password
         factory.setExcludedProtocols(excludedProtocols);
 
-        SslContextFactory sslContextFactory = factory.configureSslContextFactory(new SslContextFactory());
-        assertThat(ImmutableList.copyOf(sslContextFactory.getExcludeProtocols())).isEqualTo(excludedProtocols);
+        SslContextFactory sslContextFactory = factory.configureSslContextFactory(new SslContextFactory.Server());
+        assertThat(Arrays.asList(sslContextFactory.getExcludeProtocols())).isEqualTo(excludedProtocols);
     }
 
     @Test
@@ -134,7 +135,7 @@ public class HttpsConnectorFactoryTest {
         final HttpsConnectorFactory factory = new HttpsConnectorFactory();
         factory.setKeyStoreType(WINDOWS_MY_KEYSTORE_NAME);
 
-        assertNotNull(factory.configureSslContextFactory(new SslContextFactory()));
+        assertNotNull(factory.configureSslContextFactory(new SslContextFactory.Server()));
     }
 
     @Test(expected = IllegalStateException.class)
@@ -143,7 +144,7 @@ public class HttpsConnectorFactoryTest {
 
         final HttpsConnectorFactory factory = new HttpsConnectorFactory();
         factory.setKeyStoreType(WINDOWS_MY_KEYSTORE_NAME);
-        factory.configureSslContextFactory(new SslContextFactory());
+        factory.configureSslContextFactory(new SslContextFactory.Server());
     }
 
     @Test

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/setup/ServletEnvironmentTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/setup/ServletEnvironmentTest.java
@@ -78,7 +78,7 @@ public class ServletEnvironmentTest {
 
     @Test
     public void addsFilterInstances() throws Exception {
-        final Filter filter = mock(Filter.class);
+        final Filter filter = new WelcomeFilter();
 
         final FilterRegistration.Dynamic builder = environment.addFilter("filter", filter);
         assertThat(builder)
@@ -90,8 +90,7 @@ public class ServletEnvironmentTest {
         assertThat(holder.getValue().getName())
                 .isEqualTo("filter");
 
-        assertThat(holder.getValue().getFilter())
-                .isEqualTo(filter);
+        assertThat(holder.getValue()).hasFieldOrPropertyWithValue("_instance", filter);
     }
 
     @Test


### PR DESCRIPTION
###### Problem:

My org is in the process of upgrading Jetty to a recent version in light of [CVE-2019-10247](https://github.com/advisories/GHSA-xc67-hjx6-cgg6) and other vulnerabilities.  We're still using Dropwizard 1.3, which uses `9.4.18.v20190429`.  When we pin a more recent version of Jetty in our projects, services fail to start up with SSL with this error:

```
java.lang.IllegalStateException: KeyStores with multiple certificates are not supported on the base class org.eclipse.jetty.util.ssl.SslContextFactory. (Use org.eclipse.jetty.util.ssl.SslContextFactory$Server or org.eclipse.jetty.util.ssl.SslContextFactory$Client instead)
```

###### Solution:

- Cherry-pick the changes from #2734 to instantiate `SslContextFactory.Server` instead of the deprecated `SslContextFactory`
    -  This might have been meant to be backported to Dropwizard 1.3 anyways, given that DW13 advanced its version of Jetty twice after that (https://github.com/dropwizard/dropwizard/commit/3500399b5b128f5988b6aaf6aa702ae1d1b56c5d & https://github.com/dropwizard/dropwizard/commit/eec03a99e077ce06c053d4e61b64d913d9469fd3).
- Bump the Jetty version to the most recent and secure one ,`9.4.30.v20200611`, which is also in use by Dropwizard 2.0.

###### Result:

I also cherry-picked the changes from #2460, which were also required for the newer Jetty version, and pulled in the latest Jetty by cherry-picking all of the previous Jetty bumps (for maximum traceability).

I modified the cherry-picked commits to avoid the introduction of JUnit 5 and the `dropwizard-dependencies` module, in order to prevent any breaking changes to Dropwizard 1.3.