### PR TITLE
Make `driverClass` configuration setting optional

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -684,7 +684,7 @@ queueSize              256                                      The maximum capa
 discardingThreshold    -1                                       When the blocking queue has only the capacity mentioned in
                                                                 discardingThreshold remaining, it will drop events of level TRACE,
                                                                 DEBUG and INFO, keeping only events of level WARN and ERROR.
-                                                                If no discarding threshold is specified (-1), then a default of 
+                                                                If no discarding threshold is specified (-1), then a default of
                                                                 queueSize / 5 (logback's default ratio) is used.
                                                                 To keep all events, set discardingThreshold to 0.
 timeZone               UTC                                      The time zone to which event timestamps will be converted.
@@ -739,7 +739,7 @@ queueSize                    256                                        The maxi
 discardingThreshold          -1                                         When the blocking queue has only the capacity mentioned in discardingThreshold
                                                                         remaining, it will drop events of level TRACE, DEBUG and INFO, keeping only events
                                                                         of level WARN and ERROR. If no discarding threshold is specified (-1), then a default
-                                                                        of queueSize / 5 (logback's default ratio) is used. To keep all events, set 
+                                                                        of queueSize / 5 (logback's default ratio) is used. To keep all events, set
                                                                         discardingThreshold to 0.
 archive                      true                                       Whether or not to archive old events in separate files.
 archivedLogFilenamePattern   (none)                                     Required if ``archive`` is ``true``.
@@ -881,7 +881,7 @@ FilterFactories
 A factory used for request logging appenders should implement ``io.dropwizard.logging.filter.FilterFactory<IAccessEvent>``
 while one used for regular logging should implement ``io.dropwizard.logging.filter.FilterFactory<ILoggingEvent>``.
 To register a factory, its fully qualified classname must be listed in
-``META-INF/services/io.dropwizard.logging.filter.FilterFactory``. The factory then can be referenced in the configuration 
+``META-INF/services/io.dropwizard.logging.filter.FilterFactory``. The factory then can be referenced in the configuration
 either via its simple classname or via type name, if factory class annotated with ``@JsonTypeName``.
 
 
@@ -1046,7 +1046,7 @@ additionalFields         (empty)                      Map of fields to add in th
 
 .. _DateTimeFormatter:  https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html
 
-.. _TeeFilter: https://logback.qos.ch/access.html#teeFilter           
+.. _TeeFilter: https://logback.qos.ch/access.html#teeFilter
 
 .. _register: https://github.com/dropwizard/dropwizard/issues/2045#issuecomment-299149563
 
@@ -1465,9 +1465,11 @@ Database
 ============================    =====================    ===============================================================
 Name                            Default                  Description
 ============================    =====================    ===============================================================
-driverClass                     REQUIRED                 The full name of the JDBC driver class.
-
 url                             REQUIRED                 The URL of the server.
+
+driverClass                     none                     The fully qualified class name of the JDBC driver class.
+                                                         Only required if there were no JDBC drivers registered in
+                                                         ``META-INF/services/java.sql.Driver``.
 
 user                            none                     The username used to connect to the server.
 

--- a/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
+++ b/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
@@ -7,11 +7,11 @@ import io.dropwizard.util.Duration;
 import io.dropwizard.validation.MinDuration;
 import io.dropwizard.validation.ValidationMethod;
 import org.apache.tomcat.jdbc.pool.PoolProperties;
-import javax.validation.constraints.NotEmpty;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import java.sql.Connection;
 import java.util.LinkedHashMap;
@@ -32,14 +32,17 @@ import java.util.concurrent.TimeUnit;
  *         <td>Description</td>
  *     </tr>
  *     <tr>
- *         <td>{@code driverClass}</td>
- *         <td><b>REQUIRED</b></td>
- *         <td>The full name of the JDBC driver class.</td>
- *     </tr>
- *     <tr>
  *         <td>{@code url}</td>
  *         <td><b>REQUIRED</b></td>
  *         <td>The URL of the server.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code driverClass}</td>
+ *         <td><b>none</b></td>
+ *         <td>
+ *             The fully qualified class name of the JDBC driver class.
+ *             Only required if there were no JDBC drivers registered in {@code META-INF/services/java.sql.Driver}.
+ *         </td>
  *     </tr>
  *     <tr>
  *         <td>{@code user}</td>
@@ -329,8 +332,8 @@ public class DataSourceFactory implements PooledDataSourceFactory {
         }
     }
 
-    @NotEmpty
-    private String driverClass = "";
+    @Nullable
+    private String driverClass;
 
     @Min(0)
     @Max(100)
@@ -443,6 +446,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
         this.autoCommentsEnabled = autoCommentsEnabled;
     }
 
+    @Nullable
     @JsonProperty
     @Override
     public String getDriverClass() {
@@ -450,7 +454,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
     }
 
     @JsonProperty
-    public void setDriverClass(String driverClass) {
+    public void setDriverClass(@Nullable String driverClass) {
         this.driverClass = driverClass;
     }
 
@@ -461,7 +465,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
     }
 
     @JsonProperty
-    public void setUser(String user) {
+    public void setUser(@Nullable String user) {
         this.user = user;
     }
 
@@ -472,7 +476,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
     }
 
     @JsonProperty
-    public void setPassword(String password) {
+    public void setPassword(@Nullable String password) {
         this.password = password;
     }
 
@@ -633,7 +637,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
     }
 
     @JsonProperty
-    public void setAutoCommitByDefault(Boolean autoCommit) {
+    public void setAutoCommitByDefault(@Nullable Boolean autoCommit) {
         this.autoCommitByDefault = autoCommit;
     }
 
@@ -644,7 +648,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
     }
 
     @JsonProperty
-    public void setDefaultCatalog(String defaultCatalog) {
+    public void setDefaultCatalog(@Nullable String defaultCatalog) {
         this.defaultCatalog = defaultCatalog;
     }
 
@@ -655,7 +659,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
     }
 
     @JsonProperty
-    public void setReadOnlyByDefault(Boolean readOnlyByDefault) {
+    public void setReadOnlyByDefault(@Nullable Boolean readOnlyByDefault) {
         this.readOnlyByDefault = readOnlyByDefault;
     }
 
@@ -696,7 +700,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
     }
 
     @JsonProperty
-    public void setInitializationQuery(String query) {
+    public void setInitializationQuery(@Nullable String query) {
         this.initializationQuery = query;
     }
 
@@ -726,7 +730,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
     }
 
     @JsonProperty
-    public void setMaxConnectionAge(Duration age) {
+    public void setMaxConnectionAge(@Nullable Duration age) {
         this.maxConnectionAge = age;
     }
 
@@ -814,7 +818,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
     }
 
     @JsonProperty
-    public void setValidationQueryTimeout(Duration validationQueryTimeout) {
+    public void setValidationQueryTimeout(@Nullable Duration validationQueryTimeout) {
         this.validationQueryTimeout = validationQueryTimeout;
     }
 
@@ -911,7 +915,7 @@ public class DataSourceFactory implements PooledDataSourceFactory {
         poolConfig.setTimeBetweenEvictionRunsMillis((int) evictionInterval.toMilliseconds());
         poolConfig.setValidationInterval(validationInterval.toMilliseconds());
 
-        getValidationQueryTimeout().map(x -> (int)x.toSeconds()).ifPresent(poolConfig::setValidationQueryTimeout);
+        getValidationQueryTimeout().map(x -> (int) x.toSeconds()).ifPresent(poolConfig::setValidationQueryTimeout);
         validatorClassName.ifPresent(poolConfig::setValidatorClassName);
         jdbcInterceptors.ifPresent(poolConfig::setJdbcInterceptors);
         return new ManagedPooledDataSource(poolConfig, metricRegistry);

--- a/dropwizard-db/src/main/java/io/dropwizard/db/PooledDataSourceFactory.java
+++ b/dropwizard-db/src/main/java/io/dropwizard/db/PooledDataSourceFactory.java
@@ -3,6 +3,7 @@ package io.dropwizard.db;
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.util.Duration;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Optional;
 
@@ -67,6 +68,7 @@ public interface PooledDataSourceFactory {
      *
      * @return the JDBC driver class as a string
      */
+    @Nullable
     String getDriverClass();
 
     /**

--- a/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceConfigurationTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceConfigurationTest.java
@@ -12,10 +12,10 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DataSourceConfigurationTest {
+class DataSourceConfigurationTest {
 
     @Test
-    public void testFullConfiguration() throws Exception {
+    void testFullConfiguration() throws Exception {
         DataSourceFactory ds = getDataSourceFactory("yaml/full_db_pool.yml");
 
         assertThat(ds.getDriverClass()).isEqualTo("org.postgresql.Driver");
@@ -59,7 +59,7 @@ public class DataSourceConfigurationTest {
     }
 
     @Test
-    public void testMinimalConfiguration() throws Exception {
+    void testMinimalConfiguration() throws Exception {
         DataSourceFactory ds = getDataSourceFactory("yaml/minimal_db_pool.yml");
 
         assertThat(ds.getDriverClass()).isEqualTo("org.postgresql.Driver");
@@ -101,7 +101,7 @@ public class DataSourceConfigurationTest {
     }
 
     @Test
-    public void testInlineUserPasswordConfiguration() throws Exception {
+    void testInlineUserPasswordConfiguration() throws Exception {
         DataSourceFactory ds = getDataSourceFactory("yaml/inline_user_pass_db_pool.yml");
 
         assertThat(ds.getDriverClass()).isEqualTo("org.postgresql.Driver");
@@ -109,10 +109,17 @@ public class DataSourceConfigurationTest {
         assertThat(ds.getUser()).isNull();
         assertThat(ds.getPassword()).isNull();
     }
+
     @Test
-    public void testInitialSizeZeroIsAllowed() throws Exception {
+    void testInitialSizeZeroIsAllowed() throws Exception {
         DataSourceFactory ds = getDataSourceFactory("yaml/empty_initial_pool.yml");
         assertThat(ds.getInitialSize()).isEqualTo(0);
+    }
+
+    @Test
+    void testEmptyDriverClassIsAllowed() throws Exception {
+        DataSourceFactory ds = getDataSourceFactory("yaml/empty_driver_class_db_pool.yml");
+        assertThat(ds.getDriverClass()).isNull();
     }
 
     private DataSourceFactory getDataSourceFactory(String resourceName) throws Exception {

--- a/dropwizard-db/src/test/resources/yaml/empty_driver_class_db_pool.yml
+++ b/dropwizard-db/src/test/resources/yaml/empty_driver_class_db_pool.yml
@@ -1,0 +1,3 @@
+user: pg-user
+password: iAMs00perSecrEET
+url: jdbc:postgresql://db.example.com/db-prod


### PR DESCRIPTION
The `driverClass` configuration setting is only required if no JDBC drivers have been registered with the Java service loader (`META-INF/services/java.sql.Driver`).

Closes #3506