### PR TITLE
Bump tomcat-jdbc from 9.0.40 to 9.0.41

### DIFF
--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -59,7 +59,7 @@
         <mustache-compiler.version>0.9.7</mustache-compiler.version>
         <nullaway.version>0.8.0</nullaway.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <tomcat-jdbc.version>9.0.40</tomcat-jdbc.version>
+        <tomcat-jdbc.version>9.0.41</tomcat-jdbc.version>
         <usertype.core.version>7.0.0.CR1</usertype.core.version>
 
         <!-- Test dependencies -->


### PR DESCRIPTION
https://tomcat.apache.org/tomcat-9.0-doc/changelog.html#Tomcat_9.0.41_(markt)