### PR TITLE
add assertions for json-logging start() and stop() methods

### DIFF
--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/EventJsonLayoutBaseFactoryTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/EventJsonLayoutBaseFactoryTest.java
@@ -43,6 +43,8 @@ class EventJsonLayoutBaseFactoryTest {
         ThrowableHandlingConverter converter = factory.createThrowableProxyConverter(new LoggerContext());
         converter.start();
 
+        assertThat(converter.isStarted()).isTrue();
+
         // Verify the original stack includes the excluded packages
         assertThat(proxy.getThrowable()).hasStackTraceContaining(packageFilter);
 
@@ -66,6 +68,8 @@ class EventJsonLayoutBaseFactoryTest {
 
         ThrowableHandlingConverter converter = factory.createThrowableProxyConverter(new LoggerContext());
         converter.start();
+
+        assertThat(converter.isStarted()).isTrue();
 
         String conversion = converter.convert(event);
 

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/AccessJsonLayoutTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/AccessJsonLayoutTest.java
@@ -214,7 +214,14 @@ public class AccessJsonLayoutTest {
         accessJsonLayout.setRequestAttributes(attributes.keySet());
         assertThat(accessJsonLayout.toJsonMap(event))
             .containsEntry("requestAttributes", attributes);
+    }
 
+    @Test
+    public void testStartAndStop() {
+        accessJsonLayout.start();
+        assertThat(accessJsonLayout.isStarted()).isTrue();
+        accessJsonLayout.stop();
+        assertThat(accessJsonLayout.isStarted()).isFalse();
     }
 
     @Test

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/EventJsonLayoutTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/EventJsonLayoutTest.java
@@ -189,12 +189,16 @@ public class EventJsonLayoutTest {
     void testStartThrowableConverter() {
         eventJsonLayout.start();
 
+        assertThat(eventJsonLayout.isStarted()).isTrue();
+
         verify(throwableProxyConverter).start();
     }
 
     @Test
     void testStopThrowableConverter() {
         eventJsonLayout.stop();
+
+        assertThat(eventJsonLayout.isStarted()).isFalse();
 
         verify(throwableProxyConverter).stop();
     }


### PR DESCRIPTION
###### Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->

verify start() and stop() behavior in dropwizard-json-logging

###### Solution:
<!-- Describe the modifications you've done. -->

add new assertions to dropwizard-json-logging test suite

###### Result:
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->
