### PR TITLE
DropwizardAppExtension support for RegisterExtension

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardAppExtension.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardAppExtension.java
@@ -20,6 +20,9 @@ import javax.ws.rs.client.Client;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 //@formatter:off
 /**
@@ -33,7 +36,8 @@ import java.util.function.Function;
  * @param <C> the configuration type
  */
 //@formatter:on
-public class DropwizardAppExtension<C extends Configuration> implements DropwizardExtension {
+public class DropwizardAppExtension<C extends Configuration> implements DropwizardExtension,
+    BeforeAllCallback, AfterAllCallback {
 
     private static final int DEFAULT_CONNECT_TIMEOUT_MS = 1000;
     private static final int DEFAULT_READ_TIMEOUT_MS = 5000;
@@ -173,6 +177,16 @@ public class DropwizardAppExtension<C extends Configuration> implements Dropwiza
                 environment.lifecycle().manage(managed);
             }
         });
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) throws Exception {
+        this.before();
+    }
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) {
+        this.after();
     }
 
     @Override

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/AbstractDropwizardAppExtensionTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/AbstractDropwizardAppExtensionTest.java
@@ -1,0 +1,85 @@
+package io.dropwizard.testing.junit5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.app.DropwizardTestApplication;
+import io.dropwizard.testing.app.TestConfiguration;
+import java.util.Optional;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+abstract class AbstractDropwizardAppExtensionTest {
+
+    @Test
+    void canGetExpectedResourceOverHttp() {
+        final String content = ClientBuilder.newClient().target(
+                "http://localhost:" + getExtension().getLocalPort() + "/test").request().get(String.class);
+
+        assertThat(content).isEqualTo("Yes, it's here");
+    }
+
+    @Test
+    void returnsConfiguration() {
+        final TestConfiguration config = getExtension().getConfiguration();
+        assertThat(config.getMessage()).isEqualTo("Yes, it's here");
+    }
+
+    @Test
+    void returnsApplication() {
+        final DropwizardTestApplication application = getExtension().getApplication();
+        Assertions.assertNotNull(application);
+    }
+
+    @Test
+    void returnsEnvironment() {
+        final Environment environment = getExtension().getEnvironment();
+        assertThat(environment.getName()).isEqualTo("DropwizardTestApplication");
+    }
+
+    @Test
+    void canPerformAdminTask() {
+        final String response
+                = getExtension().client().target("http://localhost:"
+                + getExtension().getAdminPort() + "/tasks/hello?name=test_user")
+                .request()
+                .post(Entity.entity("", MediaType.TEXT_PLAIN), String.class);
+
+        assertThat(response).isEqualTo("Hello has been said to test_user");
+    }
+
+    @Test
+    void canPerformAdminTaskWithPostBody() {
+        final String response = getExtension().client()
+                .target("http://localhost:" + getExtension().getAdminPort() + "/tasks/echo")
+                .request()
+                .post(Entity.entity("Custom message", MediaType.TEXT_PLAIN), String.class);
+
+        assertThat(response).isEqualTo("Custom message");
+    }
+
+    @Test
+    void clientUsesJacksonMapperFromEnvironment() {
+        final Optional<String> message = getExtension().client()
+                .target("http://localhost:" + getExtension().getLocalPort() + "/message")
+                .request()
+                .get(DropwizardTestApplication.MessageView.class)
+                .getMessage();
+        assertThat(message)
+                .hasValue("Yes, it's here");
+    }
+
+    @Test
+    void clientSupportsPatchMethod() {
+        final String method = getExtension().client()
+                .target("http://localhost:" + getExtension().getLocalPort() + "/echoPatch")
+                .request()
+                .method("PATCH", Entity.text("Patch is working"), String.class);
+        assertThat(method).isEqualTo("Patch is working");
+    }
+
+    abstract DropwizardAppExtension<TestConfiguration> getExtension();
+}

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionRegisterExtensionTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionRegisterExtensionTest.java
@@ -1,15 +1,15 @@
 package io.dropwizard.testing.junit5;
 
-import io.dropwizard.testing.app.DropwizardTestApplication;
-import io.dropwizard.testing.app.TestConfiguration;
-import org.junit.jupiter.api.extension.ExtendWith;
-
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 
-@ExtendWith(DropwizardExtensionsSupport.class)
-class DropwizardAppExtensionTest extends AbstractDropwizardAppExtensionTest {
+import io.dropwizard.testing.app.DropwizardTestApplication;
+import io.dropwizard.testing.app.TestConfiguration;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-    private static final DropwizardAppExtension<TestConfiguration> EXTENSION =
+class DropwizardAppExtensionRegisterExtensionTest extends AbstractDropwizardAppExtensionTest {
+
+    @RegisterExtension
+    public static final DropwizardAppExtension<TestConfiguration> EXTENSION =
             new DropwizardAppExtension<>(DropwizardTestApplication.class, resourceFilePath("test-config.yaml"));
 
     @Override


### PR DESCRIPTION
This PR enables us to use DropwizardAppExtension with JUnit 5's "RegisterExtension" annotation.

###### Problem:
We're adding JUnit 5 capabilities to our open source framework [sda-dropwizard-commons](https://github.com/SDA-SE/sda-dropwizard-commons/). We noticed that JUnit 4's RuleChain is no longer available and are looking for a different solution to specify the order of the execution of the extensions. This is needed to spin up a service (e.g. with Wiremock) beforehand and configure URLs and ports in our application afterwards.

JUnit 5 provides these solutions as far as I know:
- declare the order by enumerating all extensions in your `ExtendWith` annotation
- declare the order by the order of the fields that have a `RegisterExtension` annotation
- you can also add an `Order` annotation to the fields that already have the `RegisterExtension` annotation.

Unfortunately you can't mix these two approaches very well.

You can find more information in the [official documentation](https://junit.org/junit5/docs/current/user-guide/#extensions-registration).

We need to use the programmatic extension registration to be able to configure the test resources in most cases. Declaratice extension is not an alternative.

###### Solution:

We'd like the existing DropwizardAppExtension support the programmatic approach. The only thing that needs to be added are two interfaces. I don't see any disadvantages - I even think using this approach is even easier because you only need one line of code; no need to also add `ExtendWith` annotation.

###### Result:

The changes we made are backwards compatible. The app extension can now be used with JUnit 5's `RegisterExtension`.

If you think the change is valid I'm happy to also add the new feature to the documentation. :) 