### PR TITLE
fix flaky test

### DIFF
--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/MapBuilderTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/MapBuilderTest.java
@@ -18,7 +18,7 @@ public class MapBuilderTest {
     @Test
     public void testIncludeStringValue() {
         assertThat(mapBuilder.add("message", true, message).build())
-            .containsOnly(entry("message", message));
+            .contains(entry("message", message));
     }
 
     @Test


### PR DESCRIPTION
###### Problem:
Fixing Flaky Tests: io.dropwizard.logging.json.layout.MapBuilderTest.testIncludeStringValue
The test running order is not preserved in junit so using containsOnly will make this test flaky if other tests are ran before this.

###### Solution:
Change .containsOnly => .contains

###### Result:
io.dropwizard.logging.json.layout.MapBuilderTest.testIncludeStringValue will not be flaky