### PR TITLE
Support parsing system property configuration values as arrays when the field does not exist

### DIFF
--- a/dropwizard-configuration/pom.xml
+++ b/dropwizard-configuration/pom.xml
@@ -68,6 +68,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationMetadata.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationMetadata.java
@@ -1,0 +1,159 @@
+package io.dropwizard.configuration;
+
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonObjectFormatVisitor;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A class to get metadata about the properties that are available in a configuration class. It can
+ * be used to get information about the type of the properties. The names are stored as nested paths
+ * (e.g. parent.config.field).
+ *
+ * <p>Given the following simple configuration:</p>
+ * <pre>
+ * public class ExampleConfiguration extends Configuration {
+ *     &#064;NotNull
+ *     private String name;
+ *
+ *     private List&lt;String&gt names = Collections.emptyList();
+ *
+ *     &#064;JsonProperty
+ *     public String getName() {
+ *         return name;
+ *     }
+ *
+ *     &#064;JsonProperty
+ *     public List&lt;String&gt; getNames() {
+ *         return names;
+ *     }
+ * }
+ * </pre>
+ *
+ * This leads to the following entries:
+ * <ul>
+ *     <li><pre>{@code name -> {SimpleType} "[simple type, class java.lang.String]"}</pre></li>
+ *     <li><pre>{@code names -> {CollectionType} "[collection type; class java.util.List, contains [simple type, class java.lang.String]]"}</pre></li>
+ * </ul>
+ *
+ * Restrictions: The field-tree is only discovered correctly when no inheritance is present. It is
+ * hard to discover the correct class, so this sticks to the defaultImpl that is provided.
+ */
+public class ConfigurationMetadata extends JsonFormatVisitorWrapper.Base {
+
+    // Just a safety option if someone uses recursive configuration classes
+    private static final int MAX_DEPTH = 100;
+
+    private final ObjectMapper mapper;
+
+    // Field is package-private to be visible for unit tests
+    final Map<String, JavaType> fields = new HashMap<>();
+
+    private String currentPrefix = "";
+    private int currentDepth = 0;
+
+    /**
+     * Create a metadata instance and
+     *
+     * @param mapper the {@link ObjectMapper} that is used to parse the configuration file
+     * @param klass the target class of the configuration
+     */
+    public ConfigurationMetadata(ObjectMapper mapper, Class<?> klass) {
+        this.mapper = mapper;
+
+        try {
+            mapper.acceptJsonFormatVisitor(klass, this);
+        } catch (JsonMappingException ignored) {
+            // empty
+        }
+    }
+
+    private Optional<JavaType> getTypeOfField(String fieldName) {
+        // normalize the field name to recognize arrays correctly
+        // (input is field[1].prop but stored as field[*].prop)
+        return Optional.ofNullable(fields.get(fieldName.replaceAll("\\[\\d+]", "[*]")));
+    }
+
+    /**
+     * Check if a field is a collection of strings.
+     *
+     * @param fieldName the field name
+     * @return true, if the field is a collection of strings
+     */
+    public boolean isCollectionOfStrings(String fieldName) {
+        Optional<JavaType> propertyType = getTypeOfField(fieldName);
+
+        if (!propertyType.isPresent()) {
+            return false;
+        }
+
+        if (!propertyType.get().isCollectionLikeType() && !propertyType.get().isArrayType()) {
+            return false;
+        }
+
+        return propertyType.get().getContentType().isTypeOrSubTypeOf(String.class);
+    }
+
+    @Override
+    public JsonObjectFormatVisitor expectObjectFormat(JavaType type) throws JsonMappingException {
+        // store the pointer to the own instance
+        final ConfigurationMetadata thiss = this;
+
+        return new JsonObjectFormatVisitor.Base() {
+            @Override
+            public void optionalProperty(BeanProperty prop) throws JsonMappingException {
+                // don't run into an infinite loop with circular dependencies
+                if (currentDepth > MAX_DEPTH) {
+                    return;
+                }
+
+                // build the complete field path
+                String name = !currentPrefix.isEmpty() ? currentPrefix + "." + prop.getName()
+                    : prop.getName();
+
+                // set state for the recursive traversal
+                int oldFieldSize = fields.size();
+                String oldPrefix = currentPrefix;
+                currentPrefix = name;
+                currentDepth++;
+
+                // the type of the field
+                JavaType fieldType = prop.getType();
+
+                // if the field is a collection or array, use the content type instead and add [*]
+                // to the path
+                if (fieldType.isCollectionLikeType() || fieldType.isArrayType()) {
+                    fieldType = fieldType.getContentType();
+                    currentPrefix += "[*]";
+                }
+
+                // get the type deserializer
+                TypeDeserializer typeDeserializer =
+                    mapper.getDeserializationConfig().findTypeDeserializer(fieldType);
+
+                // get the default impl if available
+                Class<?> defaultImpl =
+                    typeDeserializer != null ? typeDeserializer.getDefaultImpl() : null;
+
+                // visit the type of the property (or its defaultImpl).
+                mapper.acceptJsonFormatVisitor(
+                    defaultImpl == null ? fieldType.getRawClass() : defaultImpl, thiss);
+
+                // reset state after the recursive traversal
+                currentDepth--;
+                currentPrefix = oldPrefix;
+
+                // if no new fields are discovered, we assume that we are at an primitive field
+                if (oldFieldSize == fields.size()) {
+                    fields.put(name, prop.getType());
+                }
+            }
+        };
+    }
+}

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/BaseConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/BaseConfigurationFactoryTest.java
@@ -152,6 +152,7 @@ public abstract class BaseConfigurationFactoryTest {
     protected File emptyFile = new File("/");
     protected File invalidFile = new File("/");
     protected File validFile = new File("/");
+    protected File validNoTypeFile = new File("/");
     protected File typoFile = new File("/");
     protected File wrongTypeFile = new File("/");
     protected File malformedAdvancedFile = new File("/");
@@ -256,6 +257,16 @@ public abstract class BaseConfigurationFactoryTest {
                 .isEqualTo("overridden");
         assertThat(example.getType().size())
                 .isEqualTo(1);
+    }
+
+    @Test
+    public void handlesArrayOverrideIntoValidNoTypeFile() throws Exception {
+        System.setProperty("dw.type", "coder,wizard,overridden");
+        final Example example = factory.build(validNoTypeFile);
+        assertThat(example.getType().get(2))
+            .isEqualTo("overridden");
+        assertThat(example.getType().size())
+            .isEqualTo(3);
     }
 
     @Test

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationMetadataTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationMetadataTest.java
@@ -1,0 +1,146 @@
+package io.dropwizard.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.dropwizard.jackson.Jackson;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ConfigurationMetadataTest {
+
+    @SuppressWarnings("UnusedDeclaration")
+    public static class ExampleConfiguration {
+
+        @JsonProperty
+        private int port = 8000;
+
+        @JsonProperty
+        private ExampleInterface example = new DefaultExampleInterface();
+
+        @JsonProperty
+        private ExampleInterfaceWithDefaultImpl exampleWithDefault = new DefaultExampleInterface();
+
+        @JsonProperty
+        private List<ExampleInterfaceWithDefaultImpl> exampleWithDefaults = new ArrayList<>();
+
+        public int getPort() {
+            return port;
+        }
+
+        public ExampleInterface getExample() {
+            return example;
+        }
+
+        public ExampleInterfaceWithDefaultImpl getExampleWithDefault() {
+            return exampleWithDefault;
+        }
+
+        public List<ExampleInterfaceWithDefaultImpl> getExampleWithDefaults() {
+            return exampleWithDefaults;
+        }
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    public interface ExampleInterface {
+
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = DefaultExampleInterface.class)
+    public interface ExampleInterfaceWithDefaultImpl {
+
+    }
+
+    @SuppressWarnings("UnusedDeclaration")
+    public static class DefaultExampleInterface implements ExampleInterface,
+        ExampleInterfaceWithDefaultImpl {
+
+        @JsonProperty
+        private String[] array = new String[]{};
+
+        @JsonProperty
+        private List<String> list = Collections.emptyList();
+
+        @JsonProperty
+        private Set<String> set = Collections.emptySet();
+
+        public String[] getArray() {
+            return array;
+        }
+
+        public List<String> getList() {
+            return list;
+        }
+
+        public Set<String> getSet() {
+            return set;
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideArgsForShouldDiscoverAllFields")
+    public void shouldDiscoverAllFields(String name, boolean isPrimitive,
+        boolean isCollectionOrArrayType,
+        Class<?> klass) {
+        final ConfigurationMetadata metadata = new ConfigurationMetadata(
+            Jackson.newObjectMapper(), ExampleConfiguration.class);
+
+        assertThat(metadata.fields.get(name)).isNotNull().satisfies((f) -> {
+            assertThat(f.isPrimitive()).isEqualTo(isPrimitive);
+            assertThat(f.isCollectionLikeType() || f.isArrayType())
+                .isEqualTo(isCollectionOrArrayType);
+
+            if (isCollectionOrArrayType) {
+                assertThat(f.getContentType().isTypeOrSubTypeOf(klass)).isTrue();
+            } else {
+                assertThat(f.isTypeOrSubTypeOf(klass)).isTrue();
+            }
+        });
+    }
+
+    private static Stream<Arguments> provideArgsForShouldDiscoverAllFields() {
+        return Stream.of(
+            Arguments.of("port", true, false, Integer.TYPE),
+            Arguments.of("example", false, false, ExampleInterface.class),
+            Arguments.of("exampleWithDefault.array", false, true, String.class),
+            Arguments.of("exampleWithDefault.list", false, true, String.class),
+            Arguments.of("exampleWithDefault.set", false, true, String.class),
+            Arguments.of("exampleWithDefaults[*].array", false, true, String.class),
+            Arguments.of("exampleWithDefaults[*].list", false, true, String.class),
+            Arguments.of("exampleWithDefaults[*].set", false, true, String.class)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideArgsForIsCollectionOfStringsShouldWork")
+    public void isCollectionOfStringsShouldWork(String name, boolean isCollectionOfStrings) {
+        final ConfigurationMetadata metadata = new ConfigurationMetadata(
+            Jackson.newObjectMapper(), ExampleConfiguration.class);
+
+        assertThat(metadata.isCollectionOfStrings(name)).isEqualTo(isCollectionOfStrings);
+    }
+
+
+    private static Stream<Arguments> provideArgsForIsCollectionOfStringsShouldWork() {
+        return Stream.of(
+            Arguments.of("doesnotexist", false),
+            Arguments.of("port", false),
+            Arguments.of("example.array", false),
+            Arguments.of("example.list", false),
+            Arguments.of("example.set", false),
+            Arguments.of("exampleWithDefault.array", true),
+            Arguments.of("exampleWithDefault.list", true),
+            Arguments.of("exampleWithDefault.set", true),
+            Arguments.of("exampleWithDefaults[0].array", true),
+            Arguments.of("exampleWithDefaults[0].list", true),
+            Arguments.of("exampleWithDefaults[0].set", true)
+        );
+    }
+}

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/JsonConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/JsonConfigurationFactoryTest.java
@@ -22,6 +22,7 @@ public class JsonConfigurationFactoryTest extends BaseConfigurationFactoryTest {
         this.emptyFile = resourceFileName("factory-test-empty.json");
         this.invalidFile = resourceFileName("factory-test-invalid.json");
         this.validFile = resourceFileName("factory-test-valid.json");
+        this.validNoTypeFile = resourceFileName("factory-test-valid-no-type.json");
         this.commentFile = resourceFileName("factory-test-comment.json");
         this.typoFile = resourceFileName("factory-test-typo.json");
         this.wrongTypeFile = resourceFileName("factory-test-wrong-type.json");

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/YamlConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/YamlConfigurationFactoryTest.java
@@ -14,6 +14,7 @@ public class YamlConfigurationFactoryTest extends BaseConfigurationFactoryTest {
         this.emptyFile = resourceFileName("factory-test-empty.yml");
         this.invalidFile = resourceFileName("factory-test-invalid.yml");
         this.validFile = resourceFileName("factory-test-valid.yml");
+        this.validNoTypeFile = resourceFileName("factory-test-valid-no-type.yml");
         this.typoFile = resourceFileName("factory-test-typo.yml");
         this.wrongTypeFile = resourceFileName("factory-test-wrong-type.yml");
         this.malformedAdvancedFile = resourceFileName("factory-test-malformed-advanced.yml");

--- a/dropwizard-configuration/src/test/resources/factory-test-valid-no-type.json
+++ b/dropwizard-configuration/src/test/resources/factory-test-valid-no-type.json
@@ -1,0 +1,21 @@
+{
+	"name": "Coda Hale",
+	"properties": {
+		"debug": true,
+		"settings.enabled": false
+	},
+	"servers": [
+		{
+			"port": 8080
+		},
+		{
+			"port": 8081
+		},
+		{
+			"port": 8082
+		}
+	],
+	"my.logger": {
+		"level": "info"
+	}
+}

--- a/dropwizard-configuration/src/test/resources/factory-test-valid-no-type.yml
+++ b/dropwizard-configuration/src/test/resources/factory-test-valid-no-type.yml
@@ -1,0 +1,10 @@
+name: Coda Hale
+properties:
+  debug: true
+  settings.enabled: false
+servers:
+  - port: 8080
+  - port: 8081
+  - port: 8082
+my.logger:
+  level: info


### PR DESCRIPTION
###### Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->

This PR resolves the following limitation when overriding configurations by System Properties:

> The array override facility only handles configuration elements that are arrays of simple strings. *Also, the setting in question must already exist in your configuration file as an array; this mechanism will not work if the configuration key being overridden does not exist in your configuration file. If it does not exist or is not an array setting, it will get added as a simple string setting, including the ‘,’ characters as part of the string.*

We ship our services in Docker Containers to be run in our customer's infrastructure and want to give them the possibility to configure rarely used configurations with System Properties. This includes for example the proxy settings of HTTP Clients. We don't usually configure this in our `config.yml` and don't want them to exchange it with their own. It is usually infrastructure-dependent and a manual exchange will possibly lead to compatibility problems in future updates of a service. But the setting `nonProxyHosts` is not settable when it is not defined in the `config.yml`, since the parser doesn't recognize the field as being an array/collection.

###### Solution:
<!-- Describe the modifications you've done. -->

We propose to add a `ConfigurationMetadata` class that discovers the type of all fields and can be used while parsing the overridden properties. For now, it is only used to check whether a missing node should actually be an array.

This doesn't work well with inheritance in the configuration file (like the `ServerFactory` class in the default `Configuration`). The parser only works when a `defaultImpl` is registered. If it is missing, it can't discover any further properties.

<!--###### Result:-->
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->

Do you think that would be a valuable addition to the existing logic?