### PR TITLE
Dropwizard 1.3.x updates and bug-fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,12 @@ jobs:
   build:
     working_directory: ~/dropwizard
     environment:
-      JAVA_TOOL_OPTIONS: -Xms512m -Xmx2g
+      JAVA_TOOL_OPTIONS: -Xms512m -Xmx2g -XX:+TieredCompilation -XX:TieredStopAtLevel=1
     docker:
       - image: circleci/openjdk:8u171-jdk
     steps:
       - checkout
-      - run: mvn test
+      - run: ./mvnw -V -B -ntp test
       - run:
           name: Save test results
           command: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: "Code Scanning - Action"
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  CodeQL-Build:
+
+    strategy:
+      fail-fast: false
+
+    # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: java
+
+      # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below).
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
+
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
+
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following
+      #    three lines and modify them (or add more) to build your code if your
+      #    project uses a compiled language
+
+      #- run: |
+      #   make bootstrap
+      #   make release
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,6 +30,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Initialize CodeQL
+      if: matrix.java_version == '8'
       uses: github/codeql-action/init@v1
       with:
         languages: java
@@ -38,4 +39,5 @@ jobs:
     - name: Run tests
       run: ./mvnw --no-transfer-progress -V -B -ff verify
     - name: Perform CodeQL Analysis
+      if: matrix.java_version == '8'
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,41 @@
+name: Java CI
+on:
+  push:
+    branches:
+    - master
+    - release/*
+  pull_request:
+    branches:
+    - master
+    - release/*
+jobs:
+  build:
+    runs-on: 'ubuntu-latest'
+    strategy:
+      fail-fast: false
+      matrix:
+        java_version: ['8', '11', '14']
+    env:
+      JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK
+      uses: joschi/setup-jdk@v1
+      with:
+        java-version: ${{ matrix.java_version }}
+    - uses: actions/cache@v1
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: java
+    - name: Build with Maven
+      run: ./mvnw --no-transfer-progress -V -B -ff install '-DskipTests=true' '-Dmaven.javadoc.skip=true'
+    - name: Run tests
+      run: ./mvnw --no-transfer-progress -V -B -ff verify
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2007-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.net.*;
+import java.io.*;
+import java.nio.channels.*;
+import java.util.Properties;
+
+public class MavenWrapperDownloader {
+
+    private static final String WRAPPER_VERSION = "0.5.6";
+    /**
+     * Default URL to download the maven-wrapper.jar from, if no 'downloadUrl' is provided.
+     */
+    private static final String DEFAULT_DOWNLOAD_URL = "https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/"
+        + WRAPPER_VERSION + "/maven-wrapper-" + WRAPPER_VERSION + ".jar";
+
+    /**
+     * Path to the maven-wrapper.properties file, which might contain a downloadUrl property to
+     * use instead of the default one.
+     */
+    private static final String MAVEN_WRAPPER_PROPERTIES_PATH =
+            ".mvn/wrapper/maven-wrapper.properties";
+
+    /**
+     * Path where the maven-wrapper.jar will be saved to.
+     */
+    private static final String MAVEN_WRAPPER_JAR_PATH =
+            ".mvn/wrapper/maven-wrapper.jar";
+
+    /**
+     * Name of the property which should be used to override the default download url for the wrapper.
+     */
+    private static final String PROPERTY_NAME_WRAPPER_URL = "wrapperUrl";
+
+    public static void main(String args[]) {
+        System.out.println("- Downloader started");
+        File baseDirectory = new File(args[0]);
+        System.out.println("- Using base directory: " + baseDirectory.getAbsolutePath());
+
+        // If the maven-wrapper.properties exists, read it and check if it contains a custom
+        // wrapperUrl parameter.
+        File mavenWrapperPropertyFile = new File(baseDirectory, MAVEN_WRAPPER_PROPERTIES_PATH);
+        String url = DEFAULT_DOWNLOAD_URL;
+        if(mavenWrapperPropertyFile.exists()) {
+            FileInputStream mavenWrapperPropertyFileInputStream = null;
+            try {
+                mavenWrapperPropertyFileInputStream = new FileInputStream(mavenWrapperPropertyFile);
+                Properties mavenWrapperProperties = new Properties();
+                mavenWrapperProperties.load(mavenWrapperPropertyFileInputStream);
+                url = mavenWrapperProperties.getProperty(PROPERTY_NAME_WRAPPER_URL, url);
+            } catch (IOException e) {
+                System.out.println("- ERROR loading '" + MAVEN_WRAPPER_PROPERTIES_PATH + "'");
+            } finally {
+                try {
+                    if(mavenWrapperPropertyFileInputStream != null) {
+                        mavenWrapperPropertyFileInputStream.close();
+                    }
+                } catch (IOException e) {
+                    // Ignore ...
+                }
+            }
+        }
+        System.out.println("- Downloading from: " + url);
+
+        File outputFile = new File(baseDirectory.getAbsolutePath(), MAVEN_WRAPPER_JAR_PATH);
+        if(!outputFile.getParentFile().exists()) {
+            if(!outputFile.getParentFile().mkdirs()) {
+                System.out.println(
+                        "- ERROR creating output directory '" + outputFile.getParentFile().getAbsolutePath() + "'");
+            }
+        }
+        System.out.println("- Downloading to: " + outputFile.getAbsolutePath());
+        try {
+            downloadFileFromURL(url, outputFile);
+            System.out.println("Done");
+            System.exit(0);
+        } catch (Throwable e) {
+            System.out.println("- Error downloading");
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+
+    private static void downloadFileFromURL(String urlString, File destination) throws Exception {
+        if (System.getenv("MVNW_USERNAME") != null && System.getenv("MVNW_PASSWORD") != null) {
+            String username = System.getenv("MVNW_USERNAME");
+            char[] password = System.getenv("MVNW_PASSWORD").toCharArray();
+            Authenticator.setDefault(new Authenticator() {
+                @Override
+                protected PasswordAuthentication getPasswordAuthentication() {
+                    return new PasswordAuthentication(username, password);
+                }
+            });
+        }
+        URL website = new URL(urlString);
+        ReadableByteChannel rbc;
+        rbc = Channels.newChannel(website.openStream());
+        FileOutputStream fos = new FileOutputStream(destination);
+        fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
+        fos.close();
+        rbc.close();
+    }
+
+}

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.6.2/apache-maven-3.6.2-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ before_install:
 - rm ~/.m2/settings.xml || true
 - ulimit -c unlimited -S
 script:
-- ./mvnw verify -B
-- ./mvnw site -pl docs -B
+- ./mvnw verify -B -ntp
+- ./mvnw site -pl docs -B -ntp
 after_success:
 - bash .travis_after_success.sh
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,3 @@
 test_script:
-  - mvn package
+  - ./mvnw -B -ntp package
 build: off

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,17 +1,18 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
-    faraday (0.14.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
-    multipart-post (2.0.0)
-    octokit (4.8.0)
+    multipart-post (2.1.1)
+    octokit (4.18.0)
+      faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    public_suffix (3.0.2)
-    sawyer (0.8.1)
-      addressable (>= 2.3.5, < 2.6)
-      faraday (~> 0.8, < 1.0)
+    public_suffix (4.0.5)
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
 
 PLATFORMS
   ruby

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -28,7 +28,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>parse-version</id>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -12,9 +12,15 @@
     <name>Dropwizard Documentation</name>
 
     <properties>
-        <jar.skipIfEmpty>true</jar.skipIfEmpty>
+        <checkstyle.skip>true</checkstyle.skip>
         <mpir.skip>true</mpir.skip>
+        <maven.test.skip>true</maven.test.skip>
+        <maven.source.skip>true</maven.source.skip>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <maven.install.skip>true</maven.install.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+        <gpg.skip>true</gpg.skip>
     </properties>
 
     <build>
@@ -22,22 +28,25 @@
             <resource>
                 <directory>${basedir}/source</directory>
                 <filtering>true</filtering>
+                <includes>
+                    <include>conf.py</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>${basedir}/source</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>conf.py</exclude>
+                </excludes>
             </resource>
         </resources>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.2.0</version>
-                <executions>
-                    <execution>
-                        <id>parse-version</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>parse-version</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <skipIfEmpty>true</skipIfEmpty>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/dropwizard-archetypes/java-simple/src/main/resources/archetype-resources/pom.xml
+++ b/dropwizard-archetypes/java-simple/src/main/resources/archetype-resources/pom.xml
@@ -113,6 +113,11 @@
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.2.0</version>
+                <configuration>
+                    <doclint>none</doclint>
+                    <quiet>true</quiet>
+                    <source>8</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -138,6 +143,11 @@
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.2.0</version>
+                <configuration>
+                    <doclint>none</doclint>
+                    <quiet>true</quiet>
+                    <source>8</source>
+                </configuration>
             </plugin>
         </plugins>
     </reporting>

--- a/dropwizard-archetypes/java-simple/src/main/resources/archetype-resources/pom.xml
+++ b/dropwizard-archetypes/java-simple/src/main/resources/archetype-resources/pom.xml
@@ -47,7 +47,7 @@
 #if( $shaded == "true" )
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.4.1</version>
+                <version>3.2.4</version>
                 <configuration>
                     <createDependencyReducedPom>true</createDependencyReducedPom>
                     <transformers>
@@ -80,7 +80,7 @@
 #end
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>3.2.0</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -92,7 +92,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -100,7 +100,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -112,7 +112,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0-M1</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -129,7 +129,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.8.1</version>
+                <version>3.1.0</version>
                 <configuration>
                     <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
                     <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
@@ -137,7 +137,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
+                <version>3.2.0</version>
             </plugin>
         </plugins>
     </reporting>

--- a/dropwizard-archetypes/pom.xml
+++ b/dropwizard-archetypes/pom.xml
@@ -32,18 +32,19 @@
       <extension>
         <groupId>org.apache.maven.archetype</groupId>
         <artifactId>archetype-packaging</artifactId>
-        <version>3.0.1</version>
+        <version>3.2.0</version>
       </extension>
     </extensions>
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-archetype-plugin</artifactId>
-          <version>3.0.1</version>
+          <version>3.2.0</version>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.0.2</version>
           <configuration>
             <escapeString>\</escapeString>
           </configuration>
@@ -56,8 +57,8 @@
            - If any of the above executions fail, the build fails -->
         <plugin>
           <!-- clean any existing integration tests -->
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>2.6.1</version>
           <executions>
             <execution>
               <id>prepare-integration-test</id>
@@ -80,8 +81,9 @@
           </executions>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-invoker-plugin</artifactId>
-          <version>3.0.1</version>
+          <version>3.2.1</version>
           <configuration>
             <!-- custom settings.xml to have invoker use our local M2 repo for artifacts -->
             <settingsFile>${project.parent.basedir}/src/test/resources/settings.xml</settingsFile>
@@ -139,8 +141,8 @@
 
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.0.2</version>
         <executions>
           <execution>
             <id>package-tools</id>

--- a/dropwizard-archetypes/pom.xml
+++ b/dropwizard-archetypes/pom.xml
@@ -102,7 +102,7 @@
               </goals>
               <configuration>
                 <goals>
-                  <goal>org.apache.maven.plugins:maven-archetype-plugin:generate</goal>
+                  <goal>-ntp org.apache.maven.plugins:maven-archetype-plugin:generate</goal>
                 </goals>
                 <pomIncludes>
                   <pomInclude>*</pomInclude>
@@ -126,7 +126,7 @@
               </goals>
               <configuration>
                 <goals>
-                  <goal>verify</goal>
+                  <goal>-ntp verify</goal>
                 </goals>
                 <pomIncludes>
                   <pomInclude>*/*/pom.xml</pomInclude>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -28,7 +28,7 @@
         <slf4j.version>1.7.30</slf4j.version>
         <logback.version>1.2.3</logback.version>
         <h2.version>1.4.197</h2.version>
-        <jdbi3.version>3.5.1</jdbi3.version>
+        <jdbi3.version>3.14.3</jdbi3.version>
     </properties>
 
     <dependencyManagement>
@@ -207,21 +207,6 @@
                 <version>${jdbi3.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.jdbi</groupId>
-                <artifactId>jdbi3-core</artifactId>
-                <version>${jdbi3.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jdbi</groupId>
-                <artifactId>jdbi3-jodatime2</artifactId>
-                <version>${jdbi3.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jdbi</groupId>
-                <artifactId>jdbi3-guava</artifactId>
-                <version>${jdbi3.version}</version>
             </dependency>
 
             <!-- Jetty -->

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.8.1</version>
+                <version>3.11</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -147,7 +147,7 @@
             <dependency>
                 <groupId>org.hsqldb</groupId>
                 <artifactId>hsqldb</artifactId>
-                <version>2.4.1</version>
+                <version>2.5.1</version>
             </dependency>
             <dependency>
                 <groupId>org.liquibase</groupId>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -194,7 +194,7 @@
             <dependency>
                 <groupId>org.freemarker</groupId>
                 <artifactId>freemarker</artifactId>
-                <version>2.3.28</version>
+                <version>2.3.30</version>
             </dependency>
             <dependency>
                 <groupId>org.jdbi</groupId>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -97,7 +97,7 @@
             <dependency>
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-jdbc</artifactId>
-                <version>9.0.16</version>
+                <version>9.0.37</version>
             </dependency>
             <dependency>
                 <groupId>com.h2database</groupId>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -310,7 +310,7 @@
             <dependency>
                 <groupId>org.eclipse.jetty.toolchain.setuid</groupId>
                 <artifactId>jetty-setuid-java</artifactId>
-                <version>1.0.3</version>
+                <version>1.0.4</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.eclipse.jetty</groupId>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -66,7 +66,7 @@
             <dependency>
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
-                <version>2.10.1</version>
+                <version>2.10.6</version>
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -22,7 +22,7 @@
         <guava.version>24.1.1-jre</guava.version>
         <jersey.version>2.25.1</jersey.version>
         <jackson.version>2.9.10.20200621</jackson.version>
-        <jetty.version>9.4.18.v20190429</jetty.version>
+        <jetty.version>9.4.31.v20200723</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.0.5</metrics4.version>
         <slf4j.version>1.7.26</slf4j.version>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -25,7 +25,7 @@
         <jetty.version>9.4.31.v20200723</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
         <metrics4.version>4.0.7</metrics4.version>
-        <slf4j.version>1.7.26</slf4j.version>
+        <slf4j.version>1.7.30</slf4j.version>
         <logback.version>1.2.3</logback.version>
         <h2.version>1.4.197</h2.version>
         <jdbi3.version>3.5.1</jdbi3.version>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -46,7 +46,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>
-                <version>1.2</version>
+                <version>1.9</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -24,7 +24,7 @@
         <jackson.version>2.9.10.20200621</jackson.version>
         <jetty.version>9.4.31.v20200723</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
-        <metrics4.version>4.0.7</metrics4.version>
+        <metrics4.version>4.1.12.1</metrics4.version>
         <slf4j.version>1.7.30</slf4j.version>
         <logback.version>1.2.3</logback.version>
         <h2.version>1.4.197</h2.version>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -86,7 +86,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.5.10</version>
+                <version>4.5.12</version>
                 <exclusions>
                     <exclusion>
                         <groupId>commons-logging</groupId>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -137,7 +137,7 @@
             <dependency>
                 <groupId>org.javassist</groupId>
                 <artifactId>javassist</artifactId>
-                <version>3.24.1-GA</version>
+                <version>3.27.0-GA</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml</groupId>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -333,6 +333,12 @@
                 <version>${jetty.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>2.3.1</version>
+            </dependency>
+
             <!-- Jackson -->
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -152,7 +152,7 @@
             <dependency>
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-core</artifactId>
-                <version>3.6.3</version>
+                <version>3.10.2</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.yaml</groupId>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -36,7 +36,7 @@
             <dependency>
                 <groupId>org.objenesis</groupId>
                 <artifactId>objenesis</artifactId>
-                <version>2.6</version>
+                <version>3.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -142,7 +142,7 @@
             <dependency>
                 <groupId>com.fasterxml</groupId>
                 <artifactId>classmate</artifactId>
-                <version>1.4.0</version>
+                <version>1.5.1</version>
             </dependency>
             <dependency>
                 <groupId>org.hsqldb</groupId>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -24,7 +24,7 @@
         <jackson.version>2.9.10.20200621</jackson.version>
         <jetty.version>9.4.31.v20200723</jetty.version>
         <servlet.version>3.0.0.v201112011016</servlet.version>
-        <metrics4.version>4.0.5</metrics4.version>
+        <metrics4.version>4.0.7</metrics4.version>
         <slf4j.version>1.7.26</slf4j.version>
         <logback.version>1.2.3</logback.version>
         <h2.version>1.4.197</h2.version>

--- a/dropwizard-core/src/main/java/io/dropwizard/sslreload/SslReloadTask.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/sslreload/SslReloadTask.java
@@ -21,7 +21,7 @@ public class SslReloadTask extends Task {
     public void execute(ImmutableMultimap<String, String> parameters, PrintWriter output) throws Exception {
         // Iterate through all the reloaders first to ensure valid configuration
         for (SslReload reloader : getReloaders()) {
-            reloader.reload(new SslContextFactory());
+            reloader.reload(new SslContextFactory.Server());
         }
 
         // Now we know that configuration is valid, reload for real

--- a/dropwizard-example/pom.xml
+++ b/dropwizard-example/pom.xml
@@ -131,7 +131,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -141,12 +141,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.20.1</version>
+                    <version>2.22.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -156,22 +156,22 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.7.0</version>
+                    <version>3.8.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.2.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -181,7 +181,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.6</version>
+                    <version>3.9.1</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -260,7 +260,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.17</version>
+                <version>3.0.0</version>
                 <configuration>
                     <configLocation>../checkstyle.xml</configLocation>
                 </configuration>
@@ -280,7 +280,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.0</version>
+                <version>0.8.5</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>
@@ -311,25 +311,20 @@
             </build>
         </profile>
         <profile>
-            <id>jdk9</id>
+            <id>jdk11</id>
             <activation>
-                <jdk>9</jdk>
+                <jdk>[11,)</jdk>
             </activation>
             <properties>
-                <maven.compiler.source>1.9</maven.compiler.source>
-                <maven.compiler.target>1.9</maven.compiler.target>
+                <maven.compiler.source>11</maven.compiler.source>
+                <maven.compiler.target>11</maven.compiler.target>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <argLine>--add-modules java.xml.bind</argLine>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 </project>

--- a/dropwizard-example/pom.xml
+++ b/dropwizard-example/pom.xml
@@ -26,7 +26,7 @@
         <repository>
             <id>sonatype-nexus-snapshots</id>
             <name>Sonatype Nexus Snapshots</name>
-            <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
     </repositories>
 

--- a/dropwizard-http2/pom.xml
+++ b/dropwizard-http2/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -12,9 +13,7 @@
     <name>Dropwizard HTTP/2 Support</name>
 
     <properties>
-        <!-- Default alpn-boot version. See <profiles> for specific profiles. -->
-        <alpn-boot.version>8.1.13.v20181017</alpn-boot.version>
-        <argLine>"-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar" -Duser.language=en -Duser.region=US</argLine>
+        <argLine>-Duser.language=en -Duser.region=US</argLine>
     </properties>
 
     <dependencyManagement>
@@ -59,12 +58,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-alpn-openjdk8-client</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>
             <scope>test</scope>
@@ -73,22 +66,6 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-alpn-conscrypt-server</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-alpn-openjdk8-server</artifactId>
-        </dependency>
-
-        <!-- This needs to be on your JVM's bootpath for HTTP2 to work with ALPN protocol
-            -Xbootclasspath/p:/<path_to_alpn_boot_jar>/alpn-boot-${alpn-boot.version}.jar
-             The correct version depends on the specific JVM version.
-             Consult http://www.eclipse.org/jetty/documentation/current/alpn-chapter.html for the reference -->
-        <dependency>
-            <groupId>org.mortbay.jetty.alpn</groupId>
-            <artifactId>alpn-boot</artifactId>
-            <version>${alpn-boot.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -116,6 +93,26 @@
             </dependencies>
         </profile>
         <profile>
+            <id>jdk8</id>
+            <activation>
+                <jdk>[1.8.0,9)</jdk>
+            </activation>
+            <properties>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-alpn-openjdk8-client</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-alpn-openjdk8-server</artifactId>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>jdk-1.8.0</id>
             <activation>
                 <property>
@@ -125,7 +122,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.0.v20141016</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_05</id>
@@ -137,7 +146,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.0.v20141016</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_11</id>
@@ -149,7 +170,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.0.v20141016</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_20</id>
@@ -161,7 +194,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.0.v20141016</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_25</id>
@@ -173,7 +218,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.2.v20141202</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_31</id>
@@ -185,7 +242,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.3.v20150130</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_40</id>
@@ -197,7 +266,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.3.v20150130</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_45</id>
@@ -209,7 +290,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.3.v20150130</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_51</id>
@@ -221,7 +314,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.4.v20150727</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_60</id>
@@ -233,7 +338,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.5.v20150921</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_65</id>
@@ -245,7 +362,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.6.v20151105</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_66</id>
@@ -257,7 +386,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.6.v20151105</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_71</id>
@@ -269,7 +410,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.7.v20160121</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_72</id>
@@ -281,7 +434,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.7.v20160121</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_73</id>
@@ -293,7 +458,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.7.v20160121</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_74</id>
@@ -305,7 +482,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.7.v20160121</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_77</id>
@@ -317,7 +506,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.7.v20160121</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_91</id>
@@ -329,7 +530,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.7.v20160121</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_92</id>
@@ -341,7 +554,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.8.v20160420</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_101</id>
@@ -353,7 +578,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.9.v20160720</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_102</id>
@@ -365,7 +602,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.9.v20160720</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_111</id>
@@ -377,7 +626,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.9.v20160720</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_112</id>
@@ -389,7 +650,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.10.v20161026</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_121</id>
@@ -401,7 +674,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.11.v20170118</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_131</id>
@@ -413,7 +698,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.11.v20170118</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_141</id>
@@ -425,7 +722,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.11.v20170118</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_144</id>
@@ -437,7 +746,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.11.v20170118</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_151</id>
@@ -449,7 +770,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.11.v20170118</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_152</id>
@@ -461,7 +794,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.11.v20170118</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_161</id>
@@ -473,7 +818,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.12.v20180117</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_162</id>
@@ -485,7 +842,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.12.v20180117</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_171</id>
@@ -497,7 +866,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.12.v20180117</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_172</id>
@@ -509,7 +890,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.12.v20180117</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_181</id>
@@ -521,7 +914,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.12.v20180117</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_191</id>
@@ -533,7 +938,19 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.13.v20181017</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>jdk-1.8.0_192</id>
@@ -545,7 +962,259 @@
             </activation>
             <properties>
                 <alpn-boot.version>8.1.13.v20181017</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_201</id>
+            <activation>
+                <property>
+                    <name>java.version</name>
+                    <value>1.8.0_201</value>
+                </property>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.13.v20181017</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_202</id>
+            <activation>
+                <property>
+                    <name>java.version</name>
+                    <value>1.8.0_202</value>
+                </property>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.13.v20181017</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_211</id>
+            <activation>
+                <property>
+                    <name>java.version</name>
+                    <value>1.8.0_211</value>
+                </property>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.13.v20181017</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_212</id>
+            <activation>
+                <property>
+                    <name>java.version</name>
+                    <value>1.8.0_212</value>
+                </property>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.13.v20181017</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_221</id>
+            <activation>
+                <property>
+                    <name>java.version</name>
+                    <value>1.8.0_221</value>
+                </property>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.13.v20181017</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_222</id>
+            <activation>
+                <property>
+                    <name>java.version</name>
+                    <value>1.8.0_222</value>
+                </property>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.13.v20181017</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_231</id>
+            <activation>
+                <property>
+                    <name>java.version</name>
+                    <value>1.8.0_231</value>
+                </property>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.13.v20181017</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_232</id>
+            <activation>
+                <property>
+                    <name>java.version</name>
+                    <value>1.8.0_232</value>
+                </property>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.13.v20181017</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_241</id>
+            <activation>
+                <property>
+                    <name>java.version</name>
+                    <value>1.8.0_241</value>
+                </property>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.13.v20181017</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk-1.8.0_242</id>
+            <activation>
+                <property>
+                    <name>java.version</name>
+                    <value>1.8.0_242</value>
+                </property>
+            </activation>
+            <properties>
+                <alpn-boot.version>8.1.13.v20181017</alpn-boot.version>
+                <argLine>
+                    "-Xbootclasspath/p:/${user.home}/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/${alpn-boot.version}/alpn-boot-${alpn-boot.version}.jar"
+                    -Duser.language=en -Duser.region=US
+                </argLine>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <version>${alpn-boot.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 </project>

--- a/dropwizard-http2/pom.xml
+++ b/dropwizard-http2/pom.xml
@@ -102,13 +102,11 @@
             <dependencies>
                 <dependency>
                     <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-alpn-openjdk8-client</artifactId>
-                    <scope>test</scope>
+                    <artifactId>jetty-alpn-openjdk8-server</artifactId>
                 </dependency>
                 <dependency>
                     <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-alpn-openjdk8-server</artifactId>
-                    <scope>runtime</scope>
+                    <artifactId>jetty-alpn-openjdk8-client</artifactId>
                 </dependency>
             </dependencies>
         </profile>

--- a/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2ConnectorFactory.java
+++ b/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2ConnectorFactory.java
@@ -112,7 +112,7 @@ public class Http2ConnectorFactory extends HttpsConnectorFactory {
         final NegotiatingServerConnectionFactory alpn = new ALPNServerConnectionFactory(H2, H2_17);
         alpn.setDefaultProtocol(HTTP_1_1); // Speak HTTP 1.1 over TLS if negotiation fails
 
-        final SslContextFactory sslContextFactory = configureSslContextFactory(new SslContextFactory());
+        final SslContextFactory sslContextFactory = configureSslContextFactory(new SslContextFactory.Server());
         sslContextFactory.addLifeCycleListener(logSslInfoOnStart(sslContextFactory));
         server.addBean(sslContextFactory);
         server.addBean(new SslReload(sslContextFactory, this::configureSslContextFactory));

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/AbstractHttp2Test.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/AbstractHttp2Test.java
@@ -28,7 +28,7 @@ public class AbstractHttp2Test {
         BootstrapLogging.bootstrap();
     }
 
-    final SslContextFactory sslContextFactory = new SslContextFactory();
+    final SslContextFactory sslContextFactory = new SslContextFactory.Server();
     HttpClient client;
 
     @Before

--- a/dropwizard-jersey/pom.xml
+++ b/dropwizard-jersey/pom.xml
@@ -37,6 +37,10 @@
             <artifactId>dropwizard-logging</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
         </dependency>

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/FuzzyEnumParamConverterProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/FuzzyEnumParamConverterProviderTest.java
@@ -1,6 +1,8 @@
 package io.dropwizard.jersey.validation;
 
 import io.dropwizard.jersey.errors.ErrorMessage;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.InstanceOfAssertFactory;
 import org.junit.Test;
 
 import javax.annotation.Nullable;
@@ -10,6 +12,7 @@ import javax.ws.rs.ext.ParamConverter;
 import java.lang.annotation.Annotation;
 
 import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
@@ -160,10 +163,10 @@ public class FuzzyEnumParamConverterProviderTest {
 
         final WebApplicationException throwable = catchThrowableOfType(() -> converter.fromString("B"), WebApplicationException.class);
         assertThat(throwable.getResponse())
-            .extracting(Response::getEntity)
-            .matches(e -> ((ErrorMessage) e.get(0)).getCode() == 400)
-            .matches(e -> ((ErrorMessage) e.get(0)).getMessage().contains("A_1"))
-            .matches(e -> ((ErrorMessage) e.get(0)).getMessage().contains("A_2"));
+            .extracting(Response::getEntity, as(new InstanceOfAssertFactory<>(ErrorMessage.class, Assertions::assertThat)))
+            .matches(e -> e.getCode() == 400)
+            .matches(e -> e.getMessage().contains("A_1"))
+            .matches(e -> e.getMessage().contains("A_2"));
     }
 
 
@@ -185,9 +188,9 @@ public class FuzzyEnumParamConverterProviderTest {
         assertThat(converter.fromString("2")).isSameAs(ExplicitFromString.B);
         final WebApplicationException throwable = catchThrowableOfType(() -> converter.fromString("3"), WebApplicationException.class);
         assertThat(throwable.getResponse())
-            .extracting(Response::getEntity)
-            .matches(e -> ((ErrorMessage) e.get(0)).getCode() == 400)
-            .matches(e -> ((ErrorMessage) e.get(0)).getMessage().contains("is not a valid ExplicitFromString"));
+            .extracting(Response::getEntity, as(new InstanceOfAssertFactory<>(ErrorMessage.class, Assertions::assertThat)))
+            .matches(e -> e.getCode() == 400)
+            .matches(e -> e.getMessage().contains("is not a valid ExplicitFromString"));
     }
 
     @Test
@@ -196,9 +199,9 @@ public class FuzzyEnumParamConverterProviderTest {
             getConverter(ExplicitFromStringThrowsWebApplicationException.class);
         final WebApplicationException throwable = catchThrowableOfType(() -> converter.fromString("3"), WebApplicationException.class);
         assertThat(throwable.getResponse())
-            .extracting(Response::getStatusInfo)
-            .matches(e -> ((Response.StatusType) e.get(0)).getStatusCode() == 418)
-            .matches(e -> ((Response.StatusType) e.get(0)).getReasonPhrase().contains("I am a teapot"));
+            .extracting(Response::getStatusInfo, as(new InstanceOfAssertFactory<>(Response.StatusType.class, Assertions::assertThat)))
+            .matches(e -> e.getStatusCode() == 418)
+            .matches(e -> e.getReasonPhrase().contains("I am a teapot"));
     }
 
     @Test
@@ -207,9 +210,9 @@ public class FuzzyEnumParamConverterProviderTest {
             getConverter(ExplicitFromStringThrowsOtherException.class);
         final WebApplicationException throwable = catchThrowableOfType(() -> converter.fromString("1"), WebApplicationException.class);
         assertThat(throwable.getResponse())
-            .extracting(Response::getEntity)
-            .matches(e -> ((ErrorMessage) e.get(0)).getCode() == 400)
-            .matches(e -> ((ErrorMessage) e.get(0)).getMessage().contains("Failed to convert"));
+            .extracting(Response::getEntity, as(new InstanceOfAssertFactory<>(ErrorMessage.class, Assertions::assertThat)))
+            .matches(e -> e.getCode() == 400)
+            .matches(e -> e.getMessage().contains("Failed to convert"));
     }
 
     @Test
@@ -217,10 +220,10 @@ public class FuzzyEnumParamConverterProviderTest {
         final ParamConverter<ExplicitFromStringNonStatic> converter = getConverter(ExplicitFromStringNonStatic.class);
         final WebApplicationException throwable = catchThrowableOfType(() -> converter.fromString("1"), WebApplicationException.class);
         assertThat(throwable.getResponse())
-            .extracting(Response::getEntity)
-            .matches(e -> ((ErrorMessage) e.get(0)).getCode() == 400)
-            .matches(e -> ((ErrorMessage) e.get(0)).getMessage().contains("A"))
-            .matches(e -> ((ErrorMessage) e.get(0)).getMessage().contains("B"));
+            .extracting(Response::getEntity, as(new InstanceOfAssertFactory<>(ErrorMessage.class, Assertions::assertThat)))
+            .matches(e -> e.getCode() == 400)
+            .matches(e -> e.getMessage().contains("A"))
+            .matches(e -> e.getMessage().contains("B"));
 
         assertThat(converter.fromString("A")).isSameAs(ExplicitFromStringNonStatic.A);
     }
@@ -230,8 +233,8 @@ public class FuzzyEnumParamConverterProviderTest {
         final ParamConverter<ExplicitFromStringPrivate> converter = getConverter(ExplicitFromStringPrivate.class);
         final WebApplicationException throwable = catchThrowableOfType(() -> converter.fromString("1"), WebApplicationException.class);
         assertThat(throwable.getResponse())
-            .extracting(Response::getEntity)
-            .matches(e -> ((ErrorMessage) e.get(0)).getCode() == 400)
-            .matches(e -> ((ErrorMessage) e.get(0)).getMessage().contains("Not permitted to call"));
+            .extracting(Response::getEntity, as(new InstanceOfAssertFactory<>(ErrorMessage.class, Assertions::assertThat)))
+            .matches(e -> e.getCode() == 400)
+            .matches(e -> e.getMessage().contains("Not permitted to call"));
     }
 }

--- a/dropwizard-jetty/pom.xml
+++ b/dropwizard-jetty/pom.xml
@@ -59,6 +59,11 @@
             <artifactId>jetty-http</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- For GzipHandler tests -->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/ContextRoutingHandler.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/ContextRoutingHandler.java
@@ -2,9 +2,8 @@ package io.dropwizard.jetty;
 
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.jetty.server.handler.AbstractHandlerContainer;
 import org.eclipse.jetty.util.ArrayTernaryTrie;
-import org.eclipse.jetty.util.Trie;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -15,8 +14,8 @@ import java.util.Map;
 /**
  * A Jetty router which routes requests based on context path.
  */
-public class ContextRoutingHandler extends AbstractHandler {
-    private final Trie<Handler> handlers;
+public class ContextRoutingHandler extends AbstractHandlerContainer {
+    private final ArrayTernaryTrie<Handler> handlers;
 
     public ContextRoutingHandler(Map<String, ? extends Handler> handlers) {
         this.handlers = new ArrayTernaryTrie<>(false);
@@ -37,5 +36,26 @@ public class ContextRoutingHandler extends AbstractHandler {
         if (handler != null) {
             handler.handle(target, baseRequest, request, response);
         }
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
+        for (String key : handlers.keySet()) {
+            handlers.get(key).start();
+        }
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        super.doStop();
+        for (String key : handlers.keySet()) {
+            handlers.get(key).stop();
+        }
+    }
+
+    @Override
+    public Handler[] getHandlers() {
+        return handlers.entrySet().stream().map(Map.Entry::getValue).toArray(Handler[]::new);
     }
 }

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
@@ -596,7 +596,7 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
 
         final HttpConnectionFactory httpConnectionFactory = buildHttpConnectionFactory(httpConfig);
 
-        final SslContextFactory sslContextFactory = configureSslContextFactory(new SslContextFactory());
+        final SslContextFactory sslContextFactory = configureSslContextFactory(new SslContextFactory.Server());
         sslContextFactory.addLifeCycleListener(logSslInfoOnStart(sslContextFactory));
 
         server.addBean(sslContextFactory);

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/ContextRoutingHandlerTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/ContextRoutingHandlerTest.java
@@ -5,29 +5,28 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.InOrder;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class ContextRoutingHandlerTest {
-    private final Request baseRequest = mock(Request.class);
-    private final HttpServletRequest request = mock(HttpServletRequest.class);
-    private final HttpServletResponse response = mock(HttpServletResponse.class);
-
-    private final Handler handler1 = mock(Handler.class);
-    private final Handler handler2 = mock(Handler.class);
+    private Request baseRequest = mock(Request.class);
+    private HttpServletRequest request = mock(HttpServletRequest.class);
+    private HttpServletResponse response = mock(HttpServletResponse.class);
+    private Handler handler1 = mock(Handler.class);
+    private Handler handler2 = mock(Handler.class);
 
     private ContextRoutingHandler handler;
 
     @Before
     public void setUp() throws Exception {
+        openMocks(this);
         this.handler = new ContextRoutingHandler(ImmutableMap.of(
                 "/", handler1,
                 "/admin", handler2
@@ -67,10 +66,11 @@ public class ContextRoutingHandlerTest {
     @Test
     public void startsAndStopsAllHandlers() throws Exception {
         handler.start();
-        handler.stop();
+        verify(handler1).start();
+        verify(handler2).start();
 
-        final InOrder inOrder = inOrder(handler1, handler2);
-        inOrder.verify(handler1).start();
-        inOrder.verify(handler2).start();
+        handler.stop();
+        verify(handler1).stop();
+        verify(handler2).stop();
     }
 }

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
@@ -93,7 +93,7 @@ public class HttpsConnectorFactoryTest {
         factory.setKeyStorePassword("password"); // necessary to avoid a prompt for a password
         factory.setSupportedProtocols(supportedProtocols);
 
-        SslContextFactory sslContextFactory = factory.configureSslContextFactory(new SslContextFactory());
+        SslContextFactory sslContextFactory = factory.configureSslContextFactory(new SslContextFactory.Server());
         assertThat(ImmutableList.copyOf(sslContextFactory.getIncludeProtocols())).isEqualTo(supportedProtocols);
     }
 
@@ -105,7 +105,7 @@ public class HttpsConnectorFactoryTest {
         factory.setKeyStorePassword("password"); // necessary to avoid a prompt for a password
         factory.setExcludedProtocols(excludedProtocols);
 
-        SslContextFactory sslContextFactory = factory.configureSslContextFactory(new SslContextFactory());
+        SslContextFactory sslContextFactory = factory.configureSslContextFactory(new SslContextFactory.Server());
         assertThat(ImmutableList.copyOf(sslContextFactory.getExcludeProtocols())).isEqualTo(excludedProtocols);
     }
 
@@ -134,7 +134,7 @@ public class HttpsConnectorFactoryTest {
         final HttpsConnectorFactory factory = new HttpsConnectorFactory();
         factory.setKeyStoreType(WINDOWS_MY_KEYSTORE_NAME);
 
-        assertNotNull(factory.configureSslContextFactory(new SslContextFactory()));
+        assertNotNull(factory.configureSslContextFactory(new SslContextFactory.Server()));
     }
 
     @Test(expected = IllegalStateException.class)
@@ -143,7 +143,7 @@ public class HttpsConnectorFactoryTest {
 
         final HttpsConnectorFactory factory = new HttpsConnectorFactory();
         factory.setKeyStoreType(WINDOWS_MY_KEYSTORE_NAME);
-        factory.configureSslContextFactory(new SslContextFactory());
+        factory.configureSslContextFactory(new SslContextFactory.Server());
     }
 
     @Test

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/setup/ServletEnvironmentTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/setup/ServletEnvironmentTest.java
@@ -78,7 +78,7 @@ public class ServletEnvironmentTest {
 
     @Test
     public void addsFilterInstances() throws Exception {
-        final Filter filter = mock(Filter.class);
+        final Filter filter = new WelcomeFilter();
 
         final FilterRegistration.Dynamic builder = environment.addFilter("filter", filter);
         assertThat(builder)
@@ -90,8 +90,7 @@ public class ServletEnvironmentTest {
         assertThat(holder.getValue().getName())
                 .isEqualTo("filter");
 
-        assertThat(holder.getValue().getFilter())
-                .isEqualTo(filter);
+        assertThat(holder.getValue()).hasFieldOrPropertyWithValue("_instance", filter);
     }
 
     @Test

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/AppenderFactoryCustomLayoutTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/AppenderFactoryCustomLayoutTest.java
@@ -46,7 +46,7 @@ public class AppenderFactoryCustomLayoutTest {
         final ConsoleAppenderFactory<ILoggingEvent> appender = factory.build(loadResource());
         assertThat(appender.getLayout()).isNotNull().isInstanceOf(TestLayoutFactory.class);
         TestLayoutFactory layoutFactory = (TestLayoutFactory) appender.getLayout();
-        assertThat(layoutFactory).isNotNull().extracting(TestLayoutFactory::isIncludeSeparator).contains(true);
+        assertThat(layoutFactory).isNotNull().extracting(TestLayoutFactory::isIncludeSeparator).isEqualTo(true);
     }
 
     @Test

--- a/dropwizard-logging/src/test/resources/yaml/logging-tcp-buffered.yml
+++ b/dropwizard-logging/src/test/resources/yaml/logging-tcp-buffered.yml
@@ -2,6 +2,6 @@ level: INFO
 appenders:
   - type: tcp
     host: localhost
-    port: 24562
+    port: ${tcp.server.port}
     immediateFlush: false
     sendBufferSize: 1KB

--- a/dropwizard-logging/src/test/resources/yaml/logging-tcp.yml
+++ b/dropwizard-logging/src/test/resources/yaml/logging-tcp.yml
@@ -2,4 +2,4 @@ level: INFO
 appenders:
   - type: tcp
     host: localhost
-    port: 24562
+    port: ${tcp.server.port}

--- a/dropwizard-testing/pom.xml
+++ b/dropwizard-testing/pom.xml
@@ -76,23 +76,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.junit.platform</groupId>
-                        <artifactId>junit-platform-surefire-provider</artifactId>
-                        <version>1.2.0</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.junit.jupiter</groupId>
-                        <artifactId>junit-jupiter-engine</artifactId>
-                        <version>${junit5.version}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <argLine>-Duser.language=en -Duser.region=US</argLine>
 
         <junit.version>4.12</junit.version>
-        <junit5.version>5.2.0</junit5.version>
+        <junit5.version>5.6.2</junit5.version>
         <assertj.version>3.9.1</assertj.version>
         <mockito.version>2.24.0</mockito.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -521,12 +521,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>3.2.0</version>
                     <dependencies>
                         <dependency>
                             <groupId>org.apache.maven.shared</groupId>
                             <artifactId>maven-filtering</artifactId>
-                            <version>3.1.1</version>
+                            <version>3.2.0</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -360,12 +360,12 @@
                             <dependency>
                                 <groupId>org.codehaus.plexus</groupId>
                                 <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                                <version>2.8.2</version>
+                                <version>2.8.6</version>
                             </dependency>
                             <dependency>
                                 <groupId>com.google.errorprone</groupId>
                                 <artifactId>error_prone_core</artifactId>
-                                <version>2.2.0</version>
+                                <version>2.3.4</version>
                             </dependency>
                         </dependencies>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,7 @@
                                 <path>
                                     <groupId>com.uber.nullaway</groupId>
                                     <artifactId>nullaway</artifactId>
-                                    <version>0.3.2</version>
+                                    <version>0.7.10</version>
                                 </path>
                             </annotationProcessorPaths>
                             <compilerArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -648,7 +648,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.1</version>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -548,7 +548,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>2.9</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>kr.motd.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -496,7 +496,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.2.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
         <repository>
             <id>sonatype-nexus-snapshots</id>
             <name>Sonatype Nexus Snapshots</name>
-            <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
             <releases>
                 <enabled>false</enabled>
             </releases>
@@ -238,7 +238,7 @@
         <snapshotRepository>
             <id>sonatype-nexus-snapshots</id>
             <name>Sonatype Nexus Snapshots</name>
-            <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>
             <id>sonatype-nexus-staging</id>

--- a/pom.xml
+++ b/pom.xml
@@ -402,7 +402,7 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.8.0</version>
+                        <version>0.8.5</version>
                         <executions>
                             <execution>
                                 <id>prepare-agent</id>

--- a/pom.xml
+++ b/pom.xml
@@ -683,12 +683,12 @@
                             <report>index</report>
                             <report>summary</report>
                             <report>dependency-info</report>
-                            <report>license</report>
+                            <report>licenses</report>
                             <report>scm</report>
-                            <report>issue-tracking</report>
-                            <report>mailing-list</report>
-                            <report>cim</report>
-                            <report>project-team</report>
+                            <report>issue-management</report>
+                            <report>mailing-lists</report>
+                            <report>ci-management</report>
+                            <report>team</report>
                             <report>dependencies</report>
                             <report>dependency-convergence</report>
                             <report>modules</report>

--- a/pom.xml
+++ b/pom.xml
@@ -511,7 +511,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -533,7 +533,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <junit.version>4.12</junit.version>
         <junit5.version>5.6.2</junit5.version>
         <assertj.version>3.9.1</assertj.version>
-        <mockito.version>2.24.0</mockito.version>
+        <mockito.version>3.4.6</mockito.version>
     </properties>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -553,7 +553,7 @@
                 <plugin>
                     <groupId>kr.motd.maven</groupId>
                     <artifactId>sphinx-maven-plugin</artifactId>
-                    <version>1.7.0</version>
+                    <version>2.9.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -538,7 +538,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.7</version>
+                    <version>3.9.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.eluder.coveralls</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -501,7 +501,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 
         <junit.version>4.12</junit.version>
         <junit5.version>5.6.2</junit5.version>
-        <assertj.version>3.9.1</assertj.version>
+        <assertj.version>3.16.1</assertj.version>
         <mockito.version>3.4.6</mockito.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -702,6 +702,7 @@
                 <configuration>
                     <doclint>none</doclint>
                     <quiet>true</quiet>
+                    <source>8</source>
                 </configuration>
                 <reportSets>
                     <reportSet>


### PR DESCRIPTION
Pull dependency updates into `release/1.3.x` branch as far as it makes sense.

There are no functional changes in Dropwizard itself except for a few tests which behave differently with different Java versions.

I've tried to have one commit per change so that we can revert/remove changes we do not want to have in the Dropwizard 1.3.x line.

Everything _should_ be backwards-compatible but I'm planning to publish at least one release candidate for Dropwizard 1.3.25 so that people can easier test it.