### PR TITLE
Stop ignoring exceptions in dropwizard-logging tests

### DIFF
--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/TcpServer.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/TcpServer.java
@@ -1,16 +1,15 @@
 package io.dropwizard.logging;
 
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.net.SocketException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class TcpServer {
 
@@ -26,19 +25,13 @@ class TcpServer {
                 Socket socket;
                 try {
                     socket = serverSocket.accept();
-                } catch (SocketException e) {
-                    break;
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    fail("Error setting up logging server", e);
                     continue;
                 }
                 new Thread(() -> readAndVerifyData(socket)).start();
             }
         });
-    }
-
-    ServerSocket getServerSocket() {
-        return serverSocket;
     }
 
     int getMessageCount() {
@@ -77,7 +70,7 @@ class TcpServer {
                 latch.countDown();
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            fail("Error reading logs", e);
         }
     }
 }

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/TcpSocketAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/TcpSocketAppenderFactoryTest.java
@@ -29,9 +29,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class TcpSocketAppenderFactoryTest {
 
-    private TcpServer tcpServer = new TcpServer(createServerSocket());
-    private ObjectMapper objectMapper = Jackson.newObjectMapper();
-    private YamlConfigurationFactory<DefaultLoggingFactory> yamlConfigurationFactory = new YamlConfigurationFactory<>(
+    private final TcpServer tcpServer = new TcpServer(createServerSocket());
+    private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+    private final YamlConfigurationFactory<DefaultLoggingFactory> yamlConfigurationFactory = new YamlConfigurationFactory<>(
         DefaultLoggingFactory.class, BaseValidator.newValidator(), objectMapper, "dw-tcp");
 
     @BeforeEach

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/UdpSocketAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/UdpSocketAppenderFactoryTest.java
@@ -16,12 +16,12 @@ import java.io.File;
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
-import java.net.SocketException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class UdpSocketAppenderFactoryTest {
 
@@ -30,8 +30,8 @@ public class UdpSocketAppenderFactoryTest {
     private Thread thread;
     private DatagramSocket datagramSocket;
 
-    private int messagesCount = 100;
-    private CountDownLatch countDownLatch = new CountDownLatch(messagesCount);
+    private final int messagesCount = 100;
+    private final CountDownLatch countDownLatch = new CountDownLatch(messagesCount);
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -45,10 +45,8 @@ public class UdpSocketAppenderFactoryTest {
                     assertThat(new String(buffer, 0, datagramPacket.getLength(), StandardCharsets.UTF_8))
                         .startsWith("INFO").contains("com.example.app: Application log " + i);
                     countDownLatch.countDown();
-                } catch (SocketException e) {
-                    break;
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    fail("Error reading logs", e);
                 }
             }
         });


### PR DESCRIPTION
We were catching some exceptions and dumping the stack trace. It would be better to fail the tests with details of the exception.

This makes error-prone a little happier.