### PR TITLE
Upgrade to Liquibase 3.10.2

### DIFF
--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -51,7 +51,7 @@
         <jetty.version>9.4.30.v20200611</jetty.version>
         <joda-time.version>2.10.6</joda-time.version>
         <jsr305.version>3.0.2</jsr305.version>
-        <liquibase-core.version>3.10.0</liquibase-core.version>
+        <liquibase-core.version>3.10.2</liquibase-core.version>
         <liquibase-slf4j.version>2.0.0</liquibase-slf4j.version>
         <logback-throttling-appender.version>1.1.0</logback-throttling-appender.version>
         <logback.version>1.2.3</logback.version>


### PR DESCRIPTION
https://github.com/liquibase/liquibase/releases/tag/v3.10.2
https://www.liquibase.org/blog/liquibase-3-10-2-released