### PR TITLE
Disable Checkstyle for Code Climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,7 +3,7 @@ engines:
     enabled: true
     channel: "beta"
   checkstyle:
-    enabled: true
+    enabled: false
     config:
       file: "checkstyle.xml"
     channel: "beta"


### PR DESCRIPTION
Since checkstyle was removed in #2693 , disabling it in the codeclimate config in order to fix the badge
