### PR TITLE
Register jackson-blackbird on JDK11 and beyond

### DIFF
--- a/dropwizard-jackson/pom.xml
+++ b/dropwizard-jackson/pom.xml
@@ -58,6 +58,10 @@
             <artifactId>jackson-module-afterburner</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-blackbird</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
         </dependency>

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
@@ -1,7 +1,5 @@
 package io.dropwizard.jackson;
 
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
-
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
@@ -9,10 +7,13 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
+import com.fasterxml.jackson.module.blackbird.BlackbirdModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import io.dropwizard.util.JavaVersion;
 
 import javax.annotation.Nullable;
+
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 
 /**
  * A utility class for Jackson.
@@ -63,6 +64,9 @@ public class Jackson {
         mapper.registerModule(new JodaModule());
         if (JavaVersion.isJava8()) {
             mapper.registerModule(new AfterburnerModule());
+        }
+        if (JavaVersion.isJava11OrHigher()) {
+            mapper.registerModule(new BlackbirdModule());
         }
         mapper.registerModule(new FuzzyEnumModule());
         mapper.registerModule(new ParameterNamesModule());

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonTest.java
@@ -75,6 +75,7 @@ public class JacksonTest {
         Set<Object> registeredModuleIds = Jackson.newObjectMapper().getRegisteredModuleIds();
 
         assertThat(registeredModuleIds).extracting(Object::toString)
+            .isNotEmpty()
             .doesNotContain("com.fasterxml.jackson.module.blackbird.BlackbirdModule");
     }
 

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonTest.java
@@ -59,22 +59,30 @@ public class JacksonTest {
         ).doesNotThrowAnyException();
     }
 
-
     @Test
-    @EnabledOnJre({JRE.JAVA_11, JRE.JAVA_15})
     void blackbirdIsEnabledOnJdk11() {
-        Set<Object> registeredModuleIds = Jackson.newObjectMapper().getRegisteredModuleIds();
+        System.setProperty("java.specification.version", "11");
 
-        assertThat(registeredModuleIds).extracting(Object::toString)
+        assertThat(Jackson.newObjectMapper().getRegisteredModuleIds())
+            .extracting(Object::toString)
             .contains("com.fasterxml.jackson.module.blackbird.BlackbirdModule");
     }
 
     @Test
-    @EnabledOnJre(JRE.JAVA_8)
-    void blackbirdIsNotEnabledOnJdk8() {
-        Set<Object> registeredModuleIds = Jackson.newObjectMapper().getRegisteredModuleIds();
+    void blackbirdIsEnabledOnJdk15() {
+        System.setProperty("java.specification.version", "15");
 
-        assertThat(registeredModuleIds).extracting(Object::toString)
+        assertThat(Jackson.newObjectMapper().getRegisteredModuleIds())
+            .extracting(Object::toString)
+            .contains("com.fasterxml.jackson.module.blackbird.BlackbirdModule");
+    }
+
+    @Test
+    void blackbirdIsNotEnabledOnJdk8() {
+        System.setProperty("java.specification.version", "1.8.0_222");
+
+        assertThat(Jackson.newObjectMapper().getRegisteredModuleIds())
+            .extracting(Object::toString)
             .isNotEmpty()
             .doesNotContain("com.fasterxml.jackson.module.blackbird.BlackbirdModule");
     }

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonTest.java
@@ -3,12 +3,16 @@ package io.dropwizard.jackson;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
 import org.mockito.Mockito;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
@@ -53,6 +57,25 @@ public class JacksonTest {
             Jackson.newObjectMapper()
                 .readValue("{\"unknown\": 4711, \"path\": \"/var/log/app/server.log\"}", LogMetadata.class)
         ).doesNotThrowAnyException();
+    }
+
+
+    @Test
+    @EnabledOnJre({JRE.JAVA_11, JRE.JAVA_15})
+    public void blackbirdIsEnabledOnJdk11() {
+        Set<Object> registeredModuleIds = Jackson.newObjectMapper().getRegisteredModuleIds();
+
+        assertThat(registeredModuleIds).extracting(Object::toString)
+            .contains("com.fasterxml.jackson.module.blackbird.BlackbirdModule");
+    }
+
+    @Test
+    @EnabledOnJre(JRE.JAVA_8)
+    public void blackbirdIsNotEnabledOnJdk8() {
+        Set<Object> registeredModuleIds = Jackson.newObjectMapper().getRegisteredModuleIds();
+
+        assertThat(registeredModuleIds).extracting(Object::toString)
+            .doesNotContain("com.fasterxml.jackson.module.blackbird.BlackbirdModule");
     }
 
     static class LogMetadata {

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonTest.java
@@ -62,7 +62,7 @@ public class JacksonTest {
 
     @Test
     @EnabledOnJre({JRE.JAVA_11, JRE.JAVA_15})
-    public void blackbirdIsEnabledOnJdk11() {
+    void blackbirdIsEnabledOnJdk11() {
         Set<Object> registeredModuleIds = Jackson.newObjectMapper().getRegisteredModuleIds();
 
         assertThat(registeredModuleIds).extracting(Object::toString)
@@ -71,7 +71,7 @@ public class JacksonTest {
 
     @Test
     @EnabledOnJre(JRE.JAVA_8)
-    public void blackbirdIsNotEnabledOnJdk8() {
+    void blackbirdIsNotEnabledOnJdk8() {
         Set<Object> registeredModuleIds = Jackson.newObjectMapper().getRegisteredModuleIds();
 
         assertThat(registeredModuleIds).extracting(Object::toString)

--- a/dropwizard-util/src/main/java/io/dropwizard/util/JavaVersion.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/JavaVersion.java
@@ -15,13 +15,11 @@ public final class JavaVersion {
     }
 
     public static boolean isJava11OrHigher() {
-        final int numericVersion;
         try {
-            numericVersion = Integer.parseInt(getJavaSpecVersion());
+            return Integer.parseInt(getJavaSpecVersion()) >= 11;
         } catch (NumberFormatException ignore) {
             return false;
         }
-        return numericVersion >= 11;
     }
 
     @Nullable

--- a/dropwizard-util/src/main/java/io/dropwizard/util/JavaVersion.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/JavaVersion.java
@@ -15,13 +15,9 @@ public final class JavaVersion {
     }
 
     public static boolean isJava11OrHigher() {
-        final String specVersion = getJavaSpecVersion();
-        if (specVersion == null) {
-            return false;
-        }
         final int numericVersion;
         try {
-            numericVersion = Integer.parseInt(specVersion);
+            numericVersion = Integer.parseInt(getJavaSpecVersion());
         } catch (NumberFormatException ignore) {
             return false;
         }

--- a/dropwizard-util/src/main/java/io/dropwizard/util/JavaVersion.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/JavaVersion.java
@@ -14,6 +14,20 @@ public final class JavaVersion {
         return specVersion != null && specVersion.startsWith("1.8");
     }
 
+    public static boolean isJava11OrHigher() {
+        final String specVersion = getJavaSpecVersion();
+        if (specVersion == null) {
+            return false;
+        }
+        final int numericVersion;
+        try {
+            numericVersion = Integer.parseInt(specVersion);
+        } catch (NumberFormatException ignore) {
+            return false;
+        }
+        return numericVersion >= 11;
+    }
+
     @Nullable
     private static String getJavaSpecVersion() {
         try {

--- a/dropwizard-util/src/test/java/io/dropwizard/util/JavaVersionTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/JavaVersionTest.java
@@ -1,6 +1,8 @@
 package io.dropwizard.util;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -21,5 +23,17 @@ class JavaVersionTest {
     void isJava8_returns_true_if_specVersion_is_Java_11() {
         System.setProperty("java.specification.version", "11");
         assertThat(JavaVersion.isJava8()).isFalse();
+    }
+
+    @Test
+    @EnabledOnJre({JRE.JAVA_11, JRE.JAVA_15})
+    void isJava11_or_higher_returns_true_on_Java_11_15() {
+        assertThat(JavaVersion.isJava11OrHigher()).isTrue();
+    }
+
+    @Test
+    @EnabledOnJre(JRE.JAVA_8)
+    void isJava11_or_higher_returns_false_on_Java_8() {
+        assertThat(JavaVersion.isJava11OrHigher()).isTrue();
     }
 }

--- a/dropwizard-util/src/test/java/io/dropwizard/util/JavaVersionTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/JavaVersionTest.java
@@ -26,14 +26,20 @@ class JavaVersionTest {
     }
 
     @Test
-    @EnabledOnJre({JRE.JAVA_11, JRE.JAVA_15})
-    void isJava11_or_higher_returns_true_on_Java_11_15() {
+    void isJava11_or_higher_returns_true_on_Java_11() {
+        System.setProperty("java.specification.version", "11");
         assertThat(JavaVersion.isJava11OrHigher()).isTrue();
     }
 
     @Test
-    @EnabledOnJre(JRE.JAVA_8)
+    void isJava11_or_higher_returns_true_on_Java_15() {
+        System.setProperty("java.specification.version", "15");
+        assertThat(JavaVersion.isJava11OrHigher()).isTrue();
+    }
+
+    @Test
     void isJava11_or_higher_returns_false_on_Java_8() {
+        System.setProperty("java.specification.version", "1.8.0_222");
         assertThat(JavaVersion.isJava11OrHigher()).isFalse();
     }
 }

--- a/dropwizard-util/src/test/java/io/dropwizard/util/JavaVersionTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/JavaVersionTest.java
@@ -34,6 +34,6 @@ class JavaVersionTest {
     @Test
     @EnabledOnJre(JRE.JAVA_8)
     void isJava11_or_higher_returns_false_on_Java_8() {
-        assertThat(JavaVersion.isJava11OrHigher()).isTrue();
+        assertThat(JavaVersion.isJava11OrHigher()).isFalse();
     }
 }


### PR DESCRIPTION
Jackson 2.12 shipped a new module `jackson-blackbird` for generating data-binding code dynamically. It is
a `jackson-afterburner` alternative which doesn't use `sun.misc.unsafe` for bytecode manipulation, but instead uses the official `LambdaMetafactory` API.

Closes #3652