### PR TITLE
Rename `jdbi3` to `db` packages in example docs

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -55,7 +55,7 @@ which tends to look like this:
   * ``cli``: :ref:`man-core-commands`
   * ``client``: :ref:`Client <man-client>` code that accesses external HTTP services.
   * ``core``: Domain implementation; where objects not used in the API such as POJOs, validations, crypto, etc, reside.
-  * ``jdbi3``: :ref:`Database <man-jdbi3>` access classes
+  * ``db``: :ref:`Database <man-jdbi3>` access classes
   * ``health``: :ref:`man-core-healthchecks`
   * ``resources``: :ref:`man-core-resources`
   * ``MyApplication``: The :ref:`application <man-core-application>` class


### PR DESCRIPTION
###### Problem:
Core page of documentation presents standard project structure incorrectly. Among packages that really exist such as `api`, `health` and `resources` it has `jdbi3` which isn't really a standard structure package judging by [example project](https://github.com/dropwizard/dropwizard/tree/master/dropwizard-example/src/main/java/com/example/helloworld) and also project structure generated from maven archetype.

###### Solution:
Replace `jdbi3` with `db` in the docs.

###### Result:
More accurate docs.