### PR TITLE
Add support for testing plain Command classes

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/cli/ConfiguredCommand.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/ConfiguredCommand.java
@@ -45,6 +45,17 @@ public abstract class ConfiguredCommand<T extends Configuration> extends Command
     }
 
     /**
+     * Returns the parsed configuration or {@code null} if it hasn't been parsed yet.
+     *
+     * @return Returns the parsed configuration or {@code null} if it hasn't been parsed yet
+     * @since 2.0.19
+     */
+    @Nullable
+    public T getConfiguration() {
+        return configuration;
+    }
+
+    /**
      * Configure the command's {@link Subparser}. <p><strong> N.B.: if you override this method, you
      * <em>must</em> call {@code super.override(subparser)} in order to preserve the configuration
      * file parameter in the subparser. </strong></p>

--- a/dropwizard-core/src/main/java/io/dropwizard/cli/EnvironmentCommand.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/EnvironmentCommand.java
@@ -6,6 +6,8 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import net.sourceforge.argparse4j.inf.Namespace;
 
+import javax.annotation.Nullable;
+
 /**
  * A command which executes with a configured {@link Environment}.
  *
@@ -14,6 +16,8 @@ import net.sourceforge.argparse4j.inf.Namespace;
  */
 public abstract class EnvironmentCommand<T extends Configuration> extends ConfiguredCommand<T> {
     private final Application<T> application;
+    @Nullable
+    private Environment environment;
 
     /**
      * Creates a new environment command.
@@ -27,15 +31,26 @@ public abstract class EnvironmentCommand<T extends Configuration> extends Config
         this.application = application;
     }
 
+    /**
+     * Returns the constructed environment or {@code null} if it hasn't been constructed yet.
+     *
+     * @return Returns the constructed environment or {@code null} if it hasn't been constructed yet
+     * @since 2.0.19
+     */
+    @Nullable
+    public Environment getEnvironment() {
+        return environment;
+    }
+
     @Override
     protected void run(Bootstrap<T> bootstrap, Namespace namespace, T configuration) throws Exception {
-        final Environment environment = new Environment(bootstrap.getApplication().getName(),
-                                                        bootstrap.getObjectMapper(),
-                                                        bootstrap.getValidatorFactory(),
-                                                        bootstrap.getMetricRegistry(),
-                                                        bootstrap.getClassLoader(),
-                                                        bootstrap.getHealthCheckRegistry(),
-                                                        configuration);
+        this.environment = new Environment(bootstrap.getApplication().getName(),
+                                           bootstrap.getObjectMapper(),
+                                           bootstrap.getValidatorFactory(),
+                                           bootstrap.getMetricRegistry(),
+                                           bootstrap.getClassLoader(),
+                                           bootstrap.getHealthCheckRegistry(),
+                                           configuration);
         configuration.getMetricsFactory().configure(environment.lifecycle(),
                                                     bootstrap.getMetricRegistry());
         configuration.getServerFactory().configure(environment);

--- a/dropwizard-e2e/src/main/java/com/example/badlog/BadLogApp.java
+++ b/dropwizard-e2e/src/main/java/com/example/badlog/BadLogApp.java
@@ -14,10 +14,6 @@ public class BadLogApp extends Application<Configuration> {
         LOGGER.warn("Mayday we're going down");
     }
 
-    public static void runMe(String[] args) throws Exception {
-        new BadLogApp().run(args);
-    }
-
     @Override
     public void run(Configuration configuration, Environment environment) throws Exception {
         throw new RuntimeException("I'm a bad app");

--- a/dropwizard-e2e/src/test/java/com/example/badlog/BadLogTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/badlog/BadLogTest.java
@@ -4,9 +4,11 @@ import io.dropwizard.Configuration;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.DropwizardTestSupport;
 import io.dropwizard.testing.ResourceHelpers;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,52 +17,53 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 
-public class BadLogTest {
+@DisabledOnOs(OS.WINDOWS)
+class BadLogTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(BadLogTest.class);
-    private static ByteArrayOutputStream out;
-    private static ByteArrayOutputStream err;
-    private static PrintStream oldOut = System.out;
-    private static PrintStream oldErr = System.err;
+    private static final PrintStream oldOut = System.out;
+    private static final PrintStream oldErr = System.err;
+    private ByteArrayOutputStream out;
+    private ByteArrayOutputStream err;
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         out = new ByteArrayOutputStream();
         err = new ByteArrayOutputStream();
         System.setOut(new PrintStream(out));
         System.setErr(new PrintStream(err));
     }
 
-    @AfterEach
-    public void teardown() {
+    @AfterAll
+    static void teardown() {
         System.setOut(oldOut);
         System.setErr(oldErr);
     }
 
     @Test
-    public void thatLoggingIsntBrokenOnCleanup() throws Exception {
-        BadLogApp.runMe(new String[]{"server"});
+    void thatLoggingIsNotBrokenOnCleanup() throws Exception {
+        new BadLogApp().run("server");
         LOGGER.info("I'm after the test");
         Thread.sleep(100);
 
-        assertThat(new String(out.toByteArray(), UTF_8))
+        assertThat(out.toByteArray()).asString(UTF_8)
             .contains("Mayday we're going down")
             .contains("I'm after the test");
 
-        assertThat(new String(err.toByteArray(), UTF_8))
+        assertThat(err.toByteArray()).asString(UTF_8)
             .contains("I'm a bad app");
     }
 
     @Test
-    public void testSupportShouldResetLogging(@TempDir Path tempDir) throws Exception {
-        final Path logFile = tempDir.resolve("example.log");
-
+    void testSupportShouldResetLogging(@TempDir Path tempDir) throws Exception {
         // Clear out the log file
-        Files.write(logFile, new byte[]{});
+        final Path logFile = Files.write(tempDir.resolve("example.log"), new byte[0]);
 
         final ConfigOverride logOverride = ConfigOverride.config("logging.appenders[0].currentLogFilename", logFile.toString());
         final String configPath = ResourceHelpers.resourceFilePath("badlog/config.yaml");
@@ -76,19 +79,19 @@ public class BadLogTest {
         // Explicitly run the command so that the fatal error function runs
         app.getApplication().run("server", configPath);
         app.after();
+        Thread.sleep(100L);
 
         // Since our dropwizard app is only using the file appender, the console
         // appender should not contain our logging statements
-        assertThat(new String(out.toByteArray(), UTF_8))
-            .doesNotContain("Mayday we're going down");
+        assertThat(out.toByteArray()).asString(UTF_8).doesNotContain("Mayday we're going down");
         out.reset();
 
         // and the file should have our logging statements
-        final String contents = new String(Files.readAllBytes(logFile), UTF_8);
-        assertThat(contents).contains("Mayday we're going down");
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(
+                () -> assertThat(Files.readAllBytes(logFile)).asString(UTF_8).contains("Mayday we're going down"));
 
         // Clear out the log file
-        Files.write(logFile, new byte[]{});
+        Files.write(logFile, new byte[0]);
 
         final DropwizardTestSupport<Configuration> app2 = new DropwizardTestSupport<>(BadLogApp.class, new Configuration());
         assertThatThrownBy(app2::before).hasMessage("I'm a bad app");
@@ -96,10 +99,10 @@ public class BadLogTest {
         // Explicitly run the command so that the fatal error function runs
         app2.getApplication().run("server");
         app2.after();
+        Thread.sleep(100L);
 
         // Now the console appender will see the fatal error
-        assertThat(new String(out.toByteArray(), UTF_8))
-            .contains("Mayday we're going down");
+        assertThat(out.toByteArray()).asString(UTF_8).contains("Mayday we're going down");
         out.reset();
 
         // and the old log file shouldn't
@@ -109,7 +112,7 @@ public class BadLogTest {
         // And for the final set of assertions will make sure that going back to the app
         // that logs to a file is still behaviorally correct.
         // Clear out the log file
-        Files.write(logFile, new byte[]{});
+        Files.write(logFile, new byte[0]);
 
         final DropwizardTestSupport<Configuration> app3 = new DropwizardTestSupport<>(BadLogApp.class, configPath, logOverride);
         assertThatThrownBy(app3::before).hasMessage("I'm a bad app");
@@ -120,14 +123,14 @@ public class BadLogTest {
         // Explicitly run the command so that the fatal error function runs
         app3.getApplication().run("server", configPath);
         app3.after();
+        Thread.sleep(100L);
 
         // Since our dropwizard app is only using the file appender, the console
         // appender should not contain our logging statements
-        assertThat(new String(out.toByteArray(), UTF_8))
-            .doesNotContain("Mayday we're going down");
+        assertThat(out.toByteArray()).asString(UTF_8).doesNotContain("Mayday we're going down");
 
         // and the file should have our logging statements
-        final String contents3 = new String(Files.readAllBytes(logFile), UTF_8);
-        assertThat(contents3).contains("Mayday we're going down");
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(
+                () -> assertThat(Files.readAllBytes(logFile)).asString(UTF_8).contains("Mayday we're going down"));
     }
 }

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.cli.Command;
+import io.dropwizard.cli.ConfiguredCommand;
+import io.dropwizard.cli.EnvironmentCommand;
 import io.dropwizard.cli.ServerCommand;
 import io.dropwizard.configuration.ConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
@@ -285,8 +287,6 @@ public class DropwizardTestSupport<C extends Configuration> {
             @Override
             public void run(C configuration, Environment environment) throws Exception {
                 environment.lifecycle().addServerLifecycleListener(server -> jettyServer = server);
-                DropwizardTestSupport.this.configuration = configuration;
-                DropwizardTestSupport.this.environment = environment;
                 super.run(configuration, environment);
                 for (ServiceListener<C> listener : listeners) {
                     try {
@@ -324,23 +324,34 @@ public class DropwizardTestSupport<C extends Configuration> {
         final Namespace namespace = new Namespace(namespaceAttributes);
         final Command command = commandInstantiator.apply(application);
         command.run(bootstrap, namespace);
+
+        if (command instanceof EnvironmentCommand) {
+            @SuppressWarnings("unchecked")
+            EnvironmentCommand<C> environmentCommand = (EnvironmentCommand<C>) command;
+            this.configuration = environmentCommand.getConfiguration();
+            this.environment = environmentCommand.getEnvironment();
+        } else if (command instanceof ConfiguredCommand) {
+            @SuppressWarnings("unchecked")
+            ConfiguredCommand<C> configuredCommand = (ConfiguredCommand<C>) command;
+            this.configuration = configuredCommand.getConfiguration();
+        }
     }
 
     public C getConfiguration() {
-        return requireNonNull(configuration);
+        return requireNonNull(configuration, "configuration");
     }
 
     public int getLocalPort() {
-        return ((ServerConnector) requireNonNull(jettyServer).getConnectors()[0]).getLocalPort();
+        return getPort(0);
     }
 
     public int getAdminPort() {
-        final Connector[] connectors = requireNonNull(jettyServer).getConnectors();
+        final Connector[] connectors = requireNonNull(jettyServer, "jettyServer").getConnectors();
         return ((ServerConnector) connectors[connectors.length - 1]).getLocalPort();
     }
 
     public int getPort(int connectorIndex) {
-        return ((ServerConnector) requireNonNull(jettyServer).getConnectors()[connectorIndex]).getLocalPort();
+        return ((ServerConnector) requireNonNull(jettyServer, "jettyServer").getConnectors()[connectorIndex]).getLocalPort();
     }
 
     public Application<C> newApplication() {
@@ -353,11 +364,11 @@ public class DropwizardTestSupport<C extends Configuration> {
 
     @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})
     public <A extends Application<C>> A getApplication() {
-        return (A) requireNonNull(application);
+        return (A) requireNonNull(application, "application");
     }
 
     public Environment getEnvironment() {
-        return requireNonNull(environment);
+        return requireNonNull(environment, "environment");
     }
 
     public ObjectMapper getObjectMapper() {

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionWithCheckCommandTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionWithCheckCommandTest.java
@@ -1,0 +1,34 @@
+package io.dropwizard.testing.junit5;
+
+import io.dropwizard.cli.CheckCommand;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
+import io.dropwizard.testing.app.DropwizardTestApplication;
+import io.dropwizard.testing.app.TestConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+class DropwizardAppExtensionWithCheckCommandTest {
+
+    private static final DropwizardAppExtension<TestConfiguration> EXTENSION = new DropwizardAppExtension<>(
+        DropwizardTestApplication.class, "test-config.yaml", new ResourceConfigurationSourceProvider(), null, CheckCommand::new);
+
+
+    @Test
+    void returnsConfiguration() {
+        assertThat(EXTENSION.getConfiguration().getMessage()).isEqualTo("Yes, it's here");
+    }
+
+    @Test
+    void returnsApplication() {
+        assertThat(EXTENSION.<DropwizardTestApplication>getApplication()).isNotNull();
+    }
+
+    @Test
+    void environmentIsNull() {
+        assertThatNullPointerException().isThrownBy(EXTENSION::getEnvironment);
+    }
+}

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionWithConfiguredCommandTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionWithConfiguredCommandTest.java
@@ -1,0 +1,42 @@
+package io.dropwizard.testing.junit5;
+
+import io.dropwizard.cli.ConfiguredCommand;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.testing.app.DropwizardTestApplication;
+import io.dropwizard.testing.app.TestConfiguration;
+import net.sourceforge.argparse4j.inf.Namespace;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+class DropwizardAppExtensionWithConfiguredCommandTest {
+
+    private static final DropwizardAppExtension<TestConfiguration> EXTENSION = new DropwizardAppExtension<>(
+        DropwizardTestApplication.class, "test-config.yaml", new ResourceConfigurationSourceProvider(), null,
+        application -> new ConfiguredCommand<TestConfiguration>("test", "Test command") {
+            @Override
+            protected void run(Bootstrap<TestConfiguration> bootstrap, Namespace namespace, TestConfiguration configuration) throws Exception {
+
+            }
+        });
+
+
+    @Test
+    void returnsConfiguration() {
+        assertThat(EXTENSION.getConfiguration().getMessage()).isEqualTo("Yes, it's here");
+    }
+
+    @Test
+    void returnsApplication() {
+        assertThat(EXTENSION.<DropwizardTestApplication>getApplication()).isNotNull();
+    }
+
+    @Test
+    void environmentIsNull() {
+        assertThatNullPointerException().isThrownBy(EXTENSION::getEnvironment);
+    }
+}

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionWithCustomCommandTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionWithCustomCommandTest.java
@@ -1,0 +1,46 @@
+package io.dropwizard.testing.junit5;
+
+import io.dropwizard.cli.Command;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.testing.app.DropwizardTestApplication;
+import io.dropwizard.testing.app.TestConfiguration;
+import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparser;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+class DropwizardAppExtensionWithCustomCommandTest {
+
+    private static final DropwizardAppExtension<TestConfiguration> EXTENSION = new DropwizardAppExtension<>(
+        DropwizardTestApplication.class, "test-config.yaml", new ResourceConfigurationSourceProvider(), null,
+        application -> new Command("test", "Test command") {
+            @Override
+            public void configure(Subparser subparser) {
+            }
+
+            @Override
+            public void run(Bootstrap<?> bootstrap, Namespace namespace) throws Exception {
+            }
+        });
+
+
+    @Test
+    void configurationIsNull() {
+        assertThatNullPointerException().isThrownBy(EXTENSION::getConfiguration);
+    }
+
+    @Test
+    void returnsApplication() {
+        assertThat(EXTENSION.<DropwizardTestApplication>getApplication()).isNotNull();
+    }
+
+    @Test
+    void environmentIsNull() {
+        assertThatNullPointerException().isThrownBy(EXTENSION::getEnvironment);
+    }
+}


### PR DESCRIPTION
`DropwizardTestSupport` didn't support running plain `Command` or `ConfiguredCommand<C>` classes which have been with the `commandInstantiator` parameter in the `DropwizardAppExtension` extension (JUnit 5) or `DropwizardAppRule` rule (JUnit 4).