### PR TITLE
Add ConfigOverride for random application ports during tests

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/ConfigOverride.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/ConfigOverride.java
@@ -30,42 +30,40 @@ import java.util.function.Supplier;
  * <li><code>ConfigOverride.config("logging.loggers.com\\.example\\.bar",
  * "DEBUG")</code> will add a logger with the name "com.example.bar" configured
  * for debug logging.</li>
+ * <li><code>ConfigOverride.randomPorts()</code> will change the ports of the
+ * default applicationConnectors and adminConnectors to 0 so the tests start
+ * with random ports.</li>
  * </ul>
  */
-public class ConfigOverride {
+public abstract class ConfigOverride {
 
     public static final String DEFAULT_PREFIX = "dw.";
-    private final String key;
-    private final Supplier<String> value;
-    private final String propertyPrefix;
-
-    private ConfigOverride(String propertyPrefix, String key, Supplier<String> value) {
-        this.key = key;
-        this.value = value;
-        this.propertyPrefix = propertyPrefix.endsWith(".") ? propertyPrefix : propertyPrefix + ".";
-    }
 
     public static ConfigOverride config(String key, String value) {
-        return new ConfigOverride(DEFAULT_PREFIX, key, () -> value);
+        return new ConfigOverrideValue(DEFAULT_PREFIX, key, () -> value);
     }
 
     public static ConfigOverride config(String propertyPrefix, String key, String value) {
-        return new ConfigOverride(propertyPrefix, key, () -> value);
+        return new ConfigOverrideValue(propertyPrefix, key, () -> value);
     }
 
     public static ConfigOverride config(String key, Supplier<String> value) {
-        return new ConfigOverride(DEFAULT_PREFIX, key, value);
+        return new ConfigOverrideValue(DEFAULT_PREFIX, key, value);
     }
 
     public static ConfigOverride config(String propertyPrefix, String key, Supplier<String> value) {
-        return new ConfigOverride(propertyPrefix, key, value);
+        return new ConfigOverrideValue(propertyPrefix, key, value);
     }
 
-    public void addToSystemProperties() {
-        System.setProperty(propertyPrefix + key, value.get());
+    public static ConfigOverride randomPorts() {
+        return new ConfigOverrideRandomPorts(DEFAULT_PREFIX);
     }
 
-    public void removeFromSystemProperties() {
-        System.clearProperty(propertyPrefix + key);
+    public static ConfigOverride randomPorts(String propertyPrefix) {
+        return new ConfigOverrideRandomPorts(propertyPrefix);
     }
+
+    public abstract void addToSystemProperties();
+
+    public abstract void removeFromSystemProperties();
 }

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/ConfigOverrideRandomPorts.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/ConfigOverrideRandomPorts.java
@@ -1,0 +1,23 @@
+package io.dropwizard.testing;
+
+public class ConfigOverrideRandomPorts extends ConfigOverride {
+
+    private static final String SERVER_APPLICATION_CONNECTORS_PORT = "server.applicationConnectors[0].port";
+    private static final String SERVER_ADMIN_CONNECTORS_PORT = "server.adminConnectors[0].port";
+
+    private final String propertyPrefix;
+
+    ConfigOverrideRandomPorts(String propertyPrefix) {
+        this.propertyPrefix = propertyPrefix.endsWith(".") ? propertyPrefix : propertyPrefix + ".";
+    }
+
+    public void addToSystemProperties() {
+        System.setProperty(propertyPrefix + SERVER_APPLICATION_CONNECTORS_PORT, "0");
+        System.setProperty(propertyPrefix + SERVER_ADMIN_CONNECTORS_PORT, "0");
+    }
+
+    public void removeFromSystemProperties() {
+        System.clearProperty(propertyPrefix + SERVER_APPLICATION_CONNECTORS_PORT);
+        System.clearProperty(propertyPrefix + SERVER_ADMIN_CONNECTORS_PORT);
+    }
+}

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/ConfigOverrideValue.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/ConfigOverrideValue.java
@@ -1,0 +1,24 @@
+package io.dropwizard.testing;
+
+import java.util.function.Supplier;
+
+public class ConfigOverrideValue extends ConfigOverride {
+
+    private final String key;
+    private final Supplier<String> value;
+    private final String propertyPrefix;
+
+    ConfigOverrideValue(String propertyPrefix, String key, Supplier<String> value) {
+        this.key = key;
+        this.value = value;
+        this.propertyPrefix = propertyPrefix.endsWith(".") ? propertyPrefix : propertyPrefix + ".";
+    }
+
+    public void addToSystemProperties() {
+        System.setProperty(propertyPrefix + key, value.get());
+    }
+
+    public void removeFromSystemProperties() {
+        System.clearProperty(propertyPrefix + key);
+    }
+}

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionRandomPortsConfigOverrideTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionRandomPortsConfigOverrideTest.java
@@ -1,0 +1,39 @@
+package io.dropwizard.testing.junit5;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.dropwizard.jetty.HttpConnectorFactory;
+import io.dropwizard.server.DefaultServerFactory;
+import io.dropwizard.testing.app.TestApplication;
+import io.dropwizard.testing.app.TestConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+class DropwizardAppExtensionRandomPortsConfigOverrideTest {
+
+    private static final DropwizardAppExtension<TestConfiguration> EXTENSION =
+        new DropwizardAppExtension<>(TestApplication.class,
+            null,
+            "app-rule",
+            randomPorts("app-rule"),
+            config("app-rule", "message", "A new way to say Hooray!"),
+            config("app-rule", "extra", () -> "supplied"));
+
+    @Test
+    void supportsRandomPortsConfigAttributeOverrides() {
+        DefaultServerFactory serverFactory = (DefaultServerFactory) EXTENSION.getConfiguration()
+            .getServerFactory();
+
+        assertThat(
+            serverFactory.getApplicationConnectors().stream().map(HttpConnectorFactory.class::cast))
+            .extracting(
+                HttpConnectorFactory::getPort).containsExactly(0);
+        assertThat(
+            serverFactory.getAdminConnectors().stream().map(HttpConnectorFactory.class::cast))
+            .extracting(
+                HttpConnectorFactory::getPort).containsExactly(0);
+    }
+}


### PR DESCRIPTION
###### Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->

We are doing a lot of integration testing where we need to start the application. We primarily use the config overrides instead of a `test-config.yaml` to do the configuration. Our config files of the test module often only contain the configuration for the random ports:
```yaml
server:
  applicationConnectors:
    - type: http
      port: 0
  adminConnectors:
    - type: http
      port: 0
```

It would be nice to be able to use random ports with the `DropwizardAppRule`/`DropwizardAppExtension` programmatically.

###### Solution:
<!-- Describe the modifications you've done. -->

Add a Config Override that configures the default application and admin connectors to use port `0`.

```java
private static final DropwizardAppExtension<MyConfiguration> EXTENSION =
    new DropwizardAppExtension<>(MyApplication.class,
        // no config file
        null,
        // adds all necessary config overrides for random ports
        randomPorts());
```

I refactored the `ConfigOverride` class to an abstract class and added two implementations: `ConfigOverrideValue` (the existing behavior) and `ConfigOverrideRandomPorts` (the new option). Both are instanciated from static functions in `ConfigOverride`. This change would also allow application developers to build reusable grouped config overrides if needed.

Do you think this is a valid extension? I am happy to discuss the changes and do changes if needed.