### PR TITLE
Remove usage of deprecated Mockito#initMocks()

### DIFF
--- a/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
@@ -18,7 +18,6 @@ import org.apache.http.HttpHeaders;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
-import org.apache.http.ProtocolException;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.NTCredentials;
@@ -79,8 +78,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.validateMockitoUsage;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
-
 
 class AnotherHttpClientBuilder extends org.apache.http.impl.client.HttpClientBuilder {
     public static AnotherHttpClientBuilder create() {
@@ -150,7 +147,6 @@ public class HttpClientBuilderTest {
         connectionManager = spy(new InstrumentedHttpClientConnectionManager(metricRegistry, registry));
         apacheBuilder = org.apache.http.impl.client.HttpClientBuilder.create();
         anotherApacheBuilder = spy(AnotherHttpClientBuilder.create());
-        initMocks(this);
     }
 
     @AfterEach
@@ -675,7 +671,7 @@ public class HttpClientBuilderTest {
             @Override
             public boolean isRedirected(HttpRequest httpRequest,
                                         HttpResponse httpResponse,
-                                        HttpContext httpContext) throws ProtocolException {
+                                        HttpContext httpContext) {
                 return false;
             }
 
@@ -683,7 +679,7 @@ public class HttpClientBuilderTest {
             @Nullable
             public HttpUriRequest getRedirect(HttpRequest httpRequest,
                                               HttpResponse httpResponse,
-                                              HttpContext httpContext) throws ProtocolException {
+                                              HttpContext httpContext) {
                 return null;
             }
         };
@@ -760,7 +756,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void configureCredentialReturnsNTCredentialsForNTLMConfig() throws Exception {
+    public void configureCredentialReturnsNTCredentialsForNTLMConfig() {
         AuthConfiguration ntlmConfig = new AuthConfiguration("username", "password", "NTLM", "realm", "hostname", "domain", "NT");
 
         Credentials credentials = builder.configureCredentials(ntlmConfig);
@@ -770,7 +766,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void configureCredentialReturnsNTCredentialsForBasicConfig() throws Exception {
+    public void configureCredentialReturnsNTCredentialsForBasicConfig() {
         AuthConfiguration ntlmConfig = new AuthConfiguration("username", "password");
 
         Credentials credentials = builder.configureCredentials(ntlmConfig);

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/PersonResourceTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/PersonResourceTest.java
@@ -6,7 +6,6 @@ import io.dropwizard.jackson.Jackson;
 import io.dropwizard.testing.app.PeopleStore;
 import io.dropwizard.testing.app.Person;
 import io.dropwizard.testing.app.PersonResource;
-import io.dropwizard.testing.junit.ResourceTestRule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,10 +21,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 /**
- * Tests {@link ResourceTestRule}.
+ * Tests {@link ResourceExtension}.
  */
 @ExtendWith(DropwizardExtensionsSupport.class)
 class PersonResourceTest {
@@ -50,7 +48,6 @@ class PersonResourceTest {
 
     @BeforeEach
     void setup() {
-        initMocks(peopleStore);
         when(peopleStore.fetchPerson("blah")).thenReturn(person);
     }
 


### PR DESCRIPTION
Remove calls to this deprecated method. Neither of the test classes used Mockito annotations, so it wasn't necessary.