### PR TITLE
Support custom StatsCounter in CachingAuthenticator/CachingAuthorization

### DIFF
--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/CachingAuthorizer.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/CachingAuthorizer.java
@@ -84,7 +84,7 @@ public class CachingAuthorizer<P extends Principal> implements Authorizer<P> {
      *
      * @param metricRegistry the application's registry of metrics
      * @param authorizer     the underlying authorizer
-     * @param builder        a {@link CaffeineSpec}
+     * @param builder        a {@link Caffeine} spec
      * @param supplier       a {@link Supplier<StatsCounter>}
      */
     public CachingAuthorizer(

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/CachingAuthorizer.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/CachingAuthorizer.java
@@ -8,6 +8,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.CaffeineSpec;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import com.github.benmanes.caffeine.cache.stats.StatsCounter;
 import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.util.Sets;
 
@@ -17,6 +18,7 @@ import java.security.Principal;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static com.codahale.metrics.MetricRegistry.name;
@@ -74,11 +76,28 @@ public class CachingAuthorizer<P extends Principal> implements Authorizer<P> {
         final MetricRegistry metricRegistry,
         final Authorizer<P> authorizer,
         final Caffeine<Object, Object> builder) {
+        this(metricRegistry, authorizer, builder, () -> new MetricsStatsCounter(metricRegistry, name(CachingAuthorizer.class)));
+    }
+
+    /**
+     * Creates a new cached authorizer.
+     *
+     * @param metricRegistry the application's registry of metrics
+     * @param authorizer     the underlying authorizer
+     * @param builder        a {@link CaffeineSpec}
+     * @param supplier       a {@link Supplier<StatsCounter>}
+     */
+    public CachingAuthorizer(
+        final MetricRegistry metricRegistry,
+        final Authorizer<P> authorizer,
+        final Caffeine<Object, Object> builder,
+        final Supplier<StatsCounter> supplier
+        ) {
         this.underlying = authorizer;
         this.cacheMisses = metricRegistry.meter(name(authorizer.getClass(), "cache-misses"));
         this.getsTimer = metricRegistry.timer(name(authorizer.getClass(), "gets"));
         this.cache = builder
-                .recordStats(() -> new MetricsStatsCounter(metricRegistry, name(CachingAuthorizer.class)))
+                .recordStats(supplier)
                 .build(key -> {
                     cacheMisses.mark();
                     return underlying.authorize(key.getPrincipal(), key.getRole(), key.getRequestContext());


### PR DESCRIPTION
###### Problem:

Caffeine does not allow to [register more than one StatsCounter](https://github.com/ben-manes/caffeine/blob/master/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Caffeine.java#L945), raising an `IllegalStateException` if you do so. Since Dropwizard attempt to add its own automatically when using Caffeine, this prevent anyone from using a custom one.

###### Solution:

This adds a new constructor providing a way to supply a custom `StatsCounter` if needed for `CachingAuthorizer` and `CachingAuthorization`, that will replace the dropwizard one if provided.
