### PR TITLE
Don't specify scope in dependencyManagement of BOM

### DIFF
--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -338,14 +338,12 @@
                 <artifactId>jetty-servlet</artifactId>
                 <classifier>tests</classifier>
                 <version>${jetty.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-http</artifactId>
                 <classifier>tests</classifier>
                 <version>${jetty.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty.toolchain.setuid</groupId>

--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -473,25 +473,21 @@
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-junit-jupiter</artifactId>
                 <version>${mockito.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${assertj.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk15on</artifactId>
                 <version>${bcprov-jdk15on.version}</version>
-                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
`<dependencyManagement>` is commonly used for locking down the version of a dependency, not its scope. Doing that breaks the scope of transitive dependencies and is very hard to troubleshoot.

###### Problem:

I've a dependency in my project:

```
<dependency>
    <groupId>org.keycloak</groupId>
    <artifactId>keycloak-core</artifactId>
    <version>${keycloak.version}</version>
</dependency>
```

`keycloak-core`'s `pom.xml` has the following `compile` dependency:

```
<dependency>
    <groupId>org.bouncycastle</groupId>
    <artifactId>bcprov-jdk15on</artifactId>
    <version>${bouncycastle.version}</version>
</dependency>
```

With `dropwizard-dependencies` BOM in my project, here is how `keycloak-core` looks like in the output of maven dependency tree:

```
[INFO] +- org.keycloak:keycloak-core:jar:8.0.2:compile
[INFO] | +- org.keycloak:keycloak-common:jar:8.0.2:compile
[INFO] | \- org.bouncycastle:bcprov-jdk15on:jar:1.65.01:test
```
(edited for brevity)

The problem is in the last line, the bouncy castle dependency got its scope changed to `test`, because `dropwizard-dependency`'s `<dependencyManagement>` section specifies a `<scope>` for the bouncy castle artifact which takes precedence and converts all transitive dependencies on that artifact to the `test` scope. I believe the intention here was to lock down transitive dependencies versions not scopes. The scope is always specified alongside the `<dependency>` declaration in the actual `<dependencies>` anyway.

###### Solution:

Remove `<scope>` declaration from `<dependencyManagement>`. 

###### Result:

Avoid surprises during builds. The BOM is intended to lock versions not scopes.
