### PR TITLE
Use SslContextFactory.Server over deprecated SslContextFactory

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/sslreload/SslReloadTask.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/sslreload/SslReloadTask.java
@@ -21,7 +21,7 @@ public class SslReloadTask extends Task {
     public void execute(ImmutableMultimap<String, String> parameters, PrintWriter output) throws Exception {
         // Iterate through all the reloaders first to ensure valid configuration
         for (SslReload reloader : getReloaders()) {
-            reloader.reload(new SslContextFactory());
+            reloader.reload(new SslContextFactory.Server());
         }
 
         // Now we know that configuration is valid, reload for real

--- a/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2ConnectorFactory.java
+++ b/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2ConnectorFactory.java
@@ -112,7 +112,7 @@ public class Http2ConnectorFactory extends HttpsConnectorFactory {
         final NegotiatingServerConnectionFactory alpn = new ALPNServerConnectionFactory(H2, H2_17);
         alpn.setDefaultProtocol(HTTP_1_1); // Speak HTTP 1.1 over TLS if negotiation fails
 
-        final SslContextFactory sslContextFactory = configureSslContextFactory(new SslContextFactory());
+        final SslContextFactory sslContextFactory = configureSslContextFactory(new SslContextFactory.Server());
         sslContextFactory.addLifeCycleListener(logSslInfoOnStart(sslContextFactory));
         server.addBean(sslContextFactory);
         server.addBean(new SslReload(sslContextFactory, this::configureSslContextFactory));

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/AbstractHttp2Test.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/AbstractHttp2Test.java
@@ -28,7 +28,7 @@ public class AbstractHttp2Test {
         BootstrapLogging.bootstrap();
     }
 
-    final SslContextFactory sslContextFactory = new SslContextFactory();
+    final SslContextFactory sslContextFactory = new SslContextFactory.Server();
     HttpClient client;
 
     @Before

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
@@ -596,7 +596,7 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
 
         final HttpConnectionFactory httpConnectionFactory = buildHttpConnectionFactory(httpConfig);
 
-        final SslContextFactory sslContextFactory = configureSslContextFactory(new SslContextFactory());
+        final SslContextFactory sslContextFactory = configureSslContextFactory(new SslContextFactory.Server());
         sslContextFactory.addLifeCycleListener(logSslInfoOnStart(sslContextFactory));
 
         server.addBean(sslContextFactory);

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
@@ -93,7 +93,7 @@ public class HttpsConnectorFactoryTest {
         factory.setKeyStorePassword("password"); // necessary to avoid a prompt for a password
         factory.setSupportedProtocols(supportedProtocols);
 
-        SslContextFactory sslContextFactory = factory.configureSslContextFactory(new SslContextFactory());
+        SslContextFactory sslContextFactory = factory.configureSslContextFactory(new SslContextFactory.Server());
         assertThat(ImmutableList.copyOf(sslContextFactory.getIncludeProtocols())).isEqualTo(supportedProtocols);
     }
 
@@ -105,7 +105,7 @@ public class HttpsConnectorFactoryTest {
         factory.setKeyStorePassword("password"); // necessary to avoid a prompt for a password
         factory.setExcludedProtocols(excludedProtocols);
 
-        SslContextFactory sslContextFactory = factory.configureSslContextFactory(new SslContextFactory());
+        SslContextFactory sslContextFactory = factory.configureSslContextFactory(new SslContextFactory.Server());
         assertThat(ImmutableList.copyOf(sslContextFactory.getExcludeProtocols())).isEqualTo(excludedProtocols);
     }
 
@@ -134,7 +134,7 @@ public class HttpsConnectorFactoryTest {
         final HttpsConnectorFactory factory = new HttpsConnectorFactory();
         factory.setKeyStoreType(WINDOWS_MY_KEYSTORE_NAME);
 
-        assertNotNull(factory.configureSslContextFactory(new SslContextFactory()));
+        assertNotNull(factory.configureSslContextFactory(new SslContextFactory.Server()));
     }
 
     @Test(expected = IllegalStateException.class)
@@ -143,7 +143,7 @@ public class HttpsConnectorFactoryTest {
 
         final HttpsConnectorFactory factory = new HttpsConnectorFactory();
         factory.setKeyStoreType(WINDOWS_MY_KEYSTORE_NAME);
-        factory.configureSslContextFactory(new SslContextFactory());
+        factory.configureSslContextFactory(new SslContextFactory.Server());
     }
 
     @Test


### PR DESCRIPTION
###### Problem:

Same as #3369:

>When we pin a more recent version of Jetty in our projects, services fail to start up with SSL with this error:
>
>```
>java.lang.IllegalStateException: KeyStores with multiple certificates are not supported on the base class org.eclipse.jetty.util.ssl.SslContextFactory. (Use org.eclipse.jetty.util.ssl.SslContextFactory$Server or org.eclipse.jetty.util.ssl.SslContextFactory$Client instead)
>```

###### Solution:

Exactly the title.  Does not bump the Jetty version, but allows users to pin a later version if they so desire without any conflicts.

This is hopefully a more palatable approach than that taken in #3369 &mdash; it's definitely much simpler.