### PR TITLE
Revert "Replace invalid default excludedProtocols in HttpsConnectorFactory"

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -470,8 +470,8 @@ validatePeers                    false                            Whether or not
                                                                   implemented.
 supportedProtocols               (none)                           A list of protocols (e.g., ``SSLv3``, ``TLSv1``) which are supported. All
                                                                   other protocols will be refused.
-excludedProtocols                ["SSLv2Hello", "SSLv3",          A list of protocols (e.g., ``SSLv3``, ``TLSv1``) which are excluded. These
-                                  "TLSv1", "TLSv1.1"]             protocols will be refused.
+excludedProtocols                ["SSL.*", "TLSv1", "TLSv1\\.1"]  A list of protocols (e.g., ``SSLv3``, ``TLSv1``) which are excluded. These
+                                                                  protocols will be refused.
 supportedCipherSuites            (none)                           A list of cipher suites (e.g., ``TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256``) which
                                                                   are supported. All other cipher suites will be refused.
 excludedCipherSuites             (none)                           A list of cipher suites (e.g., ``TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256``) which

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
@@ -182,7 +182,7 @@ import java.util.stream.Collectors;
  *     </tr>
  *     <tr>
  *         <td>{@code excludedProtocols}</td>
- *         <td>["SSLv3", "TLSv1", "TLSv1.1"]</td>
+ *         <td>["SSL.*", "TLSv1", "TLSv1\.1"]</td>
  *         <td>
  *             A list of protocols (e.g., {@code SSLv3}, {@code TLSv1}) which are excluded. These
  *             protocols will be refused.
@@ -287,7 +287,7 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
     private List<String> supportedProtocols;
 
     @Nullable
-    private List<String> excludedProtocols = Arrays.asList("SSLv2Hello", "SSLv3", "TLSv1", "TLSv1.1");
+    private List<String> excludedProtocols = Arrays.asList("SSL.*", "TLSv1", "TLSv1\\.1");
 
     @Nullable
     private List<String> supportedCipherSuites;


### PR DESCRIPTION
Jetty 9.4.34.v20201102 added support for regular expressions in included/excluded protocols.

https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.34.v20201102

Refs #3533
Refs https://github.com/eclipse/jetty.project/issues/5535
This partially reverts commit 206e858b9171d4dff0c71a55a017909cf2b67d22.