### PR TITLE
Run SonarCloud analysis only in dropwizard/dropwizard

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,7 +42,7 @@ jobs:
           ${{ runner.os }}-maven-
     - name: Cache SonarCloud packages
       uses: actions/cache@v2.1.2
-      if: matrix.java_version == '11'
+      if: ${{ github.repository == 'dropwizard/dropwizard' && matrix.java_version == '11' }}
       with:
         path: ~/.sonar/cache
         key: ${{ runner.os }}-sonar
@@ -55,7 +55,7 @@ jobs:
     - name: Build
       run: ./mvnw --no-transfer-progress -Pjakarta-apis -V -B -ff -s .github/settings.xml install
     - name: Analyze with SonarCloud
-      if: matrix.java_version == '11'
+      if: ${{ github.repository == 'dropwizard/dropwizard' && matrix.java_version == '11' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Forked repositories don't have access to the `SONAR_TOKEN` secret and thus cannot run the SonarCloud analysis as part of the build.