### PR TITLE
Replace Streams usage with String#join

### DIFF
--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/BaseConfigurationFactory.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/BaseConfigurationFactory.java
@@ -172,8 +172,7 @@ public abstract class BaseConfigurationFactory<T> implements ConfigurationFactor
             }
             final ObjectNode obj = (ObjectNode) node;
 
-            final String remainingPath = parts.subList(i, parts.size()).stream()
-                    .collect(Collectors.joining("."));
+            final String remainingPath = String.join(".", parts.subList(i, parts.size()));
             if (obj.has(remainingPath) && !remainingPath.equals(key)) {
                 if (obj.get(remainingPath).isValueNode()) {
                     obj.put(remainingPath, value);

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/ServerPushFilterFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/ServerPushFilterFactory.java
@@ -143,9 +143,7 @@ public class ServerPushFilterFactory {
         handler.setInitParameter("associatePeriod", String.valueOf(associatePeriod.toMilliseconds()));
         handler.setInitParameter("maxAssociations", String.valueOf(maxAssociations));
         if (refererHosts != null) {
-            final String hosts = refererHosts.stream()
-                    .collect(Collectors.joining(","));
-            handler.setInitParameter("hosts", hosts);
+            handler.setInitParameter("hosts", String.join(",", refererHosts));
         }
         if (refererPorts != null) {
             final String ports = refererPorts.stream()


### PR DESCRIPTION
###### Problem:
In a couple of places we use the Streams API to join a String list with a delimiter. `String.join()` is a simpler way to do this.

###### Solution:
Replace `Stream` usage with `String.join` where possible.

###### Result:
Maybe things will be quicker? Certainly there's a little less code.