### PR TITLE
Add missing parentheses in example docs

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -1472,7 +1472,7 @@ this:
                         @NotNull @Valid Notification notification) {
         final long id = store.add(userId.get(), notification);
         return Response.created(UriBuilder.fromResource(NotificationResource.class)
-                                          .build(userId.get(), id)
+                                          .build(userId.get(), id))
                        .build();
     }
 


### PR DESCRIPTION
###### Problem:
One of examples in the core docs misses a parentheses. `UriBuilder.fromResource(NotificationResource.class).build(userId.get(), id)` here is an argument of `Response.created()` which in turn returns `ResponseBuilder()` that requires one more `build()` call to return actual `Response`.

###### Solution:
Add missing parentheses.

###### Result:
Better docs.
