### PR TITLE
Skip errors when visiting default implementations in ConfigurationMetadata

### DIFF
--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationMetadata.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationMetadata.java
@@ -162,7 +162,7 @@ public class ConfigurationMetadata extends JsonFormatVisitorWrapper.Base {
                 try {
                     mapper.acceptJsonFormatVisitor(defaultImpl == null ? fieldType.getRawClass() : defaultImpl, thiss);
                 } catch (NoClassDefFoundError | Exception e) {
-                    e.printStackTrace();
+                    System.err.println(getClass() + ": " e.getMessage());
                 }
 
                 // reset state after the recursive traversal

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationMetadata.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationMetadata.java
@@ -159,8 +159,11 @@ public class ConfigurationMetadata extends JsonFormatVisitorWrapper.Base {
                 parentProps.add(prop);
 
                 // visit the type of the property (or its defaultImpl).
-                mapper.acceptJsonFormatVisitor(
-                        defaultImpl == null ? fieldType.getRawClass() : defaultImpl, thiss);
+                try {
+                    mapper.acceptJsonFormatVisitor(defaultImpl == null ? fieldType.getRawClass() : defaultImpl, thiss);
+                } catch (NoClassDefFoundError | Exception e) {
+                    e.printStackTrace();
+                }
 
                 // reset state after the recursive traversal
                 parentProps.remove(prop);

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationMetadata.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationMetadata.java
@@ -162,7 +162,7 @@ public class ConfigurationMetadata extends JsonFormatVisitorWrapper.Base {
                 try {
                     mapper.acceptJsonFormatVisitor(defaultImpl == null ? fieldType.getRawClass() : defaultImpl, thiss);
                 } catch (NoClassDefFoundError | Exception e) {
-                    System.err.println(getClass() + ": " e.getMessage());
+                    System.err.println(getClass() + ": " + e.getMessage());
                 }
 
                 // reset state after the recursive traversal

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationMetadata.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationMetadata.java
@@ -106,6 +106,7 @@ public class ConfigurationMetadata extends JsonFormatVisitorWrapper.Base {
     }
 
     @Override
+    @SuppressWarnings("java:S106")
     public JsonObjectFormatVisitor expectObjectFormat(JavaType type) throws JsonMappingException {
         // store the pointer to the own instance
         final ConfigurationMetadata thiss = this;


### PR DESCRIPTION
```
java.lang.NoClassDefFoundError: ch/qos/logback/classic/spi/LoggerContextListener
	at io.dropwizard.configuration.ConfigurationMetadata$1.optionalProperty(ConfigurationMetadata.java:163)
	at io.dropwizard.configuration.ConfigurationMetadata.<init>(ConfigurationMetadata.java:76)
	at io.dropwizard.configuration.BaseConfigurationFactory.<init>(BaseConfigurationFactory.java:76)
	at io.dropwizard.configuration.YamlConfigurationFactory.<init>(YamlConfigurationFactory.java:29)
	at io.dropwizard.configuration.DefaultConfigurationFactoryFactory.create(DefaultConfigurationFactoryFactory.java:18)
	at io.dropwizard.cli.ConfiguredCommand.parseConfiguration(ConfiguredCommand.java:124)
	at io.dropwizard.cli.ConfiguredCommand.run(ConfiguredCommand.java:74)
	at io.dropwizard.cli.Cli.run(Cli.java:78)
	at io.dropwizard.Application.run(Application.java:94)
	at com.github.joschi.dropwizard.ExternalLogApplication.main(ExternalLogApplication.java:10)
Caused by: java.lang.ClassNotFoundException: ch.qos.logback.classic.spi.LoggerContextListener
```

Fixes #3557