### PR TITLE
Remove public modifiers from dropwizard-assets tests

### DIFF
--- a/dropwizard-assets/src/test/java/io/dropwizard/assets/AssetsBundleTest.java
+++ b/dropwizard-assets/src/test/java/io/dropwizard/assets/AssetsBundleTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class AssetsBundleTest {
+class AssetsBundleTest {
     private final ServletEnvironment servletEnvironment = mock(ServletEnvironment.class);
     private final Environment environment = mock(Environment.class);
 
@@ -29,12 +29,12 @@ public class AssetsBundleTest {
     private String servletPath = "";
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         when(environment.servlets()).thenReturn(servletEnvironment);
     }
 
     @Test
-    public void hasADefaultPath() {
+    void hasADefaultPath() {
         runBundle(new AssetsBundle());
 
         assertThat(servletPath)
@@ -51,7 +51,7 @@ public class AssetsBundleTest {
     }
 
     @Test
-    public void canHaveCustomPaths() {
+    void canHaveCustomPaths() {
         runBundle(new AssetsBundle("/json"));
 
         assertThat(servletPath)
@@ -68,7 +68,7 @@ public class AssetsBundleTest {
     }
 
     @Test
-    public void canHaveDifferentUriAndResourcePaths() {
+    void canHaveDifferentUriAndResourcePaths() {
         runBundle(new AssetsBundle("/json", "/what"));
 
         assertThat(servletPath)
@@ -85,7 +85,7 @@ public class AssetsBundleTest {
     }
 
     @Test
-    public void canSupportDifferentAssetsBundleName() {
+    void canSupportDifferentAssetsBundleName() {
         runBundle(new AssetsBundle("/json", "/what/new", "index.txt", "customAsset1"), "customAsset1");
 
         assertThat(servletPath)
@@ -115,7 +115,7 @@ public class AssetsBundleTest {
     }
 
     @Test
-    public void canHaveDifferentUriAndResourcePathsAndIndexFilename() {
+    void canHaveDifferentUriAndResourcePathsAndIndexFilename() {
         runBundle(new AssetsBundle("/json", "/what", "index.txt"));
 
         assertThat(servletPath)
@@ -132,7 +132,7 @@ public class AssetsBundleTest {
     }
 
     @Test
-    public void canHaveDifferentDefaultMediaType() {
+    void canHaveDifferentDefaultMediaType() {
         runBundle(new AssetsBundle("/assets", "/assets", "index.html", "assets", "text/plain"));
 
         assertThat(servletPath).isEqualTo("/assets/*");


### PR DESCRIPTION
JUnit 5 no longer requires test classes and methods to be declared public and Sonar grumbles about this.

If this is alright, I'm happy to do it to the rest of the tests, but it'll either be a large MR for everything or a lot of medium sized MRs. Let me know what you think.