### PR TITLE
Replace deprecated AssertJ assertions

### DIFF
--- a/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
@@ -151,9 +151,9 @@ class DefaultServerFactoryTest {
         http.build(environment);
         assertThat(environment.jersey().getResourceConfig().getSingletons())
             .filteredOn(x -> x instanceof ExceptionMapperBinder)
-            .map(x -> (ExceptionMapperBinder)x)
+            .map(x -> (ExceptionMapperBinder) x)
             .singleElement()
-            .hasFieldOrPropertyWithValue("showDetails", false);
+            .satisfies(x -> assertThat(x.isShowDetails()).isFalse());
     }
 
     @Test
@@ -163,9 +163,9 @@ class DefaultServerFactoryTest {
         http.build(environment);
         assertThat(environment.jersey().getResourceConfig().getSingletons())
             .filteredOn(x -> x instanceof ExceptionMapperBinder)
-            .map(x -> (ExceptionMapperBinder)x)
+            .map(x -> (ExceptionMapperBinder) x)
             .singleElement()
-            .hasFieldOrPropertyWithValue("showDetails", true);
+            .satisfies(x -> assertThat(x.isShowDetails()).isTrue());
     }
 
     @Test

--- a/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
@@ -147,23 +147,25 @@ class DefaultServerFactoryTest {
     }
 
     @Test
-    void defaultsDetailedJsonProcessingExceptionToFalse() throws Exception {
+    void defaultsDetailedJsonProcessingExceptionToFalse() {
         http.build(environment);
         assertThat(environment.jersey().getResourceConfig().getSingletons())
             .filteredOn(x -> x instanceof ExceptionMapperBinder)
-            .hasOnlyOneElementSatisfying(x ->
-                assertThat(((ExceptionMapperBinder) x).isShowDetails()).isFalse());
+            .map(x -> (ExceptionMapperBinder)x)
+            .singleElement()
+            .hasFieldOrPropertyWithValue("showDetails", false);
     }
 
     @Test
-    void doesNotDefaultDetailedJsonProcessingExceptionToFalse() throws Exception {
+    void doesNotDefaultDetailedJsonProcessingExceptionToFalse() {
         http.setDetailedJsonProcessingExceptionMapper(true);
 
         http.build(environment);
         assertThat(environment.jersey().getResourceConfig().getSingletons())
             .filteredOn(x -> x instanceof ExceptionMapperBinder)
-            .hasOnlyOneElementSatisfying(x ->
-                assertThat(((ExceptionMapperBinder) x).isShowDetails()).isTrue());
+            .map(x -> (ExceptionMapperBinder)x)
+            .singleElement()
+            .hasFieldOrPropertyWithValue("showDetails", true);
     }
 
     @Test


### PR DESCRIPTION
###### Problem:
`hasOnlyOneElementSatisfying()` has been deprecated and replaced by `singleElement()`

###### Solution:
I adjusted the assertions to use non-deprecated methods. I wasn't too sure about the use of `hasFieldOrPropertyWithValue` though. It feels like there should be a more type-safe way to do this.

###### Result:
Fewer deprecation warnings.