### PR TITLE
Use System.lineSeparator() instead of String.format(%n")

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
@@ -705,8 +705,8 @@ public abstract class AbstractServerFactory implements ServerFactory {
         final URL resource = Thread.currentThread().getContextClassLoader().getResource("banner.txt");
         if (resource != null) {
             try (final InputStream resourceStream = resource.openStream();
-                final InputStreamReader inputStreamReader = new InputStreamReader(resourceStream);
-                final BufferedReader bufferedReader = new BufferedReader(inputStreamReader)) {
+                 final InputStreamReader inputStreamReader = new InputStreamReader(resourceStream);
+                 final BufferedReader bufferedReader = new BufferedReader(inputStreamReader)) {
                 final String banner = bufferedReader
                         .lines()
                         .collect(Collectors.joining(System.lineSeparator()));

--- a/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
@@ -705,11 +705,11 @@ public abstract class AbstractServerFactory implements ServerFactory {
         final URL resource = Thread.currentThread().getContextClassLoader().getResource("banner.txt");
         if (resource != null) {
             try (final InputStream resourceStream = resource.openStream();
-                 final InputStreamReader inputStreamReader = new InputStreamReader(resourceStream);
-                 final BufferedReader bufferedReader = new BufferedReader(inputStreamReader)) {
+                final InputStreamReader inputStreamReader = new InputStreamReader(resourceStream);
+                final BufferedReader bufferedReader = new BufferedReader(inputStreamReader)) {
                 final String banner = bufferedReader
                         .lines()
-                        .collect(Collectors.joining(String.format("%n")));
+                        .collect(Collectors.joining(System.lineSeparator()));
                 msg = String.format("Starting %s%n%s", name, banner);
             } catch (IllegalArgumentException | IOException ignored) {
             }


### PR DESCRIPTION
###### Problem:
`String.format("%n")` is a rather heavyweight way to get the system's line separator.

###### Solution:
Use `System.lineSeparator()` instead. They are specified as being equivalent.

###### Result:
An undetectable performance improvement.