### PR TITLE
Refactor testing of thrown exceptions

### DIFF
--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/JsonConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/JsonConfigurationFactoryTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.IOException;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class JsonConfigurationFactoryTest extends BaseConfigurationFactoryTest {
@@ -37,12 +38,12 @@ public class JsonConfigurationFactoryTest extends BaseConfigurationFactoryTest {
 
     @Override
     public void printsDetailedInformationOnMalformedContent() {
-        assertThatThrownBy(super::printsDetailedInformationOnMalformedContent)
-                .isInstanceOf(ConfigurationParsingException.class)
-                .hasMessageContaining(String.format(
-                        "%s has an error:%n" +
-                        "  * Malformed JSON at line: 7, column: 3; Unexpected close marker '}': expected ']'",
-                        malformedAdvancedFile.getName()));
+        assertThatExceptionOfType(ConfigurationParsingException.class)
+            .isThrownBy(super::printsDetailedInformationOnMalformedContent)
+            .withMessageContaining(String.format(
+                    "%s has an error:%n" +
+                    "  * Malformed JSON at line: 7, column: 3; Unexpected close marker '}': expected ']'",
+                    malformedAdvancedFile.getName()));
     }
 
     @Test

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/SubstitutingSourceProviderTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/SubstitutingSourceProviderTest.java
@@ -1,8 +1,5 @@
 package io.dropwizard.configuration;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -12,6 +9,9 @@ import java.nio.charset.StandardCharsets;
 import org.apache.commons.text.StringSubstitutor;
 import org.apache.commons.text.lookup.StringLookup;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class SubstitutingSourceProviderTest {
     @Test
@@ -23,9 +23,9 @@ public class SubstitutingSourceProviderTest {
         assertThat(provider.open("foo: ${bar}")).hasSameContentAs(new ByteArrayInputStream("foo: baz".getBytes(StandardCharsets.UTF_8)));
 
         // ensure that opened streams are closed
-        assertThatThrownBy(() -> dummyProvider.lastStream.read())
-                .isInstanceOf(IOException.class)
-                .hasMessage("Stream closed");
+        assertThatExceptionOfType(IOException.class)
+            .isThrownBy(() -> dummyProvider.lastStream.read())
+            .withMessage("Stream closed");
     }
 
     @Test

--- a/dropwizard-core/src/test/java/io/dropwizard/cli/ServerCommandTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/cli/ServerCommandTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -56,19 +56,19 @@ public class ServerCommandTest {
     }
 
     @Test
-    public void hasAName() throws Exception {
+    public void hasAName() {
         assertThat(command.getName())
                 .isEqualTo("server");
     }
 
     @Test
-    public void hasADescription() throws Exception {
+    public void hasADescription() {
         assertThat(command.getDescription())
                 .isEqualTo("Runs the Dropwizard application as an HTTP server");
     }
 
     @Test
-    public void hasTheApplicationsConfigurationClass() throws Exception {
+    public void hasTheApplicationsConfigurationClass() {
         assertThat(command.getConfigurationClass())
                 .isEqualTo(application.getConfigurationClass());
     }
@@ -82,7 +82,7 @@ public class ServerCommandTest {
     }
 
     @Test
-    public void stopsAServerIfThereIsAnErrorStartingIt() throws Exception {
+    public void stopsAServerIfThereIsAnErrorStartingIt() {
         this.throwException = true;
         server.addBean(new AbstractLifeCycle() {
             @Override
@@ -91,13 +91,9 @@ public class ServerCommandTest {
             }
         });
 
-        try {
-            command.run(environment, namespace, configuration);
-            failBecauseExceptionWasNotThrown(IOException.class);
-        } catch (IOException e) {
-            assertThat(e.getMessage())
-                    .isEqualTo("oh crap");
-        }
+        assertThatExceptionOfType(IOException.class)
+            .isThrownBy(() -> command.run(environment, namespace, configuration))
+            .withMessage("oh crap");
 
         assertThat(server.isStarted())
                 .isFalse();

--- a/dropwizard-db/src/test/java/io/dropwizard/db/ManagedPooledDataSourceTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/ManagedPooledDataSourceTest.java
@@ -6,8 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.sql.SQLFeatureNotSupportedException;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class ManagedPooledDataSourceTest {
     private final PoolProperties config = new PoolProperties();
@@ -15,12 +14,8 @@ public class ManagedPooledDataSourceTest {
     private final ManagedPooledDataSource dataSource = new ManagedPooledDataSource(config, metricRegistry);
 
     @Test
-    public void hasNoParentLogger() throws Exception {
-        try {
-            dataSource.getParentLogger();
-            failBecauseExceptionWasNotThrown(SQLFeatureNotSupportedException.class);
-        } catch (SQLFeatureNotSupportedException e) {
-            assertThat((Object) e).isInstanceOf(SQLFeatureNotSupportedException.class);
-        }
+    public void hasNoParentLogger() {
+        assertThatExceptionOfType(SQLFeatureNotSupportedException.class)
+            .isThrownBy(dataSource::getParentLogger);
     }
 }

--- a/dropwizard-example/src/test/java/com/example/helloworld/resources/ProtectedClassResourceTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/resources/ProtectedClassResourceTest.java
@@ -17,7 +17,7 @@ import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.core.HttpHeaders;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 public final class ProtectedClassResourceTest {
@@ -72,14 +72,11 @@ public final class ProtectedClassResourceTest {
 
     @Test
     public void testProtectedBasicUserEndpointPrincipalIsNotAuthorized403() {
-        try {
-            RULE.target("/protected").request()
+        assertThatExceptionOfType(ForbiddenException.class)
+            .isThrownBy(() -> RULE.target("/protected").request()
             .header(HttpHeaders.AUTHORIZATION, "Basic Z3Vlc3Q6c2VjcmV0")
-            .get(String.class);
-            failBecauseExceptionWasNotThrown(ForbiddenException.class);
-        } catch (ForbiddenException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(403);
-        }
+            .get(String.class))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(403));
     }
 
 }

--- a/dropwizard-example/src/test/java/com/example/helloworld/resources/ProtectedResourceTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/resources/ProtectedResourceTest.java
@@ -18,7 +18,7 @@ import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.core.HttpHeaders;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 public class ProtectedResourceTest {
@@ -48,31 +48,23 @@ public class ProtectedResourceTest {
 
     @Test
     public void testProtectedEndpointNoCredentials401() {
-        try {
-            RULE.target("/protected").request()
-                .get(String.class);
-            failBecauseExceptionWasNotThrown(NotAuthorizedException.class);
-        } catch (NotAuthorizedException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(401);
-            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
-                    .containsOnly("Basic realm=\"SUPER SECRET STUFF\"");
-        }
-
+        assertThatExceptionOfType(NotAuthorizedException.class)
+            .isThrownBy(() -> RULE.target("/protected").request()
+                .get(String.class))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(401))
+            .satisfies(e -> assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
+            .containsOnly("Basic realm=\"SUPER SECRET STUFF\""));
     }
 
     @Test
     public void testProtectedEndpointBadCredentials401() {
-        try {
-            RULE.target("/protected").request()
+        assertThatExceptionOfType(NotAuthorizedException.class)
+            .isThrownBy(() -> RULE.target("/protected").request()
                 .header(HttpHeaders.AUTHORIZATION, "Basic c25lYWt5LWJhc3RhcmQ6YXNkZg==")
-                .get(String.class);
-            failBecauseExceptionWasNotThrown(NotAuthorizedException.class);
-        } catch (NotAuthorizedException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(401);
-            assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
-                .containsOnly("Basic realm=\"SUPER SECRET STUFF\"");
-        }
-
+                .get(String.class))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(401))
+            .satisfies(e -> assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
+                .containsOnly("Basic realm=\"SUPER SECRET STUFF\""));
     }
 
     @Test
@@ -85,13 +77,10 @@ public class ProtectedResourceTest {
 
     @Test
     public void testProtectedAdminEndpointPrincipalIsNotAuthorized403() {
-        try {
-            RULE.target("/protected/admin").request()
+        assertThatExceptionOfType(ForbiddenException.class)
+            .isThrownBy(() -> RULE.target("/protected/admin").request()
                     .header(HttpHeaders.AUTHORIZATION, "Basic Z29vZC1ndXk6c2VjcmV0")
-                    .get(String.class);
-            failBecauseExceptionWasNotThrown(ForbiddenException.class);
-        } catch (ForbiddenException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(403);
-        }
+                    .get(String.class))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(403));
     }
 }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
@@ -37,7 +37,7 @@ import java.util.Collections;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -154,7 +154,7 @@ public class JerseyIntegrationTest extends JerseyTest {
     }
 
     @Test
-    public void findsExistingData() throws Exception {
+    public void findsExistingData() {
         final Person coda = target("/people/Coda").request(MediaType.APPLICATION_JSON).get(Person.class);
 
         assertThat(coda.getName())
@@ -168,19 +168,15 @@ public class JerseyIntegrationTest extends JerseyTest {
     }
 
     @Test
-    public void doesNotFindMissingData() throws Exception {
-        try {
-            target("/people/Poof").request(MediaType.APPLICATION_JSON)
-                    .get(Person.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus())
-                    .isEqualTo(404);
-        }
+    public void doesNotFindMissingData() {
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> target("/people/Poof").request(MediaType.APPLICATION_JSON)
+                    .get(Person.class))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(404));
     }
 
     @Test
-    public void createsNewData() throws Exception {
+    public void createsNewData() {
         final Person person = new Person();
         person.setName("Hank");
         person.setEmail("hank@example.com");
@@ -204,7 +200,7 @@ public class JerseyIntegrationTest extends JerseyTest {
 
 
     @Test
-    public void testSqlExceptionIsHandled() throws Exception {
+    public void testSqlExceptionIsHandled() {
         final Person person = new Person();
         person.setName("Jeff");
         person.setEmail("jeff.hammersmith@targetprocessinc.com");

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkApplicationListenerTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkApplicationListenerTest.java
@@ -17,7 +17,7 @@ import org.mockito.InOrder;
 import java.lang.reflect.Method;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.hibernate.resource.transaction.spi.TransactionStatus.ACTIVE;
 import static org.hibernate.resource.transaction.spi.TransactionStatus.NOT_ACTIVE;
 import static org.mockito.Mockito.doAnswer;
@@ -235,9 +235,9 @@ public class UnitOfWorkApplicationListenerTest {
     @Test
     public void throwsExceptionOnNotRegisteredDatabase() throws Exception {
         prepareResourceMethod("methodWithUnitOfWorkOnNotRegisteredDatabase");
-        assertThatThrownBy(this::execute)
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Unregistered Hibernate bundle: 'warehouse'");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(this::execute)
+            .withMessage("Unregistered Hibernate bundle: 'warehouse'");
     }
 
     private void prepareResourceMethod(String resourceMethodName) throws NoSuchMethodException {
@@ -326,7 +326,7 @@ public class UnitOfWorkApplicationListenerTest {
         }
     }
 
-    public static interface MockResourceInterface {
+    public interface MockResourceInterface {
 
         void handlingMethodAnnotated();
 

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/FuzzyEnumModuleTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/FuzzyEnumModuleTest.java
@@ -13,7 +13,7 @@ import java.sql.ClientInfoStatus;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FuzzyEnumModuleTest {
     private final ObjectMapper mapper = new ObjectMapper();
@@ -120,15 +120,12 @@ public class FuzzyEnumModuleTest {
     }
 
     @Test
-    public void failsOnIncorrectValue() throws Exception {
-        try {
-            mapper.readValue("\"wrong\"", TimeUnit.class);
-            failBecauseExceptionWasNotThrown(JsonMappingException.class);
-        } catch (JsonMappingException e) {
-            assertThat(e.getOriginalMessage())
-                    .isEqualTo("Cannot deserialize value of type `java.util.concurrent.TimeUnit` from String \"wrong\": " +
-                        "wrong was not one of [NANOSECONDS, MICROSECONDS, MILLISECONDS, SECONDS, MINUTES, HOURS, DAYS]");
-        }
+    public void failsOnIncorrectValue() {
+        assertThatExceptionOfType(JsonMappingException.class)
+            .isThrownBy(() -> mapper.readValue("\"wrong\"", TimeUnit.class))
+            .satisfies(e -> assertThat(e.getOriginalMessage())
+                .isEqualTo("Cannot deserialize value of type `java.util.concurrent.TimeUnit` from String \"wrong\": " +
+                    "wrong was not one of [NANOSECONDS, MICROSECONDS, MILLISECONDS, SECONDS, MINUTES, HOURS, DAYS]"));
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/ErrorEntityWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/ErrorEntityWriterTest.java
@@ -17,7 +17,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class ErrorEntityWriterTest extends AbstractJerseyTest {
 
@@ -53,20 +53,16 @@ public class ErrorEntityWriterTest extends AbstractJerseyTest {
 
     @Test
     public void formatsErrorsAsHtml() {
-
-        try {
-            target("/exception/html-exception")
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> target("/exception/html-exception")
                 .request(MediaType.TEXT_HTML_TYPE)
-                .get(String.class);
-
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-
-        } catch (WebApplicationException e) {
-            final Response response = e.getResponse();
-            assertThat(response.getStatus()).isEqualTo(400);
-            assertThat(response.getMediaType()).isEqualTo(MediaType.TEXT_HTML_TYPE);
-            assertThat(response.readEntity(String.class)).isEqualTo("<!DOCTYPE html><html><body>BIFF</body></html>");
-        }
+                .get(String.class))
+            .satisfies(e -> {
+                final Response response = e.getResponse();
+                assertThat(response.getStatus()).isEqualTo(400);
+                assertThat(response.getMediaType()).isEqualTo(MediaType.TEXT_HTML_TYPE);
+                assertThat(response.readEntity(String.class)).isEqualTo("<!DOCTYPE html><html><body>BIFF</body></html>");
+            });
     }
 
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/LoggingExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/LoggingExceptionMapperTest.java
@@ -8,11 +8,9 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class LoggingExceptionMapperTest extends AbstractJerseyTest {
 
@@ -25,56 +23,42 @@ public class LoggingExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void returnsAnErrorMessage() throws Exception {
-        try {
-            target("/exception/").request(MediaType.APPLICATION_JSON).get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            final Response response = e.getResponse();
-
-            assertThat(response.getStatus()).isEqualTo(500);
-            assertThat(response.readEntity(String.class)).startsWith("{\"code\":500,\"message\":"
-                    + "\"There was an error processing your request. It has been logged (ID ");
-        }
+    public void returnsAnErrorMessage() {
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> target("/exception/").request(MediaType.APPLICATION_JSON).get(String.class))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(500))
+            .satisfies(e -> assertThat(e.getResponse().readEntity(String.class)).startsWith("{\"code\":500,\"message\":"
+                + "\"There was an error processing your request. It has been logged (ID "));
     }
 
     @Test
-    public void handlesJsonMappingException() throws Exception {
-        try {
-            target("/exception/json-mapping-exception").request(MediaType.APPLICATION_JSON).get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            final Response response = e.getResponse();
-
-            assertThat(response.getStatus()).isEqualTo(500);
-            assertThat(response.readEntity(String.class)).startsWith("{\"code\":500,\"message\":"
-                    + "\"There was an error processing your request. It has been logged (ID ");
-        }
+    public void handlesJsonMappingException() {
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> target("/exception/json-mapping-exception").request(MediaType.APPLICATION_JSON).get(String.class))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(500))
+            .satisfies(e -> assertThat(e.getResponse().readEntity(String.class)).startsWith("{\"code\":500,\"message\":"
+                + "\"There was an error processing your request. It has been logged (ID "));
     }
 
     @Test
     public void handlesMethodNotAllowedWithHeaders() {
-        final Throwable thrown = catchThrowable(() -> target("/exception/json-mapping-exception")
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> target("/exception/json-mapping-exception")
             .request(MediaType.APPLICATION_JSON)
-            .post(Entity.json("A"), String.class));
-        assertThat(thrown).isInstanceOf(WebApplicationException.class);
-        final Response resp = ((WebApplicationException) thrown).getResponse();
-        assertThat(resp.getStatus()).isEqualTo(405);
-        assertThat(resp.getAllowedMethods()).containsOnly("GET", "OPTIONS");
-        assertThat(resp.readEntity(String.class)).isEqualTo("{\"code\":405,\"message\":\"HTTP 405 Method Not Allowed\"}");
+            .post(Entity.json("A"), String.class))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(405))
+            .satisfies(e -> assertThat(e.getResponse().getAllowedMethods()).containsOnly("GET", "OPTIONS"))
+            .satisfies(e -> assertThat(e.getResponse().readEntity(String.class))
+                .isEqualTo("{\"code\":405,\"message\":\"HTTP 405 Method Not Allowed\"}"));
     }
 
     @Test
-    public void formatsWebApplicationException() throws Exception {
-        try {
-            target("/exception/web-application-exception").request(MediaType.APPLICATION_JSON).get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            final Response response = e.getResponse();
-
-            assertThat(response.getStatus()).isEqualTo(400);
-            assertThat(response.readEntity(String.class)).isEqualTo("{\"code\":400,\"message\":\"KAPOW\"}");
-        }
+    public void formatsWebApplicationException() {
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> target("/exception/web-application-exception").request(MediaType.APPLICATION_JSON).get(String.class))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(400))
+            .satisfies(e -> assertThat(e.getResponse().readEntity(String.class))
+                .isEqualTo("{\"code\":400,\"message\":\"KAPOW\"}"));
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalMessageBodyWriterTest.java
@@ -17,7 +17,7 @@ import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class OptionalMessageBodyWriterTest extends AbstractJerseyTest {
 
@@ -29,7 +29,7 @@ public class OptionalMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void presentOptionalsReturnTheirValue() throws Exception {
+    public void presentOptionalsReturnTheirValue() {
         assertThat(target("/optional-return/")
                 .queryParam("id", "woo").request()
                 .get(String.class))
@@ -37,14 +37,10 @@ public class OptionalMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void absentOptionalsThrowANotFound() throws Exception {
-        try {
-            target("/optional-return/").request().get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus())
-                    .isEqualTo(404);
-        }
+    public void absentOptionalsThrowANotFound() {
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> target("/optional-return/").request().get(String.class))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(404));
     }
 
     @Path("/optional-return/")

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalDoubleMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalDoubleMessageBodyWriterTest.java
@@ -19,8 +19,7 @@ import javax.ws.rs.core.Response;
 import java.util.OptionalDouble;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class OptionalDoubleMessageBodyWriterTest extends AbstractJerseyTest {
 
@@ -32,7 +31,7 @@ public class OptionalDoubleMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void presentOptionalsReturnTheirValue() throws Exception {
+    public void presentOptionalsReturnTheirValue() {
         assertThat(target("optional-return")
                 .queryParam("id", "1").request()
                 .get(Double.class))
@@ -40,7 +39,7 @@ public class OptionalDoubleMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void presentOptionalsReturnTheirValueWithResponse() throws Exception {
+    public void presentOptionalsReturnTheirValueWithResponse() {
         assertThat(target("optional-return/response-wrapped")
                 .queryParam("id", "1").request()
                 .get(Double.class))
@@ -48,13 +47,10 @@ public class OptionalDoubleMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void absentOptionalsThrowANotFound() throws Exception {
-        try {
-            target("optional-return").request().get(Double.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(404);
-        }
+    public void absentOptionalsThrowANotFound() {
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> target("optional-return").request().get(Double.class))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(404));
     }
 
     @Test
@@ -73,17 +69,21 @@ public class OptionalDoubleMessageBodyWriterTest extends AbstractJerseyTest {
 
     @Test
     public void valueEmptyReturnsDefault() {
-        assertThat(target("optional-return/default").queryParam("id", "").request().get(Double.class))
-            .isEqualTo(target("optional-return/double/default").queryParam("id", "").request().get(Double.class))
+        assertThat(target("optional-return/default").queryParam("id", "")
+            .request().get(Double.class))
+            .isEqualTo(target("optional-return/double/default").queryParam("id", "")
+                .request().get(Double.class))
             .isEqualTo(0);
     }
 
     @Test
     public void valueInvalidReturns404() {
-        assertThatThrownBy(() -> target("optional-return/default").queryParam("id", "invalid").request().get(Double.class))
-            .isInstanceOf(NotFoundException.class);
-        assertThatThrownBy(() -> target("optional-return/double/default").queryParam("id", "invalid").request().get(Double.class))
-            .isInstanceOf(NotFoundException.class);
+        assertThatExceptionOfType(NotFoundException.class)
+            .isThrownBy(() -> target("optional-return/default").queryParam("id", "invalid")
+                .request().get(Double.class));
+        assertThatExceptionOfType(NotFoundException.class)
+            .isThrownBy(() -> target("optional-return/double/default").queryParam("id", "invalid")
+                .request().get(Double.class));
     }
 
     @Path("optional-return")

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalDoubleParamConverterProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalDoubleParamConverterProviderTest.java
@@ -3,13 +3,13 @@ package io.dropwizard.jersey.optional;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class OptionalDoubleParamConverterProviderTest {
     @Test
     public void verifyInvalidDefaultValueFailsFast() {
-        assertThatThrownBy(() -> new OptionalDoubleParamConverterProvider.OptionalDoubleParamConverter("invalid").fromString("invalid"))
-            .isInstanceOf(NumberFormatException.class);
+        assertThatExceptionOfType(NumberFormatException.class)
+            .isThrownBy(() -> new OptionalDoubleParamConverterProvider.OptionalDoubleParamConverter("invalid").fromString("invalid"));
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalIntMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalIntMessageBodyWriterTest.java
@@ -19,8 +19,7 @@ import javax.ws.rs.core.Response;
 import java.util.OptionalInt;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class OptionalIntMessageBodyWriterTest extends AbstractJerseyTest {
 
@@ -32,7 +31,7 @@ public class OptionalIntMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void presentOptionalsReturnTheirValue() throws Exception {
+    public void presentOptionalsReturnTheirValue() {
         assertThat(target("optional-return")
                 .queryParam("id", "1").request()
                 .get(Integer.class))
@@ -40,7 +39,7 @@ public class OptionalIntMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void presentOptionalsReturnTheirValueWithResponse() throws Exception {
+    public void presentOptionalsReturnTheirValueWithResponse() {
         assertThat(target("optional-return/response-wrapped")
                 .queryParam("id", "1").request()
                 .get(Integer.class))
@@ -48,19 +47,18 @@ public class OptionalIntMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void absentOptionalsThrowANotFound() throws Exception {
-        try {
-            target("optional-return").request().get(Integer.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(404);
-        }
+    public void absentOptionalsThrowANotFound() {
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> target("optional-return").request().get(Integer.class))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(404));
     }
 
     @Test
     public void valueSetIgnoresDefault() {
-        assertThat(target("optional-return/default").queryParam("id", "1").request().get(Integer.class))
-            .isEqualTo(target("optional-return/int/default").queryParam("id", "1").request().get(Integer.class))
+        assertThat(target("optional-return/default").queryParam("id", "1")
+            .request().get(Integer.class))
+            .isEqualTo(target("optional-return/int/default").queryParam("id", "1")
+                .request().get(Integer.class))
             .isEqualTo(1);
     }
 
@@ -73,23 +71,28 @@ public class OptionalIntMessageBodyWriterTest extends AbstractJerseyTest {
 
     @Test
     public void valueEmptyReturnsDefault() {
-        assertThat(target("optional-return/default").queryParam("id", "").request().get(Integer.class))
-            .isEqualTo(target("optional-return/int/default").queryParam("id", "").request().get(Integer.class))
+        assertThat(target("optional-return/default").queryParam("id", "")
+            .request().get(Integer.class))
+            .isEqualTo(target("optional-return/int/default").queryParam("id", "")
+                .request().get(Integer.class))
             .isEqualTo(0);
     }
 
     @Test
     public void valueInvalidReturns404() {
-        assertThatThrownBy(() -> target("optional-return/default").queryParam("id", "invalid").request().get(Integer.class))
-            .isInstanceOf(NotFoundException.class);
-        assertThatThrownBy(() -> target("optional-return/int/default").queryParam("id", "invalid").request().get(Integer.class))
-            .isInstanceOf(NotFoundException.class);
+        assertThatExceptionOfType(NotFoundException.class)
+            .isThrownBy(() -> target("optional-return/default").queryParam("id", "invalid")
+                .request().get(Integer.class));
+        assertThatExceptionOfType(NotFoundException.class)
+            .isThrownBy(() -> target("optional-return/int/default").queryParam("id", "invalid")
+                .request().get(Integer.class));
     }
 
     @Test
     public void verifyInvalidDefaultValueFailsFast() {
-        assertThatThrownBy(() -> new OptionalIntParamConverterProvider.OptionalIntParamConverter("invalid").fromString("invalid"))
-            .isInstanceOf(NumberFormatException.class);
+        assertThatExceptionOfType(NumberFormatException.class)
+            .isThrownBy(() -> new OptionalIntParamConverterProvider.OptionalIntParamConverter("invalid")
+                .fromString("invalid"));
     }
 
     @Path("optional-return")

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalIntParamConverterProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalIntParamConverterProviderTest.java
@@ -3,13 +3,13 @@ package io.dropwizard.jersey.optional;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class OptionalIntParamConverterProviderTest {
     @Test
     public void verifyInvalidDefaultValueFailsFast() {
-        assertThatThrownBy(() -> new OptionalIntParamConverterProvider.OptionalIntParamConverter("invalid").fromString("invalid"))
-            .isInstanceOf(NumberFormatException.class);
+        assertThatExceptionOfType(NumberFormatException.class)
+            .isThrownBy(() -> new OptionalIntParamConverterProvider.OptionalIntParamConverter("invalid").fromString("invalid"));
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalLongMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalLongMessageBodyWriterTest.java
@@ -19,8 +19,7 @@ import javax.ws.rs.core.Response;
 import java.util.OptionalLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class OptionalLongMessageBodyWriterTest extends AbstractJerseyTest {
 
@@ -32,7 +31,7 @@ public class OptionalLongMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void presentOptionalsReturnTheirValue() throws Exception {
+    public void presentOptionalsReturnTheirValue() {
         assertThat(target("optional-return")
                 .queryParam("id", "1").request()
                 .get(Long.class))
@@ -40,7 +39,7 @@ public class OptionalLongMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void presentOptionalsReturnTheirValueWithResponse() throws Exception {
+    public void presentOptionalsReturnTheirValueWithResponse() {
         assertThat(target("optional-return/response-wrapped")
                 .queryParam("id", "1").request()
                 .get(Long.class))
@@ -48,13 +47,10 @@ public class OptionalLongMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void absentOptionalsThrowANotFound() throws Exception {
-        try {
-            target("optional-return").request().get(Long.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(404);
-        }
+    public void absentOptionalsThrowANotFound() {
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> target("optional-return").request().get(Long.class))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(404));
     }
 
     @Test
@@ -80,10 +76,12 @@ public class OptionalLongMessageBodyWriterTest extends AbstractJerseyTest {
 
     @Test
     public void valueInvalidReturns404() {
-        assertThatThrownBy(() -> target("optional-return/default").queryParam("id", "invalid").request().get(Long.class))
-            .isInstanceOf(NotFoundException.class);
-        assertThatThrownBy(() -> target("optional-return/long/default").queryParam("id", "invalid").request().get(Long.class))
-            .isInstanceOf(NotFoundException.class);
+        assertThatExceptionOfType(NotFoundException.class)
+            .isThrownBy(() -> target("optional-return/default").queryParam("id", "invalid")
+                .request().get(Long.class));;
+        assertThatExceptionOfType(NotFoundException.class)
+            .isThrownBy(() -> target("optional-return/long/default").queryParam("id", "invalid")
+                .request().get(Long.class));
     }
 
     @Path("optional-return")

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalLongParamConverterProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalLongParamConverterProviderTest.java
@@ -3,13 +3,13 @@ package io.dropwizard.jersey.optional;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class OptionalLongParamConverterProviderTest {
     @Test
     public void verifyInvalidDefaultValueFailsFast() {
-        assertThatThrownBy(() -> new OptionalLongParamConverterProvider.OptionalLongParamConverter("invalid").fromString("invalid"))
-            .isInstanceOf(NumberFormatException.class);
+        assertThatExceptionOfType(NumberFormatException.class)
+            .isThrownBy(() -> new OptionalLongParamConverterProvider.OptionalLongParamConverter("invalid").fromString("invalid"));
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalMessageBodyWriterTest.java
@@ -17,7 +17,7 @@ import javax.ws.rs.core.Response;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class OptionalMessageBodyWriterTest extends AbstractJerseyTest {
 
@@ -29,7 +29,7 @@ public class OptionalMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void presentOptionalsReturnTheirValue() throws Exception {
+    public void presentOptionalsReturnTheirValue() {
         assertThat(target("optional-return")
                 .queryParam("id", "woo").request()
                 .get(String.class))
@@ -37,7 +37,7 @@ public class OptionalMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void presentOptionalsReturnTheirValueWithResponse() throws Exception {
+    public void presentOptionalsReturnTheirValueWithResponse() {
         assertThat(target("optional-return/response-wrapped")
                 .queryParam("id", "woo").request()
                 .get(String.class))
@@ -45,14 +45,10 @@ public class OptionalMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void absentOptionalsThrowANotFound() throws Exception {
-        try {
-            target("optional-return").request().get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus())
-                    .isEqualTo(404);
-        }
+    public void absentOptionalsThrowANotFound() {
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> target("optional-return").request().get(String.class))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(404));
     }
 
     @Path("optional-return")

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/BooleanParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/BooleanParamTest.java
@@ -7,49 +7,28 @@ import javax.annotation.Nullable;
 import javax.ws.rs.WebApplicationException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class BooleanParamTest {
-    private void booleanParamNegativeTest(@Nullable String input) {
-        assertThatThrownBy(() -> new BooleanParam(input))
-            .isInstanceOfSatisfying(WebApplicationException.class, e -> {
-                assertThat(e.getResponse().getStatus()).isEqualTo(400);
-                assertThat(e.getResponse().getEntity()).isEqualTo(
-                    new ErrorMessage(400, "Parameter must be \"true\" or \"false\".")
-                );
-            });
-    }
 
     @Test
     public void trueReturnsTrue() {
-        final BooleanParam param = new BooleanParam("true");
-
-        assertThat(param.get())
-                .isTrue();
+        assertThat(new BooleanParam("true").get()).isTrue();
     }
 
     @Test
     public void uppercaseTrueReturnsTrue() {
-        final BooleanParam param = new BooleanParam("TRUE");
-
-        assertThat(param.get())
-                .isTrue();
+        assertThat(new BooleanParam("TRUE").get()).isTrue();
     }
 
     @Test
     public void falseReturnsFalse() {
-        final BooleanParam param = new BooleanParam("false");
-
-        assertThat(param.get())
-                .isFalse();
+        assertThat(new BooleanParam("false").get()).isFalse();
     }
 
     @Test
     public void uppercaseFalseReturnsFalse() {
-        final BooleanParam param = new BooleanParam("FALSE");
-
-        assertThat(param.get())
-                .isFalse();
+        assertThat(new BooleanParam("FALSE").get()).isFalse();
     }
 
     @Test
@@ -60,5 +39,13 @@ public class BooleanParamTest {
     @Test
     public void nonBooleanValuesThrowAnException() {
         booleanParamNegativeTest("foo");
+    }
+
+    private void booleanParamNegativeTest(@Nullable String input) {
+        final ErrorMessage expected = new ErrorMessage(400, "Parameter must be \"true\" or \"false\".");
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> new BooleanParam(input))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(400))
+            .satisfies(e -> assertThat(e.getResponse().getEntity()).isEqualTo(expected));
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/DurationParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/DurationParamTest.java
@@ -7,25 +7,23 @@ import org.junit.jupiter.api.Test;
 import javax.ws.rs.WebApplicationException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class DurationParamTest {
 
     @Test
     public void parseDurationSeconds() {
-        final DurationParam param = new DurationParam("10 seconds");
-        assertThat(param.get())
+        assertThat(new DurationParam("10 seconds").get())
             .isEqualTo(Duration.seconds(10));
     }
 
     @Test
     public void badValueThrowsException() {
-        assertThatThrownBy(() -> new DurationParam("invalid", "param_name"))
-            .isInstanceOfSatisfying(WebApplicationException.class, e -> {
-                assertThat(e.getResponse().getStatus()).isEqualTo(400);
-                assertThat(e.getResponse().getEntity()).isEqualTo(
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> new DurationParam("invalid", "param_name"))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(400))
+            .satisfies(e -> assertThat(e.getResponse().getEntity()).isEqualTo(
                     new ErrorMessage(400, "param_name is not a valid duration.")
-                );
-            });
+                ));
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/InstantParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/InstantParamTest.java
@@ -1,8 +1,5 @@
 package io.dropwizard.jersey.params;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import io.dropwizard.jersey.errors.ErrorMessage;
 import org.junit.jupiter.api.Test;
 
@@ -10,6 +7,9 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.LocalDateTime;
 import javax.ws.rs.WebApplicationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class InstantParamTest {
     @Test
@@ -24,12 +24,11 @@ public class InstantParamTest {
 
     @Test
     public void nullThrowsAnException() {
-        assertThatThrownBy(() -> new InstantParam(null, "myDate"))
-            .isInstanceOfSatisfying(WebApplicationException.class, e -> {
-                assertThat(e.getResponse().getStatus()).isEqualTo(400);
-                assertThat(e.getResponse().getEntity()).isEqualTo(
-                    new ErrorMessage(400, "myDate must be in a ISO-8601 format.")
-                );
-            });
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> new InstantParam(null, "myDate"))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(400))
+            .satisfies(e -> assertThat(e.getResponse().getEntity()).isEqualTo(
+                new ErrorMessage(400, "myDate must be in a ISO-8601 format.")
+            ));
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/IntParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/IntParamTest.java
@@ -6,58 +6,51 @@ import org.junit.jupiter.api.Test;
 import javax.ws.rs.WebApplicationException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class IntParamTest {
     @Test
     public void anIntegerReturnsAnInteger() {
-        final IntParam param = new IntParam("200");
-
-        assertThat(param.get())
-                .isEqualTo(200);
+        assertThat(new IntParam("200").get()).isEqualTo(200);
     }
 
     @Test
     public void nullThrowsAnException() {
-        assertThatThrownBy(() -> new IntParam(null))
-                .isInstanceOfSatisfying(WebApplicationException.class, e -> {
-                    assertThat(e.getResponse().getStatus()).isEqualTo(400);
-                    assertThat(e.getResponse().getEntity()).isEqualTo(
-                            new ErrorMessage(400, "Parameter is not a number.")
-                    );
-                });
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> new IntParam(null))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(400))
+            .satisfies(e -> assertThat(e.getResponse().getEntity()).isEqualTo(
+                new ErrorMessage(400, "Parameter is not a number.")
+            ));
     }
 
     @Test
     public void emptyStringThrowsAnException() {
-        assertThatThrownBy(() -> new IntParam(""))
-                .isInstanceOfSatisfying(WebApplicationException.class, e -> {
-                    assertThat(e.getResponse().getStatus()).isEqualTo(400);
-                    assertThat(e.getResponse().getEntity()).isEqualTo(
-                            new ErrorMessage(400, "Parameter is not a number.")
-                    );
-                });
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> new IntParam(""))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(400))
+            .satisfies(e -> assertThat(e.getResponse().getEntity()).isEqualTo(
+                new ErrorMessage(400, "Parameter is not a number.")
+            ));
     }
 
     @Test
     public void aNonIntegerThrowsAnException() {
-        assertThatThrownBy(() -> new IntParam("foo"))
-            .isInstanceOfSatisfying(WebApplicationException.class, e -> {
-                assertThat(e.getResponse().getStatus()).isEqualTo(400);
-                assertThat(e.getResponse().getEntity()).isEqualTo(
-                    new ErrorMessage(400, "Parameter is not a number.")
-                );
-            });
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> new IntParam("foo"))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(400))
+            .satisfies(e -> assertThat(e.getResponse().getEntity()).isEqualTo(
+                new ErrorMessage(400, "Parameter is not a number.")
+            ));
     }
 
     @Test
     public void aNonIntegerThrowsAnExceptionWithCustomName() {
-        assertThatThrownBy(() -> new IntParam("foo", "customName"))
-            .isInstanceOfSatisfying(WebApplicationException.class, e -> {
-                assertThat(e.getResponse().getStatus()).isEqualTo(400);
-                assertThat(e.getResponse().getEntity()).isEqualTo(
-                    new ErrorMessage(400, "customName is not a number.")
-                );
-            });
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> new IntParam("foo", "customName"))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(400))
+            .satisfies(e -> assertThat(e.getResponse().getEntity()).isEqualTo(
+                new ErrorMessage(400, "customName is not a number.")
+            ));
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/LongParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/LongParamTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import javax.ws.rs.WebApplicationException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class LongParamTest {
     @Test
@@ -19,45 +19,41 @@ public class LongParamTest {
 
     @Test
     public void nullThrowsAnException() {
-        assertThatThrownBy(() -> new LongParam(null))
-                .isInstanceOfSatisfying(WebApplicationException.class, e -> {
-                    assertThat(e.getResponse().getStatus()).isEqualTo(400);
-                    assertThat(e.getResponse().getEntity()).isEqualTo(
-                            new ErrorMessage(400, "Parameter is not a number.")
-                    );
-                });
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> new LongParam(null))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(400))
+            .satisfies(e -> assertThat(e.getResponse().getEntity()).isEqualTo(
+                new ErrorMessage(400, "Parameter is not a number.")
+            ));
     }
 
     @Test
     public void emptyStringThrowsAnException() {
-        assertThatThrownBy(() -> new LongParam(""))
-                .isInstanceOfSatisfying(WebApplicationException.class, e -> {
-                    assertThat(e.getResponse().getStatus()).isEqualTo(400);
-                    assertThat(e.getResponse().getEntity()).isEqualTo(
-                            new ErrorMessage(400, "Parameter is not a number.")
-                    );
-                });
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> new LongParam(null))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(400))
+            .satisfies(e -> assertThat(e.getResponse().getEntity()).isEqualTo(
+                new ErrorMessage(400, "Parameter is not a number.")
+            ));
     }
 
     @Test
     public void aNonIntegerThrowsAnException() {
-        assertThatThrownBy(() -> new LongParam("foo"))
-            .isInstanceOfSatisfying(WebApplicationException.class, e -> {
-                assertThat(e.getResponse().getStatus()).isEqualTo(400);
-                assertThat(e.getResponse().getEntity()).isEqualTo(
-                    new ErrorMessage(400, "Parameter is not a number.")
-                );
-            });
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> new LongParam("foo"))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(400))
+            .satisfies(e -> assertThat(e.getResponse().getEntity()).isEqualTo(
+                new ErrorMessage(400, "Parameter is not a number.")
+            ));
     }
 
     @Test
     public void aNonIntegerThrowsAnExceptionWithCustomName() {
-        assertThatThrownBy(() -> new LongParam("foo", "customName"))
-            .isInstanceOfSatisfying(WebApplicationException.class, e -> {
-                assertThat(e.getResponse().getStatus()).isEqualTo(400);
-                assertThat(e.getResponse().getEntity()).isEqualTo(
-                    new ErrorMessage(400, "customName is not a number.")
-                );
-            });
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> new LongParam("foo", "customName"))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(400))
+            .satisfies(e -> assertThat(e.getResponse().getEntity()).isEqualTo(
+                new ErrorMessage(400, "customName is not a number.")
+            ));
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/SizeParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/SizeParamTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import javax.ws.rs.WebApplicationException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class SizeParamTest {
 
@@ -20,12 +20,11 @@ public class SizeParamTest {
 
     @Test
     public void badValueThrowsException() {
-        assertThatThrownBy(() -> new SizeParam("10 kelvins", "degrees"))
-            .isInstanceOfSatisfying(WebApplicationException.class, e -> {
-                assertThat(e.getResponse().getStatus()).isEqualTo(400);
-                assertThat(e.getResponse().getEntity()).isEqualTo(
-                    new ErrorMessage(400, "degrees is not a valid size.")
-                );
-            });
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> new SizeParam("10 kelvins", "degrees"))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(400))
+            .satisfies(e -> assertThat(e.getResponse().getEntity()).isEqualTo(
+                new ErrorMessage(400, "degrees is not a valid size.")
+            ));
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/UUIDParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/UUIDParamTest.java
@@ -7,17 +7,16 @@ import javax.ws.rs.WebApplicationException;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class UUIDParamTest {
     private void UuidParamNegativeTest(String input) {
-        assertThatThrownBy(() -> new UUIDParam(input))
-            .isInstanceOfSatisfying(WebApplicationException.class, e -> {
-                assertThat(e.getResponse().getStatus()).isEqualTo(400);
-                assertThat(e.getResponse().getEntity()).isEqualTo(
-                    new ErrorMessage(400, "Parameter is not a UUID.")
-                );
-            });
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> new UUIDParam(input))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(400))
+            .satisfies(e -> assertThat(e.getResponse().getEntity()).isEqualTo(
+                new ErrorMessage(400, "Parameter is not a UUID.")
+            ));
     }
 
     @Test
@@ -25,9 +24,7 @@ public class UUIDParamTest {
         final String uuidString = "067e6162-3b6f-4ae2-a171-2470b63dff00";
         final UUID uuid = UUID.fromString(uuidString);
 
-        final UUIDParam param = new UUIDParam(uuidString);
-        assertThat(param.get())
-                .isEqualTo(uuid);
+        assertThat(new UUIDParam(uuidString).get()).isEqualTo(uuid);
     }
 
     @Test

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/assets/ResourceURLTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/assets/ResourceURLTest.java
@@ -11,7 +11,7 @@ import java.nio.file.Path;
 import java.util.jar.JarEntry;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class ResourceURLTest {
@@ -112,12 +112,12 @@ class ResourceURLTest {
     void isDirectoryThrowsResourceNotFoundExceptionForMissingDirectories() throws Exception {
         final URL url = Resources.getResource("META-INF/");
         final URL nurl = new URL(url.toExternalForm() + "missing");
-        assertThatThrownBy(() -> ResourceURL.isDirectory(nurl))
-            .isInstanceOf(ResourceNotFoundException.class);
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+            .isThrownBy(() -> ResourceURL.isDirectory(nurl));
     }
 
     @Test
-    void appendTrailingSlashAddsASlash() throws Exception {
+    void appendTrailingSlashAddsASlash() {
         final URL url = Resources.getResource("META-INF");
 
         assertThat(url.toExternalForm())
@@ -127,7 +127,7 @@ class ResourceURLTest {
     }
 
     @Test
-    void appendTrailingSlashDoesntASlashWhenOneIsAlreadyPresent() throws Exception {
+    void appendTrailingSlashDoesntASlashWhenOneIsAlreadyPresent() {
         final URL url = Resources.getResource("META-INF/");
 
         assertThat(url.toExternalForm())

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportWithMissingConfigurationTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportWithMissingConfigurationTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.FileNotFoundException;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class DropwizardTestSupportWithMissingConfigurationTest {
     @Test
@@ -14,8 +14,8 @@ class DropwizardTestSupportWithMissingConfigurationTest {
         final DropwizardTestSupport<TestConfiguration> testSupport =
                 new DropwizardTestSupport<>(TestApplication.class, "not-found.yaml");
 
-        assertThatThrownBy(testSupport::before)
-                .isInstanceOf(FileNotFoundException.class)
-                .hasMessage("File not-found.yaml not found");
+        assertThatExceptionOfType(FileNotFoundException.class)
+            .isThrownBy(testSupport::before)
+            .withMessage("File not-found.yaml not found");
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DAOTestRuleTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DAOTestRuleTest.java
@@ -11,7 +11,6 @@ import java.io.Serializable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 public class DAOTestRuleTest {
     @SuppressWarnings("deprecation")
@@ -56,19 +55,14 @@ public class DAOTestRuleTest {
 
         // when we prepare an update of that entity
         testEntity.setDescription("newDescription");
-        try {
-            // ... but cause a constraint violation during the actual update
-            daoTestRule.inTransaction(() -> {
+        // ... but cause a constraint violation during the actual update
+        assertThatExceptionOfType(ConstraintViolationException.class)
+            .isThrownBy(() -> daoTestRule.inTransaction(() -> {
                 persist(testEntity);
                 persist(new TestEntity(null));
-            });
-            failBecauseExceptionWasNotThrown(ConstraintViolationException.class);
-        } catch (ConstraintViolationException ignoredException) {
-            // keep calm and carry on
-            // ... the entity has the original value
-            final TestEntity sameTestEntity = get(testEntity.getId());
-            assertThat(sameTestEntity.getDescription()).isEqualTo("description");
-        }
+            }));
+        // ... the entity has the original value
+        assertThat(get(testEntity.getId()).getDescription()).isEqualTo("description");
     }
 
 

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DAOTestExtensionTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DAOTestExtensionTest.java
@@ -11,7 +11,7 @@ import javax.validation.ConstraintViolationException;
 import java.io.Serializable;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 class DAOTestExtensionTest {
@@ -55,19 +55,14 @@ class DAOTestExtensionTest {
 
         // when we prepare an update of that entity
         testEntity.setDescription("newDescription");
-        try {
-            // ... but cause a constraint violation during the actual update
-            daoTestExtension.inTransaction(() -> {
+        // ... but cause a constraint violation during the actual update
+        assertThatExceptionOfType(ConstraintViolationException.class)
+            .isThrownBy(() -> daoTestExtension.inTransaction(() -> {
                 persist(testEntity);
                 persist(new TestEntity(null));
-            });
-            failBecauseExceptionWasNotThrown(ConstraintViolationException.class);
-        } catch (ConstraintViolationException ignoredException) {
-            // keep calm and carry on
-            // ... the entity has the original value
-            final TestEntity sameTestEntity = get(testEntity.getId());
-            assertThat(sameTestEntity.getDescription()).isEqualTo("junit 5 description");
-        }
+            }));
+        // ... the entity has the original value
+        assertThat(get(testEntity.getId()).getDescription()).isEqualTo("junit 5 description");
     }
 
 

--- a/dropwizard-util/src/test/java/io/dropwizard/util/DataSizeTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/DataSizeTest.java
@@ -10,7 +10,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class DataSizeTest {
     @Test
@@ -222,23 +222,23 @@ class DataSizeTest {
 
     @Test
     void unableParseWrongDataSizeCount() {
-        assertThatThrownBy(() -> DataSize.parse("three bytes"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Invalid size: three bytes");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> DataSize.parse("three bytes"))
+            .withMessage("Invalid size: three bytes");
     }
 
     @Test
     void unableParseWrongDataSizeUnit() {
-        assertThatThrownBy(() -> DataSize.parse("1EB"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Invalid size: 1EB. Wrong size unit");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> DataSize.parse("1EB"))
+            .withMessage("Invalid size: 1EB. Wrong size unit");
     }
 
     @Test
     void unableParseWrongDataSizeFormat() {
-        assertThatThrownBy(() -> DataSize.parse("1 mega byte"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Invalid size: 1 mega byte");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> DataSize.parse("1 mega byte"))
+            .withMessage("Invalid size: 1 mega byte");
     }
 
     @Test

--- a/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/FreemarkerViewRendererTest.java
+++ b/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/FreemarkerViewRendererTest.java
@@ -28,7 +28,7 @@ import javax.ws.rs.core.Response;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FreemarkerViewRendererTest extends JerseyTest {
     static {
@@ -92,52 +92,40 @@ public class FreemarkerViewRendererTest extends JerseyTest {
     }
 
     @Test
-    public void rendersViewsWithAbsoluteTemplatePaths() throws Exception {
+    public void rendersViewsWithAbsoluteTemplatePaths() {
         final String response = target("/test/absolute")
                 .request().get(String.class);
         assertThat(response).isEqualTo("Woop woop. yay\n");
     }
 
     @Test
-    public void rendersViewsWithRelativeTemplatePaths() throws Exception {
+    public void rendersViewsWithRelativeTemplatePaths() {
         final String response = target("/test/relative")
                 .request().get(String.class);
         assertThat(response).isEqualTo("Ok.\n");
     }
 
     @Test
-    public void returnsA500ForViewsWithBadTemplatePaths() throws Exception {
-        try {
-            target("/test/bad")
-                    .request().get(String.class);
-
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus())
-                    .isEqualTo(500);
-
-            assertThat(e.getResponse().readEntity(String.class))
-                .isEqualTo(ViewRenderExceptionMapper.TEMPLATE_ERROR_MSG);
-        }
+    public void returnsA500ForViewsWithBadTemplatePaths() {
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> target("/test/bad").request().get(String.class))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(500))
+            .satisfies(e -> assertThat(e.getResponse().readEntity(String.class))
+                .isEqualTo(ViewRenderExceptionMapper.TEMPLATE_ERROR_MSG));
     }
 
     @Test
     @Disabled("Flaky on JUnit5")
-    public void returnsA500ForViewsThatCantCompile() throws Exception {
-        try {
-            target("/test/error").request().get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus())
-                    .isEqualTo(500);
-
-            assertThat(e.getResponse().readEntity(String.class))
-                    .isEqualTo(ViewRenderExceptionMapper.TEMPLATE_ERROR_MSG);
-        }
+    public void returnsA500ForViewsThatCantCompile() {
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> target("/test/error").request().get(String.class))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(500))
+            .satisfies(e -> assertThat(e.getResponse().readEntity(String.class))
+                .isEqualTo(ViewRenderExceptionMapper.TEMPLATE_ERROR_MSG));
     }
 
     @Test
-    public void rendersViewsUsingUnsafeInputWithAutoEscapingEnabled() throws Exception {
+    public void rendersViewsUsingUnsafeInputWithAutoEscapingEnabled() {
         final String unsafe = "<script>alert(\"hello\")</script>";
         final Response response = target("/test/auto-escaping")
             .request().post(Entity.form(new Form("input", unsafe)));

--- a/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererFileSystemTest.java
+++ b/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererFileSystemTest.java
@@ -21,12 +21,12 @@ import javax.ws.rs.core.MediaType;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * Test class for {@link MustacheViewRenderer} configured to load Mustache
  * templates from the file system.
- * 
+ *
  * @since 1.1.0
  */
 public class MustacheViewRendererFileSystemTest extends JerseyTest {
@@ -86,43 +86,33 @@ public class MustacheViewRendererFileSystemTest extends JerseyTest {
     }
 
     @Test
-    public void rendersViewsWithAbsoluteTemplatePaths() throws Exception {
+    public void rendersViewsWithAbsoluteTemplatePaths() {
         final String response = target("/test/absolute").request().get(String.class);
         assertThat(response).isEqualTo("Woop woop. yay\n");
     }
 
     @Test
-    public void rendersViewsWithRelativeTemplatePaths() throws Exception {
+    public void rendersViewsWithRelativeTemplatePaths() {
         final String response = target("/test/relative").request().get(String.class);
         assertThat(response).isEqualTo("Ok.\n");
     }
 
     @Test
-    public void returnsA500ForViewsWithBadTemplatePaths() throws Exception {
-        try {
-            target("/test/bad").request().get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus())
-                    .isEqualTo(500);
-
-            assertThat(e.getResponse().readEntity(String.class))
-                    .isEqualTo(ViewRenderExceptionMapper.TEMPLATE_ERROR_MSG);
-        }
+    public void returnsA500ForViewsWithBadTemplatePaths() {
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> target("/test/bad").request().get(String.class))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(500))
+            .satisfies(e -> assertThat(e.getResponse().readEntity(String.class))
+                .isEqualTo(ViewRenderExceptionMapper.TEMPLATE_ERROR_MSG));
     }
 
     @Test
-    public void returnsA500ForViewsThatCantCompile() throws Exception {
-        try {
-            target("/test/error").request().get(String.class);
-            failBecauseExceptionWasNotThrown(WebApplicationException.class);
-        } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus())
-                    .isEqualTo(500);
-
-            assertThat(e.getResponse().readEntity(String.class))
-                .isEqualTo(ViewRenderExceptionMapper.TEMPLATE_ERROR_MSG);
-        }
+    public void returnsA500ForViewsThatCantCompile() {
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> target("/test/error").request().get(String.class))
+            .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(500))
+            .satisfies(e -> assertThat(e.getResponse().readEntity(String.class))
+                .isEqualTo(ViewRenderExceptionMapper.TEMPLATE_ERROR_MSG));
     }
 
 }


### PR DESCRIPTION
Simplify and normalise the test assertions relating to exceptions, favouring `assertThatExceptionOfType` over other mechanisms.

Sorry, it's quite big.