### PR TITLE
Added DualSessionFactory component within the existing Hibernate Unit…

### DIFF
--- a/dropwizard-hibernate/pom.xml
+++ b/dropwizard-hibernate/pom.xml
@@ -146,6 +146,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/HibernateBundle.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/HibernateBundle.java
@@ -23,11 +23,11 @@ public abstract class HibernateBundle<T> implements ConfiguredBundle<T>, Databas
     public static final String DEFAULT_NAME = "hibernate";
 
     @Nullable
-    private SessionFactory sessionFactory;
-    private boolean lazyLoadingEnabled = true;
+    protected SessionFactory sessionFactory;
+    protected boolean lazyLoadingEnabled = true;
 
-    private final List<Class<?>> entities;
-    private final SessionFactoryFactory sessionFactoryFactory;
+    protected final List<Class<?>> entities;
+    protected final SessionFactoryFactory sessionFactoryFactory;
 
     protected HibernateBundle(Class<?> entity, Class<?>... entities) {
         final List<Class<?>> entityClasses = new ArrayList<>();
@@ -69,7 +69,7 @@ public abstract class HibernateBundle<T> implements ConfiguredBundle<T>, Databas
     }
 
     @Override
-    public final void run(T configuration, Environment environment) throws Exception {
+    public void run(T configuration, Environment environment) throws Exception {
         final PooledDataSourceFactory dbConfig = getDataSourceFactory(configuration);
         this.sessionFactory = requireNonNull(sessionFactoryFactory.build(this, environment, dbConfig,
             entities, name()));

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/dual/DualSessionFactory.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/dual/DualSessionFactory.java
@@ -1,0 +1,171 @@
+package io.dropwizard.hibernate.dual;
+
+import org.hibernate.Cache;
+import org.hibernate.HibernateException;
+import org.hibernate.Metamodel;
+import org.hibernate.Session;
+import org.hibernate.SessionBuilder;
+import org.hibernate.SessionFactory;
+import org.hibernate.StatelessSession;
+import org.hibernate.StatelessSessionBuilder;
+import org.hibernate.TypeHelper;
+import org.hibernate.boot.spi.SessionFactoryOptions;
+import org.hibernate.engine.spi.FilterDefinition;
+import org.hibernate.metadata.ClassMetadata;
+import org.hibernate.metadata.CollectionMetadata;
+import org.hibernate.stat.Statistics;
+
+import javax.naming.NamingException;
+import javax.naming.Reference;
+import javax.persistence.EntityGraph;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceUnitUtil;
+import javax.persistence.Query;
+import javax.persistence.SynchronizationType;
+import javax.persistence.criteria.CriteriaBuilder;
+
+import java.sql.Connection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Represents a wrapper/decorator class for a Hibernate session factory that can manage
+ *  both a primary session factory and a read-only session factory.
+ *
+ * @author smalleyd2
+ * @version 2.1
+ * @since 11/25/2020
+ *
+ */
+
+@SuppressWarnings({"deprecation", "rawtypes"})
+public class DualSessionFactory implements SessionFactory {
+
+    private static final long serialVersionUID = 1L;
+
+    private final SessionFactory primary;
+    private final SessionFactory reader;
+    private final ThreadLocal<SessionFactory> current = new ThreadLocal<SessionFactory>();
+
+    public DualSessionFactory(final SessionFactory primary, final SessionFactory reader) {
+        this.primary = primary;
+        this.reader = reader;
+        this.current.set(primary);    // Main thread should use primary.
+    }
+
+    /** Activates either the primary or the reader session factory depending on the readOnly parameter.
+     * 
+     * @param readOnly
+     * @return the session factory in use
+     */
+    public SessionFactory prepare(final boolean readOnly) {
+        final SessionFactory factory = readOnly ? reader : primary;
+        current.set(factory);
+
+        return factory;
+    }
+
+    public SessionFactory current() { return current.get(); }
+
+    @Override
+    public EntityManager createEntityManager() { return current().createEntityManager(); }
+
+    @Override
+    public EntityManager createEntityManager(final Map map) { return current().createEntityManager(map); }
+
+    @Override
+    public EntityManager createEntityManager(final SynchronizationType synchronizationType) { return current().createEntityManager(synchronizationType); }
+
+    @Override
+    public EntityManager createEntityManager(final SynchronizationType synchronizationType, final Map map) { return current().createEntityManager(synchronizationType, map); }
+
+    @Override
+    public CriteriaBuilder getCriteriaBuilder() { return current().getCriteriaBuilder(); }
+
+    @Override
+    public boolean isOpen() { return current().isOpen(); }
+
+    @Override
+    public Map<String, Object> getProperties() { return current().getProperties(); }
+
+    @Override
+    public PersistenceUnitUtil getPersistenceUnitUtil() { return current().getPersistenceUnitUtil(); }
+
+    @Override
+    public void addNamedQuery(String name, Query query) { current().addNamedQuery(name, query); }
+
+    @Override
+    public <T> T unwrap(Class<T> cls) { return current().unwrap(cls); }
+
+    @Override
+    public <T> void addNamedEntityGraph(String graphName, EntityGraph<T> entityGraph) { current().addNamedEntityGraph(graphName, entityGraph); }
+
+    @Override
+    public <T> List<EntityGraph<? super T>> findEntityGraphsByType(Class<T> entityClass) { return current().findEntityGraphsByType(entityClass); }
+
+    @Override
+    public Metamodel getMetamodel() { return current().getMetamodel(); }
+
+    @Override
+    public Reference getReference() throws NamingException { return current().getReference(); }
+
+    @Override
+    public SessionFactoryOptions getSessionFactoryOptions() { return current().getSessionFactoryOptions(); }
+
+    @Override
+    public SessionBuilder withOptions() { return current().withOptions(); }
+
+    @Override
+    public Session openSession() throws HibernateException { return current().openSession(); }
+
+    @Override
+    public Session getCurrentSession() throws HibernateException { return current().getCurrentSession(); }
+
+    @Override
+    public StatelessSessionBuilder withStatelessOptions() { return current().withStatelessOptions(); }
+
+    @Override
+    public StatelessSession openStatelessSession() { return current().openStatelessSession(); }
+
+    @Override
+    public StatelessSession openStatelessSession(Connection connection) { return current().openStatelessSession(connection); }
+
+    @Override
+    public Statistics getStatistics() { return current().getStatistics(); }
+
+    @Override
+    public void close() throws HibernateException { current().close(); }
+
+    @Override
+    public boolean isClosed() { return current().isClosed(); }
+
+    @Override
+    public Cache getCache() { return current().getCache(); }
+
+    @Override
+    public Set getDefinedFilterNames() { return current().getDefinedFilterNames(); }
+
+    @Override
+    public FilterDefinition getFilterDefinition(String filterName) throws HibernateException { return current().getFilterDefinition(filterName); }
+
+    @Override
+    public boolean containsFetchProfileDefinition(String name) { return current().containsFetchProfileDefinition(name); }
+
+    @Override
+    public TypeHelper getTypeHelper() { return current().getTypeHelper(); }
+
+    @Override
+    public ClassMetadata getClassMetadata(Class entityClass) { return current().getClassMetadata(entityClass); }
+
+    @Override
+    public ClassMetadata getClassMetadata(String entityName) { return current().getClassMetadata(entityName); }
+
+    @Override
+    public CollectionMetadata getCollectionMetadata(String roleName) { return current().getCollectionMetadata(roleName); }
+
+    @Override
+    public Map<String, ClassMetadata> getAllClassMetadata() { return current().getAllClassMetadata(); }
+
+    @Override
+    public Map getAllCollectionMetadata() { return current().getAllCollectionMetadata(); }
+}

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/dual/HibernateBundle.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/dual/HibernateBundle.java
@@ -1,0 +1,82 @@
+package io.dropwizard.hibernate.dual;
+
+import static java.util.Objects.requireNonNull;
+
+import io.dropwizard.db.PooledDataSourceFactory;
+import io.dropwizard.hibernate.SessionFactoryFactory;
+import io.dropwizard.hibernate.SessionFactoryHealthCheck;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.util.Duration;
+import org.hibernate.SessionFactory;
+
+import java.util.List;
+
+public abstract class HibernateBundle<T> extends io.dropwizard.hibernate.HibernateBundle<T>
+{
+    public static final String PRIMARY = "hibernate-primary";
+    public static final String READER = "hibernate-reader";
+
+    protected HibernateBundle(Class<?> entity, Class<?>... entities) {
+        super(entity, entities);
+    }
+
+    protected HibernateBundle(List<Class<?>> entities,
+                              SessionFactoryFactory sessionFactoryFactory) {
+        super(entities, sessionFactoryFactory);
+    }
+
+    @Override
+    protected String name() {
+        return PRIMARY;
+    }
+
+    protected String reader() {
+        return READER;
+    }
+
+    abstract public PooledDataSourceFactory getReadSourceFactory(T configuration);
+
+    @Override
+    public final void run(T configuration, Environment environment) throws Exception {
+        final PooledDataSourceFactory primaryConfig = getDataSourceFactory(configuration);
+        final SessionFactory primary = requireNonNull(sessionFactoryFactory.build(this, environment, primaryConfig,
+            entities, name()));
+        final PooledDataSourceFactory readerConfig = getDataSourceFactory(configuration);
+        final SessionFactory reader = requireNonNull(sessionFactoryFactory.build(this, environment, readerConfig,
+            entities, reader()));
+        final DualSessionFactory factory = new DualSessionFactory(primary, reader);
+        registerUnitOfWorkListenerIfAbsent(environment).registerSessionFactory(name(), factory);
+        environment.healthChecks().register(name(),
+                                            new SessionFactoryHealthCheck(
+                                                    environment.getHealthCheckExecutorService(),
+                                                    primaryConfig.getValidationQueryTimeout().orElse(Duration.seconds(5)),
+                                                    this.sessionFactory = factory,
+                                                    primaryConfig.getValidationQuery()));
+    }
+
+    private UnitOfWorkApplicationListener registerUnitOfWorkListenerIfAbsent(Environment environment) {
+        for (Object singleton : environment.jersey().getResourceConfig().getSingletons()) {
+            if (singleton instanceof UnitOfWorkApplicationListener) {
+                return (UnitOfWorkApplicationListener) singleton;
+            }
+        }
+        final UnitOfWorkApplicationListener listener = new UnitOfWorkApplicationListener();
+        environment.jersey().register(listener);
+        return listener;
+    }
+
+    public boolean isLazyLoadingEnabled() {
+        return lazyLoadingEnabled;
+    }
+
+    public void setLazyLoadingEnabled(boolean lazyLoadingEnabled) {
+        this.lazyLoadingEnabled = lazyLoadingEnabled;
+    }
+
+    public SessionFactory getSessionFactory() {
+        return requireNonNull(sessionFactory);
+    }
+
+    protected void configure(org.hibernate.cfg.Configuration configuration) {
+    }
+}

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/dual/UnitOfWorkApplicationListener.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/dual/UnitOfWorkApplicationListener.java
@@ -1,0 +1,109 @@
+package io.dropwizard.hibernate.dual;
+
+import io.dropwizard.hibernate.UnitOfWork;
+
+import org.glassfish.jersey.server.internal.process.MappableException;
+import org.glassfish.jersey.server.model.ResourceMethod;
+import org.glassfish.jersey.server.monitoring.ApplicationEvent;
+import org.glassfish.jersey.server.monitoring.ApplicationEventListener;
+import org.glassfish.jersey.server.monitoring.RequestEvent;
+import org.glassfish.jersey.server.monitoring.RequestEventListener;
+
+import javax.ws.rs.ext.Provider;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/** Jersey server listener that wraps dual Hibernate session factories (writer & reader).
+ * 
+ * @author smalleyd
+ * @version 2.1.13
+ * @since 5/16/2016
+ *
+ */
+
+@Provider
+public class UnitOfWorkApplicationListener implements ApplicationEventListener {
+
+    private ConcurrentMap<ResourceMethod, Optional<UnitOfWork>> methodMap = new ConcurrentHashMap<>();
+    private Map<String, DualSessionFactory> sessionFactories = new HashMap<>();
+
+    public UnitOfWorkApplicationListener() {
+    }
+
+    /**
+     * Construct an application event listener using the given name and session factory.
+     *
+     * <p/>
+     * When using this constructor, the {@link UnitOfWorkApplicationListener}
+     * should be added to a Jersey {@code ResourceConfig} as a singleton.
+     *
+     * @param name a name of a Hibernate bundle
+     * @param sessionFactory a {@link SessionFactory}
+     */
+    public UnitOfWorkApplicationListener(String name, DualSessionFactory sessionFactory) {
+        registerSessionFactory(name, sessionFactory);
+    }
+
+    /**
+     * Register a session factory with the given name.
+     *
+     * @param name a name of a Hibernate bundle
+     * @param sessionFactory a {@link SessionFactory}
+     */
+    public void registerSessionFactory(String name, DualSessionFactory sessionFactory) {
+        sessionFactories.put(name, sessionFactory);
+    }
+
+    private static class UnitOfWorkEventListener implements RequestEventListener {
+        private ConcurrentMap<ResourceMethod, Optional<UnitOfWork>> methodMap;
+        private final UnitOfWorkAspect unitOfWorkAspect;
+
+        UnitOfWorkEventListener(ConcurrentMap<ResourceMethod, Optional<UnitOfWork>> methodMap,
+                                Map<String, DualSessionFactory> sessionFactories) {
+            this.methodMap = methodMap;
+            unitOfWorkAspect = new UnitOfWorkAspect(sessionFactories);
+        }
+
+        @Override
+        public void onEvent(RequestEvent event) {
+            final RequestEvent.Type eventType = event.getType();
+            if (eventType == RequestEvent.Type.RESOURCE_METHOD_START) {
+                Optional<UnitOfWork> unitOfWork = methodMap.computeIfAbsent(event.getUriInfo()
+                        .getMatchedResourceMethod(), UnitOfWorkEventListener::registerUnitOfWorkAnnotations);
+                unitOfWorkAspect.beforeStart(unitOfWork.orElse(null));
+            } else if (eventType == RequestEvent.Type.RESP_FILTERS_START) {
+                try {
+                    unitOfWorkAspect.afterEnd();
+                } catch (Exception e) {
+                    throw new MappableException(e);
+                }
+            } else if (eventType == RequestEvent.Type.ON_EXCEPTION) {
+                unitOfWorkAspect.onError();
+            } else if (eventType == RequestEvent.Type.FINISHED) {
+                unitOfWorkAspect.onFinish();
+            }
+        }
+
+        private static Optional<UnitOfWork> registerUnitOfWorkAnnotations(ResourceMethod method) {
+            UnitOfWork annotation = method.getInvocable().getDefinitionMethod().getAnnotation(UnitOfWork.class);
+            if (annotation == null) {
+                annotation = method.getInvocable().getHandlingMethod().getAnnotation(UnitOfWork.class);
+            }
+            return Optional.ofNullable(annotation);
+        }
+    }
+
+    @Override
+    public void onEvent(ApplicationEvent event) {
+    }
+
+    @Override
+    public RequestEventListener onRequest(RequestEvent event) {
+        return new UnitOfWorkEventListener(methodMap, sessionFactories);
+    }
+
+
+}

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/dual/UnitOfWorkAspect.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/dual/UnitOfWorkAspect.java
@@ -1,0 +1,209 @@
+package io.dropwizard.hibernate.dual;
+
+import io.dropwizard.hibernate.UnitOfWork;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.context.internal.ManagedSessionContext;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/** Wrapper class for the operations to perform on a primary SessionFactory and a reader SessionFactory for
+ *  a single UnitOfWork.
+ * 
+ * @author smalleyd
+ * @version 2.1.13
+ * @since 5/16/2016
+ *
+ */
+
+public class UnitOfWorkAspect {
+
+    private final Map<String, DualSessionFactory> sessionFactories;
+
+    public UnitOfWorkAspect(Map<String, DualSessionFactory> sessionFactories) {
+        this.sessionFactories = sessionFactories;
+    }
+
+    // Context variables
+    @Nullable
+    private UnitOfWork unitOfWork;
+
+    @Nullable
+    private Session session;
+
+    @Nullable
+    private SessionFactory sessionFactory;
+
+    // was the session created by this aspect?
+    private boolean sessionCreated;
+    // do we manage the transaction or did we join an existing one?
+    private boolean transactionStarted;
+
+    public void beforeStart(@Nullable UnitOfWork unitOfWork) {
+        if (unitOfWork == null) {
+            return;
+        }
+        this.unitOfWork = unitOfWork;
+
+        DualSessionFactory dual = sessionFactories.get(unitOfWork.value());
+        if (dual == null) {
+            // If the user didn't specify the name of a session factory,
+            // and we have only one registered, we can assume that it's the right one.
+            if (unitOfWork.value().equals(HibernateBundle.PRIMARY) && sessionFactories.size() == 1) {
+                dual = sessionFactories.values().iterator().next();
+            } else {
+                throw new IllegalArgumentException("Unregistered Hibernate bundle: '" + unitOfWork.value() + "'");
+            }
+        }
+
+        // Get either the primary session factory or the reader session factory.
+        sessionFactory = dual.prepare(unitOfWork.readOnly());
+
+        Session existingSession = null;
+        if(ManagedSessionContext.hasBind(sessionFactory)) {
+            existingSession = sessionFactory.getCurrentSession();
+        }
+
+        if(existingSession != null) {
+            sessionCreated = false;
+            session = existingSession;
+            validateSession();
+        } else {
+            sessionCreated = true;
+            session = sessionFactory.openSession();
+            try {
+                configureSession();
+                ManagedSessionContext.bind(session);
+            } catch (Throwable th) {
+                session.close();
+                session = null;
+                ManagedSessionContext.unbind(sessionFactory);
+                throw th;
+            }
+        }
+        beginTransaction(unitOfWork, session);
+    }
+
+    public void afterEnd() {
+        if (unitOfWork == null || session == null) {
+            return;
+        }
+
+        try {
+            commitTransaction(unitOfWork, session);
+        } catch (Exception e) {
+            rollbackTransaction(unitOfWork, session);
+            throw e;
+        }
+        // We should not close the session to let the lazy loading work during serializing a response to the client.
+        // If the response successfully serialized, then the session will be closed by the `onFinish` method
+    }
+
+    public void onError() {
+        if (unitOfWork == null || session == null) {
+            return;
+        }
+
+        try {
+            rollbackTransaction(unitOfWork, session);
+        } finally {
+            onFinish();
+        }
+    }
+
+    public void onFinish() {
+        try {
+            if (sessionCreated && session != null) {
+                session.close();
+            }
+        } finally {
+            session = null;
+            if(sessionCreated) {
+                ManagedSessionContext.unbind(sessionFactory);
+            }
+        }
+    }
+
+    protected void configureSession() {
+        if (unitOfWork == null || session == null) {
+            throw new NullPointerException("unitOfWork or session is null. This is a bug!");
+        }
+        session.setDefaultReadOnly(unitOfWork.readOnly());
+        session.setCacheMode(unitOfWork.cacheMode());
+        session.setHibernateFlushMode(unitOfWork.flushMode());
+    }
+
+    protected void validateSession() {
+        if (unitOfWork == null || session == null) {
+            throw new NullPointerException("unitOfWork or session is null. This is a bug!");
+        }
+        if(unitOfWork.readOnly() != session.isDefaultReadOnly()) {
+            throw new IllegalStateException(String.format(
+                "Existing session readOnly state (%b) does not match requested state (%b)",
+                session.isDefaultReadOnly(),
+                unitOfWork.readOnly()
+            ));
+        }
+        if(unitOfWork.cacheMode() != session.getCacheMode()) {
+            throw new IllegalStateException(String.format(
+                "Existing session cache mode (%s) does not match requested mode (%s)",
+                session.getCacheMode(),
+                unitOfWork.cacheMode()
+            ));
+        }
+        if(unitOfWork.flushMode() != session.getHibernateFlushMode()) {
+            throw new IllegalStateException(String.format(
+                "Existing session flush mode (%s) does not match requested mode (%s)",
+                session.getHibernateFlushMode(),
+                unitOfWork.flushMode()
+            ));
+        }
+    }
+
+    private void beginTransaction(UnitOfWork unitOfWork, Session session) {
+        if (!unitOfWork.transactional()) {
+            return;
+        }
+        final Transaction txn = session.getTransaction();
+        if(txn != null && txn.isActive()) {
+            transactionStarted = false;
+        } else {
+            session.beginTransaction();
+            transactionStarted = true;
+        }
+    }
+
+    private void rollbackTransaction(UnitOfWork unitOfWork, Session session) {
+        if (!unitOfWork.transactional()) {
+            return;
+        }
+        final Transaction txn = session.getTransaction();
+        if (transactionStarted && txn != null && txn.getStatus().canRollback()) {
+            txn.rollback();
+        }
+    }
+
+    private void commitTransaction(UnitOfWork unitOfWork, Session session) {
+        if (!unitOfWork.transactional()) {
+            return;
+        }
+        final Transaction txn = session.getTransaction();
+        if (transactionStarted && txn != null && txn.getStatus().canRollback()) {
+            txn.commit();
+        }
+    }
+
+    protected Session getSession() {
+        return requireNonNull(session);
+    }
+
+    protected SessionFactory getSessionFactory() {
+        return requireNonNull(sessionFactory);
+    }
+
+}

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/dual/DualSessionFactoryTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/dual/DualSessionFactoryTest.java
@@ -1,0 +1,81 @@
+package io.dropwizard.hibernate.dual;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** Unit test class that verifies the DualSessionFactory wrapper.
+ * 
+ * @author smalleyd
+ * @version 2.1
+ * @since 11/25/2020
+ *
+ */
+
+public class DualSessionFactoryTest {
+
+    private static final Session primary = mock(Session.class);
+    private static final SessionFactory primaryFactory = mock(SessionFactory.class);
+    private static final Session reader = mock(Session.class);
+    private static final SessionFactory readerFactory = mock(SessionFactory.class);
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        when(primaryFactory.getCurrentSession()).thenReturn(primary);
+        when(readerFactory.getCurrentSession()).thenReturn(reader);
+    }
+
+    public static Stream<Arguments> current() {
+        return Stream.of(
+            arguments(false, primaryFactory),
+            arguments(true, readerFactory));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void current(final boolean readOnly, final SessionFactory expected) {
+        try (final DualSessionFactory factory = new DualSessionFactory(primaryFactory, readerFactory)) {
+            factory.prepare(readOnly);
+            assertThat(factory.current()).isEqualTo(expected);
+        }
+    }
+
+    public static Stream<Arguments> getCurrentSession() {
+        return Stream.of(
+            arguments(false, primary),
+            arguments(true, reader));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void getCurrentSession(final boolean readOnly, final Session expected) {
+        try (final DualSessionFactory factory = new DualSessionFactory(primaryFactory, readerFactory)) {
+            factory.prepare(readOnly);
+            assertThat(factory.getCurrentSession()).isEqualTo(expected);
+        }
+    }
+
+    public static Stream<Arguments> prepare() {
+        return Stream.of(
+            arguments(false, primaryFactory),
+            arguments(true, readerFactory));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void prepare(final boolean readOnly, final SessionFactory expected) {
+        try (final DualSessionFactory factory = new DualSessionFactory(primaryFactory, readerFactory)) {
+            assertThat(factory.prepare(readOnly)).isEqualTo(expected);
+        }
+    }
+}

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/dual/HibernateBundleTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/dual/HibernateBundleTest.java
@@ -1,0 +1,169 @@
+package io.dropwizard.hibernate.dual;
+
+import com.codahale.metrics.health.HealthCheckRegistry;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.hibernate5.Hibernate5Module;
+import io.dropwizard.Configuration;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.hibernate.Person;
+import io.dropwizard.hibernate.SessionFactoryFactory;
+import io.dropwizard.hibernate.SessionFactoryHealthCheck;
+import io.dropwizard.jersey.DropwizardResourceConfig;
+import io.dropwizard.jersey.setup.JerseyEnvironment;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class HibernateBundleTest {
+    private final DataSourceFactory dbConfig = new DataSourceFactory();
+    private final DataSourceFactory readConfig = new DataSourceFactory();
+    private final List<Class<?>> entities = Collections.singletonList(Person.class);
+    private final SessionFactoryFactory factory = mock(SessionFactoryFactory.class);
+    private final SessionFactory sessionFactory = mock(SessionFactory.class);
+    private final SessionFactory readFactory = mock(SessionFactory.class);
+    private final Configuration configuration = mock(Configuration.class);
+    private final HealthCheckRegistry healthChecks = mock(HealthCheckRegistry.class);
+    private final JerseyEnvironment jerseyEnvironment = mock(JerseyEnvironment.class);
+    private final Environment environment = mock(Environment.class);
+    private final HibernateBundle<Configuration> bundle = new HibernateBundle<Configuration>(entities, factory) {
+        @Override
+        public DataSourceFactory getDataSourceFactory(Configuration configuration) {
+            return dbConfig;
+        }
+
+        @Override
+        public DataSourceFactory getReadSourceFactory(Configuration configuration) {
+            return readConfig;
+        }
+    };
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        when(environment.healthChecks()).thenReturn(healthChecks);
+        when(environment.jersey()).thenReturn(jerseyEnvironment);
+        when(jerseyEnvironment.getResourceConfig()).thenReturn(new DropwizardResourceConfig());
+
+
+        when(factory.build(eq(bundle),
+                           any(Environment.class),
+                           any(DataSourceFactory.class),
+                           anyList(),
+                           eq(HibernateBundle.PRIMARY))).thenReturn(sessionFactory);
+
+        when(factory.build(eq(bundle),
+                           any(Environment.class),
+                           any(DataSourceFactory.class),
+                           anyList(),
+                           eq(HibernateBundle.READER))).thenReturn(readFactory);
+    }
+
+    @Test
+    public void addsHibernateSupportToJackson() throws Exception {
+        final ObjectMapper objectMapperFactory = mock(ObjectMapper.class);
+
+        final Bootstrap<?> bootstrap = mock(Bootstrap.class);
+        when(bootstrap.getObjectMapper()).thenReturn(objectMapperFactory);
+
+        bundle.initialize(bootstrap);
+
+        final ArgumentCaptor<Module> captor = ArgumentCaptor.forClass(Module.class);
+        verify(objectMapperFactory).registerModule(captor.capture());
+
+        assertThat(captor.getValue()).isInstanceOf(Hibernate5Module.class);
+    }
+
+    @Test
+    public void buildsASessionFactory() throws Exception {
+        bundle.run(configuration, environment);
+
+        verify(factory).build(bundle, environment, dbConfig, entities, HibernateBundle.PRIMARY);
+    }
+
+    @Test
+    public void registersATransactionalListener() throws Exception {
+        bundle.run(configuration, environment);
+
+        final ArgumentCaptor<UnitOfWorkApplicationListener> captor =
+                ArgumentCaptor.forClass(UnitOfWorkApplicationListener.class);
+        verify(jerseyEnvironment).register(captor.capture());
+    }
+
+    @Test
+    public void registersASessionFactoryHealthCheck() throws Exception {
+        dbConfig.setValidationQuery("SELECT something");
+
+        bundle.run(configuration, environment);
+
+        final ArgumentCaptor<SessionFactoryHealthCheck> captor =
+                ArgumentCaptor.forClass(SessionFactoryHealthCheck.class);
+        verify(healthChecks).register(eq(HibernateBundle.PRIMARY), captor.capture());
+
+        assertThat(captor.getValue().getSessionFactory()).isInstanceOf(DualSessionFactory.class);
+
+        assertThat(captor.getValue().getValidationQuery()).isEqualTo(Optional.of("SELECT something"));
+    }
+
+    @Test
+    public void registersACustomNameOfHealthCheckAndDBPoolMetrics() throws Exception {
+        final HibernateBundle<Configuration> customBundle = new HibernateBundle<Configuration>(entities, factory) {
+            @Override
+            public DataSourceFactory getDataSourceFactory(Configuration configuration) {
+                return dbConfig;
+            }
+
+            @Override
+            public DataSourceFactory getReadSourceFactory(Configuration configuration) {
+                return readConfig;
+            }
+
+            @Override
+            protected String name() {
+                return "custom-hibernate";
+            }
+
+            @Override
+            protected String reader() {
+                return "custom-reader";
+            }
+        };
+        when(factory.build(eq(customBundle),
+                any(Environment.class),
+                any(DataSourceFactory.class),
+                anyList(),
+                eq("custom-hibernate"))).thenReturn(sessionFactory);
+        when(factory.build(eq(customBundle),
+                any(Environment.class),
+                any(DataSourceFactory.class),
+                anyList(),
+                eq("custom-reader"))).thenReturn(readFactory);
+
+        customBundle.run(configuration, environment);
+
+        final ArgumentCaptor<SessionFactoryHealthCheck> captor =
+                ArgumentCaptor.forClass(SessionFactoryHealthCheck.class);
+        verify(healthChecks).register(eq("custom-hibernate"), captor.capture());
+    }
+
+    @Test
+    public void hasASessionFactory() throws Exception {
+        bundle.run(configuration, environment);
+
+        assertThat(bundle.getSessionFactory()).isInstanceOf(DualSessionFactory.class);
+    }
+}

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/dual/UnitOfWorkApplicationListenerTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/dual/UnitOfWorkApplicationListenerTest.java
@@ -1,0 +1,346 @@
+package io.dropwizard.hibernate.dual;
+
+import io.dropwizard.hibernate.UnitOfWork;
+
+import org.glassfish.jersey.server.ExtendedUriInfo;
+import org.glassfish.jersey.server.model.Resource;
+import org.glassfish.jersey.server.monitoring.RequestEvent;
+import org.glassfish.jersey.server.monitoring.RequestEventListener;
+import org.hibernate.CacheMode;
+import org.hibernate.FlushMode;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.context.internal.ManagedSessionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hibernate.resource.transaction.spi.TransactionStatus.ACTIVE;
+import static org.hibernate.resource.transaction.spi.TransactionStatus.NOT_ACTIVE;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class UnitOfWorkApplicationListenerTest {
+    private final SessionFactory sessionFactory = mock(SessionFactory.class);
+    private final SessionFactory analyticsSessionFactory = mock(SessionFactory.class);
+    private final DualSessionFactory factory = mock(DualSessionFactory.class);
+    private final DualSessionFactory analyticsFactory = mock(DualSessionFactory.class);
+    private final UnitOfWorkApplicationListener listener = new UnitOfWorkApplicationListener();
+    private final ExtendedUriInfo uriInfo = mock(ExtendedUriInfo.class);
+
+    private final RequestEvent requestStartEvent = mock(RequestEvent.class);
+    private final RequestEvent requestMethodStartEvent = mock(RequestEvent.class);
+    private final RequestEvent responseFiltersStartEvent = mock(RequestEvent.class);
+    private final RequestEvent responseFinishedEvent = mock(RequestEvent.class);
+    private final RequestEvent requestMethodExceptionEvent = mock(RequestEvent.class);
+    private final Session session = mock(Session.class);
+    private final Session analyticsSession = mock(Session.class);
+    private final Transaction transaction = mock(Transaction.class);
+    private final Transaction analyticsTransaction = mock(Transaction.class);
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        listener.registerSessionFactory(HibernateBundle.DEFAULT_NAME, factory);
+        listener.registerSessionFactory("analytics", analyticsFactory);
+
+        when(factory.prepare(any(Boolean.class))).thenReturn(sessionFactory);
+        when(analyticsFactory.prepare(any(Boolean.class))).thenReturn(analyticsSessionFactory);
+
+        when(sessionFactory.openSession()).thenReturn(session);
+        when(session.getSessionFactory()).thenReturn(sessionFactory);
+        when(session.beginTransaction()).thenReturn(transaction);
+        when(session.getTransaction()).thenReturn(transaction);
+        when(transaction.getStatus()).thenReturn(ACTIVE);
+
+        when(analyticsSessionFactory.openSession()).thenReturn(analyticsSession);
+        when(analyticsSession.getSessionFactory()).thenReturn(analyticsSessionFactory);
+        when(analyticsSession.beginTransaction()).thenReturn(analyticsTransaction);
+        when(analyticsSession.getTransaction()).thenReturn(analyticsTransaction);
+        when(analyticsTransaction.getStatus()).thenReturn(ACTIVE);
+
+        when(requestMethodStartEvent.getType()).thenReturn(RequestEvent.Type.RESOURCE_METHOD_START);
+        when(responseFinishedEvent.getType()).thenReturn(RequestEvent.Type.FINISHED);
+        when(requestMethodExceptionEvent.getType()).thenReturn(RequestEvent.Type.ON_EXCEPTION);
+        when(responseFiltersStartEvent.getType()).thenReturn(RequestEvent.Type.RESP_FILTERS_START);
+        when(requestMethodStartEvent.getUriInfo()).thenReturn(uriInfo);
+        when(responseFinishedEvent.getUriInfo()).thenReturn(uriInfo);
+        when(requestMethodExceptionEvent.getUriInfo()).thenReturn(uriInfo);
+
+        prepareResourceMethod("methodWithDefaultAnnotation");
+    }
+
+    @Test
+    public void opensAndClosesASession() throws Exception {
+        execute();
+
+        final InOrder inOrder = inOrder(sessionFactory, session);
+        inOrder.verify(sessionFactory).openSession();
+        inOrder.verify(session).close();
+    }
+
+    @Test
+    public void bindsAndUnbindsTheSessionToTheManagedContext() throws Exception {
+        doAnswer(invocation -> {
+            assertThat(ManagedSessionContext.hasBind(sessionFactory))
+                .isTrue();
+            return null;
+        }).when(session).beginTransaction();
+
+        execute();
+
+        assertThat(ManagedSessionContext.hasBind(sessionFactory)).isFalse();
+    }
+
+    @Test
+    public void configuresTheSessionsReadOnlyDefault() throws Exception {
+        prepareResourceMethod("methodWithReadOnlyAnnotation");
+
+        execute();
+
+        verify(session).setDefaultReadOnly(true);
+    }
+
+    @Test
+    public void configuresTheSessionsCacheMode() throws Exception {
+        prepareResourceMethod("methodWithCacheModeIgnoreAnnotation");
+
+        execute();
+
+        verify(session).setCacheMode(CacheMode.IGNORE);
+    }
+
+    @Test
+    public void configuresTheSessionsFlushMode() throws Exception {
+        prepareResourceMethod("methodWithFlushModeAlwaysAnnotation");
+
+        execute();
+
+        verify(session).setHibernateFlushMode(FlushMode.ALWAYS);
+    }
+
+    @Test
+    public void doesNotBeginATransactionIfNotTransactional() throws Exception {
+        final String resourceMethodName = "methodWithTransactionalFalseAnnotation";
+        prepareResourceMethod(resourceMethodName);
+
+        when(session.getTransaction()).thenReturn(null);
+
+        execute();
+
+        verify(session, never()).beginTransaction();
+        verifyNoMoreInteractions(transaction);
+    }
+
+    @Test
+    public void detectsAnnotationOnHandlingMethod() throws NoSuchMethodException {
+        final String resourceMethodName = "handlingMethodAnnotated";
+        prepareResourceMethod(resourceMethodName);
+
+        execute();
+
+        verify(session).setDefaultReadOnly(true);
+    }
+
+    @Test
+    public void detectsAnnotationOnDefinitionMethod() throws NoSuchMethodException {
+        final String resourceMethodName = "definitionMethodAnnotated";
+        prepareResourceMethod(resourceMethodName);
+
+        execute();
+
+        verify(session).setDefaultReadOnly(true);
+    }
+
+    @Test
+    public void annotationOnDefinitionMethodOverridesHandlingMethod() throws NoSuchMethodException {
+        final String resourceMethodName = "bothMethodsAnnotated";
+        prepareResourceMethod(resourceMethodName);
+
+        execute();
+
+        verify(session).setDefaultReadOnly(true);
+    }
+
+    @Test
+    public void beginsAndCommitsATransactionIfTransactional() throws Exception {
+        execute();
+
+        final InOrder inOrder = inOrder(session, transaction);
+        inOrder.verify(session).beginTransaction();
+        inOrder.verify(transaction).commit();
+        inOrder.verify(session).close();
+    }
+
+    @Test
+    public void rollsBackTheTransactionOnException() throws Exception {
+        executeWithException();
+
+        final InOrder inOrder = inOrder(session, transaction);
+        inOrder.verify(session).beginTransaction();
+        inOrder.verify(transaction).rollback();
+        inOrder.verify(session).close();
+    }
+
+    @Test
+    public void doesNotCommitAnInactiveTransaction() throws Exception {
+        when(transaction.getStatus()).thenReturn(NOT_ACTIVE);
+
+        execute();
+
+        verify(transaction, never()).commit();
+    }
+
+    @Test
+    public void doesNotCommitANullTransaction() throws Exception {
+        when(session.getTransaction()).thenReturn(null);
+
+        execute();
+
+        verify(transaction, never()).commit();
+    }
+
+    @Test
+    public void doesNotRollbackAnInactiveTransaction() throws Exception {
+        when(transaction.getStatus()).thenReturn(NOT_ACTIVE);
+
+        executeWithException();
+
+        verify(transaction, never()).rollback();
+    }
+
+    @Test
+    public void doesNotRollbackANullTransaction() throws Exception {
+        when(session.getTransaction()).thenReturn(null);
+
+        executeWithException();
+
+        verify(transaction, never()).rollback();
+    }
+
+    @Test
+    public void beginsAndCommitsATransactionForAnalytics() throws Exception {
+        prepareResourceMethod("methodWithUnitOfWorkOnAnalyticsDatabase");
+        execute();
+
+        final InOrder inOrder = inOrder(analyticsSession, analyticsTransaction);
+        inOrder.verify(analyticsSession).beginTransaction();
+        inOrder.verify(analyticsTransaction).commit();
+        inOrder.verify(analyticsSession).close();
+    }
+
+    @Test
+    public void throwsExceptionOnNotRegisteredDatabase() throws Exception {
+        prepareResourceMethod("methodWithUnitOfWorkOnNotRegisteredDatabase");
+        assertThatThrownBy(this::execute)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Unregistered Hibernate bundle: 'warehouse'");
+    }
+
+    private void prepareResourceMethod(String resourceMethodName) throws NoSuchMethodException {
+        final Method handlingMethod = MockResource.class.getMethod(resourceMethodName);
+        Method definitionMethod = handlingMethod;
+        Class<?> interfaceClass = MockResource.class.getInterfaces()[0];
+        if (methodDefinedOnInterface(resourceMethodName, interfaceClass.getMethods())) {
+            definitionMethod = interfaceClass.getMethod(resourceMethodName);
+        }
+        when(uriInfo.getMatchedResourceMethod()).thenReturn(Resource.builder()
+            .addMethod()
+            .handlingMethod(handlingMethod)
+            .handledBy(new MockResource(), definitionMethod)
+            .build());
+    }
+
+    private static boolean methodDefinedOnInterface(String methodName, Method[] methods) {
+        for (Method method : methods) {
+            if (method.getName().equals(methodName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void execute() {
+        RequestEventListener requestListener = listener.onRequest(requestStartEvent);
+        requestListener.onEvent(requestMethodStartEvent);
+        requestListener.onEvent(responseFiltersStartEvent);
+        requestListener.onEvent(responseFinishedEvent);
+    }
+
+    private void executeWithException() {
+        RequestEventListener requestListener = listener.onRequest(requestStartEvent);
+        requestListener.onEvent(requestMethodStartEvent);
+        requestListener.onEvent(responseFiltersStartEvent);
+        requestListener.onEvent(requestMethodExceptionEvent);
+        requestListener.onEvent(responseFinishedEvent);
+    }
+
+    public static class MockResource implements MockResourceInterface {
+
+        @UnitOfWork(readOnly = false, cacheMode = CacheMode.NORMAL, transactional = true, flushMode = FlushMode.AUTO)
+        public void methodWithDefaultAnnotation() {
+        }
+
+        @UnitOfWork(readOnly = true, cacheMode = CacheMode.NORMAL, transactional = true, flushMode = FlushMode.AUTO)
+        public void methodWithReadOnlyAnnotation() {
+        }
+
+        @UnitOfWork(readOnly = false, cacheMode = CacheMode.IGNORE, transactional = true, flushMode = FlushMode.AUTO)
+        public void methodWithCacheModeIgnoreAnnotation() {
+        }
+
+        @UnitOfWork(readOnly = false, cacheMode = CacheMode.NORMAL, transactional = true, flushMode = FlushMode.ALWAYS)
+        public void methodWithFlushModeAlwaysAnnotation() {
+        }
+
+        @UnitOfWork(readOnly = false, cacheMode = CacheMode.NORMAL, transactional = false, flushMode = FlushMode.AUTO)
+        public void methodWithTransactionalFalseAnnotation() {
+        }
+
+        @UnitOfWork(readOnly = true)
+        @Override
+        public void handlingMethodAnnotated() {
+        }
+
+        @Override
+        public void definitionMethodAnnotated() {
+        }
+
+        @UnitOfWork(readOnly = false)
+        @Override
+        public void bothMethodsAnnotated() {
+
+        }
+
+        @UnitOfWork("analytics")
+        public void methodWithUnitOfWorkOnAnalyticsDatabase() {
+
+        }
+
+        @UnitOfWork("warehouse")
+        public void methodWithUnitOfWorkOnNotRegisteredDatabase() {
+
+        }
+    }
+
+    public static interface MockResourceInterface {
+
+        void handlingMethodAnnotated();
+
+        @UnitOfWork(readOnly = true)
+        void definitionMethodAnnotated();
+
+        @UnitOfWork(readOnly = true)
+        void bothMethodsAnnotated();
+    }
+}


### PR DESCRIPTION
…OfWork framework.

###### Problem:
Modern RDBMS systems often provide read-replica clusters with separate access points. With regards to Hibernate, this requires two SessionFactory instances. One factory is for the primary/writer data source. And a separate factory is necessary for the read-replica data source. This requires the usage of the UnitOfWork name property whenever the read-replica is preferred. Ideally, no adjustments to the UnitOfWork properties should be necessary if the readOnly is properly set across endpoints.

###### Solution:
This commit provides a SessionFactory implementation that contains both a writer/primary factory and a reader factory. The DualSessionFactory comes with separate HibernateBundle, UnitOfWorkApplicationListener, and UnitOfWorkAspect classes. Prior to usage, the UnitOfWorkAspect class prepares the DualSessionFactory based on the UnitOfWork annotation readOnly property. When the dual HibernateBundle is dropped into an application, the UnitOfWork requires no changes across endpoints assuming that the readOnly property is already set accordingly.

https://github.com/dropwizard/dropwizard/issues/3542

###### Result:
This commit contains new DualSessionFactory, HibernateBundle, UnitOfWorkApplicationListener, and UnitOfWorkAspect classes.