### PR TITLE
Reduce flakiness of LayoutIntegrationTests

### DIFF
--- a/dropwizard-json-logging/pom.xml
+++ b/dropwizard-json-logging/pom.xml
@@ -116,6 +116,11 @@
             <artifactId>dropwizard-configuration</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -149,10 +150,10 @@ public class LayoutIntegrationTests {
             defaultLoggingFactory.configure(new MetricRegistry(), "json-log-test");
             Marker marker = MarkerFactory.getMarker("marker");
             LoggerFactory.getLogger("com.example.app").info(marker, "Application log");
-            Thread.sleep(100); // Need to wait, because the logger is async
+            // Need to wait, because the logger is async
+            await().atMost(1, TimeUnit.SECONDS).until(() -> !redirectedStream.toString().isEmpty());
 
             JsonNode jsonNode = objectMapper.readTree(redirectedStream.toString());
-            assertThat(jsonNode).isNotNull();
             assertThat(jsonNode.get("timestamp").isTextual()).isTrue();
             assertThat(jsonNode.get("level").asText()).isEqualTo("INFO");
             assertThat(jsonNode.get("logger").asText()).isEqualTo("com.example.app");
@@ -204,10 +205,10 @@ public class LayoutIntegrationTests {
             when(response.getHeader("Server")).thenReturn("Apache/2.4.12");
 
             requestLog.log(request, response);
-            Thread.sleep(100); // Need to wait, because the logger is async
+            // Need to wait, because the logger is async
+            await().atMost(1, TimeUnit.SECONDS).until(() -> !redirectedStream.toString().isEmpty());
 
             JsonNode jsonNode = objectMapper.readTree(redirectedStream.toString());
-            assertThat(jsonNode).isNotNull();
             assertThat(jsonNode.get("timestamp").isNumber()).isTrue();
             assertThat(jsonNode.get("requestTime").isNumber()).isTrue();
             assertThat(jsonNode.get("remoteAddress").asText()).isEqualTo("10.0.0.1");


### PR DESCRIPTION
###### Problem:
Got random build failures while working on #3530 due to two tests in `LayoutIntegrationTests` waiting for log output using a one-off call to `Thread.sleep()`. In addition to being brittle, the tests will fail with an NPE (while trying to assert on the "timestamp" field) that doesn't point to the cause of the failure directly.

###### Solution:
Using Awaitility instead of `Thread.sleep()` which will periodically check if either the log output is present or a timeout has been reached.
