### PR TITLE
Tighten up tomcat-jdbc dependency in dropwizard-migrations

### DIFF
--- a/dropwizard-migrations/pom.xml
+++ b/dropwizard-migrations/pom.xml
@@ -53,10 +53,6 @@
             <artifactId>argparse4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.tomcat</groupId>
-            <artifactId>tomcat-jdbc</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
@@ -100,6 +96,11 @@
         <dependency>
             <groupId>net.jcip</groupId>
             <artifactId>jcip-annotations</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-jdbc</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
`dropwizard-migrations` only needs it for `CloseableLiquibaseTest`. Move the dependency to `test`.

We do still depend on `dropwizard-db` which pulls it in, so there isn't really a change to the overall dependency graph here.
