### PR TITLE
#3468 - Add badge for reproducible build

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Dropwizard
 [![Javadocs](https://javadoc.io/badge/io.dropwizard/dropwizard-project.svg?color=brightgreen)](https://javadoc.io/doc/io.dropwizard/dropwizard-project)
 [![Documentation Status](https://readthedocs.org/projects/dropwizard/badge/?version=stable)](https://www.dropwizard.io/en/stable/?badge=stable)
 [![Maintainability](https://api.codeclimate.com/v1/badges/11a16ea08c8b5499e2b9/maintainability)](https://codeclimate.com/github/dropwizard/dropwizard/maintainability)
+[![Reproducible Builds](https://img.shields.io/badge/Reproducible_Builds-ok-green?labelColor=blue)](https://github.com/jvm-repo-rebuild/reproducible-central#io.dropwizard:dropwizard-core)
 
 *Dropwizard is a sneaky way of making fast Java web applications.*
 


### PR DESCRIPTION
###### Problem:
Since v2.0.10, [dropwizard-core](https://github.com/jvm-repo-rebuild/reproducible-central#io.dropwizard:dropwizard-core) is been validated as a reproducible build in [Reproducible Central project](https://github.com/jvm-repo-rebuild/reproducible-central)
But who knows?

###### Solution:
A badge in documentation might be good to follow this information. Then users can see directly from the dropwizard repository.

###### Result:
A badge with the "Reproducible build" in status "OK" will be added.

Closes #3468