### PR TITLE
Use assertThatExceptionOfType in dropwizard-auth

### DIFF
--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthBaseTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthBaseTest.java
@@ -18,7 +18,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public abstract class AuthBaseTest<T extends DropwizardResourceConfig> extends JerseyTest {
     protected static final String ADMIN_ROLE = "ADMIN";
@@ -70,15 +70,12 @@ public abstract class AuthBaseTest<T extends DropwizardResourceConfig> extends J
     }
 
     @Test
-    public void respondsToMissingCredentialsWith401() throws Exception {
-        try {
-            target("/test/admin").request().get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(401);
-            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
-                .containsOnly(getPrefix() + " realm=\"realm\"");
-        }
+    public void respondsToMissingCredentialsWith401() {
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> target("/test/admin").request().get(String.class))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(401))
+            .satisfies(e -> assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
+                .containsOnly(getPrefix() + " realm=\"realm\""));
     }
 
     @Test
@@ -98,14 +95,11 @@ public abstract class AuthBaseTest<T extends DropwizardResourceConfig> extends J
 
     @Test
     public void resourceWithAuthenticationWithoutAuthorizationNoCredentials401() {
-        try {
-            target("/test/profile").request().get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(401);
-            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
-                .containsOnly(getPrefix() + " realm=\"realm\"");
-        }
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> target("/test/profile").request().get(String.class))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(401))
+            .satisfies(e -> assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
+                .containsOnly(getPrefix() + " realm=\"realm\""));
     }
 
     @Test
@@ -133,41 +127,32 @@ public abstract class AuthBaseTest<T extends DropwizardResourceConfig> extends J
 
     @Test
     public void resourceWithAuthorizationPrincipalIsNotAuthorized403() {
-        try {
-            target("/test/admin").request()
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> target("/test/admin").request()
                 .header(HttpHeaders.AUTHORIZATION, getPrefix() + " " + getOrdinaryGuyValidToken())
-                .get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(403);
-        }
+                .get(String.class))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(403));
     }
 
 
     @Test
     public void resourceWithDenyAllAndNoAuth401() {
-        try {
-            target("/test/denied").request().get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(401);
-        }
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> target("/test/denied").request().get(String.class))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(401));
     }
 
     @Test
     public void resourceWithDenyAllAndAuth403() {
-        try {
-            target("/test/denied").request()
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> target("/test/denied").request()
                 .header(HttpHeaders.AUTHORIZATION, getPrefix() + " " + getGoodGuyValidToken())
-                .get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(403);
-        }
+                .get(String.class))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(403));
     }
 
     @Test
-    public void transformsCredentialsToPrincipals() throws Exception {
+    public void transformsCredentialsToPrincipals() {
         assertThat(target("/test/admin").request()
             .header(HttpHeaders.AUTHORIZATION, getPrefix() + " " + getGoodGuyValidToken())
             .get(String.class))
@@ -175,7 +160,7 @@ public abstract class AuthBaseTest<T extends DropwizardResourceConfig> extends J
     }
 
     @Test
-    public void transformsCredentialsToPrincipalsWhenAuthAnnotationExistsWithoutMethodAnnotation() throws Exception {
+    public void transformsCredentialsToPrincipalsWhenAuthAnnotationExistsWithoutMethodAnnotation() {
         assertThat(target("/test/implicit-permitall").request()
             .header(HttpHeaders.AUTHORIZATION, getPrefix() + " " + getGoodGuyValidToken())
             .get(String.class))
@@ -184,28 +169,22 @@ public abstract class AuthBaseTest<T extends DropwizardResourceConfig> extends J
 
 
     @Test
-    public void respondsToNonBasicCredentialsWith401() throws Exception {
-        try {
-            target("/test/admin").request()
+    public void respondsToNonBasicCredentialsWith401() {
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> target("/test/admin").request()
                 .header(HttpHeaders.AUTHORIZATION, "Derp irrelevant")
-                .get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(401);
-            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
-                .containsOnly(getPrefix() + " realm=\"realm\"");
-        }
+                .get(String.class))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(401))
+                .satisfies(e -> assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
+                    .containsOnly(getPrefix() + " realm=\"realm\""));
     }
 
     @Test
-    public void respondsToExceptionsWith500() throws Exception {
-        try {
-            target("/test/admin").request()
+    public void respondsToExceptionsWith500() {
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> target("/test/admin").request()
                 .header(HttpHeaders.AUTHORIZATION, getPrefix() + " " + getBadGuyToken())
-                .get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(500);
-        }
+                .get(String.class))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(500));
     }
 }

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/PolymorphicPrincipalEntityTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/PolymorphicPrincipalEntityTest.java
@@ -27,7 +27,7 @@ import java.security.Principal;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * Testing that polymorphic principal entity injection works.
@@ -129,12 +129,9 @@ public class PolymorphicPrincipalEntityTest extends JerseyTest {
 
     @Test
     public void jsonPrincipalEntityResourceNoAuth401() {
-        try {
-            target("/auth-test/json-principal-entity").request().get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(401);
-        }
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> target("/auth-test/json-principal-entity").request().get(String.class))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(401));
     }
 
     @Test
@@ -147,12 +144,9 @@ public class PolymorphicPrincipalEntityTest extends JerseyTest {
 
     @Test
     public void nullPrincipalEntityResourceNoAuth401() {
-        try {
-            target("/auth-test/null-principal-entity").request().get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(401);
-        }
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> target("/auth-test/null-principal-entity").request().get(String.class))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(401));
     }
 
     @Test


### PR DESCRIPTION
###### Problem:
It is (subjectively) better to specify tests in terms of success rather than terms of failure and also for there to be less code, provided it works and isn't confusing.

With that in mind, some tests could be improved slightly.

###### Solution:
translate

```
try {
    something();
    failBecauseExceptionWasNotThrown();
} catch (Exception e) {
    // assert some things about e
}
```
into
```
assertThatExceptionOfType(Exception.class)
    .isThrownBy(() -> something())
    // assert some more things
```

###### Result:
There is less code and (opinions may differ) the tests become more expressive.

If you agree this is a good thing to do, there are other places where `failBecauseExceptionWasNotThrown` is used and I'm happy to give those the same treatment if they look like suitable candidates.

Also, if these little cleanup PRs are annoying and creating unnecessary code churn and review effort, don't be afraid to say so. I like Dropwizard and have worked with it on many projects (https://github.com/alphagov/verify-hub being the only one which is public) where it has been really helpful, so I thought I'd try and do some odd bits and pieces to keep its quality up.