### PR TITLE
Refactor testing of thrown exceptions in dropwizard-client

### DIFF
--- a/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
@@ -42,7 +42,7 @@ import java.net.URI;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -90,9 +90,9 @@ public class DropwizardApacheConnectorTest {
 
     @Test
     void when_no_read_timeout_override_then_client_request_times_out() {
-        assertThatThrownBy(() ->client.target(testUri + "/long_running").request().get())
-                .isInstanceOf(ProcessingException.class)
-                .hasCauseInstanceOf(SocketTimeoutException.class);
+        assertThatExceptionOfType(ProcessingException.class)
+            .isThrownBy(() ->client.target(testUri + "/long_running").request().get())
+            .withCauseInstanceOf(SocketTimeoutException.class);
     }
 
     @Test

--- a/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactoryTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactoryTest.java
@@ -38,7 +38,6 @@ import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.bouncycastle.jce.provider.BouncyCastleProvider.PROVIDER_NAME;
 
@@ -126,9 +125,9 @@ public class DropwizardSSLConnectionSocketFactoryTest {
     void shouldErrorIfServerCertNotFoundInTruststore() {
         tlsConfiguration.setTrustStorePath(new File(ResourceHelpers.resourceFilePath("stores/server/other_cert_truststore.ts")));
         final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).build("tls_broken_client");
-        assertThatThrownBy(() -> client.target(String.format("https://localhost:%d", TLS_APP_RULE.getLocalPort())).request().get())
-            .isInstanceOf(ProcessingException.class)
-            .hasCauseInstanceOf(SSLHandshakeException.class);
+        assertThatExceptionOfType(ProcessingException.class)
+            .isThrownBy(() -> client.target(String.format("https://localhost:%d", TLS_APP_RULE.getLocalPort())).request().get())
+            .withCauseInstanceOf(SSLHandshakeException.class);
     }
 
     @Test
@@ -142,9 +141,9 @@ public class DropwizardSSLConnectionSocketFactoryTest {
     @Test
     void shouldErrorIfServerCertSelfSignedAndSelfSignedCertsNotAllowed() {
         final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).build("self_sign_failure");
-        assertThatThrownBy(() -> client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(1))).request().get(ClientResponse.class))
-            .isInstanceOf(ProcessingException.class)
-            .hasCauseInstanceOf(SSLHandshakeException.class);
+        assertThatExceptionOfType(ProcessingException.class)
+            .isThrownBy(() -> client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(1))).request().get(ClientResponse.class))
+            .withCauseInstanceOf(SSLHandshakeException.class);
     }
 
     @Test
@@ -163,9 +162,9 @@ public class DropwizardSSLConnectionSocketFactoryTest {
         tlsConfiguration.setKeyStorePassword("password");
         tlsConfiguration.setKeyStoreType("PKCS12");
         final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).build("client_auth_broken");
-        final Throwable exn = catchThrowable(() -> client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(2))).request().get());
-        assertThat(exn).isInstanceOf(ProcessingException.class);
-        assertThat(exn.getCause()).isInstanceOfAny(SocketException.class, SSLHandshakeException.class, SSLException.class);
+        assertThatExceptionOfType(ProcessingException.class)
+            .isThrownBy(() -> client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(2))).request().get())
+            .satisfies(e -> assertThat(e.getCause()).isInstanceOfAny(SocketException.class, SSLHandshakeException.class, SSLException.class));
     }
 
     @Test
@@ -186,9 +185,9 @@ public class DropwizardSSLConnectionSocketFactoryTest {
         tlsConfiguration.setKeyStoreType("PKCS12");
         tlsConfiguration.setCertAlias("2");
         final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).build("client_auth_using_cert_alias_broken");
-        final Throwable exn = catchThrowable(() -> client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(2))).request().get());
-        assertThat(exn).isInstanceOf(ProcessingException.class);
-        assertThat(exn.getCause()).isInstanceOfAny(SocketException.class, SSLHandshakeException.class, SSLException.class);
+        assertThatExceptionOfType(ProcessingException.class)
+            .isThrownBy(() -> client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(2))).request().get())
+            .satisfies(e -> assertThat(e.getCause()).isInstanceOfAny(SocketException.class, SSLHandshakeException.class, SSLException.class));
     }
 
     @Test
@@ -198,9 +197,9 @@ public class DropwizardSSLConnectionSocketFactoryTest {
         tlsConfiguration.setKeyStoreType("PKCS12");
         tlsConfiguration.setCertAlias("unknown");
         final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).build("client_auth_using_unknown_cert_alias_broken");
-        final Throwable exn = catchThrowable(() -> client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(2))).request().get());
-        assertThat(exn).isInstanceOf(ProcessingException.class);
-        assertThat(exn.getCause()).isInstanceOfAny(SocketException.class, SSLHandshakeException.class, SSLException.class);
+        assertThatExceptionOfType(ProcessingException.class)
+            .isThrownBy(() -> client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(2))).request().get())
+            .satisfies(e -> assertThat(e.getCause()).isInstanceOfAny(SocketException.class, SSLHandshakeException.class, SSLException.class));
     }
 
     @Test
@@ -246,9 +245,9 @@ public class DropwizardSSLConnectionSocketFactoryTest {
     void shouldRejectNonSupportedProtocols() {
         tlsConfiguration.setSupportedProtocols(Collections.singletonList("TLSv1.2"));
         final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).build("reject_non_supported");
-        assertThatThrownBy(() -> client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(4))).request().get())
-            .isInstanceOf(ProcessingException.class)
-            .hasRootCauseInstanceOf(IOException.class);
+        assertThatExceptionOfType(ProcessingException.class)
+            .isThrownBy(() -> client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(4))).request().get())
+            .withRootCauseInstanceOf(IOException.class);
     }
 
     @Test

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
@@ -58,7 +58,6 @@ import java.net.Proxy;
 import java.net.ProxySelector;
 import java.net.SocketAddress;
 import java.net.URI;
-import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Collections;
 import java.util.List;
@@ -67,7 +66,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -93,45 +92,33 @@ public class JerseyClientBuilderTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    public void tearDown() {
         executorService.shutdown();
     }
 
     @Test
-    public void throwsAnExceptionWithoutAnEnvironmentOrAThreadPoolAndObjectMapper() throws Exception {
-        try {
-            builder.build("test");
-            failBecauseExceptionWasNotThrown(IllegalStateException.class);
-        } catch (IllegalStateException e) {
-            assertThat(e.getMessage())
-                    .isEqualTo("Must have either an environment or both an executor service and an object mapper");
-        }
+    public void throwsAnExceptionWithoutAnEnvironmentOrAThreadPoolAndObjectMapper() {
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(() -> builder.build("test"))
+            .withMessage("Must have either an environment or both an executor service and an object mapper");
     }
 
     @Test
-    public void throwsAnExceptionWithoutAnEnvironmentAndOnlyObjectMapper() throws Exception {
-        try {
-            builder.using(objectMapper).build("test");
-            failBecauseExceptionWasNotThrown(IllegalStateException.class);
-        } catch (IllegalStateException e) {
-            assertThat(e.getMessage())
-                    .isEqualTo("Must have either an environment or both an executor service and an object mapper");
-        }
+    public void throwsAnExceptionWithoutAnEnvironmentAndOnlyObjectMapper() {
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(() -> builder.using(objectMapper).build("test"))
+            .withMessage("Must have either an environment or both an executor service and an object mapper");
     }
 
     @Test
-    public void throwsAnExceptionWithoutAnEnvironmentAndOnlyAThreadPool() throws Exception {
-        try {
-            builder.using(executorService).build("test");
-            failBecauseExceptionWasNotThrown(IllegalStateException.class);
-        } catch (IllegalStateException e) {
-            assertThat(e.getMessage())
-                    .isEqualTo("Must have either an environment or both an executor service and an object mapper");
-        }
+    public void throwsAnExceptionWithoutAnEnvironmentAndOnlyAThreadPool() {
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(() -> builder.using(executorService).build("test"))
+            .withMessage("Must have either an environment or both an executor service and an object mapper");
     }
 
     @Test
-    public void includesJerseyProperties() throws Exception {
+    public void includesJerseyProperties() {
         final Client client = builder.withProperty("poop", true)
                 .using(executorService, objectMapper)
                 .build("test");
@@ -140,7 +127,7 @@ public class JerseyClientBuilderTest {
     }
 
     @Test
-    public void includesJerseyProviderSingletons() throws Exception {
+    public void includesJerseyProviderSingletons() {
         final FakeMessageBodyReader provider = new FakeMessageBodyReader();
         final Client client = builder.withProvider(provider)
                 .using(executorService, objectMapper)
@@ -150,7 +137,7 @@ public class JerseyClientBuilderTest {
     }
 
     @Test
-    public void includesJerseyProviderClasses() throws Exception {
+    public void includesJerseyProviderClasses() {
         @SuppressWarnings("unused")
         final Client client = builder.withProvider(FakeMessageBodyReader.class)
                 .using(executorService, objectMapper)
@@ -160,7 +147,7 @@ public class JerseyClientBuilderTest {
     }
 
     @Test
-    public void createsAnRxEnabledClient() throws Exception {
+    public void createsAnRxEnabledClient() {
         final Client client =
             builder.using(executorService, objectMapper)
                 .buildRx("test", RxFlowableInvokerProvider.class);
@@ -174,7 +161,7 @@ public class JerseyClientBuilderTest {
     }
 
     @Test
-    public void usesTheGivenThreadPool() throws Exception {
+    public void usesTheGivenThreadPool() {
         final Client client = builder.using(executorService, objectMapper).build("test");
         for (Object o : client.getConfiguration().getInstances()) {
             if (o instanceof DropwizardExecutorProvider) {
@@ -186,7 +173,7 @@ public class JerseyClientBuilderTest {
     }
 
     @Test
-    public void usesTheGivenThreadPoolAndEnvironmentsObjectMapper() throws Exception {
+    public void usesTheGivenThreadPoolAndEnvironmentsObjectMapper() {
         final Client client = builder.using(environment).using(executorService).build("test");
         for (Object o : client.getConfiguration().getInstances()) {
             if (o instanceof DropwizardExecutorProvider) {
@@ -198,7 +185,7 @@ public class JerseyClientBuilderTest {
     }
 
     @Test
-    public void createsNewConnectorProvider(){
+    public void createsNewConnectorProvider() {
         final JerseyClient clientA = (JerseyClient) builder.using(executorService, objectMapper).build("testA");
         final JerseyClient clientB = (JerseyClient) builder.build("testB");
         assertThat(clientA.getConfiguration().getConnectorProvider())
@@ -206,7 +193,7 @@ public class JerseyClientBuilderTest {
     }
 
     @Test
-    public void usesSameConnectorProvider(){
+    public void usesSameConnectorProvider()  {
         final JerseyClient clientA = (JerseyClient) builder.using(executorService, objectMapper)
             .using(mock(ConnectorProvider.class))
             .build("testA");
@@ -217,7 +204,7 @@ public class JerseyClientBuilderTest {
     }
 
     @Test
-    public void addBidirectionalGzipSupportIfEnabled() throws Exception {
+    public void addBidirectionalGzipSupportIfEnabled() {
         final JerseyClientConfiguration configuration = new JerseyClientConfiguration();
         configuration.setGzipEnabled(true);
 
@@ -231,7 +218,7 @@ public class JerseyClientBuilderTest {
     }
 
     @Test
-    public void disablesGzipSupportIfDisabled() throws Exception {
+    public void disablesGzipSupportIfDisabled() {
         final JerseyClientConfiguration configuration = new JerseyClientConfiguration();
         configuration.setGzipEnabled(false);
 
@@ -247,7 +234,7 @@ public class JerseyClientBuilderTest {
 
     @Test
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public void usesAnExecutorServiceFromTheEnvironment() throws Exception {
+    public void usesAnExecutorServiceFromTheEnvironment() {
         final JerseyClientConfiguration configuration = new JerseyClientConfiguration();
         configuration.setMinThreads(7);
         configuration.setMaxThreads(532);
@@ -312,11 +299,11 @@ public class JerseyClientBuilderTest {
             new X509TrustManager() {
 
                 @Override
-                public void checkClientTrusted(X509Certificate[] xcs, String string) throws CertificateException {
+                public void checkClientTrusted(X509Certificate[] xcs, String string) {
                 }
 
                 @Override
-                public void checkServerTrusted(X509Certificate[] xcs, String string) throws CertificateException {
+                public void checkServerTrusted(X509Certificate[] xcs, String string) {
                 }
 
                 @Override
@@ -394,7 +381,7 @@ public class JerseyClientBuilderTest {
         public JerseyClientBuilderTest readFrom(Class<JerseyClientBuilderTest> type, Type genericType,
                                                 Annotation[] annotations, MediaType mediaType,
                                                 MultivaluedMap<String, String> httpHeaders, InputStream entityStream)
-            throws IOException, WebApplicationException {
+            throws WebApplicationException {
             return null;
         }
     }


### PR DESCRIPTION
Simplify and normalise the test assertions relating to exceptions, favouring `assertThatExceptionOfType` over other mechanisms.