### PR TITLE
Fix the AssertJ documentation URL

### DIFF
--- a/docs/source/manual/testing.rst
+++ b/docs/source/manual/testing.rst
@@ -114,7 +114,7 @@ This test uses `AssertJ assertions`_ and JUnit_ to test that when a ``Person`` i
 via Jackson it matches the JSON in the fixture file. (The comparison is done on a normalized JSON
 string representation, so formatting doesn't affect the results.)
 
-.. _AssertJ assertions: http://assertj.org/assertj-core-conditions.html
+.. _AssertJ assertions: https://assertj.github.io/doc/#assertj-core-assertions-guide
 .. _JUnit: http://www.junit.org/
 
 .. _man-testing-representations-deserialization:


### PR DESCRIPTION
assertj.org is now a domain squatting site. Use the docs link from README.md at
https://github.com/assertj/assertj-core