### PR TITLE
Swallow EofException when response was incomplete

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
@@ -596,6 +596,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
             jerseyRootPath.ifPresent(jersey::setUrlPattern);
             jersey.register(new JacksonFeature(objectMapper));
             jersey.register(new HibernateValidationBinder(validator));
+            jersey.register(metricRegistry);
             if (registerDefaultExceptionMappers == null || registerDefaultExceptionMappers) {
                 jersey.register(new ExceptionMapperBinder(detailedJsonProcessingExceptionMapper));
             }

--- a/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
@@ -596,7 +596,6 @@ public abstract class AbstractServerFactory implements ServerFactory {
             jerseyRootPath.ifPresent(jersey::setUrlPattern);
             jersey.register(new JacksonFeature(objectMapper));
             jersey.register(new HibernateValidationBinder(validator));
-            jersey.register(metricRegistry);
             if (registerDefaultExceptionMappers == null || registerDefaultExceptionMappers) {
                 jersey.register(new ExceptionMapperBinder(detailedJsonProcessingExceptionMapper));
             }

--- a/dropwizard-core/src/main/java/io/dropwizard/setup/ExceptionMapperBinder.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/ExceptionMapperBinder.java
@@ -1,6 +1,7 @@
 package io.dropwizard.setup;
 
 import io.dropwizard.jersey.errors.EarlyEofExceptionMapper;
+import io.dropwizard.jersey.errors.EofExceptionWriterInterceptor;
 import io.dropwizard.jersey.errors.IllegalStateExceptionMapper;
 import io.dropwizard.jersey.errors.LoggingExceptionMapper;
 import io.dropwizard.jersey.jackson.JsonProcessingExceptionMapper;
@@ -9,6 +10,7 @@ import io.dropwizard.jersey.validation.JerseyViolationExceptionMapper;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 
 import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.WriterInterceptor;
 
 /**
  * A binder that registers all the default exception mappers while allowing users to override
@@ -25,11 +27,12 @@ public class ExceptionMapperBinder extends AbstractBinder {
     protected void configure() {
         bind(new LoggingExceptionMapper<Throwable>() {
         }).to(ExceptionMapper.class);
-        bind(new JerseyViolationExceptionMapper()).to(ExceptionMapper.class);
+        bind(JerseyViolationExceptionMapper.class).to(ExceptionMapper.class);
         bind(new JsonProcessingExceptionMapper(isShowDetails())).to(ExceptionMapper.class);
-        bind(new EarlyEofExceptionMapper()).to(ExceptionMapper.class);
-        bind(new EmptyOptionalExceptionMapper()).to(ExceptionMapper.class);
-        bind(new IllegalStateExceptionMapper()).to(ExceptionMapper.class);
+        bind(EarlyEofExceptionMapper.class).to(ExceptionMapper.class);
+        bind(EofExceptionWriterInterceptor.class).to(WriterInterceptor.class);
+        bind(EmptyOptionalExceptionMapper.class).to(ExceptionMapper.class);
+        bind(IllegalStateExceptionMapper.class).to(ExceptionMapper.class);
     }
 
     public boolean isShowDetails() {

--- a/dropwizard-jersey/pom.xml
+++ b/dropwizard-jersey/pom.xml
@@ -163,6 +163,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
+            <artifactId>jersey-test-framework-provider-jetty</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-io</artifactId>
         </dependency>

--- a/dropwizard-jersey/pom.xml
+++ b/dropwizard-jersey/pom.xml
@@ -166,6 +166,12 @@
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>
             <artifactId>jersey-test-framework-provider-jetty</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -69,6 +69,7 @@ public class DropwizardResourceConfig extends ResourceConfig {
         property(ServerProperties.WADL_FEATURE_DISABLE, Boolean.TRUE);
         register(loggingListener);
 
+        register(new MetricRegistryBinder(metricRegistry));
         register(new InstrumentedResourceMethodApplicationListener(metricRegistry, Clock.defaultClock(), true));
         register(CacheControlledResponseFeature.class);
         register(io.dropwizard.jersey.guava.OptionalMessageBodyWriter.class);
@@ -375,6 +376,19 @@ public class DropwizardResourceConfig extends ResourceConfig {
         @Nullable
         public RequestEventListener onRequest(RequestEvent requestEvent) {
             return null;
+        }
+    }
+
+    static final class MetricRegistryBinder extends AbstractBinder {
+        private final MetricRegistry metricRegistry;
+
+        public MetricRegistryBinder(MetricRegistry metricRegistry) {
+            this.metricRegistry = metricRegistry;
+        }
+
+        @Override
+        protected void configure() {
+                bind(metricRegistry).to(MetricRegistry.class);
         }
     }
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/EofExceptionWriterInterceptor.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/EofExceptionWriterInterceptor.java
@@ -1,0 +1,45 @@
+package io.dropwizard.jersey.errors;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import org.eclipse.jetty.io.EofException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.ext.Provider;
+import javax.ws.rs.ext.WriterInterceptor;
+import javax.ws.rs.ext.WriterInterceptorContext;
+import java.io.IOException;
+
+/**
+ * A {@link WriterInterceptor} to swallow {@link org.eclipse.jetty.io.EofException} which occurs when a client
+ * disconnects before the complete response could be sent.
+ *
+ * @see EarlyEofExceptionMapper
+ * @see EofException
+ */
+@Provider
+@Priority(Integer.MAX_VALUE)
+public class EofExceptionWriterInterceptor implements WriterInterceptor {
+    private static final Logger LOGGER = LoggerFactory.getLogger(EofExceptionWriterInterceptor.class);
+
+    private final Counter exceptionCounter;
+
+    @Inject
+    public EofExceptionWriterInterceptor(MetricRegistry metricRegistry) {
+        this.exceptionCounter = metricRegistry.counter(MetricRegistry.name(getClass(), "eof-exceptions"));
+    }
+
+    @Override
+    public void aroundWriteTo(WriterInterceptorContext context) throws IOException, WebApplicationException {
+        try {
+            context.proceed();
+        } catch (EofException e) {
+            LOGGER.debug("Client disconnected while processing and sending response", e);
+            exceptionCounter.inc();
+        }
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/EofExceptionWriterInterceptorJerseyTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/EofExceptionWriterInterceptorJerseyTest.java
@@ -1,10 +1,8 @@
 package io.dropwizard.jersey.errors;
 
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.AbstractJerseyTest;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import org.eclipse.jetty.io.EofException;
-import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.test.jetty.JettyTestContainerFactory;
 import org.glassfish.jersey.test.spi.TestContainerException;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
@@ -34,12 +32,6 @@ public class EofExceptionWriterInterceptorJerseyTest extends AbstractJerseyTest 
     @Override
     protected Application configure() {
         return DropwizardResourceConfig.forTesting()
-            .register(new AbstractBinder() {
-                @Override
-                protected void configure() {
-                    bind(MetricRegistry.class).to(MetricRegistry.class);
-                }
-            })
             .register(EofExceptionWriterInterceptor.class)
             .register(EofExceptionCountingInterceptor.class)
             .register(TestResource.class);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/EofExceptionWriterInterceptorJerseyTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/EofExceptionWriterInterceptorJerseyTest.java
@@ -1,0 +1,84 @@
+package io.dropwizard.jersey.errors;
+
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.jersey.AbstractJerseyTest;
+import io.dropwizard.jersey.DropwizardResourceConfig;
+import org.eclipse.jetty.io.EofException;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.test.jetty.JettyTestContainerFactory;
+import org.glassfish.jersey.test.spi.TestContainerException;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
+import org.junit.jupiter.api.Test;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
+import javax.ws.rs.ext.Provider;
+import javax.ws.rs.ext.WriterInterceptor;
+import javax.ws.rs.ext.WriterInterceptorContext;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.atomic.LongAdder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EofExceptionWriterInterceptorJerseyTest extends AbstractJerseyTest {
+    @Override
+    protected TestContainerFactory getTestContainerFactory() throws TestContainerException {
+        return new JettyTestContainerFactory();
+    }
+
+    @Override
+    protected Application configure() {
+        return DropwizardResourceConfig.forTesting()
+            .register(new AbstractBinder() {
+                @Override
+                protected void configure() {
+                    bind(MetricRegistry.class).to(MetricRegistry.class);
+                }
+            })
+            .register(EofExceptionWriterInterceptor.class)
+            .register(EofExceptionCountingInterceptor.class)
+            .register(TestResource.class);
+    }
+
+    @Test
+    public void shouldCountZeroEofExceptions() throws IOException {
+        target("/").request().get(InputStream.class).close();
+        assertThat(EofExceptionCountingInterceptor.exceptionCount).isEqualByComparingTo(0L);
+    }
+
+    @Path("/")
+    public static class TestResource {
+        @GET
+        public Response streamForever() {
+            final StreamingOutput output = os -> {
+                //noinspection InfiniteLoopStatement
+                while (true) {
+                    os.write('a');
+                    os.flush();
+                }
+            };
+
+            return Response.ok(output).build();
+        }
+    }
+
+    @Provider
+    public static class EofExceptionCountingInterceptor implements WriterInterceptor {
+        static final LongAdder exceptionCount = new LongAdder();
+
+        @Override
+        public void aroundWriteTo(WriterInterceptorContext context) throws IOException, WebApplicationException {
+            try {
+                context.proceed();
+            } catch (EofException e) {
+                exceptionCount.increment();
+                throw e;
+            }
+        }
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/EofExceptionWriterInterceptorTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/EofExceptionWriterInterceptorTest.java
@@ -1,0 +1,33 @@
+package io.dropwizard.jersey.errors;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import org.eclipse.jetty.io.EofException;
+import org.junit.jupiter.api.Test;
+
+import javax.ws.rs.ext.WriterInterceptorContext;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.verify;
+
+public class EofExceptionWriterInterceptorTest {
+    @SuppressWarnings("NullAway")
+    @Test
+    public void shouldSwallowEofException() throws IOException {
+        MetricRegistry metricRegistry = new MetricRegistry();
+        EofExceptionWriterInterceptor interceptor = new EofExceptionWriterInterceptor(metricRegistry);
+        WriterInterceptorContext context = mock(WriterInterceptorContext.class);
+        doThrow(EofException.class).when(context).proceed();
+        interceptor.aroundWriteTo(context);
+
+        verify(context, only()).proceed();
+
+        Counter counter = metricRegistry.getCounters().get("io.dropwizard.jersey.errors.EofExceptionWriterInterceptor.eof-exceptions");
+        assertThat(counter).isNotNull();
+        assertThat(counter.getCount()).isEqualTo(1L);
+    }
+}

--- a/dropwizard-testing/pom.xml
+++ b/dropwizard-testing/pom.xml
@@ -59,6 +59,10 @@
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-healthchecks</artifactId>
         </dependency>
         <dependency>

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/common/DropwizardTestResourceConfig.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/common/DropwizardTestResourceConfig.java
@@ -1,14 +1,11 @@
 package io.dropwizard.testing.common;
 
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.jackson.JacksonFeature;
 import io.dropwizard.jersey.validation.HibernateValidationBinder;
 import io.dropwizard.setup.ExceptionMapperBinder;
-import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.server.ServerProperties;
 
-import javax.inject.Provider;
 import javax.servlet.ServletConfig;
 import javax.ws.rs.core.Context;
 import java.util.Map;

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/common/DropwizardTestResourceConfig.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/common/DropwizardTestResourceConfig.java
@@ -1,11 +1,14 @@
 package io.dropwizard.testing.common;
 
+import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.jackson.JacksonFeature;
 import io.dropwizard.jersey.validation.HibernateValidationBinder;
 import io.dropwizard.setup.ExceptionMapperBinder;
+import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.server.ServerProperties;
 
+import javax.inject.Provider;
 import javax.servlet.ServletConfig;
 import javax.ws.rs.core.Context;
 import java.util.Map;
@@ -29,7 +32,7 @@ class DropwizardTestResourceConfig extends DropwizardResourceConfig {
     static final String CONFIGURATION_ID = "io.dropwizard.testing.junit.resourceTestJerseyConfigurationId";
 
     DropwizardTestResourceConfig(ResourceTestJerseyConfiguration configuration) {
-        super();
+        super(configuration.metricRegistry);
 
         if (configuration.registerDefaultExceptionMappers) {
             register(new ExceptionMapperBinder(false));

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/common/Resource.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/common/Resource.java
@@ -1,5 +1,6 @@
 package io.dropwizard.testing.common;
 
+import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import io.dropwizard.jackson.Jackson;
@@ -41,6 +42,7 @@ public class Resource {
         private final Set<Supplier<?>> singletons = new HashSet<>();
         private final Set<Class<?>> providers = new HashSet<>();
         private final Map<String, Object> properties = new HashMap<>();
+        private MetricRegistry metricRegistry = new MetricRegistry();
         private ObjectMapper mapper = Jackson.newObjectMapper();
         private Validator validator = Validators.newValidator();
         private Consumer<ClientConfig> clientConfigurator = c -> {
@@ -51,6 +53,11 @@ public class Resource {
 
         public B setMapper(ObjectMapper mapper) {
             this.mapper = mapper;
+            return (B) this;
+        }
+
+        public B setMetricRegistry(MetricRegistry metricRegistry) {
+            this.metricRegistry = metricRegistry;
             return (B) this;
         }
 
@@ -121,7 +128,7 @@ public class Resource {
                 config.property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true);
             };
             return new Resource(new ResourceTestJerseyConfiguration(
-                    singletons, providers, properties, mapper, validator,
+                    singletons, providers, properties, mapper, metricRegistry, validator,
                     extendedConfigurator, testContainerFactory, registerDefaultExceptionMappers));
         }
     }

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/common/ResourceTestJerseyConfiguration.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/common/ResourceTestJerseyConfiguration.java
@@ -1,5 +1,6 @@
 package io.dropwizard.testing.common;
 
+import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.testing.junit5.ResourceExtension;
 import org.glassfish.jersey.client.ClientConfig;
@@ -22,18 +23,21 @@ class ResourceTestJerseyConfiguration {
     final Set<Class<?>> providers;
     final Map<String, Object> properties;
     final ObjectMapper mapper;
+    final MetricRegistry metricRegistry;
     final Validator validator;
     final Consumer<ClientConfig> clientConfigurator;
     final TestContainerFactory testContainerFactory;
     final boolean registerDefaultExceptionMappers;
 
     ResourceTestJerseyConfiguration(Set<Supplier<?>> singletons, Set<Class<?>> providers, Map<String, Object> properties,
-                                    ObjectMapper mapper, Validator validator, Consumer<ClientConfig> clientConfigurator,
-                                    TestContainerFactory testContainerFactory, boolean registerDefaultExceptionMappers) {
+                                    ObjectMapper mapper, MetricRegistry metricRegistry, Validator validator,
+                                    Consumer<ClientConfig> clientConfigurator, TestContainerFactory testContainerFactory,
+                                    boolean registerDefaultExceptionMappers) {
         this.singletons = singletons;
         this.providers = providers;
         this.properties = properties;
         this.mapper = mapper;
+        this.metricRegistry = metricRegistry;
         this.validator = validator;
         this.clientConfigurator = clientConfigurator;
         this.testContainerFactory = testContainerFactory;


### PR DESCRIPTION
If a client drops the connection before a response was completely sent, Jetty will emit an `org.eclipse.jetty.io.EofException` which is then caught by Jersey and logged.

This can quite noisy in the logs and should typically be swallowed instead of logged including the stack trace.

The introduced `EofExceptionWriterInterceptor` will catch `EofException` which are being thrown while writing and will swallow them (after logging on DEBUG level).

Refs #2482
Refs #2541
Refs eclipse/jetty.project#544