### PR TITLE
Remove apache commons-lang3 from tests

### DIFF
--- a/dropwizard-client/pom.xml
+++ b/dropwizard-client/pom.xml
@@ -136,10 +136,5 @@
             <artifactId>bcprov-jdk15on</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
@@ -11,7 +11,6 @@ import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Duration;
-import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.http.Header;
 import org.apache.http.HeaderIterator;
 import org.apache.http.HttpHeaders;
@@ -193,9 +192,9 @@ public class HttpClientBuilderTest {
 
         // Yes, this is gross. Thanks, Apache!
         final Field connectionOperatorField =
-                FieldUtils.getField(PoolingHttpClientConnectionManager.class, "connectionOperator", true);
+                getInaccessibleField(PoolingHttpClientConnectionManager.class, "connectionOperator");
         final Object connectOperator = connectionOperatorField.get(manager);
-        final Field dnsResolverField = FieldUtils.getField(connectOperator.getClass(), "dnsResolver", true);
+        final Field dnsResolverField = getInaccessibleField(connectOperator.getClass(), "dnsResolver");
         assertThat(dnsResolverField.get(connectOperator)).isEqualTo(resolver);
     }
 
@@ -206,9 +205,9 @@ public class HttpClientBuilderTest {
 
         // Yes, this is gross. Thanks, Apache!
         final Field connectionOperatorField =
-                FieldUtils.getField(PoolingHttpClientConnectionManager.class, "connectionOperator", true);
+                getInaccessibleField(PoolingHttpClientConnectionManager.class, "connectionOperator");
         final Object connectOperator = connectionOperatorField.get(manager);
-        final Field dnsResolverField = FieldUtils.getField(connectOperator.getClass(), "dnsResolver", true);
+        final Field dnsResolverField = getInaccessibleField(connectOperator.getClass(), "dnsResolver");
         assertThat(dnsResolverField.get(connectOperator)).isInstanceOf(SystemDefaultDnsResolver.class);
     }
 
@@ -225,7 +224,7 @@ public class HttpClientBuilderTest {
         assertThat(socketFactory).isNotNull();
 
         final Field hostnameVerifierField =
-                FieldUtils.getField(SSLConnectionSocketFactory.class, "hostnameVerifier", true);
+                getInaccessibleField(SSLConnectionSocketFactory.class, "hostnameVerifier");
         assertThat(hostnameVerifierField.get(socketFactory)).isSameAs(customVerifier);
     }
 
@@ -246,7 +245,7 @@ public class HttpClientBuilderTest {
         assertThat(socketFactory).isNotNull();
 
         final Field hostnameVerifierField =
-                FieldUtils.getField(SSLConnectionSocketFactory.class, "hostnameVerifier", true);
+                getInaccessibleField(SSLConnectionSocketFactory.class, "hostnameVerifier");
         assertThat(hostnameVerifierField.get(socketFactory)).isSameAs(customVerifier);
     }
 
@@ -261,7 +260,7 @@ public class HttpClientBuilderTest {
         assertThat(socketFactory).isNotNull();
 
         final Field hostnameVerifierField =
-                FieldUtils.getField(SSLConnectionSocketFactory.class, "hostnameVerifier", true);
+                getInaccessibleField(SSLConnectionSocketFactory.class, "hostnameVerifier");
         assertThat(hostnameVerifierField.get(socketFactory)).isInstanceOf(HostnameVerifier.class);
     }
 
@@ -280,7 +279,7 @@ public class HttpClientBuilderTest {
         assertThat(socketFactory).isNotNull();
 
         final Field hostnameVerifierField =
-                FieldUtils.getField(SSLConnectionSocketFactory.class, "hostnameVerifier", true);
+                getInaccessibleField(SSLConnectionSocketFactory.class, "hostnameVerifier");
         assertThat(hostnameVerifierField.get(socketFactory)).isInstanceOf(HostnameVerifier.class);
     }
 
@@ -291,7 +290,7 @@ public class HttpClientBuilderTest {
         assertThat(builder.using(customVerifier).createClient(apacheBuilder, connectionManager, "test")).isNotNull();
 
         final Field hostnameVerifierField =
-                FieldUtils.getField(org.apache.http.impl.client.HttpClientBuilder.class, "hostnameVerifier", true);
+                getInaccessibleField(org.apache.http.impl.client.HttpClientBuilder.class, "hostnameVerifier");
         assertThat(hostnameVerifierField.get(apacheBuilder)).isSameAs(customVerifier);
     }
 
@@ -333,7 +332,7 @@ public class HttpClientBuilderTest {
         configuration.setKeepAlive(Duration.seconds(1));
         assertThat(builder.using(configuration).createClient(apacheBuilder, connectionManager, "test")).isNotNull();
 
-        final Field field = FieldUtils.getField(httpClientBuilderClass, "keepAliveStrategy", true);
+        final Field field = getInaccessibleField(httpClientBuilderClass, "keepAliveStrategy");
         final DefaultConnectionKeepAliveStrategy strategy = (DefaultConnectionKeepAliveStrategy) field.get(apacheBuilder);
         final HttpContext context = mock(HttpContext.class);
         final HttpResponse response = mock(HttpResponse.class);
@@ -519,8 +518,7 @@ public class HttpClientBuilderTest {
         CloseableHttpClient httpClient = checkProxy(config, new HttpHost("dropwizard.io", 80),
                 new HttpHost("192.168.52.11", 8080, "http"));
         CredentialsProvider credentialsProvider = (CredentialsProvider)
-                FieldUtils.getField(httpClient.getClass(), "credentialsProvider", true)
-                        .get(httpClient);
+                getInaccessibleField(httpClient.getClass(), "credentialsProvider").get(httpClient);
 
         assertThat(credentialsProvider.getCredentials(new AuthScope("192.168.52.11", 8080)))
                 .isEqualTo(new UsernamePasswordCredentials("secret", "stuff"));
@@ -536,8 +534,7 @@ public class HttpClientBuilderTest {
         CloseableHttpClient httpClient = checkProxy(config, new HttpHost("dropwizard.io", 80),
                 new HttpHost("192.168.52.11", 8080, "http"));
         CredentialsProvider credentialsProvider = (CredentialsProvider)
-                FieldUtils.getField(httpClient.getClass(), "credentialsProvider", true)
-                        .get(httpClient);
+                getInaccessibleField(httpClient.getClass(), "credentialsProvider").get(httpClient);
 
         AuthScope authScope = new AuthScope("192.168.52.11", 8080, "realm", "NTLM");
         Credentials credentials = new NTCredentials("secret", "stuff", "host", "domain");
@@ -575,7 +572,7 @@ public class HttpClientBuilderTest {
                                            @Nullable HttpHost expectedProxy) throws Exception {
         CloseableHttpClient httpClient = builder.using(config).build("test");
         HttpRoutePlanner routePlanner = (HttpRoutePlanner)
-                FieldUtils.getField(httpClient.getClass(), "routePlanner", true).get(httpClient);
+                getInaccessibleField(httpClient.getClass(), "routePlanner").get(httpClient);
 
         HttpRoute route = routePlanner.determineRoute(target, new HttpGet(target.toURI()),
                 new BasicHttpContext());
@@ -603,8 +600,7 @@ public class HttpClientBuilderTest {
         assertThat(builder.using(HttpClientMetricNameStrategies.HOST_AND_METHOD)
                 .createClient(apacheBuilder, connectionManager, "test"))
                 .isNotNull();
-        assertThat(FieldUtils.getField(InstrumentedHttpRequestExecutor.class,
-                "metricNameStrategy", true)
+        assertThat(getInaccessibleField(InstrumentedHttpRequestExecutor.class,"metricNameStrategy")
                 .get(spyHttpClientBuilderField("requestExec", apacheBuilder)))
                 .isSameAs(HttpClientMetricNameStrategies.HOST_AND_METHOD);
     }
@@ -613,8 +609,7 @@ public class HttpClientBuilderTest {
     public void usesMethodOnlyHttpClientMetricNameStrategyByDefault() throws Exception {
         assertThat(builder.createClient(apacheBuilder, connectionManager, "test"))
                 .isNotNull();
-        assertThat(FieldUtils.getField(InstrumentedHttpRequestExecutor.class,
-                "metricNameStrategy", true)
+        assertThat(getInaccessibleField(InstrumentedHttpRequestExecutor.class, "metricNameStrategy")
                 .get(spyHttpClientBuilderField("requestExec", apacheBuilder)))
                 .isSameAs(HttpClientMetricNameStrategies.METHOD_ONLY);
     }
@@ -634,9 +629,8 @@ public class HttpClientBuilderTest {
                 .createClient(apacheBuilder, connectionManager, "test");
         assertThat(client).isNotNull();
 
-        final Boolean contentCompressionDisabled = (Boolean) FieldUtils
-                .getField(httpClientBuilderClass, "contentCompressionDisabled", true)
-                .get(apacheBuilder);
+        final Boolean contentCompressionDisabled =
+            (Boolean) getInaccessibleField(httpClientBuilderClass, "contentCompressionDisabled").get(apacheBuilder);
         assertThat(contentCompressionDisabled).isTrue();
     }
 
@@ -697,8 +691,8 @@ public class HttpClientBuilderTest {
         assertThat(client).isNotNull();
 
         @SuppressWarnings("unchecked")
-        List<? extends Header> defaultHeaders = (List<? extends Header>) FieldUtils
-                .getField(httpClientBuilderClass, "defaultHeaders", true)
+        List<? extends Header> defaultHeaders =
+            (List<? extends Header>) getInaccessibleField(httpClientBuilderClass, "defaultHeaders")
                 .get(apacheBuilder);
 
         assertThat(defaultHeaders).hasSize(1);
@@ -714,8 +708,7 @@ public class HttpClientBuilderTest {
             builder.using(httpProcessor)
                 .createClient(apacheBuilder, connectionManager, "test");
         assertThat(client).isNotNull();
-        assertThat(FieldUtils.getField(httpClientBuilderClass,
-            "httpprocessor", true)
+        assertThat(getInaccessibleField(httpClientBuilderClass, "httpprocessor")
             .get(apacheBuilder))
             .isSameAs(httpProcessor);
     }
@@ -727,8 +720,7 @@ public class HttpClientBuilderTest {
             builder.using(serviceUnavailableRetryStrategy)
                 .createClient(apacheBuilder, connectionManager, "test");
         assertThat(client).isNotNull();
-        assertThat(FieldUtils.getField(httpClientBuilderClass,
-            "serviceUnavailStrategy", true)
+        assertThat(getInaccessibleField(httpClientBuilderClass, "serviceUnavailStrategy")
             .get(apacheBuilder))
             .isSameAs(serviceUnavailableRetryStrategy);
     }
@@ -739,9 +731,7 @@ public class HttpClientBuilderTest {
         assertThat(builder.customized).isFalse();
         builder.createClient(apacheBuilder, connectionManager, "test");
         assertThat(builder.customized).isTrue();
-        assertThat(FieldUtils.getField(httpClientBuilderClass,
-            "requestExec", true)
-            .get(apacheBuilder))
+        assertThat(getInaccessibleField(httpClientBuilderClass, "requestExec").get(apacheBuilder))
             .isInstanceOf(CustomRequestExecutor.class);
     }
 
@@ -749,9 +739,7 @@ public class HttpClientBuilderTest {
     public void buildWithAnotherBuilder() throws Exception {
         CustomBuilder builder = new CustomBuilder(new MetricRegistry(), anotherApacheBuilder);
         builder.build("test");
-        assertThat(FieldUtils.getField(httpClientBuilderClass,
-            "requestExec", true)
-            .get(anotherApacheBuilder))
+        assertThat(getInaccessibleField(httpClientBuilderClass, "requestExec").get(anotherApacheBuilder))
             .isInstanceOf(CustomRequestExecutor.class);
     }
 
@@ -776,12 +764,18 @@ public class HttpClientBuilderTest {
     }
 
     private Object spyHttpClientBuilderField(final String fieldName, final Object obj) throws Exception {
-        final Field field = FieldUtils.getField(httpClientBuilderClass, fieldName, true);
+        final Field field = getInaccessibleField(httpClientBuilderClass, fieldName);
         return field.get(obj);
     }
 
     private Object spyHttpClientField(final String fieldName, final Object obj) throws Exception {
-        final Field field = FieldUtils.getField(httpClientClass, fieldName, true);
+        final Field field = getInaccessibleField(httpClientClass, fieldName);
         return field.get(obj);
+    }
+
+    private static Field getInaccessibleField(Class klass, String name) throws NoSuchFieldException {
+        Field field = klass.getDeclaredField(name);
+        field.setAccessible(true);
+        return field;
     }
 }

--- a/dropwizard-jetty/pom.xml
+++ b/dropwizard-jetty/pom.xml
@@ -122,11 +122,6 @@
             <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <!-- For GzipHandler tests -->
         <dependency>

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
@@ -694,8 +694,13 @@ public class HttpConnectorFactory implements ConnectorFactory {
     }
 
     protected ByteBufferPool buildBufferPool() {
-        return new ArrayByteBufferPool((int) minBufferPoolSize.toBytes(),
-                                       (int) bufferPoolIncrement.toBytes(),
-                                       (int) maxBufferPoolSize.toBytes());
+        return buildBufferPool((int) minBufferPoolSize.toBytes(),
+                               (int) bufferPoolIncrement.toBytes(),
+                               (int) maxBufferPoolSize.toBytes());
+    }
+
+    // This method only exists so that mockito can spy on the constructor parameters.
+    ByteBufferPool buildBufferPool(int minCapacity, int factor, int maxCapacity) {
+        return new ArrayByteBufferPool(minCapacity, factor, maxCapacity);
     }
 }

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 import java.io.File;
+import java.lang.reflect.Field;
 import java.net.URI;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -35,7 +36,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.apache.commons.lang3.reflect.FieldUtils.getField;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.entry;
@@ -289,16 +289,16 @@ class HttpsConnectorFactoryTest {
             assertThat(sslContextFactory.getKeyStoreResource())
                 .isEqualTo(Resource.newResource("/etc/app/server.ks"));
             assertThat(sslContextFactory.getKeyStoreType()).isEqualTo("JKS");
-            assertThat(getField(SslContextFactory.class, "_keyStorePassword", true).get(sslContextFactory).toString())
+            assertThat(getSSLContextFactoryPrivateField("_keyStorePassword").get(sslContextFactory).toString())
                 .isEqualTo("correct_horse");
             assertThat(sslContextFactory.getKeyStoreProvider()).isEqualTo("BC");
             assertThat(sslContextFactory.getTrustStoreResource())
                 .isEqualTo(Resource.newResource("/etc/app/server.ts"));
             assertThat(sslContextFactory.getKeyStoreType()).isEqualTo("JKS");
-            assertThat(getField(SslContextFactory.class, "_trustStorePassword", true).get(sslContextFactory).toString())
+            assertThat(getSSLContextFactoryPrivateField("_trustStorePassword").get(sslContextFactory).toString())
                 .isEqualTo("battery_staple");
             assertThat(sslContextFactory.getKeyStoreProvider()).isEqualTo("BC");
-            assertThat(getField(SslContextFactory.class, "_keyManagerPassword", true).get(sslContextFactory).toString())
+            assertThat(getSSLContextFactoryPrivateField("_keyManagerPassword").get(sslContextFactory).toString())
                 .isEqualTo("new_overlords");
             assertThat(sslContextFactory.getNeedClientAuth()).isTrue();
             assertThat(sslContextFactory.getWantClientAuth()).isTrue();
@@ -390,5 +390,11 @@ class HttpsConnectorFactoryTest {
         return violations.stream()
                 .map(input -> input.getPropertyPath().toString())
                 .collect(Collectors.toSet());
+    }
+
+    private static Field getSSLContextFactoryPrivateField(final String name) throws NoSuchFieldException {
+        final Field field = SslContextFactory.class.getDeclaredField(name);
+        field.setAccessible(true);
+        return field;
     }
 }

--- a/dropwizard-logging/pom.xml
+++ b/dropwizard-logging/pom.xml
@@ -88,11 +88,6 @@
             <artifactId>jetty-util</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/DefaultLoggingFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/DefaultLoggingFactoryTest.java
@@ -20,7 +20,6 @@ import io.dropwizard.util.Lists;
 import io.dropwizard.util.Maps;
 import io.dropwizard.util.Resources;
 import io.dropwizard.validation.BaseValidator;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringSubstitutor;
 import org.assertj.core.data.MapEntry;
 import org.junit.jupiter.api.BeforeEach;
@@ -55,7 +54,7 @@ public class DefaultLoggingFactoryTest {
     }
 
     @Test
-    public void hasADefaultLevel() throws Exception {
+    public void hasADefaultLevel() {
         assertThat(config.getLevel()).isEqualTo("INFO");
     }
 
@@ -117,13 +116,10 @@ public class DefaultLoggingFactoryTest {
 
     @Test
     public void testConfigure(@TempDir Path tempDir) throws Exception {
-        final File newAppLog = tempDir.resolve("example-new-app.log").toFile();
-        final File newAppNotAdditiveLog = tempDir.resolve("example-new-app-not-additive.log").toFile();
-        final File defaultLog = tempDir.resolve("example.log").toFile();
         final StringSubstitutor substitutor = new StringSubstitutor(Maps.of(
-                "new_app", StringUtils.removeEnd(newAppLog.getAbsolutePath(), ".log"),
-                "new_app_not_additive", StringUtils.removeEnd(newAppNotAdditiveLog.getAbsolutePath(), ".log"),
-                "default", StringUtils.removeEnd(defaultLog.getAbsolutePath(), ".log")
+                "new_app", tempDir.resolve("example-new-app").toFile().getAbsolutePath(),
+                "new_app_not_additive", tempDir.resolve("example-new-app-not-additive").toFile().getAbsolutePath(),
+                "default", tempDir.resolve("example").toFile().getAbsolutePath()
         ));
 
         final String configPath = Resources.getResource("yaml/logging_advanced.yml").getFile();
@@ -144,18 +140,18 @@ public class DefaultLoggingFactoryTest {
             config.stop();
             config.reset();
 
-            assertThat(Files.readAllLines(defaultLog.toPath())).containsOnly(
+            assertThat(Files.readAllLines(tempDir.resolve("example.log"))).containsOnly(
                     "INFO  com.example.app: Application log",
                     "DEBUG com.example.newApp: New application debug log",
                     "INFO  com.example.newApp: New application info log",
                     "DEBUG com.example.legacyApp: Legacy application debug log",
                     "INFO  com.example.legacyApp: Legacy application info log");
 
-            assertThat(Files.readAllLines(newAppLog.toPath())).containsOnly(
+            assertThat(Files.readAllLines(tempDir.resolve("example-new-app.log"))).containsOnly(
                     "DEBUG com.example.newApp: New application debug log",
                     "INFO  com.example.newApp: New application info log");
 
-            assertThat(Files.readAllLines(newAppNotAdditiveLog.toPath())).containsOnly(
+            assertThat(Files.readAllLines(tempDir.resolve("example-new-app-not-additive.log"))).containsOnly(
                     "DEBUG com.example.notAdditive: Not additive application debug log",
                     "INFO  com.example.notAdditive: Not additive application info log");
         } finally {

--- a/dropwizard-metrics-graphite/pom.xml
+++ b/dropwizard-metrics-graphite/pom.xml
@@ -66,10 +66,5 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/dropwizard-metrics-graphite/src/test/java/io/dropwizard/metrics/graphite/GraphiteReporterFactoryTest.java
+++ b/dropwizard-metrics-graphite/src/test/java/io/dropwizard/metrics/graphite/GraphiteReporterFactoryTest.java
@@ -8,10 +8,10 @@ import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.validation.BaseValidator;
-import org.apache.commons.lang3.reflect.FieldUtils;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.lang.reflect.Field;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,7 +22,7 @@ public class GraphiteReporterFactoryTest {
 
     private final GraphiteReporter.Builder builderSpy = mock(GraphiteReporter.Builder.class);
 
-    private GraphiteReporterFactory graphiteReporterFactory = new GraphiteReporterFactory() {
+    private final GraphiteReporterFactory graphiteReporterFactory = new GraphiteReporterFactory() {
         @Override
         protected GraphiteReporter.Builder builder(MetricRegistry registry) {
             return builderSpy;
@@ -30,7 +30,7 @@ public class GraphiteReporterFactoryTest {
     };
 
     @Test
-    public void isDiscoverable() throws Exception {
+    public void isDiscoverable() {
         assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
             .contains(GraphiteReporterFactory.class);
     }
@@ -70,19 +70,25 @@ public class GraphiteReporterFactoryTest {
         assertThat(getField(graphite, "address")).isNull();
     }
 
-    private static Object getField(GraphiteUDP graphite, String name) {
+    private static Object getField(GraphiteUDP graphite, String name) throws NoSuchFieldException {
         try {
-            return FieldUtils.getDeclaredField(GraphiteUDP.class, name, true).get(graphite);
+            return getInaccessibleField(GraphiteUDP.class, name).get(graphite);
         } catch (IllegalAccessException e) {
             throw new IllegalStateException(e);
         }
     }
 
-    private static Object getField(Graphite graphite, String name) {
+    private static Object getField(Graphite graphite, String name) throws NoSuchFieldException {
         try {
-            return FieldUtils.getDeclaredField(Graphite.class, name, true).get(graphite);
+            return getInaccessibleField(Graphite.class, name).get(graphite);
         } catch (IllegalAccessException e) {
             throw new IllegalStateException(e);
         }
+    }
+
+    private static Field getInaccessibleField(Class klass, String name) throws NoSuchFieldException {
+        Field field = klass.getDeclaredField(name);
+        field.setAccessible(true);
+        return field;
     }
 }

--- a/dropwizard-migrations/pom.xml
+++ b/dropwizard-migrations/pom.xml
@@ -102,10 +102,5 @@
             <artifactId>jcip-annotations</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDumpCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDumpCommandTest.java
@@ -3,7 +3,6 @@ package io.dropwizard.migrations;
 import io.dropwizard.util.Resources;
 import net.jcip.annotations.NotThreadSafe;
 import net.sourceforge.argparse4j.inf.Namespace;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -51,7 +50,7 @@ public class DbDumpCommandTest extends AbstractMigrationTest {
     @BeforeEach
     public void setUp() throws Exception {
         final String existedDbPath = new File(Resources.getResource("test-db.mv.db").toURI()).getAbsolutePath();
-        final String existedDbUrl = "jdbc:h2:" + StringUtils.removeEnd(existedDbPath, ".mv.db");
+        final String existedDbUrl = "jdbc:h2:" + existedDbPath.substring(0, existedDbPath.length() - ".mv.db".length());
         existedDbConf = createConfiguration(existedDbUrl);
         dumpCommand.setOutputStream(new PrintStream(baos));
     }

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbStatusCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbStatusCommandTest.java
@@ -3,7 +3,6 @@ package io.dropwizard.migrations;
 import io.dropwizard.util.Resources;
 import net.jcip.annotations.NotThreadSafe;
 import net.sourceforge.argparse4j.inf.Namespace;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -25,7 +24,7 @@ public class DbStatusCommandTest extends AbstractMigrationTest {
     private TestMigrationConfiguration conf;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         conf = createConfiguration(getDatabaseUrl());
 
         statusCommand.setOutputStream(new PrintStream(baos));
@@ -34,7 +33,7 @@ public class DbStatusCommandTest extends AbstractMigrationTest {
     @Test
     public void testRunOnMigratedDb() throws Exception {
         final String existedDbPath = new File(Resources.getResource("test-db.mv.db").toURI()).getAbsolutePath();
-        final String existedDbUrl = "jdbc:h2:" + StringUtils.removeEnd(existedDbPath, ".mv.db");
+        final String existedDbUrl = "jdbc:h2:" + existedDbPath.substring(0, existedDbPath.length() - ".mv.db".length());
         final TestMigrationConfiguration existedDbConf = createConfiguration(existedDbUrl);
 
         statusCommand.run(null, new Namespace(Collections.emptyMap()), existedDbConf);


### PR DESCRIPTION
###### Problem:
No real problem, just a personal vendetta. Feel free to close the PR if you disagree.

`dropwizard-jetty` tests use reflection to determine the configuration of the created `ArrayByteBufferPool`. Switch to using (in a rather icky way) Mockito spy instead. This is taken from https://github.com/dropwizard/dropwizard/pull/3661

###### Solution:
Remove Apache commons-lang3 from several sets of tests

###### Result:
commons-lang3 is only now directly depended on by

- dropwizard-jersey
- dropwizard-views

There are marginally fewer LOC.