### PR TITLE
Move DropwizardSSLConnectionSocketFactoryTest to io.dropwizard.client

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactory.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactory.java
@@ -29,7 +29,7 @@ public class DropwizardSSLConnectionSocketFactory {
     private final TlsConfiguration configuration;
 
     @Nullable
-    private final HostnameVerifier verifier;
+    final HostnameVerifier verifier;
 
     public DropwizardSSLConnectionSocketFactory(TlsConfiguration configuration) {
         this(configuration, null);

--- a/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactoryTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactoryTest.java
@@ -1,17 +1,14 @@
-package io.dropwizard.client.ssl;
+package io.dropwizard.client;
 
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
-import io.dropwizard.client.DropwizardSSLConnectionSocketFactory;
-import io.dropwizard.client.JerseyClientBuilder;
-import io.dropwizard.client.JerseyClientConfiguration;
+import io.dropwizard.client.ssl.TlsConfiguration;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.util.Duration;
-import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLInitializationException;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -35,7 +32,6 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.net.SocketException;
 import java.security.Security;
 import java.util.Collections;
@@ -115,13 +111,8 @@ public class DropwizardSSLConnectionSocketFactoryTest {
     }
 
     @Test
-    void configOnlyConstructorShouldSetNullCustomVerifier() throws Exception {
-        final DropwizardSSLConnectionSocketFactory socketFactory;
-        socketFactory = new DropwizardSSLConnectionSocketFactory(tlsConfiguration);
-
-        final Field verifierField =
-                FieldUtils.getField(DropwizardSSLConnectionSocketFactory.class, "verifier", true);
-        assertThat(verifierField.get(socketFactory)).isNull();
+    void configOnlyConstructorShouldSetNullCustomVerifier() {
+        assertThat(new DropwizardSSLConnectionSocketFactory(tlsConfiguration).verifier).isNull();
     }
 
     @Test


### PR DESCRIPTION
###### Problem:
`DropwizardSSLConnectionSocketFactoryTest` uses `commons-lang3`'s `FieldUtils` to access a private member field of `DropwizardSSLConnectionSocketFactory`.

###### Solution:
Move the test to the same package as the class it's testing and make the field package-private.

###### Result:
Less reliance on reflection, which makes the tests less fragile.