### PR TITLE
Removed some conditional tests (test smell)

### DIFF
--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/DataSizeValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/DataSizeValidatorTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class DataSizeValidatorTest {
     @SuppressWarnings("unused")
@@ -65,15 +66,17 @@ class DataSizeValidatorTest {
 
     @Test
     void returnsASetOfErrorsForAnObject() {
-        if ("en".equals(Locale.getDefault().getLanguage())) {
-            assertThat(ConstraintViolations.format(validator.validate(new Example())))
-                    .containsOnly("outOfRange must be between 10 KILOBYTES and 100 KILOBYTES",
-                            "tooBig must be less than or equal to 30 KILOBYTES",
-                            "tooSmall must be greater than or equal to 30 KILOBYTES",
-                            "maxDataSize[0].<list element> must be less than or equal to 30 KILOBYTES",
-                            "minDataSize[0].<list element> must be greater than or equal to 30 KILOBYTES",
-                            "rangeDataSize[0].<list element> must be between 10 KILOBYTES and 100 KILOBYTES");
-        }
+        assumeTrue("en".equals(Locale.getDefault().getLanguage()),
+                "This test executes when the defined language is English ('en'). If not, it is skipped.");
+
+        assertThat(ConstraintViolations.format(validator.validate(new Example())))
+                .containsOnly("outOfRange must be between 10 KILOBYTES and 100 KILOBYTES",
+                        "tooBig must be less than or equal to 30 KILOBYTES",
+                        "tooSmall must be greater than or equal to 30 KILOBYTES",
+                        "maxDataSize[0].<list element> must be less than or equal to 30 KILOBYTES",
+                        "minDataSize[0].<list element> must be greater than or equal to 30 KILOBYTES",
+                        "rangeDataSize[0].<list element> must be between 10 KILOBYTES and 100 KILOBYTES");
+
     }
 
     @Test

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/DurationValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/DurationValidatorTest.java
@@ -12,6 +12,7 @@ import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class DurationValidatorTest {
     @SuppressWarnings("unused")
@@ -73,12 +74,14 @@ public class DurationValidatorTest {
 
     @Test
     public void returnsASetOfErrorsForAnObject() throws Exception {
-        if ("en".equals(Locale.getDefault().getLanguage())) {
-            final Collection<String> errors =
-                    ConstraintViolations.format(validator.validate(new Example()));
+        assumeTrue("en".equals(Locale.getDefault().getLanguage()),
+                "This test executes when the defined language is English ('en'). If not, it is skipped.");
 
-            assertThat(errors)
-                    .containsOnly(
+        final Collection<String> errors =
+                ConstraintViolations.format(validator.validate(new Example()));
+
+        assertThat(errors)
+                .containsOnly(
                             "outOfRange must be between 10 MINUTES and 30 MINUTES",
                             "tooBig must be less than or equal to 30 SECONDS",
                             "tooBigExclusive must be less than 30 SECONDS",
@@ -87,7 +90,7 @@ public class DurationValidatorTest {
                             "maxDurs[0].<list element> must be less than or equal to 30 SECONDS",
                             "minDurs[0].<list element> must be greater than or equal to 30 SECONDS",
                             "rangeDurs[0].<list element> must be between 10 MINUTES and 30 MINUTES");
-        }
+
     }
 
     @Test

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/OneOfValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/OneOfValidatorTest.java
@@ -38,7 +38,8 @@ public class OneOfValidatorTest {
 
     @Test
     public void doesNotAllowOtherElements() throws Exception {
-        assumeTrue("en".equals(Locale.getDefault().getLanguage()));
+        assumeTrue("en".equals(Locale.getDefault().getLanguage()),
+                "This test executes when the defined language is English ('en'). If not, it is skipped.");
 
         final Example example = new Example();
         example.basic = "four";

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/SizeValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/SizeValidatorTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class SizeValidatorTest {
     @SuppressWarnings("unused")
@@ -60,15 +61,17 @@ public class SizeValidatorTest {
 
     @Test
     public void returnsASetOfErrorsForAnObject() throws Exception {
-        if ("en".equals(Locale.getDefault().getLanguage())) {
-            assertThat(ConstraintViolations.format(validator.validate(new Example())))
+        assumeTrue("en".equals(Locale.getDefault().getLanguage()),
+                "This test executes when the defined language is English ('en'). If not, it is skipped.");
+
+        assertThat(ConstraintViolations.format(validator.validate(new Example())))
                     .containsOnly("outOfRange must be between 10 KILOBYTES and 100 KILOBYTES",
                                   "tooBig must be less than or equal to 30 KILOBYTES",
                                   "tooSmall must be greater than or equal to 30 KILOBYTES",
                                    "maxSize[0].<list element> must be less than or equal to 30 KILOBYTES",
                                    "minSize[0].<list element> must be greater than or equal to 30 KILOBYTES",
                                    "rangeSize[0].<list element> must be between 10 KILOBYTES and 100 KILOBYTES");
-        }
+
     }
 
     @Test


### PR DESCRIPTION
###### Problem:
Conditions within the test method will alter the behavior of the test and its expected output, and would lead to situations where the test fails to detect defects in the production method since test statements were not executed as a condition was not met.

###### Solution:
Instead of using a conditional to control the test execution, we use the proper JUnit API with assumeTrue().

###### Result:
Before:
if("en".equals(Locale.getDefault().getLanguage()){...}
After:
assumeTrue("en".equals(Locale.getDefault().getLanguage()),
                "This test executes when the defined language is English ('en'). If not, it is skipped.");
