### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -522,7 +522,7 @@ v1.2.1: Nov 22, 2017
 * Correctly set up SO_LINGER for the HTTP connector `#2176 <https://github.com/dropwizard/dropwizard/pull/2176>`_
 * Support fromString in FuzzyEnumParamConverter `#2161 <https://github.com/dropwizard/dropwizard/pull/2161>`_
 * Upgrade to Hibernate 5.2.12.Final to address `HHH-11996 <https://hibernate.atlassian.net/browse/HHH-11996>`_, `#2206 <https://github.com/dropwizard/dropwizard/issues/2206>`_
-* Upgrade to Freemaker 2.3.27-incubating
+* Upgrade to FreeMarker 2.3.27-incubating
 
 .. _rel-1.1.6:
 

--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -878,11 +878,11 @@ FilterFactories
 ---------------
 
 
-A factory used for request loging appenders should implement ``io.dropwizard.logging.filter.FilterFactory<IAccessEvent>``
+A factory used for request logging appenders should implement ``io.dropwizard.logging.filter.FilterFactory<IAccessEvent>``
 while one used for regular logging should implement ``io.dropwizard.logging.filter.FilterFactory<ILoggingEvent>``.
 To register a factory, its fully qualified classname must be listed in
 ``META-INF/services/io.dropwizard.logging.filter.FilterFactory``. The factory then can be referenced in the configuration 
-either via its simple calssname or via type name, if factory class annotated with ``@JsonTypeName``.
+either via its simple classname or via type name, if factory class annotated with ``@JsonTypeName``.
 
 
 .. code-block:: yaml
@@ -1355,7 +1355,7 @@ authScheme      Basic              The authentication scheme used by the. Allowe
 realm           (none)             The realm, used for NTLM authentication.
 hostname        (none)             The hostname of the windows workstation, used for NTLM authentication.
 domain          (none)             The Windows Domain, used for NTLM authentication.
-credentialType  (none)             The Apache HTTP Client Credentials imeplementation used for proxy authentication.
+credentialType  (none)             The Apache HTTP Client Credentials implementation used for proxy authentication.
                                    Allowed options are: ``UsernamePassword`` or ``NT``
 nonProxyHosts   (none)             List of patterns of hosts that should be reached without proxy.
                                    The patterns may contain symbol '*' as a wildcard.

--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -939,7 +939,7 @@ Asynchronous Logging
 By default, all logging in Dropwizard is asynchronous, even to typically
 synchronous sinks such as files and the console. When a slow logger (like file
 logger on an overloaded disk) is coupled with a high load, Dropwizard will
-seemlessly drop events of lower importance (``TRACE``, ``DEBUG``, ``INFO``) in
+seamlessly drop events of lower importance (``TRACE``, ``DEBUG``, ``INFO``) in
 an attempt to maintain reasonable latency. 
 
 .. TIP::

--- a/docs/source/manual/upgrade-notes/upgrade-notes-0_7_x.rst
+++ b/docs/source/manual/upgrade-notes/upgrade-notes-0_7_x.rst
@@ -11,7 +11,7 @@ Upgrade Notes for Dropwizard 0.7.x
 -  If you use ``dropwizard-hibernate``, update Hibernate bundle by overriding ``getDataSourceFactory``;
 -  If you use ``dropwizard-migrations``, update Migrations bundle by overriding ``getDataSourceFactory﻿``;
 -  If you serve static files, add ``dropwizard-assets`` to dependencies;
--  If you use templating, add ``dropwizard-views-freemaker`` or ``dropwizard-views-mustache`` accordingly;
+-  If you use templating, add ``dropwizard-views-freemarker`` or ``dropwizard-views-mustache`` accordingly;
 -  Update the application to override ``getName()`` instead of providing the bundle with the name;
 -  Change how resources are added from ``environment.addResource(resource)`` to ``environment.jersey().register(resource)``;
 -  Once everything is compiling, rename ``*Service`` class to ``*Application``;


### PR DESCRIPTION
###### Problem:
Several documentation files contain minor typos.

###### Solution:
Corrected the typos.

###### Result:
Less typos.
