### PR TITLE
Use spying instead of reflection in dropwizard-jetty tests

### DIFF
--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
@@ -694,8 +694,13 @@ public class HttpConnectorFactory implements ConnectorFactory {
     }
 
     protected ByteBufferPool buildBufferPool() {
-        return new ArrayByteBufferPool((int) minBufferPoolSize.toBytes(),
-                                       (int) bufferPoolIncrement.toBytes(),
-                                       (int) maxBufferPoolSize.toBytes());
+        return buildBufferPool((int) minBufferPoolSize.toBytes(),
+                               (int) bufferPoolIncrement.toBytes(),
+                               (int) maxBufferPoolSize.toBytes());
+    }
+
+    // This method only exists so that mockito can spy on the constructor parameters.
+    ByteBufferPool buildBufferPool(int minCapacity, int factor, int maxCapacity) {
+        return new ArrayByteBufferPool(minCapacity, factor, maxCapacity);
     }
 }


### PR DESCRIPTION
###### Problem:
Some of the `dropwizard-jetty` tests use reflection to examine private fields of other classes. In the case of `ArrayByteBufferPool` there is no API to obtain these values.

This is inherently flaky and not type safe.

###### Solution:
Instead of examining the internals of the object using reflection, add a factory method to proxy the constructor call which we can then spy on using Mockito (I think this is the cleanest way, but maybe someone who knows Mockito better than I do can improve on it).

###### Result:
This improves type safety and reduces the change of a change to the internals of ArrayByteBufferPool breaking the tests.

All we really care about here (I think) is that the pool is created with the parameters we expect.