### PR TITLE
Do not print error message about class not found

### DIFF
--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationMetadata.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationMetadata.java
@@ -106,7 +106,6 @@ public class ConfigurationMetadata extends JsonFormatVisitorWrapper.Base {
     }
 
     @Override
-    @SuppressWarnings("java:S106")
     public JsonObjectFormatVisitor expectObjectFormat(JavaType type) throws JsonMappingException {
         // store the pointer to the own instance
         final ConfigurationMetadata thiss = this;
@@ -162,14 +161,23 @@ public class ConfigurationMetadata extends JsonFormatVisitorWrapper.Base {
                 // visit the type of the property (or its defaultImpl).
                 try {
                     mapper.acceptJsonFormatVisitor(defaultImpl == null ? fieldType.getRawClass() : defaultImpl, thiss);
-                } catch (NoClassDefFoundError | Exception e) {
-                    System.err.println(getClass() + ": " + e.getMessage());
+                } catch (NoClassDefFoundError | TypeNotPresentException e) {
+                    // this can happen if the default implementation contains
+                    // references to classes that are not in the classpath; in
+                    // that case, just ignore the default implementation
+                    if (defaultImpl != null) {
+                        return;
+                    } else {
+                        // exception has nothing to do with default
+                        // implementation, so re-throw it
+                        throw e;
+                    }
+                } finally {
+                    // reset state after the recursive traversal
+                    parentProps.remove(prop);
+                    currentDepth--;
+                    currentPrefix = oldPrefix;
                 }
-
-                // reset state after the recursive traversal
-                parentProps.remove(prop);
-                currentDepth--;
-                currentPrefix = oldPrefix;
 
                 // if no new fields are discovered, we assume that we are at an primitive field
                 if (oldFieldSize == fields.size()) {

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/LogbackExcludedTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/LogbackExcludedTest.java
@@ -1,0 +1,143 @@
+package io.dropwizard.testing.junit5;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.security.CodeSource;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import io.dropwizard.Configuration;
+import io.dropwizard.configuration.ConfigurationMetadata;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * Verify that Logback can be excluded from the classpath without generating any noise.
+ */
+public class LogbackExcludedTest {
+
+    @Test
+    public void testLogbackExcludedClassNotFound() throws Exception {
+        testBuildConfigurationMetadata(className -> {
+            if (className.startsWith("ch.qos.logback.")) {
+                throw new ClassNotFoundException();
+            }
+        });
+    }
+
+    @Test
+    public void testLogbackExcludedNoClassDef() throws Exception {
+        testBuildConfigurationMetadata(className -> {
+            if (className.startsWith("ch.qos.logback.")) {
+                throw new NoClassDefFoundError();
+            }
+        });
+    }
+
+    @Test
+    public void testPropagatedException() throws Exception {
+        AtomicReference<RuntimeException> thrown = new AtomicReference<>();
+        try {
+            testBuildConfigurationMetadata(className -> {
+                if (className.startsWith("ch.qos.logback.")) {
+                    thrown.set(new RuntimeException("Some unexpected error"));
+                    throw thrown.get();
+                }
+            });
+            fail("Expected exception to propagate out of ConfigurationMetadata");
+        } catch (InvocationTargetException e) {
+            assertThat(e.getCause()).isSameAs(thrown.get());
+        }
+    }
+
+    public void testBuildConfigurationMetadata(CheckedConsumer<String> classFilter) throws Exception {
+        try (ByteArrayOutputStream byteStream = captureStderr();
+                CustomClassLoader loader = new CustomClassLoader(classFilter)) {
+            // create class objects from custom loader
+            Class<ConfigurationMetadata> cmType = loader.reloadClass(ConfigurationMetadata.class);
+            Class<ObjectMapper> omType = loader.reloadClass(ObjectMapper.class);
+            Class<Configuration> confType = loader.reloadClass(Configuration.class);
+            // construct ConfigurationMetadata object using class object associated with custom loader so that we can
+            // simulate Logback not being in the classpath
+            cmType.getConstructor(omType, Class.class).newInstance(omType.newInstance(), confType);
+
+            // make sure nothing is emitted to stderr; previously the absence of Logback in the classpath would cause
+            // "class io.dropwizard.configuration.ConfigurationMetadata$1: Type ch.qos.logback.access.spi.IAccessEvent
+            // not present" to be emitted to stderr
+            String err = byteStream.toString();
+            assertThat(err).isEmpty();
+        }
+    }
+
+    /**
+     * Replace stderr with a byte-backed stream until the returned stream is closed.
+     */
+    private static ByteArrayOutputStream captureStderr() {
+        PrintStream err = System.err;
+        ByteArrayOutputStream byteStream = new ByteArrayOutputStream() {
+            @Override
+            public void close() {
+                System.setErr(err);
+            }
+        };
+        System.setErr(new PrintStream(byteStream));
+        return byteStream;
+    }
+
+    private static interface CheckedConsumer<T> {
+
+        void accept(T t) throws ClassNotFoundException;
+    }
+
+    /**
+     * Custom class loader to simulate classes not being in the classpath.
+     */
+    private static class CustomClassLoader extends URLClassLoader {
+
+        public final CheckedConsumer<String> classFilter;
+
+        public CustomClassLoader(CheckedConsumer<String> classFilter) {
+            super(new URL[0], null);
+            this.classFilter = classFilter;
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            classFilter.accept(name);
+            Class<?> clazz = getClassSystemLoader(name);
+            Optional<URL> url = getUrl(clazz);
+            if (!url.isPresent()) {
+                // no URL associated with class; must be standard Java
+                return clazz;
+            }
+            addURL(url.get());
+            return super.loadClass(name);
+        }
+
+        /**
+         * Get the supplied class object via this class loader so that any references made to it are resolved through
+         * this class loader.
+         */
+        public <T> Class<T> reloadClass(Class<T> clazz) throws ClassNotFoundException {
+            @SuppressWarnings("unchecked")
+            Class<T> ret = (Class<T>) loadClass(clazz.getCanonicalName());
+            return ret;
+        }
+
+        private static Class<?> getClassSystemLoader(String name) throws ClassNotFoundException {
+            return ClassLoader.getSystemClassLoader().loadClass(name);
+        }
+
+        private static Optional<URL> getUrl(Class<?> clazz) throws ClassNotFoundException {
+            return Optional.ofNullable(clazz.getProtectionDomain().getCodeSource()).map(CodeSource::getLocation);
+        }
+    }
+}


### PR DESCRIPTION
Only swallow NoClassDefFoundError if the default implementation
generated it, and do not print message to standard output about it.
Currently an error message appears whenever Logback (specifically the
logback-access dependency) is excluded, which users should be able to do
if they configuring logging externally.

###### Problem:

Dropwizard generates error output whenever Logback is excluded according to the instructions in the [documentation](https://www.dropwizard.io/en/latest/manual/core.html#logging). See the linked issue: https://github.com/dropwizard/dropwizard/issues/3615

###### Solution:

Avoid printing to standard error and only the swallow NoClassDefException generated by the default implementation.

###### Result:

Users who configure external logging will not see spurious error messages.