### PR TITLE
ci: mvn --no-transfer-progress

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -43,8 +43,8 @@ jobs:
       with:
         languages: java
     - name: Build with Maven
-      run: ./mvnw -Pjakarta-apis -V -B -ff -s .github/settings.xml install '-DskipTests=true' '-Dmaven.javadoc.skip=true'
+      run: ./mvnw --no-transfer-progress -Pjakarta-apis -V -B -ff -s .github/settings.xml install '-DskipTests=true' '-Dmaven.javadoc.skip=true'
     - name: Run tests
-      run: ./mvnw -Pjakarta-apis -V -B -ff -s .github/settings.xml verify
+      run: ./mvnw --no-transfer-progress -Pjakarta-apis -V -B -ff -s .github/settings.xml verify
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
reduce noise in the CI build by adding Maven's --no-transfer-progress parameter
