### PR TITLE
Tighten up commons-lang3 dependencies

### DIFF
--- a/dropwizard-client/pom.xml
+++ b/dropwizard-client/pom.xml
@@ -82,10 +82,6 @@
             <artifactId>jersey-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>
@@ -139,6 +135,11 @@
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>test></scope>
         </dependency>
     </dependencies>
 </project>

--- a/dropwizard-jetty/pom.xml
+++ b/dropwizard-jetty/pom.xml
@@ -50,10 +50,6 @@
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-io</artifactId>
         </dependency>
@@ -124,6 +120,11 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/dropwizard-logging/pom.xml
+++ b/dropwizard-logging/pom.xml
@@ -34,10 +34,6 @@
             <artifactId>metrics-logback</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
@@ -90,6 +86,11 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/dropwizard-migrations/pom.xml
+++ b/dropwizard-migrations/pom.xml
@@ -34,10 +34,6 @@
             <artifactId>jsr305</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
             <exclusions>
@@ -101,12 +97,15 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>net.jcip</groupId>
             <artifactId>jcip-annotations</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
###### Problem:
I noticed `dropwizard-logging` included a dependency on `commons-lang3` and thought to myself "I bet it doesn't really need that"

###### Solution:
I've discovered `commons-lang3` is mostly only used in tests, so I constrained some of the dependencies to `test` scope where possible.

###### Result:
`dropwizard-client`, `dropwizard-jetty`, `dropwizard-logging` and `dropwizard-migrations` will no longer bundle or require `commons-lang3`

In fact commons-lang3 is only used in the following non-test code:

- dropwizard-benchmarks/src/main/java/io/dropwizard/benchmarks/jersey/ConstraintViolationBenchmark.java
- dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ConstraintMessage.java
- dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ConstraintMessage.java
- dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/ConstraintMessage.java
- dropwizard-views/src/main/java/io/dropwizard/views/ViewRenderExceptionMapper.java

Almost entirely for doing reflective things