### PR TITLE
Update docs to fix updated methods

### DIFF
--- a/docs/source/manual/hibernate.rst
+++ b/docs/source/manual/hibernate.rst
@@ -28,6 +28,11 @@ To create a :ref:`managed <man-core-managed>`, instrumented ``SessionFactory`` i
         public DataSourceFactory getDataSourceFactory() {
             return database;
         }
+
+        @JsonProperty("database")
+        public void setDataSourceFactory(DataSourceFactory dataSourceFactory) {
+            this.database = dataSourceFactory;
+        }
     }
 
 Then, add a ``HibernateBundle`` instance to your application class, specifying your entity classes
@@ -118,8 +123,9 @@ contains type-safe wrappers for most of ``SessionFactory``'s common operations:
             return persist(person).getId();
         }
 
+        @SuppressWarnings("unchecked")
         public List<Person> findAll() {
-            return list(namedQuery("com.example.helloworld.core.Person.findAll"));
+            return list((Query<Person>) namedQuery("com.example.helloworld.core.Person.findAll"));
         }
     }
 


### PR DESCRIPTION
###### Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->
When piecing together code from the docs, two issues popped up.

###### Solution:
<!-- Describe the modifications you've done. -->
Added the setter to the docs so users don't end up seeing
```
Caused by: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "database" (class com.example.helloworld.HelloWorldConfiguration), not marked as ignorable (6 known properties: "server", "template", "defaultName", "logging", "metrics", "admin"])
``` 
when they start piecing their app together.

Added a cast to the usage of `namedQuery` so that people are aware that the function signature has changed since previous versions.
```
/Users/cwalker/Source/hibernate-source/src/main/java/com/example/helloworld/db/PersonDAO.java:24: error: no suitable method found for list(Query<CAP#1>)
        return list(namedQuery("com.example.helloworld.core.Person.findAll"));
               ^
    method AbstractDAO.list(Criteria) is not applicable
      (argument mismatch; Query<CAP#2> cannot be converted to Criteria)
    method AbstractDAO.list(CriteriaQuery<Person>) is not applicable
      (argument mismatch; Query<CAP#2> cannot be converted to CriteriaQuery<Person>)
    method AbstractDAO.list(Query<Person>) is not applicable
      (argument mismatch; Query<CAP#2> cannot be converted to Query<Person>)
  where CAP#1,CAP#2 are fresh type-variables:
    CAP#1 extends Object from capture of ?
    CAP#2 extends Object from capture of ?
```
This issue bit us when upgrading to dropwizard 1.3.1 to 2.0.0.
