### PR TITLE
Prevent deep recursion in ConfigurationMetadata

### DIFF
--- a/dropwizard-configuration/pom.xml
+++ b/dropwizard-configuration/pom.xml
@@ -77,6 +77,11 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationMetadataTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationMetadataTest.java
@@ -97,7 +97,7 @@ class ConfigurationMetadataTest {
     }
 
     public static class SelfReferencingConfiguration {
-        private String str;
+        private String str = "test";
 
         @JsonProperty
         public SelfReferencingConfiguration getSelfReferencingConfiguration() {
@@ -111,10 +111,10 @@ class ConfigurationMetadataTest {
     }
 
     public static class SelfReferencingIgnoredConfiguration {
-        private String str;
-        private Long number;
+        private String str = "test";
+        private Long number = 42L;
         @JsonIgnore
-        private SelfReferencingConfiguration ignored;
+        private SelfReferencingConfiguration ignored = new SelfReferencingConfiguration();
 
         @JsonIgnore
         public SelfReferencingConfiguration getSelfReferencingConfiguration() {


### PR DESCRIPTION
Processing a configuration class with self-referencing fields could lead to an `OutOfMemoryError`.

To prevent this, multiple safe guards have been added:

- Reduce recursion depth from 100 to 10 levels
- Check for loops in the parents of a property
- Take `@JsonIgnore` annotation into account

Fixes #3528