### PR TITLE
Move SonarQube settings to GitHub workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -59,7 +59,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      run: ./mvnw --no-transfer-progress -Pjakarta-apis -V -B -ff -s .github/settings.xml org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+      run: ./mvnw --no-transfer-progress -Pjakarta-apis -V -B -ff -s .github/settings.xml -Dsonar.projectKey=dropwizard_dropwizard -Dsonar.organization=dropwizard -Dsonar.host.url=https://sonarcloud.io -Dsonar.moduleKey='${project.artifactId}' org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1
       if: matrix.java_version == '8'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -59,7 +59,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      run: ./mvnw --no-transfer-progress -Pjakarta-apis -V -B -ff -s .github/settings.xml -Dsonar.projectKey=dropwizard_dropwizard -Dsonar.organization=dropwizard -Dsonar.host.url=https://sonarcloud.io -Dsonar.moduleKey='${project.artifactId}' org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+      run: ./mvnw --no-transfer-progress -Pjakarta-apis -V -B -ff -s .github/settings.xml -Dsonar.projectKey=dropwizard_dropwizard -Dsonar.organization=dropwizard -Dsonar.host.url=https://sonarcloud.io org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1
       if: matrix.java_version == '8'

--- a/pom.xml
+++ b/pom.xml
@@ -80,11 +80,6 @@
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <sonar-maven-plugin.version>3.7.0.1746</sonar-maven-plugin.version>
-
-        <sonar.projectKey>dropwizard_dropwizard</sonar.projectKey>
-        <sonar.organization>dropwizard</sonar.organization>
-        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>
     </properties>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,8 @@
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <sonar-maven-plugin.version>3.7.0.1746</sonar-maven-plugin.version>
+
+        <sonar.moduleKey>${project.groupId}:${project.artifactId}</sonar.moduleKey>
     </properties>
 
     <developers>


### PR DESCRIPTION
Avoid leaking SonarQube/SonarCloud configuration properties from `dropwizard-project`/`dropwizard-bom`/`dropwizard-dependencies` into projects using `dropwizard-dependencies` as their Parent POM.

Closes #3531