### PR TITLE
Fix logFormat configuration inconsistencies

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -694,6 +694,8 @@ target                 stdout                                   The name of the 
 logFormat              %-5p [%d{ISO8601,UTC}] %c: %m%n%rEx      The Logback pattern with which events will be formatted. See
                                                                 the Logback_ documentation for details.
                                                                 The default log pattern is ```%h %l %u [%t{dd/MMM/yyyy:HH:mm:ss Z,UTC}] "%r" %s %b "%i{Referer}" "%i{User-Agent}" %D```.
+                                                                Use the placeholder ``%dwTimeZone`` to include the value of
+                                                                ``timeZone`` in the pattern.
 filterFactories        (none)                                   The list of filters to apply to the appender, in order, after
                                                                 the threshold.
 neverBlock             false                                    Prevent the wrapping asynchronous appender from blocking when its underlying queue is full.
@@ -762,6 +764,8 @@ timeZone                     UTC                                        The time
 logFormat                    %-5p [%d{ISO8601,UTC}] %c: %m%n%rEx        The Logback pattern with which events will be formatted. See
                                                                         the Logback_ documentation for details.
                                                                         The default log pattern is ```%h %l %u [%t{dd/MMM/yyyy:HH:mm:ss Z,UTC}] "%r" %s %b "%i{Referer}" "%i{User-Agent}" %D```.
+                                                                        Use the placeholder ``%dwTimeZone`` to include the value of
+                                                                        ``timeZone`` in the pattern.
 filterFactories              (none)                                     The list of filters to apply to the appender, in order, after
                                                                         the threshold.
 neverBlock                   false                                      Prevent the wrapping asynchronous appender from blocking when its underlying queue is full.

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/AbstractAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/AbstractAppenderFactory.java
@@ -266,7 +266,6 @@ public abstract class AbstractAppenderFactory<E extends DeferredProcessingAware>
         }
     }
 
-    @SuppressWarnings("NullAway")
     protected LayoutBase<E> buildLayout(LoggerContext context, LayoutFactory<E> defaultLayoutFactory) {
         final LayoutBase<E> layoutBase;
         if (layout == null) {
@@ -276,6 +275,7 @@ public abstract class AbstractAppenderFactory<E extends DeferredProcessingAware>
         }
         if (!Strings.isNullOrEmpty(logFormat)) {
             if (layoutBase instanceof PatternLayoutBase) {
+                @SuppressWarnings("NullAway")
                 String logFormatWithTimeZone = logFormat.replace("%dwTimeZone", timeZone.getID());
                 ((PatternLayoutBase<E>)layoutBase).setPattern(logFormatWithTimeZone);
             } else {

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/AbstractAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/AbstractAppenderFactory.java
@@ -266,6 +266,7 @@ public abstract class AbstractAppenderFactory<E extends DeferredProcessingAware>
         }
     }
 
+    @SuppressWarnings("NullAway")
     protected LayoutBase<E> buildLayout(LoggerContext context, LayoutFactory<E> defaultLayoutFactory) {
         final LayoutBase<E> layoutBase;
         if (layout == null) {

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/AbstractAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/AbstractAppenderFactory.java
@@ -275,7 +275,8 @@ public abstract class AbstractAppenderFactory<E extends DeferredProcessingAware>
         }
         if (!Strings.isNullOrEmpty(logFormat)) {
             if (layoutBase instanceof PatternLayoutBase) {
-                ((PatternLayoutBase<E>)layoutBase).setPattern(logFormat);
+                String logFormatWithTimeZone = logFormat.replace("%dwTimeZone", timeZone.getID());
+                ((PatternLayoutBase<E>)layoutBase).setPattern(logFormatWithTimeZone);
             } else {
                 LOGGER.warn("Ignoring 'logFormat', because 'layout' does not extend PatternLayoutBase");
             }

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/AppenderFactoryCustomLayoutTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/AppenderFactoryCustomLayoutTest.java
@@ -8,6 +8,7 @@ import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
+import io.dropwizard.logging.TestPatternLayoutFactory.TestPatternLayout;
 import io.dropwizard.logging.async.AsyncLoggingEventAppenderFactory;
 import io.dropwizard.logging.filter.NullLevelFilterFactory;
 import io.dropwizard.logging.layout.DropwizardLayoutFactory;
@@ -33,18 +34,20 @@ public class AppenderFactoryCustomLayoutTest {
     private final YamlConfigurationFactory<ConsoleAppenderFactory> factory = new YamlConfigurationFactory<>(
         ConsoleAppenderFactory.class, BaseValidator.newValidator(), objectMapper, "dw-layout");
 
-    private static File loadResource() throws URISyntaxException {
-        return new File(Resources.getResource("yaml/appender_with_custom_layout.yml").toURI());
+    private static File loadResource(String resourceName) throws URISyntaxException {
+        return new File(Resources.getResource(resourceName).toURI());
     }
 
     @BeforeEach
     public void setUp() throws Exception {
         objectMapper.registerSubtypes(TestLayoutFactory.class);
+        objectMapper.registerSubtypes(TestPatternLayoutFactory.class);
     }
 
     @Test
     public void testLoadAppenderWithCustomLayout() throws Exception {
-        final ConsoleAppenderFactory<ILoggingEvent> appender = factory.build(loadResource());
+        final ConsoleAppenderFactory<ILoggingEvent> appender = factory
+            .build(loadResource("yaml/appender_with_custom_layout.yml"));
         assertThat(appender.getLayout()).isNotNull().isInstanceOf(TestLayoutFactory.class);
         TestLayoutFactory layoutFactory = (TestLayoutFactory) appender.getLayout();
         assertThat(layoutFactory).isNotNull().extracting(TestLayoutFactory::isIncludeSeparator).isEqualTo(true);
@@ -52,12 +55,23 @@ public class AppenderFactoryCustomLayoutTest {
 
     @Test
     public void testBuildAppenderWithCustomLayout() throws Exception {
-        AsyncAppender appender = (AsyncAppender) factory.build(loadResource())
-            .build(new LoggerContext(), "test-custom-layout", new DropwizardLayoutFactory(),
-                new NullLevelFilterFactory<>(), new AsyncLoggingEventAppenderFactory());
-
-        ConsoleAppender<?> consoleAppender = (ConsoleAppender<?>) appender.getAppender("console-appender");
+        ConsoleAppender<?> consoleAppender = buildAppender("yaml/appender_with_custom_layout.yml");
         LayoutWrappingEncoder<?> encoder = (LayoutWrappingEncoder<?>) consoleAppender.getEncoder();
         assertThat(encoder.getLayout()).isInstanceOf(TestLayoutFactory.TestLayout.class);
+    }
+
+    @Test
+    public void testBuildAppenderWithCustomPatternLayoutAndFormat() throws Exception {
+        ConsoleAppender<?> consoleAppender = buildAppender("yaml/appender_with_custom_layout_and_format.yml");
+        LayoutWrappingEncoder<?> encoder = (LayoutWrappingEncoder<?>) consoleAppender.getEncoder();
+        TestPatternLayout layout = (TestPatternLayout) encoder.getLayout();
+        assertThat(layout.getPattern()).isEqualTo("custom pattern");
+    }
+
+    private ConsoleAppender<?> buildAppender(String resourceName) throws Exception {
+        AsyncAppender appender = (AsyncAppender) factory.build(loadResource(resourceName))
+            .build(new LoggerContext(), "test-custom-layout", new DropwizardLayoutFactory(),
+                new NullLevelFilterFactory<>(), new AsyncLoggingEventAppenderFactory());
+        return (ConsoleAppender<?>) appender.getAppender("console-appender");
     }
 }

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/TestPatternLayoutFactory.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/TestPatternLayoutFactory.java
@@ -1,0 +1,33 @@
+package io.dropwizard.logging;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.LayoutBase;
+import ch.qos.logback.core.pattern.PatternLayoutBase;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.dropwizard.logging.layout.DiscoverableLayoutFactory;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.TimeZone;
+
+@JsonTypeName("test-pattern")
+public class TestPatternLayoutFactory implements DiscoverableLayoutFactory<ILoggingEvent> {
+
+    @Override
+    public LayoutBase<ILoggingEvent> build(LoggerContext context, TimeZone timeZone) {
+        return new TestPatternLayout();
+    }
+
+    public static class TestPatternLayout extends PatternLayoutBase<ILoggingEvent> {
+        @Override
+        public String doLayout(ILoggingEvent event) {
+            return "TEST PATTERN!\n";
+        }
+
+        @Override
+        public Map<String, String> getDefaultConverterMap() {
+            return Collections.emptyMap();
+        }
+    }
+}

--- a/dropwizard-logging/src/test/resources/yaml/appender_with_custom_layout_and_format.yml
+++ b/dropwizard-logging/src/test/resources/yaml/appender_with_custom_layout_and_format.yml
@@ -1,0 +1,4 @@
+type: console
+layout:
+  type: test-pattern
+logFormat: "custom pattern"

--- a/dropwizard-logging/src/test/resources/yaml/appender_with_time_zone_placeholder.yml
+++ b/dropwizard-logging/src/test/resources/yaml/appender_with_time_zone_placeholder.yml
@@ -1,0 +1,3 @@
+type: console
+timeZone: UTC
+logFormat: "custom format with %dwTimeZone"


### PR DESCRIPTION
###### Problem:
As described in #3481, there are two limitations in the appender configuration:

1. When using the **layout** option to set a custom `LayoutFactory`, the **logFormat** is always ignored.
2. The time zone information in a custom **logFormat** is a fixed part of the string and may contradict the configured **timeZone** option.

###### Solution:
1. `AbstractAppenderFactory` applies the **logFormat** to any `LayoutFactory` that derives from `PatternLayoutBase`, not just to the default factory. If a **logFormat** is set along with a non-pattern **layout**, a warning will be logged.
2. The introduction of the placeholder `%dwTimeZone` allows the time zone information in a custom log format to depend on the value of the **timeZone** option.

Closes #3481