### PR TITLE
Address SonarCloud concerns in dropwizard-auth

### DIFF
--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthValueFactoryProvider.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthValueFactoryProvider.java
@@ -38,7 +38,7 @@ public class AuthValueFactoryProvider<T extends Principal> extends AbstractValue
     @Inject
     public AuthValueFactoryProvider(MultivaluedParameterExtractorProvider mpep,
                                     PrincipalClassProvider<T> principalClassProvider) {
-        super(() -> mpep, Parameter.Source.UNKNOWN);
+        super(() -> mpep, org.glassfish.jersey.model.Parameter.Source.UNKNOWN);
         this.principalClass = principalClassProvider.clazz;
     }
 

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/PolymorphicAuthValueFactoryProvider.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/PolymorphicAuthValueFactoryProvider.java
@@ -42,7 +42,7 @@ public class PolymorphicAuthValueFactoryProvider<T extends Principal> extends Ab
         MultivaluedParameterExtractorProvider mpep,
         PrincipalClassSetProvider<T> principalClassSetProvider
     ) {
-        super(() -> mpep, Parameter.Source.UNKNOWN);
+        super(() -> mpep, org.glassfish.jersey.model.Parameter.Source.UNKNOWN);
         this.principalClassSet = principalClassSetProvider.clazzSet;
     }
 

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/CachingAuthenticatorTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/CachingAuthenticatorTest.java
@@ -95,9 +95,9 @@ class CachingAuthenticatorTest {
     @Test
     void shouldNotCacheAbsentPrincipals() throws Exception {
         when(underlying.authenticate(anyString())).thenReturn(Optional.empty());
-        assertThat(cached.authenticate("credentials")).isEqualTo(Optional.empty());
+        assertThat(cached.authenticate("credentials")).isEmpty();
         verify(underlying).authenticate("credentials");
-        assertThat(cached.size()).isEqualTo(0);
+        assertThat(cached.size()).isZero();
     }
 
     @Test
@@ -125,7 +125,7 @@ class CachingAuthenticatorTest {
         when(underlying.authenticate(anyString())).thenReturn(Optional.empty());
         Caffeine<Object, Object> caffeine = Caffeine.newBuilder().maximumSize(1L).executor(Runnable::run);
         cached = new CachingAuthenticator<>(new MetricRegistry(), underlying, caffeine, true);
-        assertThat(cached.authenticate("credentials")).isEqualTo(Optional.empty());
+        assertThat(cached.authenticate("credentials")).isEmpty();
         verify(underlying).authenticate("credentials");
         assertThat(cached.size()).isEqualTo(1);
     }

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/CachingAuthorizerTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/CachingAuthorizerTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 
 import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.core.UriInfo;
 import java.security.Principal;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -120,19 +119,19 @@ public class CachingAuthorizerTest {
         cached.authorize(principal, role, requestContext);
         assertThat(cached.size()).isEqualTo(1);
         cached.invalidateAll();
-        assertThat(cached.size()).isEqualTo(0);
+        assertThat(cached.size()).isZero();
     }
 
     @Test
     public void calculatesCacheStats() throws Exception {
-        assertThat(cached.stats().loadCount()).isEqualTo(0);
+        assertThat(cached.stats().loadCount()).isZero();
         cached.authorize(principal, role, requestContext);
         assertThat(cached.stats().loadCount()).isEqualTo(1);
         assertThat(cached.size()).isEqualTo(1);
     }
 
     @Test
-    public void shouldPropagateRuntimeException() throws AuthenticationException {
+    public void shouldPropagateRuntimeException() {
         final RuntimeException e = new NullPointerException();
         when(underlying.authorize(principal, role, requestContext)).thenThrow(e);
         assertThatNullPointerException()

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/BasicCredentialsTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/BasicCredentialsTest.java
@@ -8,35 +8,37 @@ public class BasicCredentialsTest {
     private final BasicCredentials credentials = new BasicCredentials("u", "p");
 
     @Test
-    public void hasAUsername() throws Exception {
+    public void hasAUsername() {
         assertThat(credentials.getUsername()).isEqualTo("u");
     }
 
     @Test
-    public void hasAPassword() throws Exception {
+    public void hasAPassword() {
         assertThat(credentials.getPassword()).isEqualTo("p");
     }
 
     @Test
-    @SuppressWarnings({ "ObjectEqualsNull", "EqualsBetweenInconvertibleTypes", "LiteralAsArgToStringEquals" })
-    public void hasAWorkingEqualsMethod() throws Exception {
-        assertThat(credentials).isEqualTo(credentials);
-        assertThat(credentials).isEqualTo(new BasicCredentials("u", "p"));
-        assertThat(credentials).isNotEqualTo(null);
-        assertThat(credentials).isNotEqualTo("string");
-        assertThat(credentials).isNotEqualTo(new BasicCredentials("u1", "p"));
-        assertThat(credentials).isNotEqualTo(new BasicCredentials("u", "p1"));
+    @SuppressWarnings({ "ObjectEqualsNull", "LiteralAsArgToStringEquals" })
+    public void hasAWorkingEqualsMethod() {
+        assertThat(credentials)
+            .isEqualTo(credentials)
+            .isEqualTo(new BasicCredentials("u", "p"))
+            .isNotEqualTo(null)
+            .isNotEqualTo("string")
+            .isNotEqualTo(new BasicCredentials("u1", "p"))
+            .isNotEqualTo(new BasicCredentials("u", "p1"));
     }
 
     @Test
-    public void hasAWorkingHashCode() throws Exception {
-        assertThat(credentials.hashCode()).isEqualTo(new BasicCredentials("u", "p").hashCode());
-        assertThat(credentials.hashCode()).isNotEqualTo(new BasicCredentials("u1", "p").hashCode());
-        assertThat(credentials.hashCode()).isNotEqualTo(new BasicCredentials("u", "p1").hashCode());
+    public void hasAWorkingHashCode() {
+        assertThat(credentials.hashCode())
+            .hasSameHashCodeAs(new BasicCredentials("u", "p"))
+            .isNotEqualTo(new BasicCredentials("u1", "p").hashCode())
+            .isNotEqualTo(new BasicCredentials("u", "p1").hashCode());
     }
 
     @Test
-    public void isHumanReadable() throws Exception {
-        assertThat(credentials.toString()).isEqualTo("BasicCredentials{username=u, password=**********}");
+    public void isHumanReadable() {
+        assertThat(credentials).hasToString("BasicCredentials{username=u, password=**********}");
     }
 }


### PR DESCRIPTION
Sonar didn't like the accesses of static fields on a derived type, preferring direct access to the supertype instead.

Also, some assertions in the tests can be chained and we can use a few more specialised AssertJ assertions to make the tests more expressive.