### PR TITLE
Clarify the need of calling super from ConfiguredCommand

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -722,6 +722,11 @@ location specified by ``-c``), adapt the ConfiguredCommand_ class as needed.
 
 .. _ConfiguredCommand: https://github.com/dropwizard/dropwizard/blob/master/dropwizard-core/src/main/java/io/dropwizard/cli/ConfiguredCommand.java
 
+.. note::
+
+     If you override the ``configure`` method, you **must** call ``super.override(subparser)`` (or call ``addFileArgument``) 
+     in order to preserve the configuration file parameter in the subparser.
+
 .. _man-core-tasks:
 
 Tasks


### PR DESCRIPTION
###### Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->

Not calling super from `ConfiguredCommand#configure` skips the declaration of the configuration parameter. Making it mandatory would involve some non-minor API changes so emphasised the need of the super call on the docs (The wording is pretty similar to the [javadoc](https://www.javadoc.io/doc/io.dropwizard/dropwizard-core/1.0.2/io/dropwizard/cli/ConfiguredCommand.html#configure-net.sourceforge.argparse4j.inf.Subparser-))

###### Solution:
<!-- Describe the modifications you've done. -->

Explicitly state the need for the `super` call. 

###### Result:
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->

Hopefully less people will be confused when they configure a `ConfiguredCommand` that fails to accept the configuration file as a parameter.

Closes https://github.com/dropwizard/dropwizard/issues/3669
