### PR TITLE
Remove public modifiers from tests

### DIFF
--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthBaseTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthBaseTest.java
@@ -51,13 +51,13 @@ public abstract class AuthBaseTest<T extends DropwizardResourceConfig> extends J
 
     @Override
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         super.setUp();
     }
 
     @Override
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         super.tearDown();
     }
 
@@ -70,7 +70,7 @@ public abstract class AuthBaseTest<T extends DropwizardResourceConfig> extends J
     }
 
     @Test
-    public void respondsToMissingCredentialsWith401() {
+    void respondsToMissingCredentialsWith401() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> target("/test/admin").request().get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(401))
@@ -79,14 +79,14 @@ public abstract class AuthBaseTest<T extends DropwizardResourceConfig> extends J
     }
 
     @Test
-    public void resourceWithoutAuth200() {
+    void resourceWithoutAuth200() {
         assertThat(target("/test/noauth").request()
             .get(String.class))
             .isEqualTo("hello");
     }
 
     @Test
-    public void resourceWithAuthenticationWithoutAuthorizationWithCorrectCredentials200() {
+    void resourceWithAuthenticationWithoutAuthorizationWithCorrectCredentials200() {
         assertThat(target("/test/profile").request()
             .header(HttpHeaders.AUTHORIZATION, getPrefix() + " " + getOrdinaryGuyValidToken())
             .get(String.class))
@@ -94,7 +94,7 @@ public abstract class AuthBaseTest<T extends DropwizardResourceConfig> extends J
     }
 
     @Test
-    public void resourceWithAuthenticationWithoutAuthorizationNoCredentials401() {
+    void resourceWithAuthenticationWithoutAuthorizationNoCredentials401() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> target("/test/profile").request().get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(401))
@@ -103,7 +103,7 @@ public abstract class AuthBaseTest<T extends DropwizardResourceConfig> extends J
     }
 
     @Test
-    public void resourceWithValidOptionalAuthentication200() {
+    void resourceWithValidOptionalAuthentication200() {
         assertThat(target("/test/optional").request()
             .header(HttpHeaders.AUTHORIZATION, getPrefix() + " " + getOrdinaryGuyValidToken())
             .get(String.class))
@@ -111,7 +111,7 @@ public abstract class AuthBaseTest<T extends DropwizardResourceConfig> extends J
     }
 
     @Test
-    public void resourceWithInvalidOptionalAuthentication200() {
+    void resourceWithInvalidOptionalAuthentication200() {
         assertThat(target("/test/optional").request()
             .header(HttpHeaders.AUTHORIZATION, getPrefix() + " " + getBadGuyToken())
             .get(String.class))
@@ -119,14 +119,14 @@ public abstract class AuthBaseTest<T extends DropwizardResourceConfig> extends J
     }
 
     @Test
-    public void resourceWithoutOptionalAuthentication200() {
+    void resourceWithoutOptionalAuthentication200() {
         assertThat(target("/test/optional").request()
             .get(String.class))
             .isEqualTo("principal was not present");
     }
 
     @Test
-    public void resourceWithAuthorizationPrincipalIsNotAuthorized403() {
+    void resourceWithAuthorizationPrincipalIsNotAuthorized403() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> target("/test/admin").request()
                 .header(HttpHeaders.AUTHORIZATION, getPrefix() + " " + getOrdinaryGuyValidToken())
@@ -136,14 +136,14 @@ public abstract class AuthBaseTest<T extends DropwizardResourceConfig> extends J
 
 
     @Test
-    public void resourceWithDenyAllAndNoAuth401() {
+    void resourceWithDenyAllAndNoAuth401() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> target("/test/denied").request().get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(401));
     }
 
     @Test
-    public void resourceWithDenyAllAndAuth403() {
+    void resourceWithDenyAllAndAuth403() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> target("/test/denied").request()
                 .header(HttpHeaders.AUTHORIZATION, getPrefix() + " " + getGoodGuyValidToken())
@@ -152,7 +152,7 @@ public abstract class AuthBaseTest<T extends DropwizardResourceConfig> extends J
     }
 
     @Test
-    public void transformsCredentialsToPrincipals() {
+    void transformsCredentialsToPrincipals() {
         assertThat(target("/test/admin").request()
             .header(HttpHeaders.AUTHORIZATION, getPrefix() + " " + getGoodGuyValidToken())
             .get(String.class))
@@ -160,7 +160,7 @@ public abstract class AuthBaseTest<T extends DropwizardResourceConfig> extends J
     }
 
     @Test
-    public void transformsCredentialsToPrincipalsWhenAuthAnnotationExistsWithoutMethodAnnotation() {
+    void transformsCredentialsToPrincipalsWhenAuthAnnotationExistsWithoutMethodAnnotation() {
         assertThat(target("/test/implicit-permitall").request()
             .header(HttpHeaders.AUTHORIZATION, getPrefix() + " " + getGoodGuyValidToken())
             .get(String.class))
@@ -169,7 +169,7 @@ public abstract class AuthBaseTest<T extends DropwizardResourceConfig> extends J
 
 
     @Test
-    public void respondsToNonBasicCredentialsWith401() {
+    void respondsToNonBasicCredentialsWith401() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> target("/test/admin").request()
                 .header(HttpHeaders.AUTHORIZATION, "Derp irrelevant")
@@ -180,7 +180,7 @@ public abstract class AuthBaseTest<T extends DropwizardResourceConfig> extends J
     }
 
     @Test
-    public void respondsToExceptionsWith500() {
+    void respondsToExceptionsWith500() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> target("/test/admin").request()
                 .header(HttpHeaders.AUTHORIZATION, getPrefix() + " " + getBadGuyToken())

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthBaseTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthBaseTest.java
@@ -51,13 +51,13 @@ public abstract class AuthBaseTest<T extends DropwizardResourceConfig> extends J
 
     @Override
     @BeforeEach
-    void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
     }
 
     @Override
     @AfterEach
-    void tearDown() throws Exception {
+    public void tearDown() throws Exception {
         super.tearDown();
     }
 

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthFilterTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthFilterTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.when;
 public class AuthFilterTest {
 
     @Test
-    public void isSecureShouldStayTheSame() throws Exception {
+    void isSecureShouldStayTheSame() throws Exception {
         ContainerRequestContext requestContext = new FakeSecureRequestContext();
 
         new SimpleAuthFilter().filter(requestContext);

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/CachingAuthorizerTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/CachingAuthorizerTest.java
@@ -35,12 +35,12 @@ public class CachingAuthorizerTest {
     private final ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         when(underlying.authorize(any(), anyString(), any())).thenReturn(true);
     }
 
     @Test
-    public void cachesTheFirstReturnedPrincipal() throws Exception {
+    void cachesTheFirstReturnedPrincipal() throws Exception {
         assertThat(cached.authorize(principal, role, requestContext)).isTrue();
         assertThat(cached.authorize(principal, role, requestContext)).isTrue();
 
@@ -48,7 +48,7 @@ public class CachingAuthorizerTest {
     }
 
     @Test
-    public void respectsTheCacheConfiguration() throws Exception {
+    void respectsTheCacheConfiguration() throws Exception {
         cached.authorize(principal, role, requestContext);
         // We need to make sure that background cache invalidation is done before other requests
         cached.cache.cleanUp();
@@ -63,7 +63,7 @@ public class CachingAuthorizerTest {
     }
 
     @Test
-    public void invalidatesPrincipalAndRole() throws Exception {
+    void invalidatesPrincipalAndRole() throws Exception {
         cached.authorize(principal, role, requestContext);
         cached.invalidate(principal, role, requestContext);
         cached.authorize(principal, role, requestContext);
@@ -72,7 +72,7 @@ public class CachingAuthorizerTest {
     }
 
     @Test
-    public void invalidatesSinglePrincipal() throws Exception {
+    void invalidatesSinglePrincipal() throws Exception {
         cached.authorize(principal, role, requestContext);
         cached.invalidate(principal);
         cached.authorize(principal, role, requestContext);
@@ -81,7 +81,7 @@ public class CachingAuthorizerTest {
     }
 
     @Test
-    public void invalidatesSetsofPrincipals() throws Exception {
+    void invalidatesSetsofPrincipals() throws Exception {
         cached.authorize(principal, role, requestContext);
         cached.authorize(principal2, role, requestContext);
         cached.invalidateAll(Sets.of(principal, principal2));
@@ -93,7 +93,7 @@ public class CachingAuthorizerTest {
     }
 
     @Test
-    public void invalidatesPrincipalsMatchingGivenPredicate() throws Exception {
+    void invalidatesPrincipalsMatchingGivenPredicate() throws Exception {
         cached.authorize(principal, role, requestContext);
         cached.invalidateAll(principal::equals);
         cached.authorize(principal, role, requestContext);
@@ -102,7 +102,7 @@ public class CachingAuthorizerTest {
     }
 
     @Test
-    public void invalidatesAllPrincipals() throws Exception {
+    void invalidatesAllPrincipals() throws Exception {
         cached.authorize(principal, role, requestContext);
         cached.authorize(principal2, role, requestContext);
         cached.invalidateAll();
@@ -114,7 +114,7 @@ public class CachingAuthorizerTest {
     }
 
     @Test
-    public void calculatesTheSizeOfTheCache() throws Exception {
+    void calculatesTheSizeOfTheCache() throws Exception {
         assertThat(cached.size()).isEqualTo(0);
         cached.authorize(principal, role, requestContext);
         assertThat(cached.size()).isEqualTo(1);
@@ -123,7 +123,7 @@ public class CachingAuthorizerTest {
     }
 
     @Test
-    public void calculatesCacheStats() throws Exception {
+    void calculatesCacheStats() throws Exception {
         assertThat(cached.stats().loadCount()).isZero();
         cached.authorize(principal, role, requestContext);
         assertThat(cached.stats().loadCount()).isEqualTo(1);
@@ -131,7 +131,7 @@ public class CachingAuthorizerTest {
     }
 
     @Test
-    public void shouldPropagateRuntimeException() {
+    void shouldPropagateRuntimeException() {
         final RuntimeException e = new NullPointerException();
         when(underlying.authorize(principal, role, requestContext)).thenThrow(e);
         assertThatNullPointerException()

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/OptionalAuthFilterOrderingTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/OptionalAuthFilterOrderingTest.java
@@ -28,13 +28,13 @@ public class OptionalAuthFilterOrderingTest extends JerseyTest {
 
     @Override
     @BeforeEach
-    void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
     }
 
     @Override
     @AfterEach
-    void tearDown() throws Exception {
+    public void tearDown() throws Exception {
         super.tearDown();
     }
 

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/OptionalAuthFilterOrderingTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/OptionalAuthFilterOrderingTest.java
@@ -28,13 +28,13 @@ public class OptionalAuthFilterOrderingTest extends JerseyTest {
 
     @Override
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         super.setUp();
     }
 
     @Override
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         super.tearDown();
     }
 
@@ -79,13 +79,13 @@ public class OptionalAuthFilterOrderingTest extends JerseyTest {
     }
 
     @Test
-    public void authenticationFilterShouldExecuteInAuthenticationPhaseForImplicitPermitall() {
+    void authenticationFilterShouldExecuteInAuthenticationPhaseForImplicitPermitall() {
         assertThat(target("/test/implicit-permitall").request().get(String.class))
             .isEqualTo("authorization ok");
     }
 
     @Test
-    public void authenticationFilterShouldExecuteInAuthenticationPhaseForOptionalPrincipal() {
+    void authenticationFilterShouldExecuteInAuthenticationPhaseForOptionalPrincipal() {
         assertThat(target("/test/optional").request().get(String.class))
             .isEqualTo("authorization ok");
     }

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/BasicCredentialsTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/BasicCredentialsTest.java
@@ -8,12 +8,12 @@ public class BasicCredentialsTest {
     private final BasicCredentials credentials = new BasicCredentials("u", "p");
 
     @Test
-    public void hasAUsername() {
+    void hasAUsername() {
         assertThat(credentials.getUsername()).isEqualTo("u");
     }
 
     @Test
-    public void hasAPassword() {
+    void hasAPassword() {
         assertThat(credentials.getPassword()).isEqualTo("p");
     }
 
@@ -30,7 +30,7 @@ public class BasicCredentialsTest {
     }
 
     @Test
-    public void hasAWorkingHashCode() {
+    void hasAWorkingHashCode() {
         assertThat(credentials.hashCode())
             .hasSameHashCodeAs(new BasicCredentials("u", "p"))
             .isNotEqualTo(new BasicCredentials("u1", "p").hashCode())
@@ -38,7 +38,7 @@ public class BasicCredentialsTest {
     }
 
     @Test
-    public void isHumanReadable() {
+    void isHumanReadable() {
         assertThat(credentials).hasToString("BasicCredentials{username=u, password=**********}");
     }
 }

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/chained/ChainedAuthProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/chained/ChainedAuthProviderTest.java
@@ -56,7 +56,7 @@ public class ChainedAuthProviderTest extends AuthBaseTest<ChainedAuthProviderTes
     }
 
     @Test
-    public void transformsBearerCredentialsToPrincipals() throws Exception {
+    void transformsBearerCredentialsToPrincipals() throws Exception {
         assertThat(target("/test/admin").request()
             .header(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + " " + BEARER_USER)
             .get(String.class))

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/oauth/OAuthProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/oauth/OAuthProviderTest.java
@@ -29,7 +29,7 @@ public class OAuthProviderTest extends AuthBaseTest<OAuthProviderTest.OAuthTestR
     }
 
     @Test
-    public void checksQueryStringAccessTokenIfAuthorizationHeaderMissing() {
+    void checksQueryStringAccessTokenIfAuthorizationHeaderMissing() {
         assertThat(target("/test/profile")
             .queryParam(OAuthCredentialAuthFilter.OAUTH_ACCESS_TOKEN_PARAM, getOrdinaryGuyValidToken())
             .request()

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/NoAuthPolymorphicPrincipalEntityTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/NoAuthPolymorphicPrincipalEntityTest.java
@@ -36,13 +36,13 @@ public class NoAuthPolymorphicPrincipalEntityTest extends JerseyTest {
 
     @Override
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         super.setUp();
     }
 
     @Override
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         super.tearDown();
     }
 
@@ -89,7 +89,7 @@ public class NoAuthPolymorphicPrincipalEntityTest extends JerseyTest {
     }
 
     @Test
-    public void jsonPrincipalEntityResourceWithoutAuth200() {
+    void jsonPrincipalEntityResourceWithoutAuth200() {
         String principalName = "Astar Seran";
         assertThat(target("/no-auth-test/json-principal-entity").request()
                 .header(HttpHeaders.AUTHORIZATION, "Anything here")
@@ -99,7 +99,7 @@ public class NoAuthPolymorphicPrincipalEntityTest extends JerseyTest {
     }
 
     @Test
-    public void nullPrincipalEntityResourceWithoutAuth200() {
+    void nullPrincipalEntityResourceWithoutAuth200() {
         assertThat(target("/no-auth-test/null-principal-entity").request()
                 .header(HttpHeaders.AUTHORIZATION, "Anything here")
                 .post(Entity.entity(new NullPrincipal(), MediaType.APPLICATION_JSON))
@@ -115,7 +115,7 @@ public class NoAuthPolymorphicPrincipalEntityTest extends JerseyTest {
      * logic is different for these two sources therefore must be tested separately.
      */
     @Test
-    public void annotatedJsonPrincipalEntityResourceWithoutAuth200() {
+    void annotatedJsonPrincipalEntityResourceWithoutAuth200() {
         String principalName = "Astar Seran";
         assertThat(target("/no-auth-test/annotated-json-principal-entity").request()
                 .header(HttpHeaders.AUTHORIZATION, "Anything here")
@@ -125,7 +125,7 @@ public class NoAuthPolymorphicPrincipalEntityTest extends JerseyTest {
     }
 
     @Test
-    public void annotatedNullPrincipalEntityResourceWithoutAuth200() {
+    void annotatedNullPrincipalEntityResourceWithoutAuth200() {
         assertThat(target("/no-auth-test/annotated-null-principal-entity").request()
                 .header(HttpHeaders.AUTHORIZATION, "Anything here")
                 .post(Entity.entity(new NullPrincipal(), MediaType.APPLICATION_JSON))

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/NoAuthPolymorphicPrincipalEntityTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/NoAuthPolymorphicPrincipalEntityTest.java
@@ -36,13 +36,13 @@ public class NoAuthPolymorphicPrincipalEntityTest extends JerseyTest {
 
     @Override
     @BeforeEach
-    void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
     }
 
     @Override
     @AfterEach
-    void tearDown() throws Exception {
+    public void tearDown() throws Exception {
         super.tearDown();
     }
 

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/NoAuthPrincipalEntityTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/NoAuthPrincipalEntityTest.java
@@ -34,13 +34,13 @@ public class NoAuthPrincipalEntityTest extends JerseyTest {
 
     @Override
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         super.setUp();
     }
 
     @Override
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         super.tearDown();
     }
 
@@ -80,7 +80,7 @@ public class NoAuthPrincipalEntityTest extends JerseyTest {
     }
 
     @Test
-    public void principalEntityResourceWithoutAuth200() {
+    void principalEntityResourceWithoutAuth200() {
         String principalName = "Astar Seran";
         assertThat(target("/no-auth-test/principal-entity").request()
                 .header(HttpHeaders.AUTHORIZATION, "Anything here")
@@ -97,7 +97,7 @@ public class NoAuthPrincipalEntityTest extends JerseyTest {
      * different for these two sources therefore must be tested separately.
      */
     @Test
-    public void annotatedPrincipalEntityResourceWithoutAuth200() {
+    void annotatedPrincipalEntityResourceWithoutAuth200() {
         String principalName = "Astar Seran";
         assertThat(target("/no-auth-test/annotated-principal-entity").request()
                 .header(HttpHeaders.AUTHORIZATION, "Anything here")

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/NoAuthPrincipalEntityTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/NoAuthPrincipalEntityTest.java
@@ -34,13 +34,13 @@ public class NoAuthPrincipalEntityTest extends JerseyTest {
 
     @Override
     @BeforeEach
-    void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
     }
 
     @Override
     @AfterEach
-    void tearDown() throws Exception {
+    public void tearDown() throws Exception {
         super.tearDown();
     }
 

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/PolymorphicPrincipalEntityTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/PolymorphicPrincipalEntityTest.java
@@ -44,13 +44,13 @@ public class PolymorphicPrincipalEntityTest extends JerseyTest {
 
     @Override
     @BeforeEach
-    void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
     }
 
     @Override
     @AfterEach
-    void tearDown() throws Exception {
+    public void tearDown() throws Exception {
         super.tearDown();
     }
 

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/PolymorphicPrincipalEntityTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/PolymorphicPrincipalEntityTest.java
@@ -44,13 +44,13 @@ public class PolymorphicPrincipalEntityTest extends JerseyTest {
 
     @Override
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         super.setUp();
     }
 
     @Override
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         super.tearDown();
     }
 
@@ -120,7 +120,7 @@ public class PolymorphicPrincipalEntityTest extends JerseyTest {
     }
 
     @Test
-    public void jsonPrincipalEntityResourceAuth200() {
+    void jsonPrincipalEntityResourceAuth200() {
         assertThat(target("/auth-test/json-principal-entity").request()
                    .header(HttpHeaders.AUTHORIZATION, "Basic " + JSON_USERNAME_ENCODED_TOKEN)
                    .get(String.class))
@@ -128,14 +128,14 @@ public class PolymorphicPrincipalEntityTest extends JerseyTest {
     }
 
     @Test
-    public void jsonPrincipalEntityResourceNoAuth401() {
+    void jsonPrincipalEntityResourceNoAuth401() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> target("/auth-test/json-principal-entity").request().get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(401));
     }
 
     @Test
-    public void nullPrincipalEntityResourceAuth200() {
+    void nullPrincipalEntityResourceAuth200() {
         assertThat(target("/auth-test/null-principal-entity").request()
                 .header(HttpHeaders.AUTHORIZATION, "Basic " + NULL_USERNAME_ENCODED_TOKEN)
                 .get(String.class))
@@ -143,14 +143,14 @@ public class PolymorphicPrincipalEntityTest extends JerseyTest {
     }
 
     @Test
-    public void nullPrincipalEntityResourceNoAuth401() {
+    void nullPrincipalEntityResourceNoAuth401() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> target("/auth-test/null-principal-entity").request().get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(401));
     }
 
     @Test
-    public void resourceWithValidOptionalAuthentication200() {
+    void resourceWithValidOptionalAuthentication200() {
         assertThat(target("/auth-test/optional").request()
             .header(HttpHeaders.AUTHORIZATION, "Basic " + NULL_USERNAME_ENCODED_TOKEN)
             .get(String.class))
@@ -158,7 +158,7 @@ public class PolymorphicPrincipalEntityTest extends JerseyTest {
     }
 
     @Test
-    public void resourceWithInvalidOptionalAuthentication200() {
+    void resourceWithInvalidOptionalAuthentication200() {
         assertThat(target("/auth-test/optional").request()
             .header(HttpHeaders.AUTHORIZATION, "Basic cats")
             .get(String.class))
@@ -166,14 +166,14 @@ public class PolymorphicPrincipalEntityTest extends JerseyTest {
     }
 
     @Test
-    public void resourceWithoutOptionalAuthentication200() {
+    void resourceWithoutOptionalAuthentication200() {
         assertThat(target("/auth-test/optional").request()
             .get(String.class))
             .isEqualTo("principal was not present");
     }
 
     @Test
-    public void resourceWithDifferentOptionalAuthentication200() {
+    void resourceWithDifferentOptionalAuthentication200() {
         assertThat(target("/auth-test/optional").request()
             .header(HttpHeaders.AUTHORIZATION, "Basic " + JSON_USERNAME_ENCODED_TOKEN)
             .get(String.class))

--- a/dropwizard-client/src/test/java/io/dropwizard/client/ConfiguredCloseableHttpClientTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/ConfiguredCloseableHttpClientTest.java
@@ -15,17 +15,17 @@ public class ConfiguredCloseableHttpClientTest {
     private RequestConfig defaultRequestConfigMock = Mockito.mock(RequestConfig.class);
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         configuredClient = new ConfiguredCloseableHttpClient(closeableHttpClientMock, defaultRequestConfigMock);
     }
 
     @Test
-    public void getDefaultRequestConfig_returns_config_provided_at_construction() {
+    void getDefaultRequestConfig_returns_config_provided_at_construction() {
         assertThat(configuredClient.getDefaultRequestConfig()).isEqualTo(defaultRequestConfigMock);
     }
 
     @Test
-    public void getClient_returns_config_provided_at_construction() {
+    void getClient_returns_config_provided_at_construction() {
         assertThat(configuredClient.getClient()).isEqualTo(closeableHttpClientMock);
     }
 }

--- a/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
@@ -139,7 +139,7 @@ public class HttpClientBuilderTest {
     }
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         final MetricRegistry metricRegistry = new MetricRegistry();
         configuration = new HttpClientConfiguration();
         builder = new HttpClientBuilder(metricRegistry);
@@ -149,12 +149,12 @@ public class HttpClientBuilderTest {
     }
 
     @AfterEach
-    public void validate() {
+    void validate() {
         validateMockitoUsage();
     }
 
     @Test
-    public void setsTheMaximumConnectionPoolSize() throws Exception {
+    void setsTheMaximumConnectionPoolSize() throws Exception {
         configuration.setMaxConnections(412);
         final ConfiguredCloseableHttpClient client = builder.using(configuration)
                 .createClient(apacheBuilder, builder.configureConnectionManager(connectionManager), "test");
@@ -166,7 +166,7 @@ public class HttpClientBuilderTest {
 
 
     @Test
-    public void setsTheMaximumRoutePoolSize() throws Exception {
+    void setsTheMaximumRoutePoolSize() throws Exception {
         configuration.setMaxConnectionsPerRoute(413);
         final ConfiguredCloseableHttpClient client = builder.using(configuration)
                 .createClient(apacheBuilder, builder.configureConnectionManager(connectionManager), "test");
@@ -177,7 +177,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void setsTheUserAgent() throws Exception {
+    void setsTheUserAgent() throws Exception {
         configuration.setUserAgent(Optional.of("qwerty"));
         assertThat(builder.using(configuration).createClient(apacheBuilder, connectionManager, "test")).isNotNull();
 
@@ -185,7 +185,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void canUseACustomDnsResolver() throws Exception {
+    void canUseACustomDnsResolver() throws Exception {
         final DnsResolver resolver = mock(DnsResolver.class);
         final InstrumentedHttpClientConnectionManager manager =
                 builder.using(resolver).createConnectionManager(registry, "test");
@@ -200,7 +200,7 @@ public class HttpClientBuilderTest {
 
 
     @Test
-    public void usesASystemDnsResolverByDefault() throws Exception {
+    void usesASystemDnsResolverByDefault() throws Exception {
         final InstrumentedHttpClientConnectionManager manager = builder.createConnectionManager(registry, "test");
 
         // Yes, this is gross. Thanks, Apache!
@@ -212,7 +212,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void canUseACustomHostnameVerifierWhenTlsConfigurationNotSpecified() throws Exception {
+    void canUseACustomHostnameVerifierWhenTlsConfigurationNotSpecified() throws Exception {
         final HostnameVerifier customVerifier = (s, sslSession) -> false;
 
         final Registry<ConnectionSocketFactory> configuredRegistry;
@@ -229,7 +229,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void canUseACustomHostnameVerifierWhenTlsConfigurationSpecified() throws Exception {
+    void canUseACustomHostnameVerifierWhenTlsConfigurationSpecified() throws Exception {
         final TlsConfiguration tlsConfiguration = new TlsConfiguration();
         tlsConfiguration.setVerifyHostname(true);
         configuration.setTlsConfiguration(tlsConfiguration);
@@ -250,7 +250,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void canUseASystemHostnameVerifierByDefaultWhenTlsConfigurationNotSpecified() throws Exception {
+    void canUseASystemHostnameVerifierByDefaultWhenTlsConfigurationNotSpecified() throws Exception {
         final Registry<ConnectionSocketFactory> configuredRegistry;
         configuredRegistry = builder.createConfiguredRegistry();
         assertThat(configuredRegistry).isNotNull();
@@ -265,7 +265,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void canUseASystemHostnameVerifierByDefaultWhenTlsConfigurationSpecified() throws Exception {
+    void canUseASystemHostnameVerifierByDefaultWhenTlsConfigurationSpecified() throws Exception {
         final TlsConfiguration tlsConfiguration = new TlsConfiguration();
         tlsConfiguration.setVerifyHostname(true);
         configuration.setTlsConfiguration(tlsConfiguration);
@@ -284,7 +284,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void createClientCanPassCustomVerifierToApacheBuilder() throws Exception {
+    void createClientCanPassCustomVerifierToApacheBuilder() throws Exception {
         final HostnameVerifier customVerifier = (s, sslSession) -> false;
 
         assertThat(builder.using(customVerifier).createClient(apacheBuilder, connectionManager, "test")).isNotNull();
@@ -295,7 +295,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void doesNotReuseConnectionsIfKeepAliveIsZero() throws Exception {
+    void doesNotReuseConnectionsIfKeepAliveIsZero() throws Exception {
         configuration.setKeepAlive(Duration.seconds(0));
         assertThat(builder.using(configuration).createClient(apacheBuilder, connectionManager, "test")).isNotNull();
 
@@ -305,7 +305,7 @@ public class HttpClientBuilderTest {
 
 
     @Test
-    public void reusesConnectionsIfKeepAliveIsNonZero() throws Exception {
+    void reusesConnectionsIfKeepAliveIsNonZero() throws Exception {
         configuration.setKeepAlive(Duration.seconds(1));
         assertThat(builder.using(configuration).createClient(apacheBuilder, connectionManager, "test")).isNotNull();
 
@@ -314,7 +314,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void usesKeepAliveForPersistentConnections() throws Exception {
+    void usesKeepAliveForPersistentConnections() throws Exception {
         configuration.setKeepAlive(Duration.seconds(1));
         assertThat(builder.using(configuration).createClient(apacheBuilder, connectionManager, "test")).isNotNull();
 
@@ -328,7 +328,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void usesDefaultForNonPersistentConnections() throws Exception {
+    void usesDefaultForNonPersistentConnections() throws Exception {
         configuration.setKeepAlive(Duration.seconds(1));
         assertThat(builder.using(configuration).createClient(apacheBuilder, connectionManager, "test")).isNotNull();
 
@@ -346,7 +346,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void ignoresCookiesByDefault() throws Exception {
+    void ignoresCookiesByDefault() throws Exception {
         assertThat(builder.using(configuration).createClient(apacheBuilder, connectionManager, "test")).isNotNull();
 
         assertThat(((RequestConfig) spyHttpClientBuilderField("defaultRequestConfig", apacheBuilder)).getCookieSpec())
@@ -354,7 +354,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void usesBestMatchCookiePolicyIfCookiesAreEnabled() throws Exception {
+    void usesBestMatchCookiePolicyIfCookiesAreEnabled() throws Exception {
         configuration.setCookiesEnabled(true);
         assertThat(builder.using(configuration).createClient(apacheBuilder, connectionManager, "test")).isNotNull();
 
@@ -363,7 +363,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void normalizeUriByDefault() throws Exception {
+    void normalizeUriByDefault() throws Exception {
         assertThat(builder.using(configuration).createClient(apacheBuilder, connectionManager, "test")).isNotNull();
 
         assertThat(((RequestConfig) spyHttpClientBuilderField("defaultRequestConfig", apacheBuilder)).isNormalizeUri())
@@ -371,7 +371,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void disableNormalizeUriWhenDisabled() throws Exception {
+    void disableNormalizeUriWhenDisabled() throws Exception {
         configuration.setNormalizeUriEnabled(false);
         assertThat(builder.using(configuration).createClient(apacheBuilder, connectionManager, "test")).isNotNull();
 
@@ -380,7 +380,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void setsTheSocketTimeout() throws Exception {
+    void setsTheSocketTimeout() throws Exception {
         configuration.setTimeout(Duration.milliseconds(500));
         assertThat(builder.using(configuration).createClient(apacheBuilder, connectionManager, "test")).isNotNull();
 
@@ -389,7 +389,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void setsTheConnectTimeout() throws Exception {
+    void setsTheConnectTimeout() throws Exception {
         configuration.setConnectionTimeout(Duration.milliseconds(500));
         assertThat(builder.using(configuration).createClient(apacheBuilder, connectionManager, "test")).isNotNull();
 
@@ -398,7 +398,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void setsTheConnectionRequestTimeout() throws Exception {
+    void setsTheConnectionRequestTimeout() throws Exception {
         configuration.setConnectionRequestTimeout(Duration.milliseconds(123));
 
         assertThat(builder.using(configuration).createClient(apacheBuilder, connectionManager, "test")).isNotNull();
@@ -407,14 +407,14 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void disablesNaglesAlgorithm() throws Exception {
+    void disablesNaglesAlgorithm() throws Exception {
         assertThat(builder.using(configuration).createClient(apacheBuilder, connectionManager, "test")).isNotNull();
 
         assertThat(((SocketConfig) spyHttpClientBuilderField("defaultSocketConfig", apacheBuilder)).isTcpNoDelay()).isTrue();
     }
 
     @Test
-    public void disablesStaleConnectionCheck() throws Exception {
+    void disablesStaleConnectionCheck() throws Exception {
         assertThat(builder.using(configuration).createClient(apacheBuilder, connectionManager, "test")).isNotNull();
 
         // It is fine to use the isStaleConnectionCheckEnabled deprecated API, as we are ensuring
@@ -425,7 +425,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void usesTheDefaultRoutePlanner() throws Exception {
+    void usesTheDefaultRoutePlanner() throws Exception {
         final CloseableHttpClient httpClient = builder.using(configuration)
                 .createClient(apacheBuilder, connectionManager, "test").getClient();
 
@@ -435,7 +435,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void usesACustomRoutePlanner() throws Exception {
+    void usesACustomRoutePlanner() throws Exception {
         final HttpRoutePlanner routePlanner = new SystemDefaultRoutePlanner(new ProxySelector() {
             @Override
             public List<Proxy> select(URI uri) {
@@ -456,7 +456,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void usesACustomHttpRequestRetryHandler() throws Exception {
+    void usesACustomHttpRequestRetryHandler() throws Exception {
         final HttpRequestRetryHandler customHandler = (exception, executionCount, context) -> false;
 
         configuration.setRetries(1);
@@ -467,7 +467,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void usesCredentialsProvider() throws Exception {
+    void usesCredentialsProvider() throws Exception {
         final CredentialsProvider credentialsProvider = new CredentialsProvider() {
             @Override
             public void setCredentials(AuthScope authscope, Credentials credentials) {
@@ -491,7 +491,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void usesProxy() throws Exception {
+    void usesProxy() throws Exception {
         HttpClientConfiguration config = new HttpClientConfiguration();
         ProxyConfiguration proxy = new ProxyConfiguration("192.168.52.11", 8080);
         config.setProxyConfiguration(proxy);
@@ -500,7 +500,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void usesProxyWithoutPort() throws Exception {
+    void usesProxyWithoutPort() throws Exception {
         HttpClientConfiguration config = new HttpClientConfiguration();
         ProxyConfiguration proxy = new ProxyConfiguration("192.168.52.11");
         config.setProxyConfiguration(proxy);
@@ -509,7 +509,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void usesProxyWithBasicAuth() throws Exception {
+    void usesProxyWithBasicAuth() throws Exception {
         HttpClientConfiguration config = new HttpClientConfiguration();
         AuthConfiguration auth = new AuthConfiguration("secret", "stuff");
         ProxyConfiguration proxy = new ProxyConfiguration("192.168.52.11", 8080, "http", auth);
@@ -525,7 +525,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void usesProxyWithNtlmAuth() throws Exception {
+    void usesProxyWithNtlmAuth() throws Exception {
         HttpClientConfiguration config = new HttpClientConfiguration();
         AuthConfiguration auth = new AuthConfiguration("secret", "stuff", "NTLM", "realm", "host", "domain", "NT");
         ProxyConfiguration proxy = new ProxyConfiguration("192.168.52.11", 8080, "http", auth);
@@ -544,7 +544,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void usesProxyWithNonProxyHosts() throws Exception {
+    void usesProxyWithNonProxyHosts() throws Exception {
         HttpClientConfiguration config = new HttpClientConfiguration();
         ProxyConfiguration proxy = new ProxyConfiguration("192.168.52.11", 8080);
         proxy.setNonProxyHosts(Collections.singletonList("*.example.com"));
@@ -554,7 +554,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void usesProxyWithNonProxyHostsAndTargetDoesNotMatch() throws Exception {
+    void usesProxyWithNonProxyHostsAndTargetDoesNotMatch() throws Exception {
         HttpClientConfiguration config = new HttpClientConfiguration();
         ProxyConfiguration proxy = new ProxyConfiguration("192.168.52.11");
         proxy.setNonProxyHosts(Collections.singletonList("*.example.com"));
@@ -564,7 +564,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void usesNoProxy() throws Exception {
+    void usesNoProxy() throws Exception {
         checkProxy(new HttpClientConfiguration(), new HttpHost("dropwizard.io", 80), null);
     }
 
@@ -584,7 +584,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void setValidateAfterInactivityPeriodFromConfiguration() throws Exception {
+    void setValidateAfterInactivityPeriodFromConfiguration() throws Exception {
         int validateAfterInactivityPeriod = 50000;
         configuration.setValidateAfterInactivityPeriod(Duration.milliseconds(validateAfterInactivityPeriod));
         final ConfiguredCloseableHttpClient client = builder.using(configuration)
@@ -596,7 +596,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void usesACustomHttpClientMetricNameStrategy() throws Exception {
+    void usesACustomHttpClientMetricNameStrategy() throws Exception {
         assertThat(builder.using(HttpClientMetricNameStrategies.HOST_AND_METHOD)
                 .createClient(apacheBuilder, connectionManager, "test"))
                 .isNotNull();
@@ -606,7 +606,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void usesMethodOnlyHttpClientMetricNameStrategyByDefault() throws Exception {
+    void usesMethodOnlyHttpClientMetricNameStrategyByDefault() throws Exception {
         assertThat(builder.createClient(apacheBuilder, connectionManager, "test"))
                 .isNotNull();
         assertThat(getInaccessibleField(InstrumentedHttpRequestExecutor.class, "metricNameStrategy")
@@ -615,7 +615,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void exposedConfigIsTheSameAsInternalToTheWrappedHttpClient() throws Exception {
+    void exposedConfigIsTheSameAsInternalToTheWrappedHttpClient() throws Exception {
         ConfiguredCloseableHttpClient client = builder.createClient(apacheBuilder, connectionManager, "test");
         assertThat(client).isNotNull();
 
@@ -623,7 +623,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void disablesContentCompression() throws Exception {
+    void disablesContentCompression() throws Exception {
         ConfiguredCloseableHttpClient client = builder
                 .disableContentCompression(true)
                 .createClient(apacheBuilder, connectionManager, "test");
@@ -635,7 +635,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void managedByEnvironment() throws Exception {
+    void managedByEnvironment() throws Exception {
         final Environment environment = mock(Environment.class);
         when(environment.getName()).thenReturn("test-env");
         when(environment.metrics()).thenReturn(new MetricRegistry());
@@ -660,7 +660,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void usesACustomRedirectStrategy() throws Exception {
+    void usesACustomRedirectStrategy() throws Exception {
         RedirectStrategy neverFollowRedirectStrategy = new RedirectStrategy() {
             @Override
             public boolean isRedirected(HttpRequest httpRequest,
@@ -684,7 +684,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void usesDefaultHeaders() throws Exception {
+    void usesDefaultHeaders() throws Exception {
         final ConfiguredCloseableHttpClient client =
                 builder.using(Collections.singletonList(new BasicHeader(HttpHeaders.ACCEPT_LANGUAGE, "de")))
                         .createClient(apacheBuilder, connectionManager, "test");
@@ -702,7 +702,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void usesHttpProcessor() throws Exception {
+    void usesHttpProcessor() throws Exception {
         HttpProcessor httpProcessor = mock(HttpProcessor.class);
         final ConfiguredCloseableHttpClient client =
             builder.using(httpProcessor)
@@ -714,7 +714,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void usesServiceUnavailableRetryStrategy() throws Exception {
+    void usesServiceUnavailableRetryStrategy() throws Exception {
         ServiceUnavailableRetryStrategy serviceUnavailableRetryStrategy = mock(ServiceUnavailableRetryStrategy.class);
         final ConfiguredCloseableHttpClient client =
             builder.using(serviceUnavailableRetryStrategy)
@@ -726,7 +726,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void allowsCustomBuilderConfiguration() throws Exception {
+    void allowsCustomBuilderConfiguration() throws Exception {
         CustomBuilder builder = new CustomBuilder(new MetricRegistry());
         assertThat(builder.customized).isFalse();
         builder.createClient(apacheBuilder, connectionManager, "test");
@@ -736,7 +736,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void buildWithAnotherBuilder() throws Exception {
+    void buildWithAnotherBuilder() throws Exception {
         CustomBuilder builder = new CustomBuilder(new MetricRegistry(), anotherApacheBuilder);
         builder.build("test");
         assertThat(getInaccessibleField(httpClientBuilderClass, "requestExec").get(anotherApacheBuilder))
@@ -744,7 +744,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void configureCredentialReturnsNTCredentialsForNTLMConfig() {
+    void configureCredentialReturnsNTCredentialsForNTLMConfig() {
         AuthConfiguration ntlmConfig = new AuthConfiguration("username", "password", "NTLM", "realm", "hostname", "domain", "NT");
 
         Credentials credentials = builder.configureCredentials(ntlmConfig);
@@ -754,7 +754,7 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void configureCredentialReturnsNTCredentialsForBasicConfig() {
+    void configureCredentialReturnsNTCredentialsForBasicConfig() {
         AuthConfiguration ntlmConfig = new AuthConfiguration("username", "password");
 
         Credentials credentials = builder.configureCredentials(ntlmConfig);

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
@@ -84,7 +84,7 @@ public class JerseyClientBuilderTest {
     private final HttpClientBuilder apacheHttpClientBuilder = mock(HttpClientBuilder.class);
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         when(environment.lifecycle()).thenReturn(lifecycleEnvironment);
         when(environment.getObjectMapper()).thenReturn(objectMapper);
         when(environment.getValidator()).thenReturn(validator);
@@ -92,33 +92,33 @@ public class JerseyClientBuilderTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         executorService.shutdown();
     }
 
     @Test
-    public void throwsAnExceptionWithoutAnEnvironmentOrAThreadPoolAndObjectMapper() {
+    void throwsAnExceptionWithoutAnEnvironmentOrAThreadPoolAndObjectMapper() {
         assertThatExceptionOfType(IllegalStateException.class)
             .isThrownBy(() -> builder.build("test"))
             .withMessage("Must have either an environment or both an executor service and an object mapper");
     }
 
     @Test
-    public void throwsAnExceptionWithoutAnEnvironmentAndOnlyObjectMapper() {
+    void throwsAnExceptionWithoutAnEnvironmentAndOnlyObjectMapper() {
         assertThatExceptionOfType(IllegalStateException.class)
             .isThrownBy(() -> builder.using(objectMapper).build("test"))
             .withMessage("Must have either an environment or both an executor service and an object mapper");
     }
 
     @Test
-    public void throwsAnExceptionWithoutAnEnvironmentAndOnlyAThreadPool() {
+    void throwsAnExceptionWithoutAnEnvironmentAndOnlyAThreadPool() {
         assertThatExceptionOfType(IllegalStateException.class)
             .isThrownBy(() -> builder.using(executorService).build("test"))
             .withMessage("Must have either an environment or both an executor service and an object mapper");
     }
 
     @Test
-    public void includesJerseyProperties() {
+    void includesJerseyProperties() {
         final Client client = builder.withProperty("poop", true)
                 .using(executorService, objectMapper)
                 .build("test");
@@ -127,7 +127,7 @@ public class JerseyClientBuilderTest {
     }
 
     @Test
-    public void includesJerseyProviderSingletons() {
+    void includesJerseyProviderSingletons() {
         final FakeMessageBodyReader provider = new FakeMessageBodyReader();
         final Client client = builder.withProvider(provider)
                 .using(executorService, objectMapper)
@@ -137,7 +137,7 @@ public class JerseyClientBuilderTest {
     }
 
     @Test
-    public void includesJerseyProviderClasses() {
+    void includesJerseyProviderClasses() {
         @SuppressWarnings("unused")
         final Client client = builder.withProvider(FakeMessageBodyReader.class)
                 .using(executorService, objectMapper)
@@ -147,7 +147,7 @@ public class JerseyClientBuilderTest {
     }
 
     @Test
-    public void createsAnRxEnabledClient() {
+    void createsAnRxEnabledClient() {
         final Client client =
             builder.using(executorService, objectMapper)
                 .buildRx("test", RxFlowableInvokerProvider.class);
@@ -161,7 +161,7 @@ public class JerseyClientBuilderTest {
     }
 
     @Test
-    public void usesTheGivenThreadPool() {
+    void usesTheGivenThreadPool() {
         final Client client = builder.using(executorService, objectMapper).build("test");
         for (Object o : client.getConfiguration().getInstances()) {
             if (o instanceof DropwizardExecutorProvider) {
@@ -173,7 +173,7 @@ public class JerseyClientBuilderTest {
     }
 
     @Test
-    public void usesTheGivenThreadPoolAndEnvironmentsObjectMapper() {
+    void usesTheGivenThreadPoolAndEnvironmentsObjectMapper() {
         final Client client = builder.using(environment).using(executorService).build("test");
         for (Object o : client.getConfiguration().getInstances()) {
             if (o instanceof DropwizardExecutorProvider) {
@@ -185,7 +185,7 @@ public class JerseyClientBuilderTest {
     }
 
     @Test
-    public void createsNewConnectorProvider() {
+    void createsNewConnectorProvider() {
         final JerseyClient clientA = (JerseyClient) builder.using(executorService, objectMapper).build("testA");
         final JerseyClient clientB = (JerseyClient) builder.build("testB");
         assertThat(clientA.getConfiguration().getConnectorProvider())
@@ -193,7 +193,7 @@ public class JerseyClientBuilderTest {
     }
 
     @Test
-    public void usesSameConnectorProvider()  {
+    void usesSameConnectorProvider()  {
         final JerseyClient clientA = (JerseyClient) builder.using(executorService, objectMapper)
             .using(mock(ConnectorProvider.class))
             .build("testA");
@@ -204,7 +204,7 @@ public class JerseyClientBuilderTest {
     }
 
     @Test
-    public void addBidirectionalGzipSupportIfEnabled() {
+    void addBidirectionalGzipSupportIfEnabled() {
         final JerseyClientConfiguration configuration = new JerseyClientConfiguration();
         configuration.setGzipEnabled(true);
 
@@ -218,7 +218,7 @@ public class JerseyClientBuilderTest {
     }
 
     @Test
-    public void disablesGzipSupportIfDisabled() {
+    void disablesGzipSupportIfDisabled() {
         final JerseyClientConfiguration configuration = new JerseyClientConfiguration();
         configuration.setGzipEnabled(false);
 
@@ -258,42 +258,42 @@ public class JerseyClientBuilderTest {
     }
 
     @Test
-    public void usesACustomHttpClientMetricNameStrategy() {
+    void usesACustomHttpClientMetricNameStrategy() {
         final HttpClientMetricNameStrategy customStrategy = HttpClientMetricNameStrategies.HOST_AND_METHOD;
         builder.using(customStrategy);
         verify(apacheHttpClientBuilder).using(customStrategy);
     }
 
     @Test
-    public void usesACustomHttpRequestRetryHandler() {
+    void usesACustomHttpRequestRetryHandler() {
         final DefaultHttpRequestRetryHandler customRetryHandler = new DefaultHttpRequestRetryHandler(2, true);
         builder.using(customRetryHandler);
         verify(apacheHttpClientBuilder).using(customRetryHandler);
     }
 
     @Test
-    public void usesACustomDnsResolver() {
+    void usesACustomDnsResolver() {
         final DnsResolver customDnsResolver = new SystemDefaultDnsResolver();
         builder.using(customDnsResolver);
         verify(apacheHttpClientBuilder).using(customDnsResolver);
     }
 
     @Test
-    public void usesACustomHostnameVerifier() {
+    void usesACustomHostnameVerifier() {
         final HostnameVerifier customHostnameVerifier = new NoopHostnameVerifier();
         builder.using(customHostnameVerifier);
         verify(apacheHttpClientBuilder).using(customHostnameVerifier);
     }
 
     @Test
-    public void usesACustomServiceUnavailableRetryStrategy() {
+    void usesACustomServiceUnavailableRetryStrategy() {
         final ServiceUnavailableRetryStrategy customServiceUnavailableRetryStrategy = mock(ServiceUnavailableRetryStrategy.class);
         builder.using(customServiceUnavailableRetryStrategy);
         verify(apacheHttpClientBuilder).using(customServiceUnavailableRetryStrategy);
     }
 
     @Test
-    public void usesACustomConnectionFactoryRegistry() throws Exception {
+    void usesACustomConnectionFactoryRegistry() throws Exception {
         final SSLContext ctx = SSLContext.getInstance(SSLConnectionSocketFactory.TLS);
         ctx.init(null, new TrustManager[]{
             new X509TrustManager() {
@@ -322,14 +322,14 @@ public class JerseyClientBuilderTest {
     }
 
     @Test
-    public void usesACustomEnvironmentName() {
+    void usesACustomEnvironmentName() {
         final String userAgent = "Dropwizard Jersey Client";
         builder.name(userAgent);
         verify(apacheHttpClientBuilder).name(userAgent);
     }
 
     @Test
-    public void usesACustomHttpRoutePlanner() {
+    void usesACustomHttpRoutePlanner() {
         final HttpRoutePlanner customHttpRoutePlanner = new SystemDefaultRoutePlanner(new ProxySelector() {
             @Override
             public List<Proxy> select(URI uri) {
@@ -346,14 +346,14 @@ public class JerseyClientBuilderTest {
     }
 
     @Test
-    public void usesACustomCredentialsProvider() {
+    void usesACustomCredentialsProvider() {
         CredentialsProvider customCredentialsProvider = new SystemDefaultCredentialsProvider();
         builder.using(customCredentialsProvider);
         verify(apacheHttpClientBuilder).using(customCredentialsProvider);
     }
 
     @Test
-    public void apacheConnectorCanOverridden() {
+    void apacheConnectorCanOverridden() {
         assertThat(new JerseyClientBuilder(new MetricRegistry()) {
             @Override
             protected DropwizardApacheConnector createDropwizardApacheConnector(ConfiguredCloseableHttpClient configuredClient) {

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientConfigurationTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientConfigurationTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JerseyClientConfigurationTest {
 
     @Test
-    public void testBasicJerseyClient() throws Exception {
+    void testBasicJerseyClient() throws Exception {
         final JerseyClientConfiguration configuration = new YamlConfigurationFactory<>(JerseyClientConfiguration.class,
                 Validators.newValidator(), Jackson.newObjectMapper(), "dw")
                 .build(new File(Resources.getResource("yaml/jersey-client.yml").toURI()));

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientIntegrationTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientIntegrationTest.java
@@ -59,17 +59,17 @@ public class JerseyClientIntegrationTest {
     private HttpServer httpServer;
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         httpServer = HttpServer.create(new InetSocketAddress(0), 0);
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         httpServer.stop(0);
     }
 
     @Test
-    public void testChunkedGzipPost() throws Exception {
+    void testChunkedGzipPost() throws Exception {
         httpServer.createContext("/register", httpExchange -> {
             try {
                 Headers requestHeaders = httpExchange.getRequestHeaders();
@@ -89,7 +89,7 @@ public class JerseyClientIntegrationTest {
     }
 
     @Test
-    public void testBufferedGzipPost() {
+    void testBufferedGzipPost() {
         httpServer.createContext("/register", httpExchange -> {
             try {
                 Headers requestHeaders = httpExchange.getRequestHeaders();
@@ -113,7 +113,7 @@ public class JerseyClientIntegrationTest {
     }
 
     @Test
-    public void testChunkedPost() throws Exception {
+    void testChunkedPost() throws Exception {
         httpServer.createContext("/register", httpExchange -> {
             try {
                 Headers requestHeaders = httpExchange.getRequestHeaders();
@@ -136,7 +136,7 @@ public class JerseyClientIntegrationTest {
     }
 
     @Test
-    public void testChunkedPostWithoutGzip() throws Exception {
+    void testChunkedPostWithoutGzip() throws Exception {
         httpServer.createContext("/register", httpExchange -> {
             try {
                 Headers requestHeaders = httpExchange.getRequestHeaders();
@@ -164,7 +164,7 @@ public class JerseyClientIntegrationTest {
     }
 
     @Test
-    public void testRetryHandler() throws Exception {
+    void testRetryHandler() throws Exception {
         httpServer.createContext("/register", httpExchange -> {
             try {
                 Headers requestHeaders = httpExchange.getRequestHeaders();
@@ -247,7 +247,7 @@ public class JerseyClientIntegrationTest {
 
 
     @Test
-    public void testGet() {
+    void testGet() {
         httpServer.createContext("/player", httpExchange -> {
             try {
                 assertThat(httpExchange.getRequestURI().getQuery()).isEqualTo("id=21");
@@ -286,7 +286,7 @@ public class JerseyClientIntegrationTest {
     }
 
     @Test
-    public void testSetUserAgent() {
+    void testSetUserAgent() {
         httpServer.createContext("/test", httpExchange -> {
             try {
                 assertThat(httpExchange.getRequestHeaders().get(HttpHeaders.USER_AGENT))
@@ -322,7 +322,7 @@ public class JerseyClientIntegrationTest {
      * Test for ConnectorProvider idempotency
      */
     @Test
-    public void testFilterOnAWebTarget() {
+    void testFilterOnAWebTarget() {
         httpServer.createContext("/test", httpExchange -> {
             try {
                 httpExchange.getResponseHeaders().add(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN);
@@ -360,7 +360,7 @@ public class JerseyClientIntegrationTest {
     }
 
     @Test
-    public void testAsyncWithCustomized() throws Exception {
+    void testAsyncWithCustomized() throws Exception {
         httpServer.createContext("/test", httpExchange -> {
             try {
                 httpExchange.getResponseHeaders().add(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN);

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyIgnoreRequestUserAgentHeaderFilterTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyIgnoreRequestUserAgentHeaderFilterTest.java
@@ -32,7 +32,7 @@ public class JerseyIgnoreRequestUserAgentHeaderFilterTest {
     private JerseyClientConfiguration clientConfiguration;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         clientConfiguration = new JerseyClientConfiguration();
         clientConfiguration.setConnectionTimeout(Duration.milliseconds(1000L));
         clientConfiguration.setTimeout(Duration.milliseconds(2500L));
@@ -42,7 +42,7 @@ public class JerseyIgnoreRequestUserAgentHeaderFilterTest {
     }
 
     @Test
-    public void clientIsSetRequestIsNotSet() {
+    void clientIsSetRequestIsNotSet() {
         clientConfiguration.setUserAgent(Optional.of("ClientUserAgentHeaderValue"));
         assertThat(
                 clientBuilder.using(clientConfiguration).
@@ -53,7 +53,7 @@ public class JerseyIgnoreRequestUserAgentHeaderFilterTest {
     }
 
     @Test
-    public void clientIsNotSetRequestIsSet() {
+    void clientIsNotSetRequestIsSet() {
         assertThat(
                 clientBuilder.build("ClientName").target(testUri + "/user_agent")
                         .request().header("User-Agent", "RequestUserAgentHeaderValue")
@@ -62,7 +62,7 @@ public class JerseyIgnoreRequestUserAgentHeaderFilterTest {
     }
 
     @Test
-    public void clientIsNotSetRequestIsNotSet() {
+    void clientIsNotSetRequestIsNotSet() {
         assertThat(
                 clientBuilder.build("ClientName").target(testUri + "/user_agent")
                         .request()
@@ -71,7 +71,7 @@ public class JerseyIgnoreRequestUserAgentHeaderFilterTest {
     }
 
     @Test
-    public void clientIsSetRequestIsSet() {
+    void clientIsSetRequestIsSet() {
         clientConfiguration.setUserAgent(Optional.of("ClientUserAgentHeaderValue"));
         assertThat(
                 clientBuilder.build("ClientName").target(testUri + "/user_agent")

--- a/dropwizard-client/src/test/java/io/dropwizard/client/proxy/HttpClientConfigurationTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/proxy/HttpClientConfigurationTest.java
@@ -34,13 +34,13 @@ public class HttpClientConfigurationTest {
     }
 
     @Test
-    public void testNoProxy() throws Exception {
+    void testNoProxy() throws Exception {
         load("./yaml/no_proxy.yml");
         assertThat(configuration.getProxyConfiguration()).isNull();
     }
 
     @Test
-    public void testFullConfigBasicProxy() throws Exception {
+    void testFullConfigBasicProxy() throws Exception {
         load("yaml/proxy.yml");
 
         ProxyConfiguration proxy = requireNonNull(configuration.getProxyConfiguration());
@@ -58,7 +58,7 @@ public class HttpClientConfigurationTest {
     }
 
     @Test
-    public void testFullConfigNtlmProxy() throws Exception {
+    void testFullConfigNtlmProxy() throws Exception {
         load("yaml/proxy_ntlm.yml");
 
         ProxyConfiguration proxy = requireNonNull(configuration.getProxyConfiguration());
@@ -81,7 +81,7 @@ public class HttpClientConfigurationTest {
     }
 
     @Test
-    public void testNoScheme() throws Exception {
+    void testNoScheme() throws Exception {
         load("./yaml/no_scheme.yml");
 
         ProxyConfiguration proxy = requireNonNull(configuration.getProxyConfiguration());
@@ -91,7 +91,7 @@ public class HttpClientConfigurationTest {
     }
 
     @Test
-    public void testNoAuth() throws Exception {
+    void testNoAuth() throws Exception {
         load("./yaml/no_auth.yml");
 
         ProxyConfiguration proxy = requireNonNull(configuration.getProxyConfiguration());
@@ -100,7 +100,7 @@ public class HttpClientConfigurationTest {
     }
 
     @Test
-    public void testNoPort() throws Exception {
+    void testNoPort() throws Exception {
         load("./yaml/no_port.yml");
 
         ProxyConfiguration proxy = requireNonNull(configuration.getProxyConfiguration());
@@ -109,7 +109,7 @@ public class HttpClientConfigurationTest {
     }
 
     @Test
-    public void testNoNonProxy() throws Exception {
+    void testNoNonProxy() throws Exception {
         load("./yaml/no_port.yml");
 
         ProxyConfiguration proxy = requireNonNull(configuration.getProxyConfiguration());
@@ -117,38 +117,38 @@ public class HttpClientConfigurationTest {
     }
 
     @Test
-    public void testNoHost() {
+    void testNoHost() {
         assertConfigurationValidationException("yaml/bad_host.yml");
     }
 
     @Test
-    public void testBadPort() {
+    void testBadPort() {
         assertConfigurationValidationException("./yaml/bad_port.yml");
     }
 
     @Test
-    public void testBadScheme() {
+    void testBadScheme() {
         assertThatExceptionOfType(ConfigurationParsingException.class).isThrownBy(() ->
             load("./yaml/bad_scheme.yml"));
     }
 
     @Test
-    public void testBadAuthUsername() {
+    void testBadAuthUsername() {
         assertConfigurationValidationException("./yaml/bad_auth_username.yml");
     }
 
     @Test
-    public void testBadPassword() {
+    void testBadPassword() {
         assertConfigurationValidationException("./yaml/bad_auth_password.yml");
     }
 
     @Test
-    public void testBadAuthScheme() {
+    void testBadAuthScheme() {
         assertConfigurationValidationException("./yaml/bad_auth_scheme.yml");
     }
 
     @Test
-    public void testBadCredentialType() {
+    void testBadCredentialType() {
         assertConfigurationValidationException("./yaml/bad_auth_credential_type.yml");
     }
 

--- a/dropwizard-client/src/test/java/io/dropwizard/client/proxy/NonProxyListProxyRoutePlannerTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/proxy/NonProxyListProxyRoutePlannerTest.java
@@ -19,28 +19,28 @@ public class NonProxyListProxyRoutePlannerTest {
     private HttpContext httpContext = mock(HttpContext.class);
 
     @Test
-    public void testProxyListIsNotSet() {
+    void testProxyListIsNotSet() {
         assertThat(new NonProxyListProxyRoutePlanner(proxy, null).getNonProxyHostPatterns()).isEmpty();
     }
 
     @Test
-    public void testHostNotInBlackList() throws Exception {
+    void testHostNotInBlackList() throws Exception {
         assertThat(routePlanner.determineProxy(new HttpHost("dropwizard.io"), httpRequest, httpContext))
                 .isEqualTo(proxy);
     }
 
     @Test
-    public void testPlainHostIsMatched() throws Exception {
+    void testPlainHostIsMatched() throws Exception {
         assertThat(routePlanner.determineProxy(new HttpHost("localhost"), httpRequest, httpContext)).isNull();
     }
 
     @Test
-    public void testHostWithStartWildcardIsMatched() throws Exception {
+    void testHostWithStartWildcardIsMatched() throws Exception {
         assertThat(routePlanner.determineProxy(new HttpHost("test.example.com"), httpRequest, httpContext)).isNull();
     }
 
     @Test
-    public void testHostWithEndWildcardIsMatched() throws Exception {
+    void testHostWithEndWildcardIsMatched() throws Exception {
         assertThat(routePlanner.determineProxy(new HttpHost("192.168.52.94"), httpRequest, httpContext)).isNull();
     }
 }

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/BaseConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/BaseConfigurationFactoryTest.java
@@ -159,7 +159,7 @@ public abstract class BaseConfigurationFactoryTest {
     }
 
     @AfterEach
-    public void resetConfigOverrides() {
+    void resetConfigOverrides() {
         for (Enumeration<?> props = System.getProperties().propertyNames(); props.hasMoreElements();) {
             String keyString = (String) props.nextElement();
             if (keyString.startsWith("dw.")) {
@@ -169,7 +169,7 @@ public abstract class BaseConfigurationFactoryTest {
     }
 
     @Test
-    public void usesDefaultedCacheBuilderSpec() throws Exception {
+    void usesDefaultedCacheBuilderSpec() throws Exception {
         final ExampleWithDefaults example =
             new YamlConfigurationFactory<>(ExampleWithDefaults.class, validator, Jackson.newObjectMapper(), "dw")
                 .build();
@@ -180,7 +180,7 @@ public abstract class BaseConfigurationFactoryTest {
     }
 
     @Test
-    public void loadsValidConfigFiles() throws Exception {
+    void loadsValidConfigFiles() throws Exception {
         final Example example = factory.build(validFile);
 
         assertThat(example.getName())
@@ -203,7 +203,7 @@ public abstract class BaseConfigurationFactoryTest {
     }
 
     @Test
-    public void handlesSimpleOverride() throws Exception {
+    void handlesSimpleOverride() throws Exception {
         System.setProperty("dw.name", "Coda Hale Overridden");
         final Example example = factory.build(validFile);
         assertThat(example.getName())
@@ -211,7 +211,7 @@ public abstract class BaseConfigurationFactoryTest {
     }
 
     @Test
-    public void handlesExistingOverrideWithPeriod() throws Exception {
+    void handlesExistingOverrideWithPeriod() throws Exception {
         System.setProperty("dw.my\\.logger.level", "debug");
         final Example example = factory.build(validFile);
         assertThat(example.getLogger().get("level"))
@@ -219,7 +219,7 @@ public abstract class BaseConfigurationFactoryTest {
     }
 
     @Test
-    public void handlesNewOverrideWithPeriod() throws Exception {
+    void handlesNewOverrideWithPeriod() throws Exception {
         System.setProperty("dw.my\\.logger.com\\.example", "error");
         final Example example = factory.build(validFile);
         assertThat(example.getLogger().get("com.example"))
@@ -227,7 +227,7 @@ public abstract class BaseConfigurationFactoryTest {
     }
 
     @Test
-    public void handlesArrayOverride() throws Exception {
+    void handlesArrayOverride() throws Exception {
         System.setProperty("dw.type", "coder,wizard,overridden");
         final Example example = factory.build(validFile);
         assertThat(example.getType().get(2))
@@ -237,7 +237,7 @@ public abstract class BaseConfigurationFactoryTest {
     }
 
     @Test
-    public void handlesArrayOverrideEscaped() throws Exception {
+    void handlesArrayOverrideEscaped() throws Exception {
         System.setProperty("dw.type", "coder,wizard,overr\\,idden");
         final Example example = factory.build(validFile);
         assertThat(example.getType().get(2))
@@ -247,7 +247,7 @@ public abstract class BaseConfigurationFactoryTest {
     }
 
     @Test
-    public void handlesSingleElementArrayOverride() throws Exception {
+    void handlesSingleElementArrayOverride() throws Exception {
         System.setProperty("dw.type", "overridden");
         final Example example = factory.build(validFile);
         assertThat(example.getType().get(0))
@@ -257,7 +257,7 @@ public abstract class BaseConfigurationFactoryTest {
     }
 
     @Test
-    public void handlesArrayOverrideIntoValidNoTypeFile() throws Exception {
+    void handlesArrayOverrideIntoValidNoTypeFile() throws Exception {
         System.setProperty("dw.type", "coder,wizard,overridden");
         final Example example = factory.build(validNoTypeFile);
         assertThat(example.getType().get(2))
@@ -267,7 +267,7 @@ public abstract class BaseConfigurationFactoryTest {
     }
 
     @Test
-    public void overridesArrayWithIndices() throws Exception {
+    void overridesArrayWithIndices() throws Exception {
         System.setProperty("dw.type[1]", "overridden");
         final Example example = factory.build(validFile);
 
@@ -278,7 +278,7 @@ public abstract class BaseConfigurationFactoryTest {
     }
 
     @Test
-    public void overridesArrayWithIndicesReverse() throws Exception {
+    void overridesArrayWithIndicesReverse() throws Exception {
         System.setProperty("dw.type[0]", "overridden");
         final Example example = factory.build(validFile);
 
@@ -289,7 +289,7 @@ public abstract class BaseConfigurationFactoryTest {
     }
 
     @Test
-    public void overridesArrayPropertiesWithIndices() throws Exception {
+    void overridesArrayPropertiesWithIndices() throws Exception {
         System.setProperty("dw.servers[0].port", "7000");
         System.setProperty("dw.servers[2].port", "9000");
         final Example example = factory.build(validFile);
@@ -303,7 +303,7 @@ public abstract class BaseConfigurationFactoryTest {
     }
 
     @Test
-    public void overrideMapProperty() throws Exception {
+    void overrideMapProperty() throws Exception {
         System.setProperty("dw.properties.settings.enabled", "true");
         final Example example = factory.build(validFile);
         assertThat(example.getProperties())
@@ -312,7 +312,7 @@ public abstract class BaseConfigurationFactoryTest {
     }
 
     @Test
-    public void throwsAnExceptionOnUnexpectedArrayOverride() {
+    void throwsAnExceptionOnUnexpectedArrayOverride() {
         System.setProperty("dw.servers.port", "9000");
         assertThatExceptionOfType(IllegalArgumentException.class)
             .isThrownBy(() -> factory.build(validFile))
@@ -320,14 +320,14 @@ public abstract class BaseConfigurationFactoryTest {
     }
 
     @Test
-    public void throwsAnExceptionOnArrayOverrideWithInvalidType() {
+    void throwsAnExceptionOnArrayOverrideWithInvalidType() {
         System.setProperty("dw.servers", "one,two");
 
         assertThatExceptionOfType(ConfigurationParsingException.class).isThrownBy(() -> factory.build(validFile));
     }
 
     @Test
-    public void throwsAnExceptionOnOverrideArrayIndexOutOfBounds() {
+    void throwsAnExceptionOnOverrideArrayIndexOutOfBounds() {
         System.setProperty("dw.type[2]", "invalid");
         assertThatExceptionOfType(ArrayIndexOutOfBoundsException.class)
             .isThrownBy(() -> factory.build(validFile))
@@ -335,7 +335,7 @@ public abstract class BaseConfigurationFactoryTest {
     }
 
     @Test
-    public void throwsAnExceptionOnOverrideArrayPropertyIndexOutOfBounds() {
+    void throwsAnExceptionOnOverrideArrayPropertyIndexOutOfBounds() {
         System.setProperty("dw.servers[4].port", "9000");
         assertThatExceptionOfType(ArrayIndexOutOfBoundsException.class)
             .isThrownBy(() -> factory.build(validFile))
@@ -343,20 +343,20 @@ public abstract class BaseConfigurationFactoryTest {
     }
 
     @Test
-    public void throwsAnExceptionOnMalformedFiles() {
+    void throwsAnExceptionOnMalformedFiles() {
         assertThatExceptionOfType(ConfigurationParsingException.class)
             .isThrownBy(() -> factory.build(malformedFile));
     }
 
     @Test
-    public void throwsAnExceptionOnEmptyFiles() {
+    void throwsAnExceptionOnEmptyFiles() {
         assertThatExceptionOfType(ConfigurationParsingException.class)
             .isThrownBy(() -> factory.build(emptyFile))
             .withMessageContaining(" * Configuration at " + emptyFile.toString() + " must not be empty");
     }
 
     @Test
-    public void throwsAnExceptionOnInvalidFiles() {
+    void throwsAnExceptionOnInvalidFiles() {
         ThrowableAssertAlternative<ConfigurationValidationException> t = assertThatExceptionOfType(ConfigurationValidationException.class)
             .isThrownBy(() -> factory.build(invalidFile));
 
@@ -368,7 +368,7 @@ public abstract class BaseConfigurationFactoryTest {
     }
 
     @Test
-    public void handleOverrideDefaultConfiguration() throws Exception {
+    void handleOverrideDefaultConfiguration() throws Exception {
         System.setProperty("dw.name", "Coda Hale Overridden");
         System.setProperty("dw.type", "coder,wizard,overridden");
         System.setProperty("dw.properties.settings.enabled", "true");
@@ -388,7 +388,7 @@ public abstract class BaseConfigurationFactoryTest {
     }
 
     @Test
-    public void handleDefaultConfigurationWithoutOverriding() throws Exception {
+    void handleDefaultConfigurationWithoutOverriding() throws Exception {
         final ExampleWithDefaults example =
                 new YamlConfigurationFactory<>(ExampleWithDefaults.class, validator, Jackson.newObjectMapper(), "dw")
                         .build();
@@ -402,7 +402,7 @@ public abstract class BaseConfigurationFactoryTest {
     }
 
     @Test
-    public void throwsAnExceptionIfDefaultConfigurationCantBeInstantiated() {
+    void throwsAnExceptionIfDefaultConfigurationCantBeInstantiated() {
         System.setProperty("dw.name", "Coda Hale Overridden");
         final YamlConfigurationFactory<NonInsatiableExample> factory =
             new YamlConfigurationFactory<>(NonInsatiableExample.class, validator, Jackson.newObjectMapper(), "dw");
@@ -413,7 +413,7 @@ public abstract class BaseConfigurationFactoryTest {
     }
 
     @Test
-    public void incorrectTypeIsFound() {
+    void incorrectTypeIsFound() {
         assertThatExceptionOfType(ConfigurationParsingException.class)
             .isThrownBy(() -> factory.build(wrongTypeFile))
             .withMessage(String.format("%s has an error:" + NEWLINE +
@@ -421,7 +421,7 @@ public abstract class BaseConfigurationFactoryTest {
     }
 
     @Test
-    public void printsDetailedInformationOnMalformedContent() throws Exception {
+    void printsDetailedInformationOnMalformedContent() throws Exception {
         factory.build(malformedAdvancedFile);
     }
 }

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryFactoryTest.java
@@ -22,7 +22,7 @@ public class ConfigurationFactoryFactoryTest {
     private final Validator validator = BaseValidator.newValidator();
 
     @Test
-    public void createDefaultFactory() throws Exception {
+    void createDefaultFactory() throws Exception {
         File validFile = new File(Resources.getResource("factory-test-valid.yml").toURI());
         ConfigurationFactory<Example> factory =
             factoryFactory.create(Example.class, validator, Jackson.newObjectMapper(), "dw");
@@ -32,7 +32,7 @@ public class ConfigurationFactoryFactoryTest {
     }
 
     @Test
-    public void createDefaultFactoryFailsUnknownProperty() throws Exception {
+    void createDefaultFactoryFailsUnknownProperty() throws Exception {
         File validFileWithUnknownProp = new File(
             Resources.getResource("factory-test-unknown-property.yml").toURI());
         ConfigurationFactory<Example> factory =
@@ -44,7 +44,7 @@ public class ConfigurationFactoryFactoryTest {
     }
 
     @Test
-    public void createFactoryAllowingUnknownProperties() throws Exception {
+    void createFactoryAllowingUnknownProperties() throws Exception {
         ConfigurationFactoryFactory<Example> customFactory = new PassThroughConfigurationFactoryFactory();
         File validFileWithUnknownProp = new File(
             Resources.getResource("factory-test-unknown-property.yml").toURI());

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationValidationExceptionTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationValidationExceptionTest.java
@@ -24,7 +24,7 @@ public class ConfigurationValidationExceptionTest {
     private ConfigurationValidationException e;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         assumeThat(Locale.getDefault().getLanguage()).isEqualTo("en");
 
         final Validator validator = BaseValidator.newValidator();
@@ -33,7 +33,7 @@ public class ConfigurationValidationExceptionTest {
     }
 
     @Test
-    public void formatsTheViolationsIntoAHumanReadableMessage() {
+    void formatsTheViolationsIntoAHumanReadableMessage() {
         assertThat(e.getMessage())
                 .isEqualTo(String.format(
                         "config.yml has an error:%n" +
@@ -42,7 +42,7 @@ public class ConfigurationValidationExceptionTest {
     }
 
     @Test
-    public void retainsTheSetOfExceptions() {
+    void retainsTheSetOfExceptions() {
         assertThat(e.getConstraintViolations())
                 .isNotEmpty();
     }

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/EnvironmentVariableLookupTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/EnvironmentVariableLookupTest.java
@@ -8,13 +8,13 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 
 public class EnvironmentVariableLookupTest {
     @Test
-    public void lookupThrowsExceptionInStrictMode() {
+    void lookupThrowsExceptionInStrictMode() {
         assumeThat(System.getenv("nope")).isNull();
         assertThat(new EnvironmentVariableLookup().lookup("nope")).isNull();
     }
 
     @Test
-    public void lookupReplacesWithEnvironmentVariables() {
+    void lookupReplacesWithEnvironmentVariables() {
         EnvironmentVariableLookup lookup = new EnvironmentVariableLookup();
 
         // Let's hope this doesn't break on Windows

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/EnvironmentVariableSubstitutorTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/EnvironmentVariableSubstitutorTest.java
@@ -9,13 +9,13 @@ import org.junit.jupiter.api.Test;
 public class EnvironmentVariableSubstitutorTest {
 
     @Test
-    public void defaultConstructorDisablesSubstitutionInVariables() {
+    void defaultConstructorDisablesSubstitutionInVariables() {
         EnvironmentVariableSubstitutor substitutor = new EnvironmentVariableSubstitutor();
         assertThat(substitutor.isEnableSubstitutionInVariables()).isFalse();
     }
 
     @Test
-    public void defaultConstructorEnablesStrict() {
+    void defaultConstructorEnablesStrict() {
         assumeThat(System.getenv("DOES_NOT_EXIST")).isNull();
 
         assertThatExceptionOfType(UndefinedEnvironmentVariableException.class).isThrownBy(() ->
@@ -23,19 +23,19 @@ public class EnvironmentVariableSubstitutorTest {
     }
 
     @Test
-    public void constructorEnablesSubstitutionInVariables() {
+    void constructorEnablesSubstitutionInVariables() {
         EnvironmentVariableSubstitutor substitutor = new EnvironmentVariableSubstitutor(true, true);
         assertThat(substitutor.isEnableSubstitutionInVariables()).isTrue();
     }
 
     @Test
-    public void substitutorUsesEnvironmentVariableLookup() {
+    void substitutorUsesEnvironmentVariableLookup() {
         EnvironmentVariableSubstitutor substitutor = new EnvironmentVariableSubstitutor();
         assertThat(substitutor.getStringLookup()).isInstanceOf(EnvironmentVariableLookup.class);
     }
 
     @Test
-    public void substitutorReplacesWithEnvironmentVariables() {
+    void substitutorReplacesWithEnvironmentVariables() {
         EnvironmentVariableSubstitutor substitutor = new EnvironmentVariableSubstitutor(false);
 
         assertThat(substitutor.replace("${TEST}")).isEqualTo(System.getenv("TEST"));
@@ -46,7 +46,7 @@ public class EnvironmentVariableSubstitutorTest {
     }
 
     @Test
-    public void substitutorStrictWithDefaults() {
+    void substitutorStrictWithDefaults() {
         EnvironmentVariableSubstitutor substitutor = new EnvironmentVariableSubstitutor(true);
         assertThat(substitutor.replace("${TEST} ${DOES_NOT_EXIST:-default}")).isEqualTo("test_value default");
 
@@ -55,14 +55,14 @@ public class EnvironmentVariableSubstitutorTest {
     }
 
     @Test
-    public void substitutorStrictRecurse() {
+    void substitutorStrictRecurse() {
         assumeThat(System.getenv("DOES_NOT_EXIST")).isNull();
         EnvironmentVariableSubstitutor substitutor = new EnvironmentVariableSubstitutor(true, true);
         assertThat(substitutor.replace("${DOES_NOT_EXIST:-${TEST}}")).isEqualTo(System.getenv("TEST"));
     }
 
     @Test
-    public void substitutorThrowsExceptionInStrictMode() {
+    void substitutorThrowsExceptionInStrictMode() {
         assumeThat(System.getenv("DOES_NOT_EXIST")).isNull();
 
         assertThatExceptionOfType(UndefinedEnvironmentVariableException.class).isThrownBy(() ->
@@ -70,7 +70,7 @@ public class EnvironmentVariableSubstitutorTest {
     }
 
     @Test
-    public void substitutorReplacesRecursively() {
+    void substitutorReplacesRecursively() {
         EnvironmentVariableSubstitutor substitutor = new EnvironmentVariableSubstitutor(false, true);
 
         assertThat(substitutor.replace("$${${TEST}}")).isEqualTo("${test_value}");

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/FileConfigurationSourceProviderTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/FileConfigurationSourceProviderTest.java
@@ -13,7 +13,7 @@ public class FileConfigurationSourceProviderTest {
     private final ConfigurationSourceProvider provider = new FileConfigurationSourceProvider();
 
     @Test
-    public void readsFileContents() throws Exception {
+    void readsFileContents() throws Exception {
         try (InputStream input = provider.open(Resources.getResource("example.txt").getFile());
              ByteArrayOutputStream output = new ByteArrayOutputStream()) {
             byte[] buffer = new byte[1024];

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/JsonConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/JsonConfigurationFactoryTest.java
@@ -17,7 +17,7 @@ public class JsonConfigurationFactoryTest extends BaseConfigurationFactoryTest {
     private File commentFile;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         this.factory = new JsonConfigurationFactory<>(Example.class, validator, Jackson.newObjectMapper(), "dw");
         this.malformedFile = resourceFileName("factory-test-malformed.json");
         this.emptyFile = resourceFileName("factory-test-empty.json");
@@ -47,7 +47,7 @@ public class JsonConfigurationFactoryTest extends BaseConfigurationFactoryTest {
     }
 
     @Test
-    public void defaultJsonFactoryFailsOnComment() {
+    void defaultJsonFactoryFailsOnComment() {
         assertThatThrownBy(() -> factory.build(commentFile))
                 .hasMessageContaining(String.format(
                         "%s has an error:%n" +
@@ -56,7 +56,7 @@ public class JsonConfigurationFactoryTest extends BaseConfigurationFactoryTest {
     }
 
     @Test
-    public void configuredMapperAllowsComment() throws IOException, ConfigurationException {
+    void configuredMapperAllowsComment() throws IOException, ConfigurationException {
         ObjectMapper mapper = Jackson
             .newObjectMapper()
             .configure(Feature.ALLOW_COMMENTS, true);

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/LevenshteinComparatorTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/LevenshteinComparatorTest.java
@@ -18,7 +18,7 @@ public class LevenshteinComparatorTest {
      * specifics of the environment / JVM.
      */
     @Test
-    public void testLevenshteinComparatorSort() {
+    void testLevenshteinComparatorSort() {
         // no assertions, just making sure we don't violate the compare contract
         Arrays.sort(new String[]{
             "y", "w", "y", "e",
@@ -32,7 +32,7 @@ public class LevenshteinComparatorTest {
     }
 
     @Test
-    public void testLevenshteinCompare() {
+    void testLevenshteinCompare() {
         assertThat(c.compare("z", "v")).isEqualTo(0);
         assertThat(c.compare("b", "v")).isEqualTo(-1);
         assertThat(c.compare("v", "b")).isEqualTo(1);

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ResourceConfigurationSourceProviderTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ResourceConfigurationSourceProviderTest.java
@@ -13,7 +13,7 @@ public class ResourceConfigurationSourceProviderTest {
     private final ConfigurationSourceProvider provider = new ResourceConfigurationSourceProvider();
 
     @Test
-    public void readsFileContents() throws Exception {
+    void readsFileContents() throws Exception {
         assertForWheeContent("example.txt");
         assertForWheeContent("io/dropwizard/configuration/not-root-example.txt");
         assertForWheeContent("/io/dropwizard/configuration/not-root-example.txt");

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/SubstitutingSourceProviderTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/SubstitutingSourceProviderTest.java
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class SubstitutingSourceProviderTest {
     @Test
-    public void shouldSubstituteCorrectly() throws IOException {
+    void shouldSubstituteCorrectly() throws IOException {
         StringLookup dummyLookup = (x) -> "baz";
         DummySourceProvider dummyProvider = new DummySourceProvider();
         SubstitutingSourceProvider provider = new SubstitutingSourceProvider(dummyProvider, new StringSubstitutor(dummyLookup));
@@ -29,7 +29,7 @@ public class SubstitutingSourceProviderTest {
     }
 
     @Test
-    public void shouldSubstituteOnlyExistingVariables() throws IOException {
+    void shouldSubstituteOnlyExistingVariables() throws IOException {
         StringLookup dummyLookup = (x) -> null;
         SubstitutingSourceProvider provider = new SubstitutingSourceProvider(new DummySourceProvider(), new StringSubstitutor(dummyLookup));
 
@@ -37,7 +37,7 @@ public class SubstitutingSourceProviderTest {
     }
 
     @Test
-    public void shouldSubstituteWithDefaultValue() throws IOException {
+    void shouldSubstituteWithDefaultValue() throws IOException {
         StringLookup dummyLookup = (x) -> null;
         SubstitutingSourceProvider provider = new SubstitutingSourceProvider(new DummySourceProvider(), new StringSubstitutor(dummyLookup));
 

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/UrlConfigurationSourceProviderTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/UrlConfigurationSourceProviderTest.java
@@ -13,7 +13,7 @@ public class UrlConfigurationSourceProviderTest {
     private final ConfigurationSourceProvider provider = new UrlConfigurationSourceProvider();
 
     @Test
-    public void readsFileContents() throws Exception {
+    void readsFileContents() throws Exception {
         try (InputStream input = provider.open(Resources.getResource("example.txt").toString())) {
             assertThat(new String(ByteStreams.toByteArray(input), StandardCharsets.UTF_8).trim())
                 .isEqualTo("whee");

--- a/dropwizard-core/src/test/java/io/dropwizard/ApplicationTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/ApplicationTest.java
@@ -46,26 +46,26 @@ public class ApplicationTest {
     }
 
     @Test
-    public void hasAReferenceToItsTypeParameter() throws Exception {
+    void hasAReferenceToItsTypeParameter() throws Exception {
         assertThat(new FakeApplication().getConfigurationClass())
                 .isSameAs(FakeConfiguration.class);
     }
 
     @Test
-    public void canDetermineConfiguration() throws Exception {
+    void canDetermineConfiguration() throws Exception {
         assertThat(new PoserApplication().getConfigurationClass())
                 .isSameAs(FakeConfiguration.class);
     }
 
     @Test
-    public void canDetermineWrappedConfiguration() throws Exception {
+    void canDetermineWrappedConfiguration() throws Exception {
         final PoserApplication application = new PoserApplication();
         assertThat(new WrapperApplication<>(application).getConfigurationClass())
                 .isSameAs(FakeConfiguration.class);
     }
 
     @Test
-    public void exitWithFatalErrorWhenCommandFails() throws Exception {
+    void exitWithFatalErrorWhenCommandFails() throws Exception {
         final File configFile = File.createTempFile("dropwizard-invalid-config", ".yml");
         try {
             final FakeApplication application = new FakeApplication();

--- a/dropwizard-core/src/test/java/io/dropwizard/BundleTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/BundleTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class BundleTest {
     @Test
-    public void deprecatedBundleWillBeInitializedAndRun() throws Exception {
+    void deprecatedBundleWillBeInitializedAndRun() throws Exception {
         final DeprecatedBundle deprecatedBundle = new DeprecatedBundle();
         assertThat(deprecatedBundle.wasInitialized()).isFalse();
         assertThat(deprecatedBundle.wasRun()).isFalse();

--- a/dropwizard-core/src/test/java/io/dropwizard/ConfigurationTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/ConfigurationTest.java
@@ -16,19 +16,19 @@ public class ConfigurationTest {
     private final Configuration configuration = new Configuration();
 
     @Test
-    public void hasAnHttpConfiguration() throws Exception {
+    void hasAnHttpConfiguration() throws Exception {
         assertThat(configuration.getServerFactory())
                 .isNotNull();
     }
 
     @Test
-    public void hasALoggingConfiguration() throws Exception {
+    void hasALoggingConfiguration() throws Exception {
         assertThat(configuration.getLoggingFactory())
                 .isNotNull();
     }
 
     @Test
-    public void ensureConfigSerializable() throws Exception {
+    void ensureConfigSerializable() throws Exception {
         final ObjectMapper mapper = Jackson.newObjectMapper();
         Class<?>[] dummyArray = {};
 

--- a/dropwizard-core/src/test/java/io/dropwizard/cli/CheckCommandTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/cli/CheckCommandTest.java
@@ -27,19 +27,19 @@ public class CheckCommandTest {
     private final Configuration configuration = mock(Configuration.class);
 
     @Test
-    public void hasAName() {
+    void hasAName() {
         assertThat(command.getName())
                 .isEqualTo("check");
     }
 
     @Test
-    public void hasADescription() {
+    void hasADescription() {
         assertThat(command.getDescription())
                 .isEqualTo("Parses and validates the configuration file");
     }
 
     @Test
-    public void doesNotInteractWithAnything() throws Exception {
+    void doesNotInteractWithAnything() throws Exception {
         command.run(bootstrap, namespace, configuration);
 
         verifyNoInteractions(bootstrap, namespace, configuration);

--- a/dropwizard-core/src/test/java/io/dropwizard/cli/ConfiguredCommandTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/cli/ConfiguredCommandTest.java
@@ -38,7 +38,7 @@ public class ConfiguredCommandTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void canUseCustomConfigurationFactory() throws Exception {
+    void canUseCustomConfigurationFactory() throws Exception {
 
         ConfigurationFactory<Configuration> factory = Mockito.mock(ConfigurationFactory.class);
         when(factory.build()).thenReturn(null);

--- a/dropwizard-core/src/test/java/io/dropwizard/cli/InheritedServerCommandTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/cli/InheritedServerCommandTest.java
@@ -55,30 +55,30 @@ public class InheritedServerCommandTest {
     private final Configuration configuration = mock(Configuration.class);
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         when(serverFactory.build(environment)).thenReturn(server);
         when(configuration.getServerFactory()).thenReturn(serverFactory);
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         server.stop();
     }
 
     @Test
-    public void hasAName() throws Exception {
+    void hasAName() throws Exception {
         assertThat(command.getName())
                 .isEqualTo("api");
     }
 
     @Test
-    public void hasADescription() throws Exception {
+    void hasADescription() throws Exception {
         assertThat(command.getDescription())
                 .isEqualTo("Runs the Dropwizard application as an API HTTP server");
     }
 
     @Test
-    public void buildsAndRunsAConfiguredServer() throws Exception {
+    void buildsAndRunsAConfiguredServer() throws Exception {
         command.run(environment, namespace, configuration);
 
         assertThat(server.isStarted())
@@ -86,7 +86,7 @@ public class InheritedServerCommandTest {
     }
 
     @Test
-    public void usesDefaultConfigPath() throws Exception {
+    void usesDefaultConfigPath() throws Exception {
 
         class SingletonConfigurationFactory implements ConfigurationFactory<Configuration> {
             @Override

--- a/dropwizard-core/src/test/java/io/dropwizard/cli/ServerCommandTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/cli/ServerCommandTest.java
@@ -45,36 +45,36 @@ public class ServerCommandTest {
     private boolean throwException = false;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         when(serverFactory.build(environment)).thenReturn(server);
         when(configuration.getServerFactory()).thenReturn(serverFactory);
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         server.stop();
     }
 
     @Test
-    public void hasAName() {
+    void hasAName() {
         assertThat(command.getName())
                 .isEqualTo("server");
     }
 
     @Test
-    public void hasADescription() {
+    void hasADescription() {
         assertThat(command.getDescription())
                 .isEqualTo("Runs the Dropwizard application as an HTTP server");
     }
 
     @Test
-    public void hasTheApplicationsConfigurationClass() {
+    void hasTheApplicationsConfigurationClass() {
         assertThat(command.getConfigurationClass())
                 .isEqualTo(application.getConfigurationClass());
     }
 
     @Test
-    public void buildsAndRunsAConfiguredServer() throws Exception {
+    void buildsAndRunsAConfiguredServer() throws Exception {
         command.run(environment, namespace, configuration);
 
         assertThat(server.isStarted())
@@ -82,7 +82,7 @@ public class ServerCommandTest {
     }
 
     @Test
-    public void stopsAServerIfThereIsAnErrorStartingIt() {
+    void stopsAServerIfThereIsAnErrorStartingIt() {
         this.throwException = true;
         server.addBean(new AbstractLifeCycle() {
             @Override

--- a/dropwizard-core/src/test/java/io/dropwizard/server/AbstractServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/AbstractServerFactoryTest.java
@@ -37,13 +37,13 @@ public class AbstractServerFactoryTest {
     private static final String YAML_SET_PATTERN = "/set/from/yaml/*";
 
     @BeforeEach
-    public void before() {
+    void before() {
         when(environment.jersey()).thenReturn(jerseyEnvironment);
         when(environment.getApplicationContext()).thenReturn(new MutableServletContextHandler());
     }
 
     @Test
-    public void usesYamlDefinedPattern() {
+    void usesYamlDefinedPattern() {
         serverFactory.setJerseyRootPath(YAML_SET_PATTERN);
         jerseyEnvironment.setUrlPattern(RUN_SET_PATTERN);
 
@@ -53,7 +53,7 @@ public class AbstractServerFactoryTest {
     }
 
     @Test
-    public void usesRunDefinedPatternWhenNoYaml() {
+    void usesRunDefinedPatternWhenNoYaml() {
         jerseyEnvironment.setUrlPattern(RUN_SET_PATTERN);
 
         serverFactory.build(environment);
@@ -62,7 +62,7 @@ public class AbstractServerFactoryTest {
     }
 
     @Test
-    public void usesDefaultPatternWhenNoneSet() {
+    void usesDefaultPatternWhenNoneSet() {
         serverFactory.build(environment);
 
         assertThat(jerseyEnvironment.getUrlPattern()).isEqualTo(DEFAULT_PATTERN);

--- a/dropwizard-core/src/test/java/io/dropwizard/setup/BootstrapTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/setup/BootstrapTest.java
@@ -28,42 +28,42 @@ public class BootstrapTest {
     private Bootstrap<Configuration> bootstrap;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         bootstrap = new Bootstrap<>(application);
     }
 
     @Test
-    public void hasAnApplication() throws Exception {
+    void hasAnApplication() throws Exception {
         assertThat(bootstrap.getApplication())
                 .isEqualTo(application);
     }
 
     @Test
-    public void hasAnObjectMapper() throws Exception {
+    void hasAnObjectMapper() throws Exception {
         assertThat(bootstrap.getObjectMapper())
                 .isNotNull();
     }
 
     @Test
-    public void hasHealthCheckRegistry() {
+    void hasHealthCheckRegistry() {
         assertThat(bootstrap.getHealthCheckRegistry())
             .isNotNull();
     }
 
     @Test
-    public void defaultsToUsingFilesForConfiguration() throws Exception {
+    void defaultsToUsingFilesForConfiguration() throws Exception {
         assertThat(bootstrap.getConfigurationSourceProvider())
                 .isInstanceOfAny(FileConfigurationSourceProvider.class);
     }
 
     @Test
-    public void defaultsToUsingTheDefaultClassLoader() throws Exception {
+    void defaultsToUsingTheDefaultClassLoader() throws Exception {
         assertThat(bootstrap.getClassLoader())
                 .isEqualTo(Thread.currentThread().getContextClassLoader());
     }
 
     @Test
-    public void comesWithJvmInstrumentation() throws Exception {
+    void comesWithJvmInstrumentation() throws Exception {
         bootstrap.registerMetrics();
         assertThat(bootstrap.getMetricRegistry().getNames())
                 .contains("jvm.buffers.mapped.capacity", "jvm.threads.count", "jvm.memory.heap.usage",
@@ -71,13 +71,13 @@ public class BootstrapTest {
     }
 
     @Test
-    public void defaultsToDefaultConfigurationFactoryFactory() throws Exception {
+    void defaultsToDefaultConfigurationFactoryFactory() throws Exception {
         assertThat(bootstrap.getConfigurationFactoryFactory())
                 .isInstanceOf(DefaultConfigurationFactoryFactory.class);
     }
 
     @Test
-    public void bringsYourOwnMetricRegistry() {
+    void bringsYourOwnMetricRegistry() {
         final MetricRegistry newRegistry = new MetricRegistry() {
             @Override
             public Histogram histogram(String name) {
@@ -94,7 +94,7 @@ public class BootstrapTest {
     }
 
     @Test
-    public void allowsAccessToJmxReporter() {
+    void allowsAccessToJmxReporter() {
         final MetricRegistry newRegistry = new MetricRegistry();
         bootstrap.setMetricRegistry(newRegistry);
         assertThat(bootstrap.getJmxReporter()).isNull();
@@ -103,7 +103,7 @@ public class BootstrapTest {
     }
 
     @Test
-    public void canUseCustomValidatorFactory() throws Exception {
+    void canUseCustomValidatorFactory() throws Exception {
         ValidatorFactory factory = Validation
                 .byProvider(HibernateValidator.class)
                 .configure()
@@ -114,14 +114,14 @@ public class BootstrapTest {
     }
 
     @Test
-    public void canUseCustomObjectMapper() {
+    void canUseCustomObjectMapper() {
         final ObjectMapper minimalObjectMapper = Jackson.newMinimalObjectMapper();
         bootstrap.setObjectMapper(minimalObjectMapper);
         assertThat(bootstrap.getObjectMapper()).isSameAs(minimalObjectMapper);
     }
 
     @Test
-    public void canUseCustomHealthCheckRegistry() {
+    void canUseCustomHealthCheckRegistry() {
         final HealthCheckRegistry healthCheckRegistry = new HealthCheckRegistry();
         bootstrap.setHealthCheckRegistry(healthCheckRegistry);
         assertThat(bootstrap.getHealthCheckRegistry()).isSameAs(healthCheckRegistry);

--- a/dropwizard-core/src/test/java/io/dropwizard/setup/ExceptionMapperBinderTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/setup/ExceptionMapperBinderTest.java
@@ -33,7 +33,7 @@ class ExceptionMapperBinderTest {
     private Environment environment = new Environment("testEnvironment");
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         final ObjectMapper objectMapper = environment.getObjectMapper();
         final Validator validator = environment.getValidator();
         objectMapper.getSubtypeResolver().registerSubtypes(ConsoleAppenderFactory.class,
@@ -43,7 +43,7 @@ class ExceptionMapperBinderTest {
     }
 
     @Test
-    public void testOverrideDefaultExceptionMapper() throws Exception {
+    void testOverrideDefaultExceptionMapper() throws Exception {
         environment.jersey().register(new TestValidationResource());
         environment.jersey().register(new MyJerseyExceptionMapper());
         final Server server = http.build(environment);

--- a/dropwizard-core/src/test/java/io/dropwizard/validation/InjectValidatorFeatureTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/validation/InjectValidatorFeatureTest.java
@@ -38,7 +38,7 @@ public class InjectValidatorFeatureTest {
     private ValidatorFactory validatorFactory;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         Bootstrap<Configuration> bootstrap = new Bootstrap<>(application);
         application.initialize(bootstrap);
 
@@ -46,14 +46,14 @@ public class InjectValidatorFeatureTest {
     }
 
     @Test
-    public void shouldReplaceValidatorFactory() {
+    void shouldReplaceValidatorFactory() {
         ConstraintValidatorFactory factory = validatorFactory.getConstraintValidatorFactory();
 
         assertThat(factory).isInstanceOf(MutableValidatorFactory.class);
     }
 
     @Test
-    public void shouldValidateNormally() {
+    void shouldValidateNormally() {
         Validator validator = validatorFactory.getValidator();
 
         // Run validation manually
@@ -70,7 +70,7 @@ public class InjectValidatorFeatureTest {
     }
 
     @Test
-    public void shouldInvokeUpdatedFactory() {
+    void shouldInvokeUpdatedFactory() {
         MutableValidatorFactory mutableFactory = (MutableValidatorFactory) validatorFactory
             .getConstraintValidatorFactory();
 

--- a/dropwizard-db/src/test/java/io/dropwizard/db/ManagedPooledDataSourceTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/ManagedPooledDataSourceTest.java
@@ -14,7 +14,7 @@ public class ManagedPooledDataSourceTest {
     private final ManagedPooledDataSource dataSource = new ManagedPooledDataSource(config, metricRegistry);
 
     @Test
-    public void hasNoParentLogger() {
+    void hasNoParentLogger() {
         assertThatExceptionOfType(SQLFeatureNotSupportedException.class)
             .isThrownBy(dataSource::getParentLogger);
     }

--- a/dropwizard-e2e/src/test/java/com/example/app1/App1Test.java
+++ b/dropwizard-e2e/src/test/java/com/example/app1/App1Test.java
@@ -47,7 +47,7 @@ public class App1Test {
     }
 
     @Test
-    public void custom204OnEmptyOptional() {
+    void custom204OnEmptyOptional() {
         final Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("test client 1");
         final String url = String.format("http://localhost:%d/empty-optional", RULE.getLocalPort());
         final Response response = client.target(url).request().get();
@@ -55,7 +55,7 @@ public class App1Test {
     }
 
     @Test
-    public void custom404OnViewRenderMissingMustacheTemplate() {
+    void custom404OnViewRenderMissingMustacheTemplate() {
         final Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("test client 2");
         final String url = String.format("http://localhost:%d/view-with-missing-tpl", RULE.getLocalPort());
 
@@ -64,7 +64,7 @@ public class App1Test {
     }
 
     @Test
-    public void earlyEofTest() throws IOException, InterruptedException {
+    void earlyEofTest() throws IOException, InterruptedException {
         // Only eof test so we ensure it's false before test
         ((App1)RULE.getApplication()).wasEofExceptionHit = false;
 
@@ -84,7 +84,7 @@ public class App1Test {
     }
 
     @Test
-    public void customJsonProvider() {
+    void customJsonProvider() {
         final String url = String.format("http://localhost:%d/mapper", RULE.getLocalPort());
         final String response = client.target(url)
             .request()
@@ -94,7 +94,7 @@ public class App1Test {
     }
 
     @Test
-    public void customJsonProviderMissingHeader() {
+    void customJsonProviderMissingHeader() {
         final String url = String.format("http://localhost:%d/mapper", RULE.getLocalPort());
         final Response response = client.target(url)
             .request()
@@ -103,7 +103,7 @@ public class App1Test {
     }
 
     @Test
-    public void customJsonProviderClient() {
+    void customJsonProviderClient() {
         final String url = String.format("http://localhost:%d/mapper", RULE.getLocalPort());
         final String response = client.target(url)
             .request()
@@ -113,7 +113,7 @@ public class App1Test {
     }
 
     @Test
-    public void customJsonProviderRoundtrip() {
+    void customJsonProviderRoundtrip() {
         final String url = String.format("http://localhost:%d/mapper", RULE.getLocalPort());
         final GenericType<Map<String, String>> typ = new GenericType<Map<String, String>>() {
         };
@@ -125,7 +125,7 @@ public class App1Test {
     }
 
     @Test
-    public void customBodyWriterTest() {
+    void customBodyWriterTest() {
         final String url = String.format("http://localhost:%d/custom-class", RULE.getLocalPort());
         final String response = client.target(url)
             .request()

--- a/dropwizard-e2e/src/test/java/com/example/forms/FormsAppTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/forms/FormsAppTest.java
@@ -33,12 +33,12 @@ public class FormsAppTest {
     private final JerseyClientConfiguration config = new JerseyClientConfiguration();
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         config.setTimeout(Duration.seconds(2));
     }
 
     @Test
-    public void canSubmitFormAndReceiveResponse() throws IOException {
+    void canSubmitFormAndReceiveResponse() throws IOException {
         config.setChunkedEncodingEnabled(false);
 
         final Client client = new JerseyClientBuilder(RULE.getEnvironment())
@@ -65,7 +65,7 @@ public class FormsAppTest {
      * @throws IOException
      */
     @Test
-    public void failOnNoChunkedEncoding() throws IOException {
+    void failOnNoChunkedEncoding() throws IOException {
         final Client client = new JerseyClientBuilder(RULE.getEnvironment())
             .using(config)
             .build("test client 2");

--- a/dropwizard-e2e/src/test/java/com/example/sslreload/SslReloadAppTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/sslreload/SslReloadAppTest.java
@@ -64,14 +64,14 @@ public class SslReloadAppTest {
     }
 
     @AfterEach
-    public void after() throws IOException {
+    void after() throws IOException {
         // Reset keystore to known good keystore
         final byte[] keystoreBytes = Resources.toByteArray(Resources.getResource("sslreload/keystore.jks"));
         Files.write(keystore, keystoreBytes);
     }
 
     @Test
-    public void reloadCertificateChangesTheServerCertificate() throws Exception {
+    void reloadCertificateChangesTheServerCertificate() throws Exception {
         // Copy over our new keystore that has our new certificate to the current
         // location of our keystore
         final byte[] keystore2Bytes = Resources.toByteArray(Resources.getResource("sslreload/keystore2.jks"));
@@ -92,7 +92,7 @@ public class SslReloadAppTest {
     }
 
     @Test
-    public void badReloadDoesNotChangeTheServerCertificate() throws Exception {
+    void badReloadDoesNotChangeTheServerCertificate() throws Exception {
         // This keystore has a different password than what jetty has been configured with
         // the password is "password2"
         final byte[] badKeystore = Resources.toByteArray(Resources.getResource("sslreload/keystore-diff-pwd.jks"));

--- a/dropwizard-e2e/src/test/java/com/example/validation/BeanValidatorTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/validation/BeanValidatorTest.java
@@ -47,7 +47,7 @@ public class BeanValidatorTest {
     }
 
     @Test
-    public void shouldValidateNormally() {
+    void shouldValidateNormally() {
         Entity<Map<String, Object>> entity = requestBody("My string", 5, Arrays.asList("one", "two", "three"));
         Response response = target.request(MediaType.APPLICATION_JSON_TYPE).post(entity);
 
@@ -55,7 +55,7 @@ public class BeanValidatorTest {
     }
 
     @Test
-    public void shouldFailWithNullRequestBody() throws IOException {
+    void shouldFailWithNullRequestBody() throws IOException {
         Response response = target.request(MediaType.APPLICATION_JSON_TYPE).post(null);
 
         assertThat(response.getStatus()).isEqualTo(422);
@@ -65,7 +65,7 @@ public class BeanValidatorTest {
     }
 
     @Test
-    public void shouldFailWithNullString() throws IOException {
+    void shouldFailWithNullString() throws IOException {
         Entity<Map<String, Object>> entity = requestBody(null, 5, Arrays.asList("one", "two", "three"));
         Response response = target.request(MediaType.APPLICATION_JSON_TYPE).post(entity);
 
@@ -76,7 +76,7 @@ public class BeanValidatorTest {
     }
 
     @Test
-    public void shouldFailWithNegativeNumber() throws IOException {
+    void shouldFailWithNegativeNumber() throws IOException {
         Entity<Map<String, Object>> entity = requestBody("My string", -23, Arrays.asList("one", "two", "three"));
         Response response = target.request(MediaType.APPLICATION_JSON_TYPE).post(entity);
 
@@ -86,7 +86,7 @@ public class BeanValidatorTest {
     }
 
     @Test
-    public void shouldFailWithEmptyList() throws IOException {
+    void shouldFailWithEmptyList() throws IOException {
         Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("string", "My string");
         requestBody.put("number", 5);
@@ -101,7 +101,7 @@ public class BeanValidatorTest {
     }
 
     @Test
-    public void shouldFailWithTooLongList() throws IOException {
+    void shouldFailWithTooLongList() throws IOException {
         Entity<Map<String, Object>> entity = requestBody("My string", 5, Arrays.asList("one", "two", "three", "four"));
         Response response = target.request(MediaType.APPLICATION_JSON_TYPE).post(entity);
 
@@ -111,7 +111,7 @@ public class BeanValidatorTest {
     }
 
     @Test
-    public void shouldFailWithBlankStringInList() throws IOException {
+    void shouldFailWithBlankStringInList() throws IOException {
         Entity<Map<String, Object>> entity = requestBody("My string", 5, Arrays.asList("one", " "));
         Response response = target.request(MediaType.APPLICATION_JSON_TYPE).post(entity);
 
@@ -121,7 +121,7 @@ public class BeanValidatorTest {
     }
 
     @Test
-    public void shouldFailWithAllInvalid() throws IOException {
+    void shouldFailWithAllInvalid() throws IOException {
         Entity<Map<String, Object>> entity = requestBody(null, -23, Arrays.asList("one", " ", "three", "four"));
         Response response = target.request(MediaType.APPLICATION_JSON_TYPE).post(entity);
 

--- a/dropwizard-e2e/src/test/java/com/example/validation/InjectValidatorTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/validation/InjectValidatorTest.java
@@ -22,7 +22,7 @@ public class InjectValidatorTest {
     );
 
     @Test
-    public void shouldValidateNormally() {
+    void shouldValidateNormally() {
         final Client client = RULE.client();
         final String url = String.format("http://localhost:%d/default", RULE.getLocalPort());
         final WebTarget target = client.target(url);
@@ -43,7 +43,7 @@ public class InjectValidatorTest {
     }
 
     @Test
-    public void shouldInjectValidator() {
+    void shouldInjectValidator() {
         final Client client = RULE.client();
         final String url = String.format("http://localhost:%d/injectable", RULE.getLocalPort());
 

--- a/dropwizard-example/src/test/java/com/example/helloworld/DockerIntegrationTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/DockerIntegrationTest.java
@@ -47,7 +47,7 @@ public class DockerIntegrationTest {
     }
 
     @Test
-    public void testHelloWorld() {
+    void testHelloWorld() {
         final Optional<String> name = Optional.of("Dr. IntegrationTest");
         final Saying saying = APP.client().target("http://localhost:" + APP.getLocalPort() + "/hello-world")
                 .queryParam("name", name.get())
@@ -57,7 +57,7 @@ public class DockerIntegrationTest {
     }
 
     @Test
-    public void testPostPerson() {
+    void testPostPerson() {
         final Person person = new Person("Dr. IntegrationTest", "Chief Wizard", 1525);
         final Person newPerson = postPerson(person);
         assertThat(newPerson.getFullName()).isEqualTo(person.getFullName());
@@ -65,12 +65,12 @@ public class DockerIntegrationTest {
     }
 
     @Test
-    public void testRenderingPersonFreemarker() {
+    void testRenderingPersonFreemarker() {
         testRenderingPerson("view_freemarker");
     }
 
     @Test
-    public void testRenderingPersonMustache() {
+    void testRenderingPersonMustache() {
         testRenderingPerson("view_mustache");
     }
 
@@ -90,7 +90,7 @@ public class DockerIntegrationTest {
     }
 
     @Test
-    public void testLogFileWritten() throws IOException {
+    void testLogFileWritten() throws IOException {
         // The log file is using a size and time based policy, which used to silently
         // fail (and not write to a log file). This test ensures not only that the
         // log file exists, but also contains the log line that jetty prints on startup

--- a/dropwizard-example/src/test/java/com/example/helloworld/IntegrationTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/IntegrationTest.java
@@ -48,7 +48,7 @@ public class IntegrationTest {
     }
 
     @Test
-    public void testHelloWorld() throws Exception {
+    void testHelloWorld() throws Exception {
         final Optional<String> name = Optional.of("Dr. IntegrationTest");
         final Saying saying = RULE.client().target("http://localhost:" + RULE.getLocalPort() + "/hello-world")
                 .queryParam("name", name.get())
@@ -58,7 +58,7 @@ public class IntegrationTest {
     }
 
     @Test
-    public void testPostPerson() throws Exception {
+    void testPostPerson() throws Exception {
         final Person person = new Person("Dr. IntegrationTest", "Chief Wizard", 1525);
         final Person newPerson = postPerson(person);
         assertThat(newPerson.getFullName()).isEqualTo(person.getFullName());
@@ -66,12 +66,12 @@ public class IntegrationTest {
     }
 
     @Test
-    public void testRenderingPersonFreemarker() throws Exception {
+    void testRenderingPersonFreemarker() throws Exception {
         testRenderingPerson("view_freemarker");
     }
 
     @Test
-    public void testRenderingPersonMustache() throws Exception {
+    void testRenderingPersonMustache() throws Exception {
         testRenderingPerson("view_mustache");
     }
 
@@ -91,7 +91,7 @@ public class IntegrationTest {
     }
 
     @Test
-    public void testLogFileWritten() throws IOException {
+    void testLogFileWritten() throws IOException {
         // The log file is using a size and time based policy, which used to silently
         // fail (and not write to a log file). This test ensures not only that the
         // log file exists, but also contains the log line that jetty prints on startup

--- a/dropwizard-example/src/test/java/com/example/helloworld/db/PersonDAOIntegrationTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/db/PersonDAOIntegrationTest.java
@@ -37,12 +37,12 @@ public class PersonDAOIntegrationTest {
     private PersonDAO personDAO;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         personDAO = new PersonDAO(daoTestRule.getSessionFactory());
     }
 
     @Test
-    public void createPerson() {
+    void createPerson() {
         final Person jeff = daoTestRule.inTransaction(() -> personDAO.create(new Person("Jeff", "The plumber", 1995)));
         assertThat(jeff.getId()).isGreaterThan(0);
         assertThat(jeff.getFullName()).isEqualTo("Jeff");
@@ -52,7 +52,7 @@ public class PersonDAOIntegrationTest {
     }
 
     @Test
-    public void findAll() {
+    void findAll() {
         daoTestRule.inTransaction(() -> {
             personDAO.create(new Person("Jeff", "The plumber", 1975));
             personDAO.create(new Person("Jim", "The cook", 1985));
@@ -66,7 +66,7 @@ public class PersonDAOIntegrationTest {
     }
 
     @Test
-    public void handlesNullFullName() {
+    void handlesNullFullName() {
         assertThatExceptionOfType(ConstraintViolationException.class).isThrownBy(() ->
                 daoTestRule.inTransaction(() -> personDAO.create(new Person(null, "The null", 0))));
     }

--- a/dropwizard-example/src/test/java/com/example/helloworld/db/PersonDAOTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/db/PersonDAOTest.java
@@ -24,12 +24,12 @@ public class PersonDAOTest {
     private PersonDAO personDAO;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         personDAO = new PersonDAO(daoTestRule.getSessionFactory());
     }
 
     @Test
-    public void createPerson() {
+    void createPerson() {
         final Person jeff = daoTestRule.inTransaction(() -> personDAO.create(new Person("Jeff", "The plumber", 1995)));
         assertThat(jeff.getId()).isGreaterThan(0);
         assertThat(jeff.getFullName()).isEqualTo("Jeff");
@@ -39,7 +39,7 @@ public class PersonDAOTest {
     }
 
     @Test
-    public void findAll() {
+    void findAll() {
         daoTestRule.inTransaction(() -> {
             personDAO.create(new Person("Jeff", "The plumber", 1975));
             personDAO.create(new Person("Jim", "The cook", 1985));
@@ -53,7 +53,7 @@ public class PersonDAOTest {
     }
 
     @Test
-    public void handlesNullFullName() {
+    void handlesNullFullName() {
         assertThatExceptionOfType(ConstraintViolationException.class).isThrownBy(()->
             daoTestRule.inTransaction(() -> personDAO.create(new Person(null, "The null", 0))));
     }

--- a/dropwizard-example/src/test/java/com/example/helloworld/resources/PeopleResourceTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/resources/PeopleResourceTest.java
@@ -37,7 +37,7 @@ public class PeopleResourceTest {
     private Person person;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         person = new Person();
         person.setFullName("Full Name");
         person.setJobTitle("Job Title");
@@ -45,12 +45,12 @@ public class PeopleResourceTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         reset(PERSON_DAO);
     }
 
     @Test
-    public void createPerson() {
+    void createPerson() {
         when(PERSON_DAO.create(any(Person.class))).thenReturn(person);
         final Response response = RESOURCES.target("/people")
                 .request(MediaType.APPLICATION_JSON_TYPE)
@@ -62,7 +62,7 @@ public class PeopleResourceTest {
     }
 
     @Test
-    public void createPersonFailureMinYearBorn() {
+    void createPersonFailureMinYearBorn() {
         person.setYearBorn(-1);
 
         final Response response = RESOURCES.target("/people")
@@ -74,7 +74,7 @@ public class PeopleResourceTest {
     }
 
     @Test
-    public void createPersonFailureMaxYearBorn() {
+    void createPersonFailureMaxYearBorn() {
         person.setYearBorn(10000);
 
         final Response response = RESOURCES.target("/people")
@@ -86,7 +86,7 @@ public class PeopleResourceTest {
     }
 
     @Test
-    public void listPeople() throws Exception {
+    void listPeople() throws Exception {
         final List<Person> people = Collections.singletonList(person);
         when(PERSON_DAO.findAll()).thenReturn(people);
 

--- a/dropwizard-example/src/test/java/com/example/helloworld/resources/PersonResourceTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/resources/PersonResourceTest.java
@@ -27,18 +27,18 @@ public class PersonResourceTest {
     private Person person;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         person = new Person();
         person.setId(1L);
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         reset(DAO);
     }
 
     @Test
-    public void getPersonSuccess() {
+    void getPersonSuccess() {
         when(DAO.findById(1L)).thenReturn(Optional.of(person));
 
         Person found = RULE.target("/people/1").request().get(Person.class);
@@ -48,7 +48,7 @@ public class PersonResourceTest {
     }
 
     @Test
-    public void getPersonNotFound() {
+    void getPersonNotFound() {
         when(DAO.findById(2L)).thenReturn(Optional.empty());
         final Response response = RULE.target("/people/2").request().get();
 

--- a/dropwizard-example/src/test/java/com/example/helloworld/resources/ProtectedClassResourceTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/resources/ProtectedClassResourceTest.java
@@ -39,7 +39,7 @@ public final class ProtectedClassResourceTest {
         .build();
 
     @Test
-    public void testProtectedAdminEndpoint() {
+    void testProtectedAdminEndpoint() {
         String secret = RULE.target("/protected/admin").request()
             .header(HttpHeaders.AUTHORIZATION, "Basic Y2hpZWYtd2l6YXJkOnNlY3JldA==")
             .get(String.class);
@@ -47,7 +47,7 @@ public final class ProtectedClassResourceTest {
     }
 
     @Test
-    public void testProtectedBasicUserEndpoint() {
+    void testProtectedBasicUserEndpoint() {
         String secret = RULE.target("/protected").request()
             .header(HttpHeaders.AUTHORIZATION, "Basic Z29vZC1ndXk6c2VjcmV0")
             .get(String.class);
@@ -55,7 +55,7 @@ public final class ProtectedClassResourceTest {
     }
 
     @Test
-    public void testProtectedBasicUserEndpointAsAdmin() {
+    void testProtectedBasicUserEndpointAsAdmin() {
         String secret = RULE.target("/protected").request()
             .header(HttpHeaders.AUTHORIZATION, "Basic Y2hpZWYtd2l6YXJkOnNlY3JldA==")
             .get(String.class);
@@ -63,7 +63,7 @@ public final class ProtectedClassResourceTest {
     }
 
     @Test
-    public void testProtectedGuestEndpoint() {
+    void testProtectedGuestEndpoint() {
         String secret = RULE.target("/protected/guest").request()
             .header(HttpHeaders.AUTHORIZATION, "Basic Z3Vlc3Q6c2VjcmV0")
             .get(String.class);
@@ -71,7 +71,7 @@ public final class ProtectedClassResourceTest {
     }
 
     @Test
-    public void testProtectedBasicUserEndpointPrincipalIsNotAuthorized403() {
+    void testProtectedBasicUserEndpointPrincipalIsNotAuthorized403() {
         assertThatExceptionOfType(ForbiddenException.class)
             .isThrownBy(() -> RULE.target("/protected").request()
             .header(HttpHeaders.AUTHORIZATION, "Basic Z3Vlc3Q6c2VjcmV0")

--- a/dropwizard-example/src/test/java/com/example/helloworld/resources/ProtectedResourceTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/resources/ProtectedResourceTest.java
@@ -39,7 +39,7 @@ public class ProtectedResourceTest {
             .build();
 
     @Test
-    public void testProtectedEndpoint() {
+    void testProtectedEndpoint() {
         String secret = RULE.target("/protected").request()
                 .header(HttpHeaders.AUTHORIZATION, "Basic Z29vZC1ndXk6c2VjcmV0")
                 .get(String.class);
@@ -47,7 +47,7 @@ public class ProtectedResourceTest {
     }
 
     @Test
-    public void testProtectedEndpointNoCredentials401() {
+    void testProtectedEndpointNoCredentials401() {
         assertThatExceptionOfType(NotAuthorizedException.class)
             .isThrownBy(() -> RULE.target("/protected").request()
                 .get(String.class))
@@ -57,7 +57,7 @@ public class ProtectedResourceTest {
     }
 
     @Test
-    public void testProtectedEndpointBadCredentials401() {
+    void testProtectedEndpointBadCredentials401() {
         assertThatExceptionOfType(NotAuthorizedException.class)
             .isThrownBy(() -> RULE.target("/protected").request()
                 .header(HttpHeaders.AUTHORIZATION, "Basic c25lYWt5LWJhc3RhcmQ6YXNkZg==")
@@ -68,7 +68,7 @@ public class ProtectedResourceTest {
     }
 
     @Test
-    public void testProtectedAdminEndpoint() {
+    void testProtectedAdminEndpoint() {
         String secret = RULE.target("/protected/admin").request()
                 .header(HttpHeaders.AUTHORIZATION, "Basic Y2hpZWYtd2l6YXJkOnNlY3JldA==")
                 .get(String.class);
@@ -76,7 +76,7 @@ public class ProtectedResourceTest {
     }
 
     @Test
-    public void testProtectedAdminEndpointPrincipalIsNotAuthorized403() {
+    void testProtectedAdminEndpointPrincipalIsNotAuthorized403() {
         assertThatExceptionOfType(ForbiddenException.class)
             .isThrownBy(() -> RULE.target("/protected/admin").request()
                     .header(HttpHeaders.AUTHORIZATION, "Basic Z29vZC1ndXk6c2VjcmV0")

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/AbstractDAOTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/AbstractDAOTest.java
@@ -100,7 +100,7 @@ public class AbstractDAOTest {
     private final MockDAO dao = new MockDAO(factory);
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         when(criteriaBuilder.createQuery(same(String.class))).thenReturn(criteriaQuery);
         when(factory.getCurrentSession()).thenReturn(session);
         when(session.createCriteria(String.class)).thenReturn(criteria);
@@ -110,19 +110,19 @@ public class AbstractDAOTest {
     }
 
     @Test
-    public void getsASessionFromTheSessionFactory() throws Exception {
+    void getsASessionFromTheSessionFactory() throws Exception {
         assertThat(dao.currentSession())
                 .isSameAs(session);
     }
 
     @Test
-    public void hasAnEntityClass() throws Exception {
+    void hasAnEntityClass() throws Exception {
         assertThat(dao.getEntityClass())
                 .isEqualTo(String.class);
     }
 
     @Test
-    public void getsNamedQueries() throws Exception {
+    void getsNamedQueries() throws Exception {
         assertThat(dao.namedQuery("query-name"))
                 .isEqualTo(query);
 
@@ -130,7 +130,7 @@ public class AbstractDAOTest {
     }
 
     @Test
-    public void getsTypedQueries() throws Exception {
+    void getsTypedQueries() throws Exception {
         assertThat(dao.query("HQL"))
             .isEqualTo(query);
 
@@ -138,7 +138,7 @@ public class AbstractDAOTest {
     }
 
     @Test
-    public void createsNewCriteria() throws Exception {
+    void createsNewCriteria() throws Exception {
         assertThat(dao.criteria())
                 .isEqualTo(criteria);
 
@@ -146,7 +146,7 @@ public class AbstractDAOTest {
     }
 
     @Test
-    public void createsNewCriteriaQueries() throws Exception {
+    void createsNewCriteriaQueries() throws Exception {
         assertThat(dao.criteriaQuery())
                 .isEqualTo(criteriaQuery);
 
@@ -155,7 +155,7 @@ public class AbstractDAOTest {
     }
 
     @Test
-    public void returnsUniqueResultsFromCriteriaQueries() throws Exception {
+    void returnsUniqueResultsFromCriteriaQueries() throws Exception {
         when(criteria.uniqueResult()).thenReturn("woo");
 
         assertThat(dao.uniqueResult(criteria))
@@ -163,7 +163,7 @@ public class AbstractDAOTest {
     }
 
     @Test
-    public void returnsUniqueResultsFromJpaCriteriaQueries() throws Exception {
+    void returnsUniqueResultsFromJpaCriteriaQueries() throws Exception {
         when(session.createQuery(criteriaQuery)).thenReturn(query);
         when(query.getResultList()).thenReturn(Collections.singletonList("woo"));
 
@@ -172,7 +172,7 @@ public class AbstractDAOTest {
     }
 
     @Test
-    public void throwsOnNonUniqueResultsFromJpaCriteriaQueries() throws Exception {
+    void throwsOnNonUniqueResultsFromJpaCriteriaQueries() throws Exception {
         when(session.createQuery(criteriaQuery)).thenReturn(query);
         when(query.getResultList()).thenReturn(Arrays.asList("woo", "boo"));
 
@@ -181,7 +181,7 @@ public class AbstractDAOTest {
     }
 
     @Test
-    public void returnsUniqueResultsFromQueries() throws Exception {
+    void returnsUniqueResultsFromQueries() throws Exception {
         when(query.uniqueResult()).thenReturn("woo");
 
         assertThat(dao.uniqueResult(query))
@@ -189,7 +189,7 @@ public class AbstractDAOTest {
     }
 
     @Test
-    public void returnsUniqueListsFromCriteriaQueries() throws Exception {
+    void returnsUniqueListsFromCriteriaQueries() throws Exception {
         when(criteria.list()).thenReturn(Collections.singletonList("woo"));
 
         assertThat(dao.list(criteria))
@@ -197,7 +197,7 @@ public class AbstractDAOTest {
     }
 
     @Test
-    public void returnsUniqueListsFromJpaCriteriaQueries() throws Exception {
+    void returnsUniqueListsFromJpaCriteriaQueries() throws Exception {
         when(session.createQuery(criteriaQuery)).thenReturn(query);
         when(query.getResultList()).thenReturn(Collections.singletonList("woo"));
 
@@ -206,7 +206,7 @@ public class AbstractDAOTest {
     }
 
     @Test
-    public void returnsUniqueListsFromQueries() throws Exception {
+    void returnsUniqueListsFromQueries() throws Exception {
         when(query.list()).thenReturn(Collections.singletonList("woo"));
 
         assertThat(dao.list(query))
@@ -214,7 +214,7 @@ public class AbstractDAOTest {
     }
 
     @Test
-    public void getsEntitiesById() throws Exception {
+    void getsEntitiesById() throws Exception {
         when(session.get(String.class, 200)).thenReturn("woo!");
 
         assertThat(dao.get(200))
@@ -224,7 +224,7 @@ public class AbstractDAOTest {
     }
 
     @Test
-    public void persistsEntities() throws Exception {
+    void persistsEntities() throws Exception {
         assertThat(dao.persist("woo"))
                 .isEqualTo("woo");
 
@@ -232,7 +232,7 @@ public class AbstractDAOTest {
     }
 
     @Test
-    public void initializesProxies() throws Exception {
+    void initializesProxies() throws Exception {
         final LazyInitializer initializer = mock(LazyInitializer.class);
         when(initializer.isUninitialized()).thenReturn(true);
         final HibernateProxy proxy = mock(HibernateProxy.class);

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/HibernateBundleTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/HibernateBundleTest.java
@@ -44,7 +44,7 @@ public class HibernateBundleTest {
     };
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         when(environment.healthChecks()).thenReturn(healthChecks);
         when(environment.jersey()).thenReturn(jerseyEnvironment);
         when(jerseyEnvironment.getResourceConfig()).thenReturn(new DropwizardResourceConfig());
@@ -58,7 +58,7 @@ public class HibernateBundleTest {
     }
 
     @Test
-    public void addsHibernateSupportToJackson() throws Exception {
+    void addsHibernateSupportToJackson() throws Exception {
         final ObjectMapper objectMapperFactory = mock(ObjectMapper.class);
 
         final Bootstrap<?> bootstrap = mock(Bootstrap.class);
@@ -73,14 +73,14 @@ public class HibernateBundleTest {
     }
 
     @Test
-    public void buildsASessionFactory() throws Exception {
+    void buildsASessionFactory() throws Exception {
         bundle.run(configuration, environment);
 
         verify(factory).build(bundle, environment, dbConfig, entities, "hibernate");
     }
 
     @Test
-    public void registersATransactionalListener() throws Exception {
+    void registersATransactionalListener() throws Exception {
         bundle.run(configuration, environment);
 
         final ArgumentCaptor<UnitOfWorkApplicationListener> captor =
@@ -89,7 +89,7 @@ public class HibernateBundleTest {
     }
 
     @Test
-    public void registersASessionFactoryHealthCheck() throws Exception {
+    void registersASessionFactoryHealthCheck() throws Exception {
         dbConfig.setValidationQuery("SELECT something");
 
         bundle.run(configuration, environment);
@@ -104,7 +104,7 @@ public class HibernateBundleTest {
     }
 
     @Test
-    public void registersACustomNameOfHealthCheckAndDBPoolMetrics() throws Exception {
+    void registersACustomNameOfHealthCheckAndDBPoolMetrics() throws Exception {
         final HibernateBundle<Configuration> customBundle = new HibernateBundle<Configuration>(entities, factory) {
             @Override
             public DataSourceFactory getDataSourceFactory(Configuration configuration) {
@@ -130,7 +130,7 @@ public class HibernateBundleTest {
     }
 
     @Test
-    public void hasASessionFactory() throws Exception {
+    void hasASessionFactory() throws Exception {
         bundle.run(configuration, environment);
 
         assertThat(bundle.getSessionFactory()).isEqualTo(sessionFactory);

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
@@ -88,13 +88,13 @@ public class JerseyIntegrationTest extends JerseyTest {
 
     @Override
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         super.setUp();
     }
 
     @Override
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         super.tearDown();
 
         if (sessionFactory != null) {
@@ -154,7 +154,7 @@ public class JerseyIntegrationTest extends JerseyTest {
     }
 
     @Test
-    public void findsExistingData() {
+    void findsExistingData() {
         final Person coda = target("/people/Coda").request(MediaType.APPLICATION_JSON).get(Person.class);
 
         assertThat(coda.getName())
@@ -168,7 +168,7 @@ public class JerseyIntegrationTest extends JerseyTest {
     }
 
     @Test
-    public void doesNotFindMissingData() {
+    void doesNotFindMissingData() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> target("/people/Poof").request(MediaType.APPLICATION_JSON)
                     .get(Person.class))
@@ -176,7 +176,7 @@ public class JerseyIntegrationTest extends JerseyTest {
     }
 
     @Test
-    public void createsNewData() {
+    void createsNewData() {
         final Person person = new Person();
         person.setName("Hank");
         person.setEmail("hank@example.com");
@@ -200,7 +200,7 @@ public class JerseyIntegrationTest extends JerseyTest {
 
 
     @Test
-    public void testSqlExceptionIsHandled() {
+    void testSqlExceptionIsHandled() {
         final Person person = new Person();
         person.setName("Jeff");
         person.setEmail("jeff.hammersmith@targetprocessinc.com");

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
@@ -88,13 +88,13 @@ public class JerseyIntegrationTest extends JerseyTest {
 
     @Override
     @BeforeEach
-    void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
     }
 
     @Override
     @AfterEach
-    void tearDown() throws Exception {
+    public void tearDown() throws Exception {
         super.tearDown();
 
         if (sessionFactory != null) {

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/ScanningHibernateBundleTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/ScanningHibernateBundleTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 public class ScanningHibernateBundleTest {
 
     @Test
-    public void testFindEntityClassesFromDirectory() {
+    void testFindEntityClassesFromDirectory() {
         //given
         String packageWithEntities = "io.dropwizard.hibernate.fake.entities.pckg";
         //when
@@ -23,7 +23,7 @@ public class ScanningHibernateBundleTest {
     }
 
     @Test
-    public void testFindEntityClassesFromMultipleDirectories() {
+    void testFindEntityClassesFromMultipleDirectories() {
         //given
         String packageWithEntities = "io.dropwizard.hibernate.fake.entities.pckg";
         String packageWithEntities2 = "io.dropwizard.hibernate.fake2.entities.pckg";

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryFactoryTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryFactoryTest.java
@@ -50,7 +50,7 @@ public class SessionFactoryFactoryTest {
     private SessionFactory sessionFactory;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         when(environment.metrics()).thenReturn(metricRegistry);
         when(environment.lifecycle()).thenReturn(lifecycleEnvironment);
 
@@ -67,28 +67,28 @@ public class SessionFactoryFactoryTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         if (sessionFactory != null) {
             sessionFactory.close();
         }
     }
 
     @Test
-    public void managesTheSessionFactory() throws Exception {
+    void managesTheSessionFactory() throws Exception {
         build();
 
         verify(lifecycleEnvironment).manage(any(SessionFactoryManager.class));
     }
 
     @Test
-    public void callsBundleToConfigure() throws Exception {
+    void callsBundleToConfigure() throws Exception {
         build();
 
         verify(bundle).configure(any(Configuration.class));
     }
 
     @Test
-    public void setsPoolName() {
+    void setsPoolName() {
         build();
 
         ArgumentCaptor<SessionFactoryManager> sessionFactoryManager = ArgumentCaptor.forClass(SessionFactoryManager.class);
@@ -98,7 +98,7 @@ public class SessionFactoryFactoryTest {
     }
 
     @Test
-    public void setsACustomPoolName() {
+    void setsACustomPoolName() {
         this.sessionFactory = factory.build(bundle, environment, config,
             Collections.singletonList(Person.class), "custom-hibernate-db");
 
@@ -109,7 +109,7 @@ public class SessionFactoryFactoryTest {
     }
 
     @Test
-    public void buildsAWorkingSessionFactory() throws Exception {
+    void buildsAWorkingSessionFactory() throws Exception {
         build();
 
         try (Session session = requireNonNull(sessionFactory).openSession()) {
@@ -133,7 +133,7 @@ public class SessionFactoryFactoryTest {
     }
 
     @Test
-    public void configureRunsBeforeSessionFactoryCreation() {
+    void configureRunsBeforeSessionFactoryCreation() {
         final SessionFactoryFactory customFactory = new SessionFactoryFactory() {
             @Override
             protected void configure(Configuration configuration, ServiceRegistry registry) {
@@ -150,7 +150,7 @@ public class SessionFactoryFactoryTest {
     }
 
     @Test
-    public void buildBootstrapServiceRegistryRunsBeforeSessionFactoryCreation() {
+    void buildBootstrapServiceRegistryRunsBeforeSessionFactoryCreation() {
         final SessionFactoryFactory customFactory = new SessionFactoryFactory() {
             @Override
             protected BootstrapServiceRegistryBuilder configureBootstrapServiceRegistryBuilder(BootstrapServiceRegistryBuilder builder) {

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryHealthCheckTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryHealthCheckTest.java
@@ -27,19 +27,19 @@ public class SessionFactoryHealthCheckTest {
     private final SessionFactory factory = mock(SessionFactory.class);
 
     @Test
-    public void hasASessionFactory() throws Exception {
+    void hasASessionFactory() throws Exception {
         assertThat(healthCheck().getSessionFactory())
                 .isEqualTo(factory);
     }
 
     @Test
-    public void hasAValidationQuery() throws Exception {
+    void hasAValidationQuery() throws Exception {
         assertThat(healthCheck("SELECT 1").getValidationQuery())
                 .isEqualTo(Optional.of("SELECT 1"));
     }
 
     @Test
-    public void isHealthyIfNoExceptionIsThrown() throws Exception {
+    void isHealthyIfNoExceptionIsThrown() throws Exception {
         final Session session = mock(Session.class);
         when(factory.openSession()).thenReturn(session);
 
@@ -61,7 +61,7 @@ public class SessionFactoryHealthCheckTest {
     }
 
     @Test
-    public void isHealthyIfIsValid() {
+    void isHealthyIfIsValid() {
         final Session session = mock(Session.class);
         when(factory.openSession()).thenReturn(session);
 
@@ -81,7 +81,7 @@ public class SessionFactoryHealthCheckTest {
     }
 
     @Test
-    public void isUnhealthyIfAnExceptionIsThrown() throws Exception {
+    void isUnhealthyIfAnExceptionIsThrown() throws Exception {
         final Session session = mock(Session.class);
         when(factory.openSession()).thenReturn(session);
 
@@ -108,7 +108,7 @@ public class SessionFactoryHealthCheckTest {
     }
 
     @Test
-    public void isUnhealthyIfIsNotValid() {
+    void isUnhealthyIfIsNotValid() {
         final Session session = mock(Session.class);
         when(factory.openSession()).thenReturn(session);
 

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryManagerTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryManagerTest.java
@@ -13,21 +13,21 @@ public class SessionFactoryManagerTest {
     private final SessionFactoryManager manager = new SessionFactoryManager(factory, dataSource);
 
     @Test
-    public void closesTheFactoryOnStopping() throws Exception {
+    void closesTheFactoryOnStopping() throws Exception {
         manager.stop();
 
         verify(factory).close();
     }
 
     @Test
-    public void stopsTheDataSourceOnStopping() throws Exception {
+    void stopsTheDataSourceOnStopping() throws Exception {
         manager.stop();
 
         verify(dataSource).stop();
     }
 
     @Test
-    public void startsTheDataSourceOnStarting() throws Exception {
+    void startsTheDataSourceOnStarting() throws Exception {
         manager.start();
 
         verify(dataSource).start();

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkApplicationListenerTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkApplicationListenerTest.java
@@ -46,7 +46,7 @@ public class UnitOfWorkApplicationListenerTest {
     private final Transaction analyticsTransaction = mock(Transaction.class);
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         listener.registerSessionFactory(HibernateBundle.DEFAULT_NAME, sessionFactory);
         listener.registerSessionFactory("analytics", analyticsSessionFactory);
 
@@ -74,7 +74,7 @@ public class UnitOfWorkApplicationListenerTest {
     }
 
     @Test
-    public void opensAndClosesASession() throws Exception {
+    void opensAndClosesASession() throws Exception {
         execute();
 
         final InOrder inOrder = inOrder(sessionFactory, session);
@@ -83,7 +83,7 @@ public class UnitOfWorkApplicationListenerTest {
     }
 
     @Test
-    public void bindsAndUnbindsTheSessionToTheManagedContext() throws Exception {
+    void bindsAndUnbindsTheSessionToTheManagedContext() throws Exception {
         doAnswer(invocation -> {
             assertThat(ManagedSessionContext.hasBind(sessionFactory))
                 .isTrue();
@@ -96,7 +96,7 @@ public class UnitOfWorkApplicationListenerTest {
     }
 
     @Test
-    public void configuresTheSessionsReadOnlyDefault() throws Exception {
+    void configuresTheSessionsReadOnlyDefault() throws Exception {
         prepareResourceMethod("methodWithReadOnlyAnnotation");
 
         execute();
@@ -105,7 +105,7 @@ public class UnitOfWorkApplicationListenerTest {
     }
 
     @Test
-    public void configuresTheSessionsCacheMode() throws Exception {
+    void configuresTheSessionsCacheMode() throws Exception {
         prepareResourceMethod("methodWithCacheModeIgnoreAnnotation");
 
         execute();
@@ -114,7 +114,7 @@ public class UnitOfWorkApplicationListenerTest {
     }
 
     @Test
-    public void configuresTheSessionsFlushMode() throws Exception {
+    void configuresTheSessionsFlushMode() throws Exception {
         prepareResourceMethod("methodWithFlushModeAlwaysAnnotation");
 
         execute();
@@ -123,7 +123,7 @@ public class UnitOfWorkApplicationListenerTest {
     }
 
     @Test
-    public void doesNotBeginATransactionIfNotTransactional() throws Exception {
+    void doesNotBeginATransactionIfNotTransactional() throws Exception {
         final String resourceMethodName = "methodWithTransactionalFalseAnnotation";
         prepareResourceMethod(resourceMethodName);
 
@@ -136,7 +136,7 @@ public class UnitOfWorkApplicationListenerTest {
     }
 
     @Test
-    public void detectsAnnotationOnHandlingMethod() throws NoSuchMethodException {
+    void detectsAnnotationOnHandlingMethod() throws NoSuchMethodException {
         final String resourceMethodName = "handlingMethodAnnotated";
         prepareResourceMethod(resourceMethodName);
 
@@ -146,7 +146,7 @@ public class UnitOfWorkApplicationListenerTest {
     }
 
     @Test
-    public void detectsAnnotationOnDefinitionMethod() throws NoSuchMethodException {
+    void detectsAnnotationOnDefinitionMethod() throws NoSuchMethodException {
         final String resourceMethodName = "definitionMethodAnnotated";
         prepareResourceMethod(resourceMethodName);
 
@@ -156,7 +156,7 @@ public class UnitOfWorkApplicationListenerTest {
     }
 
     @Test
-    public void annotationOnDefinitionMethodOverridesHandlingMethod() throws NoSuchMethodException {
+    void annotationOnDefinitionMethodOverridesHandlingMethod() throws NoSuchMethodException {
         final String resourceMethodName = "bothMethodsAnnotated";
         prepareResourceMethod(resourceMethodName);
 
@@ -166,7 +166,7 @@ public class UnitOfWorkApplicationListenerTest {
     }
 
     @Test
-    public void beginsAndCommitsATransactionIfTransactional() throws Exception {
+    void beginsAndCommitsATransactionIfTransactional() throws Exception {
         execute();
 
         final InOrder inOrder = inOrder(session, transaction);
@@ -176,7 +176,7 @@ public class UnitOfWorkApplicationListenerTest {
     }
 
     @Test
-    public void rollsBackTheTransactionOnException() throws Exception {
+    void rollsBackTheTransactionOnException() throws Exception {
         executeWithException();
 
         final InOrder inOrder = inOrder(session, transaction);
@@ -186,7 +186,7 @@ public class UnitOfWorkApplicationListenerTest {
     }
 
     @Test
-    public void doesNotCommitAnInactiveTransaction() throws Exception {
+    void doesNotCommitAnInactiveTransaction() throws Exception {
         when(transaction.getStatus()).thenReturn(NOT_ACTIVE);
 
         execute();
@@ -195,7 +195,7 @@ public class UnitOfWorkApplicationListenerTest {
     }
 
     @Test
-    public void doesNotCommitANullTransaction() throws Exception {
+    void doesNotCommitANullTransaction() throws Exception {
         when(session.getTransaction()).thenReturn(null);
 
         execute();
@@ -204,7 +204,7 @@ public class UnitOfWorkApplicationListenerTest {
     }
 
     @Test
-    public void doesNotRollbackAnInactiveTransaction() throws Exception {
+    void doesNotRollbackAnInactiveTransaction() throws Exception {
         when(transaction.getStatus()).thenReturn(NOT_ACTIVE);
 
         executeWithException();
@@ -213,7 +213,7 @@ public class UnitOfWorkApplicationListenerTest {
     }
 
     @Test
-    public void doesNotRollbackANullTransaction() throws Exception {
+    void doesNotRollbackANullTransaction() throws Exception {
         when(session.getTransaction()).thenReturn(null);
 
         executeWithException();
@@ -222,7 +222,7 @@ public class UnitOfWorkApplicationListenerTest {
     }
 
     @Test
-    public void beginsAndCommitsATransactionForAnalytics() throws Exception {
+    void beginsAndCommitsATransactionForAnalytics() throws Exception {
         prepareResourceMethod("methodWithUnitOfWorkOnAnalyticsDatabase");
         execute();
 
@@ -233,7 +233,7 @@ public class UnitOfWorkApplicationListenerTest {
     }
 
     @Test
-    public void throwsExceptionOnNotRegisteredDatabase() throws Exception {
+    void throwsExceptionOnNotRegisteredDatabase() throws Exception {
         prepareResourceMethod("methodWithUnitOfWorkOnNotRegisteredDatabase");
         assertThatExceptionOfType(IllegalArgumentException.class)
             .isThrownBy(this::execute)

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
@@ -31,7 +31,7 @@ public class UnitOfWorkAwareProxyFactoryTest {
     private SessionFactory sessionFactory;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         final HibernateBundle<?> bundle = mock(HibernateBundle.class);
         final Environment environment = mock(Environment.class);
         when(environment.lifecycle()).thenReturn(mock(LifecycleEnvironment.class));
@@ -59,7 +59,7 @@ public class UnitOfWorkAwareProxyFactoryTest {
     }
 
     @Test
-    public void testProxyWorks() throws Exception {
+    void testProxyWorks() throws Exception {
         final SessionDao sessionDao = new SessionDao(sessionFactory);
         final UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory =
                 new UnitOfWorkAwareProxyFactory("default", sessionFactory);
@@ -71,7 +71,7 @@ public class UnitOfWorkAwareProxyFactoryTest {
     }
 
     @Test
-    public void testProxyWorksWithoutUnitOfWork() {
+    void testProxyWorksWithoutUnitOfWork() {
         assertThat(new UnitOfWorkAwareProxyFactory("default", sessionFactory)
                 .create(PlainAuthenticator.class)
                 .authenticate("c82d11e"))
@@ -79,7 +79,7 @@ public class UnitOfWorkAwareProxyFactoryTest {
     }
 
     @Test
-    public void testProxyHandlesErrors() {
+    void testProxyHandlesErrors() {
         assertThatExceptionOfType(IllegalStateException.class).isThrownBy(()->
             new UnitOfWorkAwareProxyFactory("default", sessionFactory)
                 .create(BrokenAuthenticator.class)
@@ -88,7 +88,7 @@ public class UnitOfWorkAwareProxyFactoryTest {
     }
 
     @Test
-    public void testNewAspect() {
+    void testNewAspect() {
         final UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory =
                 new UnitOfWorkAwareProxyFactory("default", sessionFactory);
 
@@ -99,7 +99,7 @@ public class UnitOfWorkAwareProxyFactoryTest {
     }
 
     @Test
-    public void testCanBeConfiguredWithACustomAspect() {
+    void testCanBeConfiguredWithACustomAspect() {
         final SessionDao sessionDao = new SessionDao(sessionFactory);
         final UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory =
             new UnitOfWorkAwareProxyFactory("default", sessionFactory) {
@@ -115,7 +115,7 @@ public class UnitOfWorkAwareProxyFactoryTest {
     }
 
     @Test
-    public void testNestedCall() {
+    void testNestedCall() {
         final UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory =
                 new UnitOfWorkAwareProxyFactory("default", sessionFactory);
 
@@ -130,7 +130,7 @@ public class UnitOfWorkAwareProxyFactoryTest {
     }
 
     @Test
-    public void testInvalidNestedCall() {
+    void testInvalidNestedCall() {
         final UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory =
                 new UnitOfWorkAwareProxyFactory("default", sessionFactory);
 

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkTest.java
@@ -18,31 +18,31 @@ public class UnitOfWorkTest {
     private UnitOfWork unitOfWork;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         this.unitOfWork = Example.class.getDeclaredMethod("example")
                                        .getAnnotation(UnitOfWork.class);
     }
 
     @Test
-    public void defaultsToReadWrite() throws Exception {
+    void defaultsToReadWrite() throws Exception {
         assertThat(unitOfWork.readOnly())
                 .isFalse();
     }
 
     @Test
-    public void defaultsToTransactional() throws Exception {
+    void defaultsToTransactional() throws Exception {
         assertThat(unitOfWork.transactional())
                 .isTrue();
     }
 
     @Test
-    public void defaultsToNormalCaching() throws Exception {
+    void defaultsToNormalCaching() throws Exception {
         assertThat(unitOfWork.cacheMode())
                 .isEqualTo(CacheMode.NORMAL);
     }
 
     @Test
-    public void defaultsToAutomaticFlushing() throws Exception {
+    void defaultsToAutomaticFlushing() throws Exception {
         assertThat(unitOfWork.flushMode())
                 .isEqualTo(FlushMode.AUTO);
     }

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2CIntegrationTest.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2CIntegrationTest.java
@@ -43,7 +43,7 @@ public class Http2CIntegrationTest  extends AbstractHttp2Test {
     }
 
     @Test
-    public void testHttp11() {
+    void testHttp11() {
         final String hostname = "127.0.0.1";
         final int port = appRule.getLocalPort();
         final JerseyClient http11Client = new JerseyClientBuilder().build();
@@ -56,12 +56,12 @@ public class Http2CIntegrationTest  extends AbstractHttp2Test {
     }
 
     @Test
-    public void testHttp2c() throws Exception {
+    void testHttp2c() throws Exception {
         assertResponse(client.GET("http://localhost:" + appRule.getLocalPort() + "/api/test"));
     }
 
     @Test
-    public void testHttp2cManyRequests() throws Exception {
+    void testHttp2cManyRequests() throws Exception {
         performManyAsyncRequests(client, "http://localhost:" + appRule.getLocalPort() + "/api/test");
     }
 }

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2ConnectorFactoryTest.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2ConnectorFactoryTest.java
@@ -13,7 +13,7 @@ public class Http2ConnectorFactoryTest {
     private Http2ConnectorFactory http2ConnectorFactory = new Http2ConnectorFactory();
 
     @Test
-    public void testSetDefaultHttp2Cipher() {
+    void testSetDefaultHttp2Cipher() {
         http2ConnectorFactory.checkSupportedCipherSuites();
 
         assertThat(http2ConnectorFactory.getSupportedCipherSuites()).containsExactly(
@@ -21,7 +21,7 @@ public class Http2ConnectorFactoryTest {
     }
 
     @Test
-    public void testCustomCiphersAreSupported() {
+    void testCustomCiphersAreSupported() {
         http2ConnectorFactory.setSupportedCipherSuites(Arrays.asList("TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
                 "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"));
 
@@ -32,7 +32,7 @@ public class Http2ConnectorFactoryTest {
     }
 
     @Test
-    public void testThrowExceptionIfDefaultCipherIsNotSet() {
+    void testThrowExceptionIfDefaultCipherIsNotSet() {
         http2ConnectorFactory.setSupportedCipherSuites(Collections.singletonList("TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"));
 
         assertThatIllegalArgumentException().isThrownBy(() -> http2ConnectorFactory.checkSupportedCipherSuites())

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2IntegrationTest.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2IntegrationTest.java
@@ -32,7 +32,7 @@ public class Http2IntegrationTest extends AbstractHttp2Test {
     );
 
     @Test
-    public void testHttp11() throws Exception {
+    void testHttp11() throws Exception {
         final String hostname = "localhost";
         final int port = appRule.getLocalPort();
         final JerseyClient http11Client = new JerseyClientBuilder()
@@ -47,12 +47,12 @@ public class Http2IntegrationTest extends AbstractHttp2Test {
     }
 
     @Test
-    public void testHttp2() throws Exception {
+    void testHttp2() throws Exception {
         assertResponse(client.GET("https://localhost:" + appRule.getLocalPort() + "/api/test"));
     }
 
     @Test
-    public void testHttp2ManyRequests() throws Exception {
+    void testHttp2ManyRequests() throws Exception {
         performManyAsyncRequests(client, "https://localhost:" + appRule.getLocalPort() + "/api/test");
     }
 }

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2WithCustomCipherTest.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2WithCustomCipherTest.java
@@ -26,7 +26,7 @@ public class Http2WithCustomCipherTest extends AbstractHttp2Test {
     );
 
     @Test
-    public void testHttp2WithCustomCipher() throws Exception {
+    void testHttp2WithCustomCipher() throws Exception {
         assertResponse(client.GET("https://localhost:" + appRule.getLocalPort() + "/api/test"));
     }
 

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/CaffeineModuleTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/CaffeineModuleTest.java
@@ -10,13 +10,13 @@ public class CaffeineModuleTest {
     private final ObjectMapper mapper = new ObjectMapper().registerModule(new CaffeineModule());
 
     @Test
-    public void canDeserializeCacheBuilderSpecs() throws Exception {
+    void canDeserializeCacheBuilderSpecs() throws Exception {
         assertThat(mapper.readValue("\"maximumSize=30\"", CaffeineSpec.class))
                 .isEqualTo(CaffeineSpec.parse("maximumSize=30"));
     }
 
     @Test
-    public void canSerializeCacheBuilderSpecs() throws Exception {
+    void canSerializeCacheBuilderSpecs() throws Exception {
         assertThat(mapper.writeValueAsString(CaffeineSpec.parse("maximumSize=0"))).isEqualTo("\"maximumSize=0\"");
     }
 }

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/DiscoverableSubtypeResolverTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/DiscoverableSubtypeResolverTest.java
@@ -11,12 +11,12 @@ public class DiscoverableSubtypeResolverTest {
     private final DiscoverableSubtypeResolver resolver = new DiscoverableSubtypeResolver(ExampleTag.class);
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         mapper.setSubtypeResolver(resolver);
     }
 
     @Test
-    public void discoversSubtypes() throws Exception {
+    void discoversSubtypes() throws Exception {
         assertThat(mapper.readValue("{\"type\":\"a\"}", ExampleSPI.class))
                 .isInstanceOf(ImplA.class);
 

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/FuzzyEnumModuleTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/FuzzyEnumModuleTest.java
@@ -73,54 +73,54 @@ public class FuzzyEnumModuleTest {
     }
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         mapper.registerModule(new FuzzyEnumModule());
     }
 
     @Test
-    public void mapsUpperCaseEnums() throws Exception {
+    void mapsUpperCaseEnums() throws Exception {
         assertThat(mapper.readValue("\"SECONDS\"", TimeUnit.class))
                 .isEqualTo(TimeUnit.SECONDS);
     }
 
     @Test
-    public void mapsLowerCaseEnums() throws Exception {
+    void mapsLowerCaseEnums() throws Exception {
         assertThat(mapper.readValue("\"milliseconds\"", TimeUnit.class))
                 .isEqualTo(TimeUnit.MILLISECONDS);
     }
 
     @Test
-    public void mapsPaddedEnums() throws Exception {
+    void mapsPaddedEnums() throws Exception {
         assertThat(mapper.readValue("\"   MINUTES \"", TimeUnit.class))
                 .isEqualTo(TimeUnit.MINUTES);
     }
 
     @Test
-    public void mapsSpacedEnums() throws Exception {
+    void mapsSpacedEnums() throws Exception {
         assertThat(mapper.readValue("\"   MILLI SECONDS \"", TimeUnit.class))
                 .isEqualTo(TimeUnit.MILLISECONDS);
     }
 
     @Test
-    public void mapsDashedEnums() throws Exception {
+    void mapsDashedEnums() throws Exception {
         assertThat(mapper.readValue("\"REASON-UNKNOWN\"", ClientInfoStatus.class))
                 .isEqualTo(ClientInfoStatus.REASON_UNKNOWN);
     }
 
     @Test
-    public void mapsDottedEnums() throws Exception {
+    void mapsDottedEnums() throws Exception {
         assertThat(mapper.readValue("\"REASON.UNKNOWN\"", ClientInfoStatus.class))
                 .isEqualTo(ClientInfoStatus.REASON_UNKNOWN);
     }
 
     @Test
-    public void mapsWhenEnumHasCreator() throws Exception {
+    void mapsWhenEnumHasCreator() throws Exception {
         assertThat(mapper.readValue("\"BLA\"", EnumWithCreator.class))
                 .isEqualTo(EnumWithCreator.TEST);
     }
 
     @Test
-    public void failsOnIncorrectValue() {
+    void failsOnIncorrectValue() {
         assertThatExceptionOfType(JsonMappingException.class)
             .isThrownBy(() -> mapper.readValue("\"wrong\"", TimeUnit.class))
             .satisfies(e -> assertThat(e.getOriginalMessage())
@@ -129,40 +129,40 @@ public class FuzzyEnumModuleTest {
     }
 
     @Test
-    public void mapsToLowerCaseEnums() throws Exception {
+    void mapsToLowerCaseEnums() throws Exception {
         assertThat(mapper.readValue("\"lower_case_enum\"", EnumWithLowercase.class))
                 .isEqualTo(EnumWithLowercase.lower_case_enum);
     }
 
     @Test
-    public void mapsMixedCaseEnums() throws Exception {
+    void mapsMixedCaseEnums() throws Exception {
         assertThat(mapper.readValue("\"mixedCaseEnum\"", EnumWithLowercase.class))
                 .isEqualTo(EnumWithLowercase.mixedCaseEnum);
     }
 
     @Test
-    public void readsEnumsUsingToString() throws Exception {
+    void readsEnumsUsingToString() throws Exception {
         final ObjectMapper toStringEnumsMapper = mapper.copy()
                 .configure(DeserializationFeature.READ_ENUMS_USING_TO_STRING, true);
         assertThat(toStringEnumsMapper.readValue("\"Pound sterling\"", CurrencyCode.class)).isEqualTo(CurrencyCode.GBP);
     }
 
     @Test
-    public void readsUnknownEnumValuesAsNull() throws Exception {
+    void readsUnknownEnumValuesAsNull() throws Exception {
         final ObjectMapper toStringEnumsMapper = mapper.copy()
             .configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
         assertThat(toStringEnumsMapper.readValue("\"Pound sterling\"", CurrencyCode.class)).isNull();
     }
 
     @Test
-    public void readsUnknownEnumValuesUsingDefaultValue() throws Exception {
+    void readsUnknownEnumValuesUsingDefaultValue() throws Exception {
         final ObjectMapper toStringEnumsMapper = mapper.copy()
             .configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE, true);
         assertThat(toStringEnumsMapper.readValue("\"Pound sterling\"", EnumWithPropertyAnno.class)).isEqualTo(EnumWithPropertyAnno.DEFAULT);
     }
 
     @Test
-    public void readsEnumsUsingToStringWithDeserializationFeatureOff() throws Exception {
+    void readsEnumsUsingToStringWithDeserializationFeatureOff() throws Exception {
         assertThat(mapper.readValue("\"Pound sterling\"", CurrencyCode.class)).isEqualTo(CurrencyCode.GBP);
         assertThat(mapper.readValue("\"a_u_d\"", CurrencyCode.class)).isEqualTo(CurrencyCode.AUD);
         assertThat(mapper.readValue("\"c-a-d\"", CurrencyCode.class)).isEqualTo(CurrencyCode.CAD);
@@ -170,7 +170,7 @@ public class FuzzyEnumModuleTest {
     }
 
     @Test
-    public void testEnumWithJsonPropertyRename() throws Exception {
+    void testEnumWithJsonPropertyRename() throws Exception {
         final String json = mapper.writeValueAsString(new EnumWithPropertyAnno[] {
             EnumWithPropertyAnno.B, EnumWithPropertyAnno.A, EnumWithPropertyAnno.FORGOT_PASSWORD
         });

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/GuavaExtrasModuleTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/GuavaExtrasModuleTest.java
@@ -14,37 +14,37 @@ public class GuavaExtrasModuleTest {
     private final ObjectMapper mapper = new ObjectMapper();
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         mapper.registerModule(new GuavaModule());
         mapper.registerModule(new GuavaExtrasModule());
     }
 
     @Test
-    public void canDeserializeAHostAndPort() throws Exception {
+    void canDeserializeAHostAndPort() throws Exception {
         assertThat(mapper.readValue("\"example.com:8080\"", HostAndPort.class))
                 .isEqualTo(HostAndPort.fromParts("example.com", 8080));
     }
 
     @Test
-    public void canDeserializeCacheBuilderSpecs() throws Exception {
+    void canDeserializeCacheBuilderSpecs() throws Exception {
         assertThat(mapper.readValue("\"maximumSize=30\"", CacheBuilderSpec.class))
                 .isEqualTo(CacheBuilderSpec.parse("maximumSize=30"));
     }
 
     @Test
-    public void canSerializeCacheBuilderSpecs() throws Exception {
+    void canSerializeCacheBuilderSpecs() throws Exception {
         assertThat(mapper.writeValueAsString(CacheBuilderSpec.disableCaching()))
             .isEqualTo("\"maximumSize=0\"");
     }
 
     @Test
-    public void canDeserializeAbsentOptions() throws Exception {
+    void canDeserializeAbsentOptions() throws Exception {
         assertThat(mapper.readValue("null", Optional.class))
                 .isEqualTo(Optional.absent());
     }
 
     @Test
-    public void canDeserializePresentOptions() throws Exception {
+    void canDeserializePresentOptions() throws Exception {
         assertThat(mapper.readValue("\"woo\"", Optional.class))
                 .isEqualTo(Optional.of("woo"));
     }

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonDeserializationOfBigNumbersToDurationTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonDeserializationOfBigNumbersToDurationTest.java
@@ -18,55 +18,55 @@ public class JacksonDeserializationOfBigNumbersToDurationTest {
     private final ObjectMapper objectMapper = Jackson.newObjectMapper();
 
     @Test
-    public void testDoesNotAttemptToDeserializeExtremelyBigNumbers() throws Exception {
+    void testDoesNotAttemptToDeserializeExtremelyBigNumbers() throws Exception {
         Task task = objectMapper.readValue("{\"id\": 42, \"duration\": 1e1000000000}", Task.class);
         assertTimeout(Duration.ofSeconds(5L), () -> assertThat(task.getDuration()).isEqualTo(Duration.ofSeconds(0)));
     }
 
     @Test
-    public void testCanDeserializeZero() throws Exception {
+    void testCanDeserializeZero() throws Exception {
         Task task = objectMapper.readValue("{\"id\": 42, \"duration\": 0}", Task.class);
         assertThat(task.getDuration()).isEqualTo(Duration.ofSeconds(0));
     }
 
     @Test
-    public void testCanDeserializeNormalTimestamp() throws Exception {
+    void testCanDeserializeNormalTimestamp() throws Exception {
         Task task = objectMapper.readValue("{\"id\": 42, \"duration\": 30}", Task.class);
         assertThat(task.getDuration()).isEqualTo(Duration.ofSeconds(30));
     }
 
     @Test
-    public void testCanDeserializeNormalTimestampWithNanoseconds() throws Exception {
+    void testCanDeserializeNormalTimestampWithNanoseconds() throws Exception {
         Task task = objectMapper.readValue("{\"id\": 42, \"duration\": 30.314400507}", Task.class);
         assertThat(task.getDuration()).isEqualTo(Duration.ofSeconds(30, 314400507L));
     }
 
     @Test
-    public void testCanDeserializeFromString() throws Exception {
+    void testCanDeserializeFromString() throws Exception {
         Task task = objectMapper.readValue("{\"id\": 42, \"duration\": \"PT30S\"}", Task.class);
         assertThat(task.getDuration()).isEqualTo(Duration.ofSeconds(30));
     }
 
     @Test
-    public void testCanDeserializeMinDuration() throws Exception {
+    void testCanDeserializeMinDuration() throws Exception {
         Task task = objectMapper.readValue("{\"id\": 42, \"duration\": -9223372036854775808}", Task.class);
         assertThat(task.getDuration()).isEqualTo(Duration.ofSeconds(Long.MIN_VALUE));
     }
 
     @Test
-    public void testCanDeserializeMaxDuration() throws Exception {
+    void testCanDeserializeMaxDuration() throws Exception {
         Task task = objectMapper.readValue("{\"id\": 42, \"duration\": 9223372036854775807}", Task.class);
         assertThat(task.getDuration()).isEqualTo(Duration.ofSeconds(Long.MAX_VALUE));
     }
 
     @Test
-    public void testCanNotDeserializeValueMoreThanMaxDuration() {
+    void testCanNotDeserializeValueMoreThanMaxDuration() {
         assertThatExceptionOfType(JsonMappingException.class).isThrownBy(
             () -> objectMapper.readValue("{\"id\": 42, \"duration\": 9223372036854775808}", Task.class));
     }
 
     @Test
-    public void testCanNotDeserializeValueLessThanMinDuration() {
+    void testCanNotDeserializeValueLessThanMinDuration() {
         assertThatExceptionOfType(JsonMappingException.class).isThrownBy(
             () -> objectMapper.readValue("{\"id\": 42, \"duration\": -9223372036854775809}", Task.class));
     }

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonDeserializationOfBigNumbersToInstantTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonDeserializationOfBigNumbersToInstantTest.java
@@ -18,49 +18,49 @@ public class JacksonDeserializationOfBigNumbersToInstantTest {
     private final ObjectMapper objectMapper = Jackson.newObjectMapper();
 
     @Test
-    public void testDoesNotAttemptToDeserializeExtremelBigNumbers() throws Exception {
+    void testDoesNotAttemptToDeserializeExtremelBigNumbers() throws Exception {
         Event event = objectMapper.readValue("{\"id\": 42, \"createdAt\": 1e1000000000}", Event.class);
         assertTimeout(Duration.ofSeconds(5L), () -> assertThat(event.getCreatedAt()).isEqualTo(Instant.ofEpochMilli(0)));
     }
 
     @Test
-    public void testCanDeserializeZero() throws Exception {
+    void testCanDeserializeZero() throws Exception {
         Event event = objectMapper.readValue("{\"id\": 42, \"createdAt\": 0}", Event.class);
         assertThat(event.getCreatedAt()).isEqualTo(Instant.ofEpochMilli(0));
     }
 
     @Test
-    public void testCanDeserializeNormalTimestamp() throws Exception {
+    void testCanDeserializeNormalTimestamp() throws Exception {
         Event event = objectMapper.readValue("{\"id\": 42, \"createdAt\": 1538326357}", Event.class);
         assertThat(event.getCreatedAt()).isEqualTo(Instant.ofEpochMilli(1538326357000L));
     }
 
     @Test
-    public void testCanDeserializeNormalTimestampWithNanoseconds() throws Exception {
+    void testCanDeserializeNormalTimestampWithNanoseconds() throws Exception {
         Event event = objectMapper.readValue("{\"id\": 42, \"createdAt\": 1538326357.298509112}", Event.class);
         assertThat(event.getCreatedAt()).isEqualTo(Instant.ofEpochSecond(1538326357, 298509112L));
     }
 
     @Test
-    public void testCanDeserializeMinInstant() throws Exception {
+    void testCanDeserializeMinInstant() throws Exception {
         Event event = objectMapper.readValue("{\"id\": 42, \"createdAt\": -31557014167219200}", Event.class);
         assertThat(event.getCreatedAt()).isEqualTo(Instant.MIN);
     }
 
     @Test
-    public void testCanDeserializeMaxInstant() throws Exception {
+    void testCanDeserializeMaxInstant() throws Exception {
         Event event = objectMapper.readValue("{\"id\": 42, \"createdAt\": 31556889864403199.999999999}", Event.class);
         assertThat(event.getCreatedAt()).isEqualTo(Instant.MAX);
     }
 
     @Test
-    public void testCanNotDeserializeValueMoreThanMaxInstant() {
+    void testCanNotDeserializeValueMoreThanMaxInstant() {
         assertThatExceptionOfType(JsonMappingException.class).isThrownBy(
             () -> objectMapper.readValue("{\"id\": 42, \"createdAt\": 31556889864403200}", Event.class));
     }
 
     @Test
-    public void testCanNotDeserializeValueLessThanMaxInstant() {
+    void testCanNotDeserializeValueLessThanMaxInstant() {
         assertThatExceptionOfType(JsonMappingException.class).isThrownBy(
             () -> objectMapper.readValue("{\"id\": 42, \"createdAt\": -31557014167219201}", Event.class));
     }

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonTest.java
@@ -15,7 +15,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 
 public class JacksonTest {
     @Test
-    public void objectMapperUsesGivenCustomJsonFactory() {
+    void objectMapperUsesGivenCustomJsonFactory() {
         JsonFactory factory = Mockito.mock(JsonFactory.class);
 
         ObjectMapper mapper = Jackson.newObjectMapper(factory);
@@ -24,14 +24,14 @@ public class JacksonTest {
     }
 
     @Test
-    public void objectMapperCanHandleNullInsteadOfCustomJsonFactory() {
+    void objectMapperCanHandleNullInsteadOfCustomJsonFactory() {
         ObjectMapper mapper = Jackson.newObjectMapper(null);
 
         assertThat(mapper.getFactory()).isNotNull();
     }
 
     @Test
-    public void objectMapperCanDeserializeJdk7Types() throws IOException {
+    void objectMapperCanDeserializeJdk7Types() throws IOException {
         final LogMetadata metadata = Jackson.newObjectMapper()
             .readValue("{\"path\": \"/var/log/app/server.log\"}", LogMetadata.class);
         assertThat(metadata).isNotNull();
@@ -39,7 +39,7 @@ public class JacksonTest {
     }
 
     @Test
-    public void objectMapperSerializesNullValues() throws IOException {
+    void objectMapperSerializesNullValues() throws IOException {
         final ObjectMapper mapper = Jackson.newObjectMapper();
         final Issue1627 pojo = new Issue1627(null, null);
         final String json = "{\"string\":null,\"uuid\":null}";
@@ -48,7 +48,7 @@ public class JacksonTest {
     }
 
     @Test
-    public void objectMapperIgnoresUnknownProperties() {
+    void objectMapperIgnoresUnknownProperties() {
         assertThatCode(() ->
             Jackson.newObjectMapper()
                 .readValue("{\"unknown\": 4711, \"path\": \"/var/log/app/server.log\"}", LogMetadata.class)

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/ParanamerModuleTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/ParanamerModuleTest.java
@@ -15,12 +15,12 @@ public class ParanamerModuleTest {
     private final ObjectMapper mapper = new ObjectMapper();
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         mapper.registerModule(new ParameterNamesModule());
     }
 
     @Test
-    public void deserializePersonWithoutAnnotations() throws IOException {
+    void deserializePersonWithoutAnnotations() throws IOException {
         final ObjectReader reader = mapper.readerFor(Person.class);
         final Person person = reader.readValue("{ \"name\": \"Foo\", \"surname\": \"Bar\" }");
         assertThat(person.getName()).isEqualTo("Foo");
@@ -28,7 +28,7 @@ public class ParanamerModuleTest {
     }
 
     @Test
-    public void serializePersonWithoutAnnotations() throws IOException {
+    void serializePersonWithoutAnnotations() throws IOException {
         final ObjectWriter reader = mapper.writerFor(Person.class);
         final String person = reader.writeValueAsString(new Person("Foo", "Bar"));
         assertThat(person)

--- a/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/JdbiFactoryTest.java
+++ b/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/JdbiFactoryTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.*;
 
 public class JdbiFactoryTest {
     @Test
-    public void testBuild() {
+    void testBuild() {
         final Environment environment = mock(Environment.class);
         final MetricRegistry metrics = mock(MetricRegistry.class);
         final LifecycleEnvironment lifecycle = mock(LifecycleEnvironment.class);

--- a/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/JdbiHealthCheckTest.java
+++ b/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/JdbiHealthCheckTest.java
@@ -34,7 +34,7 @@ public class JdbiHealthCheckTest {
     private ExecutorService executorService;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         jdbi = mock(Jdbi.class);
         handle = mock(Handle.class);
         connection = mock(Connection.class);
@@ -46,12 +46,12 @@ public class JdbiHealthCheckTest {
     }
 
     @AfterEach
-    public void teardown() {
+    void teardown() {
         executorService.shutdown();
     }
 
     @Test
-    public void testNoTimeoutReturnsHealthy() throws Exception {
+    void testNoTimeoutReturnsHealthy() throws Exception {
         when(handle.execute(VALIDATION_QUERY)).thenReturn(0);
 
         HealthCheck.Result result = healthCheck(VALIDATION_QUERY).check();
@@ -60,7 +60,7 @@ public class JdbiHealthCheckTest {
     }
 
     @Test
-    public void tesHealthyAfterWhenMissingValidationQuery() throws Exception {
+    void tesHealthyAfterWhenMissingValidationQuery() throws Exception {
         when(connection.isValid(anyInt())).thenReturn(true);
 
         HealthCheck.Result result = healthCheck().check();
@@ -70,7 +70,7 @@ public class JdbiHealthCheckTest {
     }
 
     @Test
-    public void testItTimesOutProperly() throws Exception {
+    void testItTimesOutProperly() throws Exception {
         when(handle.execute(VALIDATION_QUERY)).thenAnswer((Answer<Integer>) invocation -> {
             TimeUnit.SECONDS.sleep(10);
             return null;
@@ -82,7 +82,7 @@ public class JdbiHealthCheckTest {
     }
 
     @Test
-    public void testUnhealthyWhenMissingValidationQuery() throws Exception {
+    void testUnhealthyWhenMissingValidationQuery() throws Exception {
         HealthCheck.Result result = healthCheck().check();
 
         assertThat(result.isHealthy()).isFalse();

--- a/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/NamePrependingTemplateEngineTest.java
+++ b/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/NamePrependingTemplateEngineTest.java
@@ -25,7 +25,7 @@ public class NamePrependingTemplateEngineTest {
     private NamePrependingTemplateEngine sut;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         original = mock(TemplateEngine.class);
         ctx = mock(StatementContext.class);
         when(original.render(TEMPLATE, ctx)).thenReturn(ORIGINAL_RENDERED);
@@ -34,7 +34,7 @@ public class NamePrependingTemplateEngineTest {
     }
 
     @Test
-    public void testNoExtensionMethodShouldReturnOriginal() {
+    void testNoExtensionMethodShouldReturnOriginal() {
         when(ctx.getExtensionMethod()).thenReturn(null);
 
         final String result = sut.render(TEMPLATE, ctx);
@@ -43,7 +43,7 @@ public class NamePrependingTemplateEngineTest {
     }
 
     @Test
-    public void testPrependsCorrectName() throws NoSuchMethodException {
+    void testPrependsCorrectName() throws NoSuchMethodException {
         final ExtensionMethod extensionMethod = new ExtensionMethod(MyDao.class, MyDao.class.getMethod("myDbCall"));
 
         when(ctx.getExtensionMethod()).thenReturn(extensionMethod);

--- a/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/bundles/JdbiExceptionsBundleTest.java
+++ b/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/bundles/JdbiExceptionsBundleTest.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.when;
 public class JdbiExceptionsBundleTest {
 
     @Test
-    public void test() {
+    void test() {
         Environment environment = mock(Environment.class);
         JerseyEnvironment jerseyEnvironment = mock(JerseyEnvironment.class);
         when(environment.jersey()).thenReturn(jerseyEnvironment);

--- a/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/jersey/LoggingJdbiExceptionMapperTest.java
+++ b/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/jersey/LoggingJdbiExceptionMapperTest.java
@@ -19,13 +19,13 @@ public class LoggingJdbiExceptionMapperTest {
     private Logger logger;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         logger = mock(Logger.class);
         jdbiExceptionMapper = new LoggingJdbiExceptionMapper(logger);
     }
 
     @Test
-    public void testSqlExceptionIsCause() throws Exception {
+    void testSqlExceptionIsCause() throws Exception {
         StatementContext statementContext = mock(StatementContext.class);
         RuntimeException runtimeException = new RuntimeException("DB is down");
         SQLException sqlException = new SQLException("DB error", runtimeException);
@@ -39,7 +39,7 @@ public class LoggingJdbiExceptionMapperTest {
     }
 
     @Test
-    public void testPlainJdbiException() throws Exception {
+    void testPlainJdbiException() throws Exception {
         JdbiException jdbiException = new TransactionException("Transaction failed for unknown reason");
 
         jdbiExceptionMapper.logException(9812, jdbiException);

--- a/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/jersey/LoggingSQLExceptionMapperTest.java
+++ b/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/jersey/LoggingSQLExceptionMapperTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.verify;
 
 public class LoggingSQLExceptionMapperTest {
     @Test
-    public void testLogException() throws Exception {
+    void testLogException() throws Exception {
         Logger logger = mock(Logger.class);
         LoggingSQLExceptionMapper sqlExceptionMapper = new LoggingSQLExceptionMapper(logger);
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/AsyncServletTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/AsyncServletTest.java
@@ -18,7 +18,7 @@ public class AsyncServletTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void testAsyncResponse() {
+    void testAsyncResponse() {
         final Response response = target("/async").request(MediaType.TEXT_PLAIN_TYPE).get();
 
         assertThat(response.getStatus()).isEqualTo(200);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/JerseyContentTypeTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/JerseyContentTypeTest.java
@@ -18,7 +18,7 @@ public class JerseyContentTypeTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void testValidContentType() {
+    void testValidContentType() {
         final Response response = target("/").request(MediaType.TEXT_PLAIN_TYPE).get();
 
         assertThat(response.getStatus()).isEqualTo(200);
@@ -26,7 +26,7 @@ public class JerseyContentTypeTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void testInvalidContentType() {
+    void testInvalidContentType() {
         final Response response = target("/").request("foo").get();
 
         assertThat(response.getStatus()).isEqualTo(406);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/ProvidersBinderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/ProvidersBinderTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ProvidersBinderTest {
 
     @Test
-    public void demonstrateThatHk2BinderIsNotPickedUpAsProvider() {
+    void demonstrateThatHk2BinderIsNotPickedUpAsProvider() {
         org.glassfish.hk2.utilities.Binder binder = new org.glassfish.hk2.utilities.binding.AbstractBinder() {
             @Override
             protected void configure() {
@@ -23,7 +23,7 @@ public class ProvidersBinderTest {
     }
 
     @Test
-    public void demonstrateThatJerseyBinderIsPickedUpAsProvider() {
+    void demonstrateThatJerseyBinderIsPickedUpAsProvider() {
         org.glassfish.jersey.internal.inject.Binder binder = new org.glassfish.jersey.internal.inject.AbstractBinder() {
             @Override
             protected void configure() {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/caching/CacheControlledResponseFeatureTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/caching/CacheControlledResponseFeatureTest.java
@@ -21,7 +21,7 @@ public class CacheControlledResponseFeatureTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void immutableResponsesHaveCacheControlHeaders() throws Exception {
+    void immutableResponsesHaveCacheControlHeaders() throws Exception {
         final Response response = target("/caching/immutable").request().get();
 
         assertThat(response.getHeaders().get(HttpHeaders.CACHE_CONTROL))
@@ -29,7 +29,7 @@ public class CacheControlledResponseFeatureTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void privateResponsesHaveCacheControlHeaders() throws Exception {
+    void privateResponsesHaveCacheControlHeaders() throws Exception {
         final Response response = target("/caching/private").request().get();
 
         assertThat(response.getHeaders().get(HttpHeaders.CACHE_CONTROL))
@@ -37,7 +37,7 @@ public class CacheControlledResponseFeatureTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void maxAgeResponsesHaveCacheControlHeaders() throws Exception {
+    void maxAgeResponsesHaveCacheControlHeaders() throws Exception {
         final Response response = target("/caching/max-age").request().get();
 
         assertThat(response.getHeaders().get(HttpHeaders.CACHE_CONTROL))
@@ -45,7 +45,7 @@ public class CacheControlledResponseFeatureTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void noCacheResponsesHaveCacheControlHeaders() throws Exception {
+    void noCacheResponsesHaveCacheControlHeaders() throws Exception {
         final Response response = target("/caching/no-cache").request().get();
 
         assertThat(response.getHeaders().get(HttpHeaders.CACHE_CONTROL))
@@ -53,7 +53,7 @@ public class CacheControlledResponseFeatureTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void noStoreResponsesHaveCacheControlHeaders() throws Exception {
+    void noStoreResponsesHaveCacheControlHeaders() throws Exception {
         final Response response = target("/caching/no-store").request().get();
 
         assertThat(response.getHeaders().get(HttpHeaders.CACHE_CONTROL))
@@ -61,7 +61,7 @@ public class CacheControlledResponseFeatureTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void noTransformResponsesHaveCacheControlHeaders() throws Exception {
+    void noTransformResponsesHaveCacheControlHeaders() throws Exception {
         final Response response = target("/caching/no-transform").request().get();
 
         assertThat(response.getHeaders().get(HttpHeaders.CACHE_CONTROL))
@@ -69,7 +69,7 @@ public class CacheControlledResponseFeatureTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void mustRevalidateResponsesHaveCacheControlHeaders() throws Exception {
+    void mustRevalidateResponsesHaveCacheControlHeaders() throws Exception {
         final Response response = target("/caching/must-revalidate").request().get();
 
         assertThat(response.getHeaders().get(HttpHeaders.CACHE_CONTROL))
@@ -77,7 +77,7 @@ public class CacheControlledResponseFeatureTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void proxyRevalidateResponsesHaveCacheControlHeaders() throws Exception {
+    void proxyRevalidateResponsesHaveCacheControlHeaders() throws Exception {
         final Response response = target("/caching/proxy-revalidate").request().get();
 
         assertThat(response.getHeaders().get(HttpHeaders.CACHE_CONTROL))
@@ -85,7 +85,7 @@ public class CacheControlledResponseFeatureTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void sharedMaxAgeResponsesHaveCacheControlHeaders() throws Exception {
+    void sharedMaxAgeResponsesHaveCacheControlHeaders() throws Exception {
         final Response response = target("/caching/shared-max-age").request().get();
 
         assertThat(response.getHeaders().get(HttpHeaders.CACHE_CONTROL))

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/EarlyEofExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/EarlyEofExceptionMapperTest.java
@@ -11,7 +11,7 @@ public class EarlyEofExceptionMapperTest {
     private final EarlyEofExceptionMapper mapper = new EarlyEofExceptionMapper();
 
     @Test
-    public void testToReponse() {
+    void testToReponse() {
         final Response reponse = mapper.toResponse(new EofException());
         Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), reponse.getStatus());
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/EofExceptionWriterInterceptorJerseyTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/EofExceptionWriterInterceptorJerseyTest.java
@@ -38,7 +38,7 @@ public class EofExceptionWriterInterceptorJerseyTest extends AbstractJerseyTest 
     }
 
     @Test
-    public void shouldCountZeroEofExceptions() throws IOException {
+    void shouldCountZeroEofExceptions() throws IOException {
         target("/").request().get(InputStream.class).close();
         assertThat(EofExceptionCountingInterceptor.exceptionCount).isEqualByComparingTo(0L);
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/EofExceptionWriterInterceptorTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/EofExceptionWriterInterceptorTest.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.verify;
 public class EofExceptionWriterInterceptorTest {
     @SuppressWarnings("NullAway")
     @Test
-    public void shouldSwallowEofException() throws IOException {
+    void shouldSwallowEofException() throws IOException {
         MetricRegistry metricRegistry = new MetricRegistry();
         EofExceptionWriterInterceptor interceptor = new EofExceptionWriterInterceptor(metricRegistry);
         WriterInterceptorContext context = mock(WriterInterceptorContext.class);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/ErrorEntityWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/ErrorEntityWriterTest.java
@@ -52,7 +52,7 @@ public class ErrorEntityWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void formatsErrorsAsHtml() {
+    void formatsErrorsAsHtml() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> target("/exception/html-exception")
                 .request(MediaType.TEXT_HTML_TYPE)

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/IllegalStateExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/IllegalStateExceptionMapperTest.java
@@ -15,7 +15,7 @@ public class IllegalStateExceptionMapperTest {
     private final IllegalStateExceptionMapper mapper = new IllegalStateExceptionMapper();
 
     @Test
-    public void delegatesToParentClass() {
+    void delegatesToParentClass() {
         @SuppressWarnings("serial")
         final Response reponse = mapper.toResponse(new IllegalStateException(getClass().getName()) {
         });
@@ -23,7 +23,7 @@ public class IllegalStateExceptionMapperTest {
     }
 
     @Test
-    public void handlesFormParamContentTypeError() {
+    void handlesFormParamContentTypeError() {
         final Response reponse = mapper
             .toResponse(new IllegalStateException(LocalizationMessages.FORM_PARAM_CONTENT_TYPE_ERROR()));
         assertThat(reponse.getStatusInfo()).isEqualTo(UNSUPPORTED_MEDIA_TYPE);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/LoggingExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/LoggingExceptionMapperTest.java
@@ -23,7 +23,7 @@ public class LoggingExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void returnsAnErrorMessage() {
+    void returnsAnErrorMessage() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> target("/exception/").request(MediaType.APPLICATION_JSON).get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(500))
@@ -32,7 +32,7 @@ public class LoggingExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void handlesJsonMappingException() {
+    void handlesJsonMappingException() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> target("/exception/json-mapping-exception").request(MediaType.APPLICATION_JSON).get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(500))
@@ -41,7 +41,7 @@ public class LoggingExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void handlesMethodNotAllowedWithHeaders() {
+    void handlesMethodNotAllowedWithHeaders() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> target("/exception/json-mapping-exception")
             .request(MediaType.APPLICATION_JSON)
@@ -53,7 +53,7 @@ public class LoggingExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void formatsWebApplicationException() {
+    void formatsWebApplicationException() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> target("/exception/web-application-exception").request(MediaType.APPLICATION_JSON).get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(400))
@@ -62,7 +62,7 @@ public class LoggingExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void handlesRedirectInWebApplicationException() {
+    void handlesRedirectInWebApplicationException() {
         String responseText = target("/exception/web-application-exception-with-redirect")
             .request(MediaType.APPLICATION_JSON)
             .get(String.class);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/AllowedMethodsFilterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/AllowedMethodsFilterTest.java
@@ -44,7 +44,7 @@ public class AllowedMethodsFilterTest extends AbstractJerseyTest {
     private final AllowedMethodsFilter filter = new AllowedMethodsFilter();
 
     @BeforeEach
-    public void setUpFilter() {
+    void setUpFilter() {
         filter.init(config);
     }
 
@@ -81,32 +81,32 @@ public class AllowedMethodsFilterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void testGetRequestAllowed() {
+    void testGetRequestAllowed() {
         assertEquals(OK_STATUS_CODE, getResponseStatusForRequestMethod("GET", false));
     }
 
     @Test
-    public void testPostRequestAllowed() {
+    void testPostRequestAllowed() {
         assertEquals(OK_STATUS_CODE, getResponseStatusForRequestMethod("POST", true));
     }
 
     @Test
-    public void testPutRequestBlocked() {
+    void testPutRequestBlocked() {
         assertEquals(DISALLOWED_STATUS_CODE, getResponseStatusForRequestMethod("PUT", true));
     }
 
     @Test
-    public void testDeleteRequestBlocked() {
+    void testDeleteRequestBlocked() {
         assertEquals(DISALLOWED_STATUS_CODE, getResponseStatusForRequestMethod("DELETE", false));
     }
 
     @Test
-    public void testTraceRequestBlocked() {
+    void testTraceRequestBlocked() {
         assertEquals(DISALLOWED_STATUS_CODE, getResponseStatusForRequestMethod("TRACE", false));
     }
 
     @Test
-    public void allowsAllowedMethod() throws Exception {
+    void allowsAllowedMethod() throws Exception {
         when(request.getMethod()).thenReturn("GET");
         filter.doFilter(request, response, chain);
 
@@ -114,7 +114,7 @@ public class AllowedMethodsFilterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void blocksDisallowedMethod() throws Exception {
+    void blocksDisallowedMethod() throws Exception {
         when(request.getMethod()).thenReturn("TRACE");
         filter.doFilter(request, response, chain);
 
@@ -122,7 +122,7 @@ public class AllowedMethodsFilterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void disallowedMethodCausesMethodNotAllowedResponse() throws IOException, ServletException {
+    void disallowedMethodCausesMethodNotAllowedResponse() throws IOException, ServletException {
         when(request.getMethod()).thenReturn("TRACE");
         filter.doFilter(request, response, chain);
         verify(response).sendError(eq(DISALLOWED_STATUS_CODE));

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/CharsetUtf8FilterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/CharsetUtf8FilterTest.java
@@ -21,7 +21,7 @@ public class CharsetUtf8FilterTest {
     private CharsetUtf8Filter charsetUtf8Filter = new CharsetUtf8Filter();
 
     @Test
-    public void testSetsCharsetEncoding() throws Exception {
+    void testSetsCharsetEncoding() throws Exception {
         when(response.getMediaType()).thenReturn(MediaType.APPLICATION_JSON_TYPE);
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_TYPE);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/RequestIdFilterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/RequestIdFilterTest.java
@@ -27,7 +27,7 @@ public class RequestIdFilterTest {
     private MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         requestIdFilter.setLogger(logger);
 
         when(request.getMethod()).thenReturn("GET");
@@ -41,7 +41,7 @@ public class RequestIdFilterTest {
     }
 
     @Test
-    public void addsRandomRequestIdHeader() throws Exception {
+    void addsRandomRequestIdHeader() throws Exception {
 
         requestIdFilter.filter(request, response);
 
@@ -53,7 +53,7 @@ public class RequestIdFilterTest {
     }
 
     @Test
-    public void doesNotAddRandomRequestIdHeaderIfItExists() throws Exception {
+    void doesNotAddRandomRequestIdHeaderIfItExists() throws Exception {
         String existedRequestId = "e286b503-aa36-43fe-8312-95ee8773e348";
         headers.add("X-Request-Id", existedRequestId);
         when(request.getHeaderString("X-Request-Id")).thenReturn(existedRequestId);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/RuntimeFilterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/RuntimeFilterTest.java
@@ -20,14 +20,14 @@ public class RuntimeFilterTest {
     private RuntimeFilter runtimeFilter = new RuntimeFilter();
 
     @Test
-    public void testSetsCurrentTimeProperty() throws Exception {
+    void testSetsCurrentTimeProperty() throws Exception {
         runtimeFilter.setCurrentTimeProvider(() -> 1510330745000000L);
         runtimeFilter.filter(request);
         Mockito.verify(request).setProperty("io.dropwizard.jersey.filter.runtime", 1510330745000000L);
     }
 
     @Test
-    public void testAddsXRuntimeHeader() throws Exception {
+    void testAddsXRuntimeHeader() throws Exception {
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         when(response.getHeaders()).thenReturn(headers);
         when(request.getProperty("io.dropwizard.jersey.filter.runtime")).thenReturn(1510330745000000L);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalCookieParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalCookieParamResourceTest.java
@@ -27,55 +27,55 @@ public class OptionalCookieParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldReturnDefaultMessageWhenMessageIsNotPresent() {
+    void shouldReturnDefaultMessageWhenMessageIsNotPresent() {
         String defaultMessage = "Default Message";
         String response = target("/optional/message").request().get(String.class);
         assertThat(response).isEqualTo(defaultMessage);
     }
 
     @Test
-    public void shouldReturnMessageWhenMessageIsBlank() {
+    void shouldReturnMessageWhenMessageIsBlank() {
         String response = target("/optional/message").request().cookie("message", "").get(String.class);
         assertThat(response).isEqualTo("");
     }
 
     @Test
-    public void shouldReturnMessageWhenMessageIsPresent() {
+    void shouldReturnMessageWhenMessageIsPresent() {
         String customMessage = "Custom Message";
         String response = target("/optional/message").request().cookie("message", customMessage).get(String.class);
         assertThat(response).isEqualTo(customMessage);
     }
 
     @Test
-    public void shouldReturnDefaultMessageWhenMyMessageIsNotPresent() {
+    void shouldReturnDefaultMessageWhenMyMessageIsNotPresent() {
         String defaultMessage = "My Default Message";
         String response = target("/optional/my-message").request().get(String.class);
         assertThat(response).isEqualTo(defaultMessage);
     }
 
     @Test
-    public void shouldReturnMyMessageWhenMyMessageIsPresent() {
+    void shouldReturnMyMessageWhenMyMessageIsPresent() {
         String myMessage = "My Message";
         String response = target("/optional/my-message").request().cookie("mymessage", myMessage).get(String.class);
         assertThat(response).isEqualTo(myMessage);
     }
 
     @Test
-    public void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() {
+    void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() {
         String invalidUUID = "invalid-uuid";
         assertThatExceptionOfType(BadRequestException.class).isThrownBy(() ->
             target("/optional/uuid").request().cookie("uuid", invalidUUID).get(String.class));
     }
 
     @Test
-    public void shouldReturnDefaultUUIDWhenUUIDIsNotPresent() {
+    void shouldReturnDefaultUUIDWhenUUIDIsNotPresent() {
         String defaultUUID = "d5672fa8-326b-40f6-bf71-d9dacf44bcdc";
         String response = target("/optional/uuid").request().get(String.class);
         assertThat(response).isEqualTo(defaultUUID);
     }
 
     @Test
-    public void shouldReturnUUIDWhenValidUUIDIsPresent() {
+    void shouldReturnUUIDWhenValidUUIDIsPresent() {
         String uuid = "fd94b00d-bd50-46b3-b42f-905a9c9e7d78";
         String response = target("/optional/uuid").request().cookie("uuid", uuid).get(String.class);
         assertThat(response).isEqualTo(uuid);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalFormParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalFormParamResourceTest.java
@@ -30,7 +30,7 @@ public class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldReturnDefaultMessageWhenMessageIsNotPresent() throws IOException {
+    void shouldReturnDefaultMessageWhenMessageIsNotPresent() throws IOException {
         final String defaultMessage = "Default Message";
         final Response response = target("/optional/message").request().post(Entity.form(new MultivaluedStringMap()));
 
@@ -38,7 +38,7 @@ public class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldReturnMessageWhenMessageBlank() throws IOException {
+    void shouldReturnMessageWhenMessageBlank() throws IOException {
         final Form form = new Form("message", "");
         final Response response = target("/optional/message").request().post(Entity.form(form));
 
@@ -46,7 +46,7 @@ public class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldReturnMessageWhenMessageIsPresent() throws IOException {
+    void shouldReturnMessageWhenMessageIsPresent() throws IOException {
         final String customMessage = "Custom Message";
         final Form form = new Form("message", customMessage);
         final Response response = target("/optional/message").request().post(Entity.form(form));
@@ -55,7 +55,7 @@ public class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldReturnDefaultMessageWhenMyMessageIsNotPresent() throws IOException {
+    void shouldReturnDefaultMessageWhenMyMessageIsNotPresent() throws IOException {
         final String defaultMessage = "My Default Message";
         final Response response = target("/optional/my-message").request().post(Entity.form(new MultivaluedStringMap()));
 
@@ -63,7 +63,7 @@ public class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldReturnMyMessageWhenMyMessageIsPresent() throws IOException {
+    void shouldReturnMyMessageWhenMyMessageIsPresent() throws IOException {
         final String myMessage = "My Message";
         final Form form = new Form("mymessage", myMessage);
         final Response response = target("/optional/my-message").request().post(Entity.form(form));
@@ -72,7 +72,7 @@ public class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() throws IOException {
+    void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() throws IOException {
         final String invalidUUID = "invalid-uuid";
         final Form form = new Form("uuid", invalidUUID);
         final Response response = target("/optional/uuid").request().post(Entity.form(form));
@@ -81,7 +81,7 @@ public class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldReturnDefaultUUIDWhenUUIDIsNotPresent() throws IOException {
+    void shouldReturnDefaultUUIDWhenUUIDIsNotPresent() throws IOException {
         final String defaultUUID = "d5672fa8-326b-40f6-bf71-d9dacf44bcdc";
         final Response response = target("/optional/uuid").request().post(Entity.form(new MultivaluedStringMap()));
 
@@ -89,7 +89,7 @@ public class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldReturnUUIDWhenValidUUIDIsPresent() throws IOException {
+    void shouldReturnUUIDWhenValidUUIDIsPresent() throws IOException {
         final String uuid = "fd94b00d-bd50-46b3-b42f-905a9c9e7d78";
         final Form form = new Form("uuid", uuid);
         final Response response = target("/optional/uuid").request().post(Entity.form(form));

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalHeaderParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalHeaderParamResourceTest.java
@@ -27,55 +27,55 @@ public class OptionalHeaderParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldReturnDefaultMessageWhenMessageIsNotPresent() {
+    void shouldReturnDefaultMessageWhenMessageIsNotPresent() {
         String defaultMessage = "Default Message";
         String response = target("/optional/message").request().get(String.class);
         assertThat(response).isEqualTo(defaultMessage);
     }
 
     @Test
-    public void shouldReturnMessageWhenMessageIsBlank() {
+    void shouldReturnMessageWhenMessageIsBlank() {
         String response = target("/optional/message").request().header("message", "").get(String.class);
         assertThat(response).isEqualTo("");
     }
 
     @Test
-    public void shouldReturnMessageWhenMessageIsPresent() {
+    void shouldReturnMessageWhenMessageIsPresent() {
         String customMessage = "Custom Message";
         String response = target("/optional/message").request().header("message", customMessage).get(String.class);
         assertThat(response).isEqualTo(customMessage);
     }
 
     @Test
-    public void shouldReturnDefaultMessageWhenMyMessageIsNotPresent() {
+    void shouldReturnDefaultMessageWhenMyMessageIsNotPresent() {
         String defaultMessage = "My Default Message";
         String response = target("/optional/my-message").request().get(String.class);
         assertThat(response).isEqualTo(defaultMessage);
     }
 
     @Test
-    public void shouldReturnMyMessageWhenMyMessageIsPresent() {
+    void shouldReturnMyMessageWhenMyMessageIsPresent() {
         String myMessage = "My Message";
         String response = target("/optional/my-message").request().header("mymessage", myMessage).get(String.class);
         assertThat(response).isEqualTo(myMessage);
     }
 
     @Test
-    public void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() {
+    void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() {
         String invalidUUID = "invalid-uuid";
         assertThatExceptionOfType(BadRequestException.class).isThrownBy(() ->
             target("/optional/uuid").request().header("uuid", invalidUUID).get(String.class));
     }
 
     @Test
-    public void shouldReturnDefaultUUIDWhenUUIDIsNotPresent() {
+    void shouldReturnDefaultUUIDWhenUUIDIsNotPresent() {
         String defaultUUID = "d5672fa8-326b-40f6-bf71-d9dacf44bcdc";
         String response = target("/optional/uuid").request().get(String.class);
         assertThat(response).isEqualTo(defaultUUID);
     }
 
     @Test
-    public void shouldReturnUUIDWhenValidUUIDIsPresent() {
+    void shouldReturnUUIDWhenValidUUIDIsPresent() {
         String uuid = "fd94b00d-bd50-46b3-b42f-905a9c9e7d78";
         String response = target("/optional/uuid").request().header("uuid", uuid).get(String.class);
         assertThat(response).isEqualTo(uuid);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalMessageBodyWriterTest.java
@@ -29,7 +29,7 @@ public class OptionalMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void presentOptionalsReturnTheirValue() {
+    void presentOptionalsReturnTheirValue() {
         assertThat(target("/optional-return/")
                 .queryParam("id", "woo").request()
                 .get(String.class))
@@ -37,7 +37,7 @@ public class OptionalMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void absentOptionalsThrowANotFound() {
+    void absentOptionalsThrowANotFound() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> target("/optional-return/").request().get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(404));

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalQueryParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalQueryParamResourceTest.java
@@ -27,27 +27,27 @@ public class OptionalQueryParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldReturnDefaultMessageWhenMessageIsNotPresent() {
+    void shouldReturnDefaultMessageWhenMessageIsNotPresent() {
         String defaultMessage = "Default Message";
         String response = target("/optional/message").request().get(String.class);
         assertThat(response).isEqualTo(defaultMessage);
     }
 
     @Test
-    public void shouldReturnMessageWhenMessageIsPresent() {
+    void shouldReturnMessageWhenMessageIsPresent() {
         String customMessage = "Custom Message";
         String response = target("/optional/message").queryParam("message", customMessage).request().get(String.class);
         assertThat(response).isEqualTo(customMessage);
     }
 
     @Test
-    public void shouldReturnMessageWhenMessageIsBlank() {
+    void shouldReturnMessageWhenMessageIsBlank() {
         String response = target("/optional/message").queryParam("message", "").request().get(String.class);
         assertThat(response).isEqualTo("");
     }
 
     @Test
-    public void shouldReturnDecodedMessageWhenEncodedMessageIsPresent() {
+    void shouldReturnDecodedMessageWhenEncodedMessageIsPresent() {
         String encodedMessage = "Custom%20Message";
         String decodedMessage = "Custom Message";
         String response = target("/optional/message").queryParam("message", encodedMessage).request().get(String.class);
@@ -55,54 +55,54 @@ public class OptionalQueryParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldReturnDefaultMessageWhenMyMessageIsNotPresent() {
+    void shouldReturnDefaultMessageWhenMyMessageIsNotPresent() {
         String defaultMessage = "My Default Message";
         String response = target("/optional/my-message").request().get(String.class);
         assertThat(response).isEqualTo(defaultMessage);
     }
 
     @Test
-    public void shouldReturnMyMessageWhenMyMessageIsPresent() {
+    void shouldReturnMyMessageWhenMyMessageIsPresent() {
         String myMessage = "My Message";
         String response = target("/optional/my-message").queryParam("mymessage", myMessage).request().get(String.class);
         assertThat(response).isEqualTo(myMessage);
     }
 
     @Test
-    public void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() {
+    void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() {
         String invalidUUID = "invalid-uuid";
         assertThatExceptionOfType(BadRequestException.class).isThrownBy(() ->
             target("/optional/uuid").queryParam("uuid", invalidUUID).request().get(String.class));
     }
 
     @Test
-    public void shouldReturnDefaultUUIDWhenUUIDIsNotPresent() {
+    void shouldReturnDefaultUUIDWhenUUIDIsNotPresent() {
         String defaultUUID = "d5672fa8-326b-40f6-bf71-d9dacf44bcdc";
         String response = target("/optional/uuid").request().get(String.class);
         assertThat(response).isEqualTo(defaultUUID);
     }
 
     @Test
-    public void shouldReturnUUIDWhenValidUUIDIsPresent() {
+    void shouldReturnUUIDWhenValidUUIDIsPresent() {
         String uuid = "fd94b00d-bd50-46b3-b42f-905a9c9e7d78";
         String response = target("/optional/uuid").queryParam("uuid", uuid).request().get(String.class);
         assertThat(response).isEqualTo(uuid);
     }
 
     @Test
-    public void shouldReturnDefaultValueWhenValueIsAbsent() {
+    void shouldReturnDefaultValueWhenValueIsAbsent() {
         String response = target("/optional/value").request().get(String.class);
         assertThat(response).isEqualTo("42");
     }
 
     @Test
-    public void shouldReturnDefaultValueWhenEmptyValueIsGiven() {
+    void shouldReturnDefaultValueWhenEmptyValueIsGiven() {
         String response = target("/optional/value").queryParam("value", "").request().get(String.class);
         assertThat(response).isEqualTo("42");
     }
 
     @Test
-    public void shouldReturnValueWhenValueIsPresent() {
+    void shouldReturnValueWhenValueIsPresent() {
         String value = "123456";
         String response = target("/optional/value").queryParam("value", value).request().get(String.class);
         assertThat(response).isEqualTo(value);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/gzip/ConfiguredGZipEncoderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/gzip/ConfiguredGZipEncoderTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 
 public class ConfiguredGZipEncoderTest {
     @Test
-    public void gzipParametersSpec() throws IOException {
+    void gzipParametersSpec() throws IOException {
         ClientRequestContext context = mock(ClientRequestContext.class);
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         when(context.getHeaders()).thenReturn(headers);
@@ -36,7 +36,7 @@ public class ConfiguredGZipEncoderTest {
     }
 
     @Test
-    public void aroundWriteToSpec() throws IOException, WebApplicationException {
+    void aroundWriteToSpec() throws IOException, WebApplicationException {
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         headers.add(HttpHeaders.CONTENT_ENCODING, "gzip");
         WriterInterceptorContextMock context = new WriterInterceptorContextMock(headers);
@@ -45,7 +45,7 @@ public class ConfiguredGZipEncoderTest {
         assertThat(context.isProceedCalled()).isTrue();
     }
     @Test
-    public void aroundWriteToSpecX_GZip() throws IOException, WebApplicationException {
+    void aroundWriteToSpecX_GZip() throws IOException, WebApplicationException {
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         headers.add(HttpHeaders.CONTENT_ENCODING, "x-gzip");
         WriterInterceptorContextMock context = new WriterInterceptorContextMock(headers);
@@ -54,7 +54,7 @@ public class ConfiguredGZipEncoderTest {
         assertThat(context.isProceedCalled()).isTrue();
     }
     @Test
-    public void otherEncodingWillNotAroundWrite() throws IOException, WebApplicationException {
+    void otherEncodingWillNotAroundWrite() throws IOException, WebApplicationException {
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         headers.add(HttpHeaders.CONTENT_ENCODING, "someOtherEnc");
         WriterInterceptorContextMock context = new WriterInterceptorContextMock(headers);
@@ -63,7 +63,7 @@ public class ConfiguredGZipEncoderTest {
         assertThat(context.isProceedCalled()).isTrue();
     }
     @Test
-    public void noEncodingwillNotAroundWrite() throws IOException, WebApplicationException {
+    void noEncodingwillNotAroundWrite() throws IOException, WebApplicationException {
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         headers.add(HttpHeaders.CONTENT_ENCODING, null);
         WriterInterceptorContextMock context = new WriterInterceptorContextMock(headers);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProviderTest.java
@@ -105,54 +105,54 @@ public class JacksonMessageBodyProviderTest {
             new JacksonMessageBodyProvider(mapper);
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         assumeThat(Locale.getDefault().getLanguage()).isEqualTo("en");
     }
 
     @Test
-    public void readsDeserializableTypes() {
+    void readsDeserializableTypes() {
         assertThat(provider.isReadable(Example.class, null, null, null))
                 .isTrue();
     }
 
     @Test
-    public void writesSerializableTypes() {
+    void writesSerializableTypes() {
         assertThat(provider.isWriteable(Example.class, null, null, null))
                 .isTrue();
     }
 
     @Test
-    public void doesNotWriteIgnoredTypes() {
+    void doesNotWriteIgnoredTypes() {
         assertThat(provider.isWriteable(Ignorable.class, null, null, null))
                 .isFalse();
     }
 
     @Test
-    public void writesUnIgnoredTypes() {
+    void writesUnIgnoredTypes() {
         assertThat(provider.isWriteable(NonIgnorable.class, null, null, null))
                 .isTrue();
     }
 
     @Test
-    public void doesNotReadIgnoredTypes() {
+    void doesNotReadIgnoredTypes() {
         assertThat(provider.isReadable(Ignorable.class, null, null, null))
                 .isFalse();
     }
 
     @Test
-    public void readsUnIgnoredTypes() {
+    void readsUnIgnoredTypes() {
         assertThat(provider.isReadable(NonIgnorable.class, null, null, null))
                 .isTrue();
     }
 
     @Test
-    public void isChunked() {
+    void isChunked() {
         assertThat(provider.getSize(null, null, null, null, null))
                 .isEqualTo(-1);
     }
 
     @Test
-    public void deserializesRequestEntities() throws Exception {
+    void deserializesRequestEntities() throws Exception {
         final ByteArrayInputStream entity = new ByteArrayInputStream("{\"id\":1}".getBytes(StandardCharsets.UTF_8));
         final Class<?> klass = Example.class;
 
@@ -171,7 +171,7 @@ public class JacksonMessageBodyProviderTest {
     }
 
     @Test
-    public void returnsPartialValidatedRequestEntities() throws Exception {
+    void returnsPartialValidatedRequestEntities() throws Exception {
         final Validated valid = mock(Validated.class);
         doReturn(Validated.class).when(valid).annotationType();
         when(valid.value()).thenReturn(new Class<?>[]{Partial1.class, Partial2.class});
@@ -194,7 +194,7 @@ public class JacksonMessageBodyProviderTest {
     }
 
     @Test
-    public void returnsPartialValidatedByGroupRequestEntities() throws Exception {
+    void returnsPartialValidatedByGroupRequestEntities() throws Exception {
         final Validated valid = mock(Validated.class);
         doReturn(Validated.class).when(valid).annotationType();
         when(valid.value()).thenReturn(new Class<?>[]{Partial1.class});
@@ -217,7 +217,7 @@ public class JacksonMessageBodyProviderTest {
     }
 
     @Test
-    public void throwsAJsonProcessingExceptionForMalformedRequestEntities() {
+    void throwsAJsonProcessingExceptionForMalformedRequestEntities() {
         final ByteArrayInputStream entity = new ByteArrayInputStream("{\"id\":-1d".getBytes(StandardCharsets.UTF_8));
         final Class<?> klass = Example.class;
 
@@ -233,7 +233,7 @@ public class JacksonMessageBodyProviderTest {
     }
 
     @Test
-    public void serializesResponseEntities() throws Exception {
+    void serializesResponseEntities() throws Exception {
         final ByteArrayOutputStream output = new ByteArrayOutputStream();
 
         final Example example = new Example();
@@ -252,21 +252,21 @@ public class JacksonMessageBodyProviderTest {
     }
 
     @Test
-    public void returnsValidatedCollectionRequestEntities() throws Exception {
+    void returnsValidatedCollectionRequestEntities() throws Exception {
         testValidatedCollectionType(Collection.class,
             new TypeReference<Collection<Example>>() {
             }.getType());
     }
 
     @Test
-    public void returnsValidatedSetRequestEntities() throws Exception {
+    void returnsValidatedSetRequestEntities() throws Exception {
         testValidatedCollectionType(Set.class,
             new TypeReference<Set<Example>>() {
             }.getType());
     }
 
     @Test
-    public void returnsValidatedListRequestEntities() throws Exception {
+    void returnsValidatedListRequestEntities() throws Exception {
         testValidatedCollectionType(List.class,
             new TypeReference<List<Example>>() {
             }.getType());

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapperTest.java
@@ -35,7 +35,7 @@ public class JsonProcessingExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void returnsA500ForNonDeserializableRepresentationClasses() throws Exception {
+    void returnsA500ForNonDeserializableRepresentationClasses() throws Exception {
         Response response = target("/json/broken").request(MediaType.APPLICATION_JSON)
                 .post(Entity.entity(new BrokenRepresentation(Collections.singletonList("whee")), MediaType.APPLICATION_JSON));
         assertThat(response.getStatus()).isEqualTo(500);
@@ -43,7 +43,7 @@ public class JsonProcessingExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void returnsA500ForListNonDeserializableRepresentationClasses() throws Exception {
+    void returnsA500ForListNonDeserializableRepresentationClasses() throws Exception {
         final List<BrokenRepresentation> ent =
                 Arrays.asList(new BrokenRepresentation(Collections.emptyList()),
                 new BrokenRepresentation(Collections.singletonList("whoo")));
@@ -55,14 +55,14 @@ public class JsonProcessingExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void returnsA500ForNonSerializableRepresentationClassesOutbound() throws Exception {
+    void returnsA500ForNonSerializableRepresentationClassesOutbound() throws Exception {
         Response response = target("/json/brokenOutbound").request(MediaType.APPLICATION_JSON).get();
         assertThat(response.getStatus()).isEqualTo(500);
         assertThat(response.getMediaType()).isEqualTo(MediaType.APPLICATION_JSON_TYPE);
     }
 
     @Test
-    public void returnsA500ForAbstractEntity() throws Exception {
+    void returnsA500ForAbstractEntity() throws Exception {
         Response response = target("/json/interface").request(MediaType.APPLICATION_JSON)
             .post(Entity.entity("\"hello\"", MediaType.APPLICATION_JSON));
         assertThat(response.getStatus()).isEqualTo(500);
@@ -70,7 +70,7 @@ public class JsonProcessingExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void returnsA500ForAbstractEntities() throws Exception {
+    void returnsA500ForAbstractEntities() throws Exception {
         Response response = target("/json/interfaceList").request(MediaType.APPLICATION_JSON)
             .post(Entity.entity("[\"hello\"]", MediaType.APPLICATION_JSON));
         assertThat(response.getStatus()).isEqualTo(500);
@@ -78,7 +78,7 @@ public class JsonProcessingExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void returnsA400ForCustomDeserializer() throws Exception {
+    void returnsA400ForCustomDeserializer() throws Exception {
         Response response = target("/json/custom").request(MediaType.APPLICATION_JSON)
             .post(Entity.entity("{}", MediaType.APPLICATION_JSON));
         assertThat(response.getStatus()).isEqualTo(400);
@@ -87,7 +87,7 @@ public class JsonProcessingExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void returnsA500ForCustomDeserializerUnexpected() throws Exception {
+    void returnsA500ForCustomDeserializerUnexpected() throws Exception {
         Response response = target("/json/custom").request(MediaType.APPLICATION_JSON)
             .post(Entity.entity("\"SQL_INECTION\"", MediaType.APPLICATION_JSON));
         assertThat(response.getStatus()).isEqualTo(500);
@@ -96,42 +96,42 @@ public class JsonProcessingExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void returnsA400ForMalformedInputCausingIoException() throws Exception {
+    void returnsA400ForMalformedInputCausingIoException() throws Exception {
         assertEndpointReturns400("url", "\"no-scheme.com\"");
     }
 
     @Test
-    public void returnsA400ForListWrongInputType() throws Exception {
+    void returnsA400ForListWrongInputType() throws Exception {
         assertEndpointReturns400("urlList", "\"no-scheme.com\"");
     }
 
     @Test
-    public void returnsA400ForMalformedListInputCausingIoException() throws Exception {
+    void returnsA400ForMalformedListInputCausingIoException() throws Exception {
         assertEndpointReturns400("urlList", "[\"no-scheme.com\"]");
     }
 
     @Test
-    public void returnsA400ForWrongInputType() throws Exception {
+    void returnsA400ForWrongInputType() throws Exception {
         assertEndpointReturns400("ok", "false");
     }
 
     @Test
-    public void returnsA400ForInvalidFormatRequestEntities() throws Exception {
+    void returnsA400ForInvalidFormatRequestEntities() throws Exception {
         assertEndpointReturns400("ok", "{\"message\": \"a\", \"date\": \"2016-01-01\"}");
     }
 
     @Test
-    public void returnsA400ForInvalidFormatRequestEntitiesWrapped() throws Exception {
+    void returnsA400ForInvalidFormatRequestEntitiesWrapped() throws Exception {
         assertEndpointReturns400("ok", "{\"message\": \"1\", \"date\": \"a\"}");
     }
 
     @Test
-    public void returnsA400ForInvalidFormatRequestEntitiesArray() throws Exception {
+    void returnsA400ForInvalidFormatRequestEntitiesArray() throws Exception {
         assertEndpointReturns400("ok", "{\"message\": \"1\", \"date\": [1,1,1,1]}");
     }
 
     @Test
-    public void returnsA400ForSemanticInvalidDate() throws Exception {
+    void returnsA400ForSemanticInvalidDate() throws Exception {
         assertEndpointReturns400("ok", "{\"message\": \"1\", \"date\": [-1,-1,-1]}");
     }
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/InstantParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/InstantParamTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class InstantParamTest {
     @Test
-    public void parsesInstants() throws Exception {
+    void parsesInstants() throws Exception {
         final InstantParam param = new InstantParam("1488751730055");
 
         assertThat(param.get())

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/InstantSecondParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/InstantSecondParamTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class InstantSecondParamTest {
     @Test
-    public void parsesInstants() throws Exception {
+    void parsesInstants() throws Exception {
         final InstantSecondParam param = new InstantSecondParam("1488752017");
 
         assertThat(param.get())

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/LocalDateParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/LocalDateParamTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class LocalDateParamTest {
     @Test
-    public void parsesDateTimes() throws Exception {
+    void parsesDateTimes() throws Exception {
         final LocalDateParam param = new LocalDateParam("2012-11-19");
 
         assertThat(param.get())

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/LocalDateTimeParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/LocalDateTimeParamTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class LocalDateTimeParamTest {
     @Test
-    public void parsesDateTimes() throws Exception {
+    void parsesDateTimes() throws Exception {
         final LocalDateTimeParam param = new LocalDateTimeParam("2012-11-19T13:37");
 
         assertThat(param.get())

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/LocalTimeParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/LocalTimeParamTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class LocalTimeParamTest {
     @Test
-    public void parsesDateTimes() throws Exception {
+    void parsesDateTimes() throws Exception {
         final LocalTimeParam param = new LocalTimeParam("12:34:56");
 
         assertThat(param.get())

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/OffsetDateTimeParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/OffsetDateTimeParamTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class OffsetDateTimeParamTest {
     @Test
-    public void parsesDateTimes() throws Exception {
+    void parsesDateTimes() throws Exception {
         final OffsetDateTimeParam param = new OffsetDateTimeParam("2012-11-19T13:37+01:00");
 
         assertThat(param.get())

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/YearMonthParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/YearMonthParamTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class YearMonthParamTest {
     @Test
-    public void parsesDateTimes() throws Exception {
+    void parsesDateTimes() throws Exception {
         final YearMonthParam param = new YearMonthParam("2012-11");
 
         assertThat(param.get())

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/YearParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/YearParamTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class YearParamTest {
     @Test
-    public void parsesDateTimes() throws Exception {
+    void parsesDateTimes() throws Exception {
         final YearParam param = new YearParam("2012");
 
         assertThat(param.get())

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/ZoneIdParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/ZoneIdParamTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ZoneIdParamTest {
     @Test
-    public void parsesDateTimes() throws Exception {
+    void parsesDateTimes() throws Exception {
         final ZoneIdParam param = new ZoneIdParam("Europe/Berlin");
 
         assertThat(param.get())

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/ZonedDateTimeParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/ZonedDateTimeParamTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ZonedDateTimeParamTest {
     @Test
-    public void parsesDateTimes() throws Exception {
+    void parsesDateTimes() throws Exception {
         final ZonedDateTimeParam param = new ZonedDateTimeParam("2012-11-19T13:37+01:00[Europe/Berlin]");
 
         assertThat(param.get())

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalBeanParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalBeanParamResourceTest.java
@@ -38,7 +38,7 @@ public class OptionalBeanParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldReturnValuesIfProvidedAndValid() {
+    void shouldReturnValuesIfProvidedAndValid() {
         Map<String, Object> response = target("/optional")
                 .path("param")
                 .queryParam("double", 1234567890D)
@@ -60,7 +60,7 @@ public class OptionalBeanParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldReturnBadRequestIfValuesInvalid() {
+    void shouldReturnBadRequestIfValuesInvalid() {
         Response response = target("/optional")
                 .path("param")
                 .queryParam("double", "invalid-double")
@@ -74,7 +74,7 @@ public class OptionalBeanParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldReturnaDefaultsIfValuesMissing() {
+    void shouldReturnaDefaultsIfValuesMissing() {
         Map<String, Object> response = target("/optional")
                 .path("param")
                 .request(MediaType.APPLICATION_JSON_TYPE)

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalCookieParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalCookieParamResourceTest.java
@@ -27,55 +27,55 @@ public class OptionalCookieParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldReturnDefaultMessageWhenMessageIsNotPresent() {
+    void shouldReturnDefaultMessageWhenMessageIsNotPresent() {
         String defaultMessage = "Default Message";
         String response = target("/optional/message").request().get(String.class);
         assertThat(response).isEqualTo(defaultMessage);
     }
 
     @Test
-    public void shouldReturnMessageWhenMessageIsBlank() {
+    void shouldReturnMessageWhenMessageIsBlank() {
         String response = target("/optional/message").request().cookie("message", "").get(String.class);
         assertThat(response).isEqualTo("");
     }
 
     @Test
-    public void shouldReturnMessageWhenMessageIsPresent() {
+    void shouldReturnMessageWhenMessageIsPresent() {
         String customMessage = "Custom Message";
         String response = target("/optional/message").request().cookie("message", customMessage).get(String.class);
         assertThat(response).isEqualTo(customMessage);
     }
 
     @Test
-    public void shouldReturnDefaultMessageWhenMyMessageIsNotPresent() {
+    void shouldReturnDefaultMessageWhenMyMessageIsNotPresent() {
         String defaultMessage = "My Default Message";
         String response = target("/optional/my-message").request().get(String.class);
         assertThat(response).isEqualTo(defaultMessage);
     }
 
     @Test
-    public void shouldReturnMyMessageWhenMyMessageIsPresent() {
+    void shouldReturnMyMessageWhenMyMessageIsPresent() {
         String myMessage = "My Message";
         String response = target("/optional/my-message").request().cookie("mymessage", myMessage).get(String.class);
         assertThat(response).isEqualTo(myMessage);
     }
 
     @Test
-    public void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() {
+    void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() {
         String invalidUUID = "invalid-uuid";
         assertThatExceptionOfType(BadRequestException.class).isThrownBy(() ->
             target("/optional/uuid").request().cookie("uuid", invalidUUID).get(String.class));
     }
 
     @Test
-    public void shouldReturnDefaultUUIDWhenUUIDIsNotPresent() {
+    void shouldReturnDefaultUUIDWhenUUIDIsNotPresent() {
         String defaultUUID = "d5672fa8-326b-40f6-bf71-d9dacf44bcdc";
         String response = target("/optional/uuid").request().get(String.class);
         assertThat(response).isEqualTo(defaultUUID);
     }
 
     @Test
-    public void shouldReturnUUIDWhenValidUUIDIsPresent() {
+    void shouldReturnUUIDWhenValidUUIDIsPresent() {
         String uuid = "fd94b00d-bd50-46b3-b42f-905a9c9e7d78";
         String response = target("/optional/uuid").request().cookie("uuid", uuid).get(String.class);
         assertThat(response).isEqualTo(uuid);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalDoubleMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalDoubleMessageBodyWriterTest.java
@@ -31,7 +31,7 @@ public class OptionalDoubleMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void presentOptionalsReturnTheirValue() {
+    void presentOptionalsReturnTheirValue() {
         assertThat(target("optional-return")
                 .queryParam("id", "1").request()
                 .get(Double.class))
@@ -39,7 +39,7 @@ public class OptionalDoubleMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void presentOptionalsReturnTheirValueWithResponse() {
+    void presentOptionalsReturnTheirValueWithResponse() {
         assertThat(target("optional-return/response-wrapped")
                 .queryParam("id", "1").request()
                 .get(Double.class))
@@ -47,28 +47,28 @@ public class OptionalDoubleMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void absentOptionalsThrowANotFound() {
+    void absentOptionalsThrowANotFound() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> target("optional-return").request().get(Double.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(404));
     }
 
     @Test
-    public void valueSetIgnoresDefault() {
+    void valueSetIgnoresDefault() {
         assertThat(target("optional-return/default").queryParam("id", "1").request().get(Double.class))
             .isEqualTo(target("optional-return/double/default").queryParam("id", "1").request().get(Double.class))
             .isEqualTo(1);
     }
 
     @Test
-    public void valueNotSetReturnsDefault() {
+    void valueNotSetReturnsDefault() {
         assertThat(target("optional-return/default").request().get(Double.class))
             .isEqualTo(target("optional-return/double/default").request().get(Double.class))
             .isEqualTo(0);
     }
 
     @Test
-    public void valueEmptyReturnsDefault() {
+    void valueEmptyReturnsDefault() {
         assertThat(target("optional-return/default").queryParam("id", "")
             .request().get(Double.class))
             .isEqualTo(target("optional-return/double/default").queryParam("id", "")
@@ -77,7 +77,7 @@ public class OptionalDoubleMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void valueInvalidReturns404() {
+    void valueInvalidReturns404() {
         assertThatExceptionOfType(NotFoundException.class)
             .isThrownBy(() -> target("optional-return/default").queryParam("id", "invalid")
                 .request().get(Double.class));

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalDoubleParamConverterProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalDoubleParamConverterProviderTest.java
@@ -7,13 +7,13 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class OptionalDoubleParamConverterProviderTest {
     @Test
-    public void verifyInvalidDefaultValueFailsFast() {
+    void verifyInvalidDefaultValueFailsFast() {
         assertThatExceptionOfType(NumberFormatException.class)
             .isThrownBy(() -> new OptionalDoubleParamConverterProvider.OptionalDoubleParamConverter("invalid").fromString("invalid"));
     }
 
     @Test
-    public void verifyInvalidValueNoDefaultReturnsNotPresent() {
+    void verifyInvalidValueNoDefaultReturnsNotPresent() {
         assertThat(new OptionalDoubleParamConverterProvider.OptionalDoubleParamConverter().fromString("invalid")).isNotPresent();
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalFormParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalFormParamResourceTest.java
@@ -30,7 +30,7 @@ public class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldReturnDefaultMessageWhenMessageIsNotPresent() throws IOException {
+    void shouldReturnDefaultMessageWhenMessageIsNotPresent() throws IOException {
         final String defaultMessage = "Default Message";
         final Response response = target("/optional/message").request().post(Entity.form(new MultivaluedStringMap()));
 
@@ -38,7 +38,7 @@ public class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldReturnMessageWhenMessageBlank() throws IOException {
+    void shouldReturnMessageWhenMessageBlank() throws IOException {
         final Form form = new Form("message", "");
         final Response response = target("/optional/message").request().post(Entity.form(form));
 
@@ -46,7 +46,7 @@ public class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldReturnMessageWhenMessageIsPresent() throws IOException {
+    void shouldReturnMessageWhenMessageIsPresent() throws IOException {
         final String customMessage = "Custom Message";
         final Form form = new Form("message", customMessage);
         final Response response = target("/optional/message").request().post(Entity.form(form));
@@ -55,7 +55,7 @@ public class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldReturnDefaultMessageWhenMyMessageIsNotPresent() throws IOException {
+    void shouldReturnDefaultMessageWhenMyMessageIsNotPresent() throws IOException {
         final String defaultMessage = "My Default Message";
         final Response response = target("/optional/my-message").request().post(Entity.form(new MultivaluedStringMap()));
 
@@ -63,7 +63,7 @@ public class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldReturnMyMessageWhenMyMessageIsPresent() throws IOException {
+    void shouldReturnMyMessageWhenMyMessageIsPresent() throws IOException {
         final String myMessage = "My Message";
         final Form form = new Form("mymessage", myMessage);
         final Response response = target("/optional/my-message").request().post(Entity.form(form));
@@ -72,7 +72,7 @@ public class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() throws IOException {
+    void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() throws IOException {
         final String invalidUUID = "invalid-uuid";
         final Form form = new Form("uuid", invalidUUID);
         final Response response = target("/optional/uuid").request().post(Entity.form(form));
@@ -81,7 +81,7 @@ public class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldReturnDefaultUUIDWhenUUIDIsNotPresent() throws IOException {
+    void shouldReturnDefaultUUIDWhenUUIDIsNotPresent() throws IOException {
         final String defaultUUID = "d5672fa8-326b-40f6-bf71-d9dacf44bcdc";
         final Response response = target("/optional/uuid").request().post(Entity.form(new MultivaluedStringMap()));
 
@@ -89,7 +89,7 @@ public class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldReturnUUIDWhenValidUUIDIsPresent() throws IOException {
+    void shouldReturnUUIDWhenValidUUIDIsPresent() throws IOException {
         final String uuid = "fd94b00d-bd50-46b3-b42f-905a9c9e7d78";
         final Form form = new Form("uuid", uuid);
         final Response response = target("/optional/uuid").request().post(Entity.form(form));

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalHeaderParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalHeaderParamResourceTest.java
@@ -27,55 +27,55 @@ public class OptionalHeaderParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldReturnDefaultMessageWhenMessageIsNotPresent() {
+    void shouldReturnDefaultMessageWhenMessageIsNotPresent() {
         String defaultMessage = "Default Message";
         String response = target("/optional/message").request().get(String.class);
         assertThat(response).isEqualTo(defaultMessage);
     }
 
     @Test
-    public void shouldReturnMessageWhenMessageIsBlank() {
+    void shouldReturnMessageWhenMessageIsBlank() {
         String response = target("/optional/message").request().header("message", "").get(String.class);
         assertThat(response).isEqualTo("");
     }
 
     @Test
-    public void shouldReturnMessageWhenMessageIsPresent() {
+    void shouldReturnMessageWhenMessageIsPresent() {
         String customMessage = "Custom Message";
         String response = target("/optional/message").request().header("message", customMessage).get(String.class);
         assertThat(response).isEqualTo(customMessage);
     }
 
     @Test
-    public void shouldReturnDefaultMessageWhenMyMessageIsNotPresent() {
+    void shouldReturnDefaultMessageWhenMyMessageIsNotPresent() {
         String defaultMessage = "My Default Message";
         String response = target("/optional/my-message").request().get(String.class);
         assertThat(response).isEqualTo(defaultMessage);
     }
 
     @Test
-    public void shouldReturnMyMessageWhenMyMessageIsPresent() {
+    void shouldReturnMyMessageWhenMyMessageIsPresent() {
         String myMessage = "My Message";
         String response = target("/optional/my-message").request().header("mymessage", myMessage).get(String.class);
         assertThat(response).isEqualTo(myMessage);
     }
 
     @Test
-    public void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() {
+    void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() {
         String invalidUUID = "invalid-uuid";
         assertThatExceptionOfType(BadRequestException.class).isThrownBy(() ->
             target("/optional/uuid").request().header("uuid", invalidUUID).get(String.class));
     }
 
     @Test
-    public void shouldReturnDefaultUUIDWhenUUIDIsNotPresent() {
+    void shouldReturnDefaultUUIDWhenUUIDIsNotPresent() {
         String defaultUUID = "d5672fa8-326b-40f6-bf71-d9dacf44bcdc";
         String response = target("/optional/uuid").request().get(String.class);
         assertThat(response).isEqualTo(defaultUUID);
     }
 
     @Test
-    public void shouldReturnUUIDWhenValidUUIDIsPresent() {
+    void shouldReturnUUIDWhenValidUUIDIsPresent() {
         String uuid = "fd94b00d-bd50-46b3-b42f-905a9c9e7d78";
         String response = target("/optional/uuid").request().header("uuid", uuid).get(String.class);
         assertThat(response).isEqualTo(uuid);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalIntMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalIntMessageBodyWriterTest.java
@@ -31,7 +31,7 @@ public class OptionalIntMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void presentOptionalsReturnTheirValue() {
+    void presentOptionalsReturnTheirValue() {
         assertThat(target("optional-return")
                 .queryParam("id", "1").request()
                 .get(Integer.class))
@@ -39,7 +39,7 @@ public class OptionalIntMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void presentOptionalsReturnTheirValueWithResponse() {
+    void presentOptionalsReturnTheirValueWithResponse() {
         assertThat(target("optional-return/response-wrapped")
                 .queryParam("id", "1").request()
                 .get(Integer.class))
@@ -47,14 +47,14 @@ public class OptionalIntMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void absentOptionalsThrowANotFound() {
+    void absentOptionalsThrowANotFound() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> target("optional-return").request().get(Integer.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(404));
     }
 
     @Test
-    public void valueSetIgnoresDefault() {
+    void valueSetIgnoresDefault() {
         assertThat(target("optional-return/default").queryParam("id", "1")
             .request().get(Integer.class))
             .isEqualTo(target("optional-return/int/default").queryParam("id", "1")
@@ -63,14 +63,14 @@ public class OptionalIntMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void valueNotSetReturnsDefault() {
+    void valueNotSetReturnsDefault() {
         assertThat(target("optional-return/default").request().get(Integer.class))
             .isEqualTo(target("optional-return/int/default").request().get(Integer.class))
             .isEqualTo(0);
     }
 
     @Test
-    public void valueEmptyReturnsDefault() {
+    void valueEmptyReturnsDefault() {
         assertThat(target("optional-return/default").queryParam("id", "")
             .request().get(Integer.class))
             .isEqualTo(target("optional-return/int/default").queryParam("id", "")
@@ -79,7 +79,7 @@ public class OptionalIntMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void valueInvalidReturns404() {
+    void valueInvalidReturns404() {
         assertThatExceptionOfType(NotFoundException.class)
             .isThrownBy(() -> target("optional-return/default").queryParam("id", "invalid")
                 .request().get(Integer.class));
@@ -89,7 +89,7 @@ public class OptionalIntMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void verifyInvalidDefaultValueFailsFast() {
+    void verifyInvalidDefaultValueFailsFast() {
         assertThatExceptionOfType(NumberFormatException.class)
             .isThrownBy(() -> new OptionalIntParamConverterProvider.OptionalIntParamConverter("invalid")
                 .fromString("invalid"));

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalIntParamConverterProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalIntParamConverterProviderTest.java
@@ -7,13 +7,13 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class OptionalIntParamConverterProviderTest {
     @Test
-    public void verifyInvalidDefaultValueFailsFast() {
+    void verifyInvalidDefaultValueFailsFast() {
         assertThatExceptionOfType(NumberFormatException.class)
             .isThrownBy(() -> new OptionalIntParamConverterProvider.OptionalIntParamConverter("invalid").fromString("invalid"));
     }
 
     @Test
-    public void verifyInvalidValueNoDefaultReturnsNotPresent() {
+    void verifyInvalidValueNoDefaultReturnsNotPresent() {
         assertThat(new OptionalIntParamConverterProvider.OptionalIntParamConverter().fromString("invalid")).isNotPresent();
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalLongMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalLongMessageBodyWriterTest.java
@@ -31,7 +31,7 @@ public class OptionalLongMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void presentOptionalsReturnTheirValue() {
+    void presentOptionalsReturnTheirValue() {
         assertThat(target("optional-return")
                 .queryParam("id", "1").request()
                 .get(Long.class))
@@ -39,7 +39,7 @@ public class OptionalLongMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void presentOptionalsReturnTheirValueWithResponse() {
+    void presentOptionalsReturnTheirValueWithResponse() {
         assertThat(target("optional-return/response-wrapped")
                 .queryParam("id", "1").request()
                 .get(Long.class))
@@ -47,35 +47,35 @@ public class OptionalLongMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void absentOptionalsThrowANotFound() {
+    void absentOptionalsThrowANotFound() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> target("optional-return").request().get(Long.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(404));
     }
 
     @Test
-    public void valueSetIgnoresDefault() {
+    void valueSetIgnoresDefault() {
         assertThat(target("optional-return/default").queryParam("id", "1").request().get(Long.class))
             .isEqualTo(target("optional-return/long/default").queryParam("id", "1").request().get(Long.class))
             .isEqualTo(1L);
     }
 
     @Test
-    public void valueNotSetReturnsDefault() {
+    void valueNotSetReturnsDefault() {
         assertThat(target("optional-return/default").request().get(Long.class))
             .isEqualTo(target("optional-return/long/default").request().get(Long.class))
             .isEqualTo(0L);
     }
 
     @Test
-    public void valueEmptyReturnsDefault() {
+    void valueEmptyReturnsDefault() {
         assertThat(target("optional-return/default").queryParam("id", "").request().get(Long.class))
             .isEqualTo(target("optional-return/long/default").queryParam("id", "").request().get(Long.class))
             .isEqualTo(0L);
     }
 
     @Test
-    public void valueInvalidReturns404() {
+    void valueInvalidReturns404() {
         assertThatExceptionOfType(NotFoundException.class)
             .isThrownBy(() -> target("optional-return/default").queryParam("id", "invalid")
                 .request().get(Long.class));;

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalLongParamConverterProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalLongParamConverterProviderTest.java
@@ -7,13 +7,13 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class OptionalLongParamConverterProviderTest {
     @Test
-    public void verifyInvalidDefaultValueFailsFast() {
+    void verifyInvalidDefaultValueFailsFast() {
         assertThatExceptionOfType(NumberFormatException.class)
             .isThrownBy(() -> new OptionalLongParamConverterProvider.OptionalLongParamConverter("invalid").fromString("invalid"));
     }
 
     @Test
-    public void verifyInvalidValueNoDefaultReturnsNotPresent() {
+    void verifyInvalidValueNoDefaultReturnsNotPresent() {
         assertThat(new OptionalLongParamConverterProvider.OptionalLongParamConverter().fromString("invalid")).isNotPresent();
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalMessageBodyWriterTest.java
@@ -29,7 +29,7 @@ public class OptionalMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void presentOptionalsReturnTheirValue() {
+    void presentOptionalsReturnTheirValue() {
         assertThat(target("optional-return")
                 .queryParam("id", "woo").request()
                 .get(String.class))
@@ -37,7 +37,7 @@ public class OptionalMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void presentOptionalsReturnTheirValueWithResponse() {
+    void presentOptionalsReturnTheirValueWithResponse() {
         assertThat(target("optional-return/response-wrapped")
                 .queryParam("id", "woo").request()
                 .get(String.class))
@@ -45,7 +45,7 @@ public class OptionalMessageBodyWriterTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void absentOptionalsThrowANotFound() {
+    void absentOptionalsThrowANotFound() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> target("optional-return").request().get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(404));

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalQueryParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalQueryParamResourceTest.java
@@ -27,27 +27,27 @@ public class OptionalQueryParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldReturnDefaultMessageWhenMessageIsNotPresent() {
+    void shouldReturnDefaultMessageWhenMessageIsNotPresent() {
         String defaultMessage = "Default Message";
         String response = target("/optional/message").request().get(String.class);
         assertThat(response).isEqualTo(defaultMessage);
     }
 
     @Test
-    public void shouldReturnMessageWhenMessageIsPresent() {
+    void shouldReturnMessageWhenMessageIsPresent() {
         String customMessage = "Custom Message";
         String response = target("/optional/message").queryParam("message", customMessage).request().get(String.class);
         assertThat(response).isEqualTo(customMessage);
     }
 
     @Test
-    public void shouldReturnMessageWhenMessageIsBlank() {
+    void shouldReturnMessageWhenMessageIsBlank() {
         String response = target("/optional/message").queryParam("message", "").request().get(String.class);
         assertThat(response).isEqualTo("");
     }
 
     @Test
-    public void shouldReturnDecodedMessageWhenEncodedMessageIsPresent() {
+    void shouldReturnDecodedMessageWhenEncodedMessageIsPresent() {
         String encodedMessage = "Custom%20Message";
         String decodedMessage = "Custom Message";
         String response = target("/optional/message").queryParam("message", encodedMessage).request().get(String.class);
@@ -55,35 +55,35 @@ public class OptionalQueryParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldReturnDefaultMessageWhenMyMessageIsNotPresent() {
+    void shouldReturnDefaultMessageWhenMyMessageIsNotPresent() {
         String defaultMessage = "My Default Message";
         String response = target("/optional/my-message").request().get(String.class);
         assertThat(response).isEqualTo(defaultMessage);
     }
 
     @Test
-    public void shouldReturnMyMessageWhenMyMessageIsPresent() {
+    void shouldReturnMyMessageWhenMyMessageIsPresent() {
         String myMessage = "My Message";
         String response = target("/optional/my-message").queryParam("mymessage", myMessage).request().get(String.class);
         assertThat(response).isEqualTo(myMessage);
     }
 
     @Test
-    public void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() {
+    void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() {
         String invalidUUID = "invalid-uuid";
         assertThatExceptionOfType(BadRequestException.class).isThrownBy(() ->
             target("/optional/uuid").queryParam("uuid", invalidUUID).request().get(String.class));
     }
 
     @Test
-    public void shouldReturnDefaultUUIDWhenUUIDIsNotPresent() {
+    void shouldReturnDefaultUUIDWhenUUIDIsNotPresent() {
         String defaultUUID = "d5672fa8-326b-40f6-bf71-d9dacf44bcdc";
         String response = target("/optional/uuid").request().get(String.class);
         assertThat(response).isEqualTo(defaultUUID);
     }
 
     @Test
-    public void shouldReturnUUIDWhenValidUUIDIsPresent() {
+    void shouldReturnUUIDWhenValidUUIDIsPresent() {
         String uuid = "fd94b00d-bd50-46b3-b42f-905a9c9e7d78";
         String response = target("/optional/uuid").queryParam("uuid", uuid).request().get(String.class);
         assertThat(response).isEqualTo(uuid);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/BooleanParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/BooleanParamTest.java
@@ -12,32 +12,32 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 public class BooleanParamTest {
 
     @Test
-    public void trueReturnsTrue() {
+    void trueReturnsTrue() {
         assertThat(new BooleanParam("true").get()).isTrue();
     }
 
     @Test
-    public void uppercaseTrueReturnsTrue() {
+    void uppercaseTrueReturnsTrue() {
         assertThat(new BooleanParam("TRUE").get()).isTrue();
     }
 
     @Test
-    public void falseReturnsFalse() {
+    void falseReturnsFalse() {
         assertThat(new BooleanParam("false").get()).isFalse();
     }
 
     @Test
-    public void uppercaseFalseReturnsFalse() {
+    void uppercaseFalseReturnsFalse() {
         assertThat(new BooleanParam("FALSE").get()).isFalse();
     }
 
     @Test
-    public void nullThrowsAnException() {
+    void nullThrowsAnException() {
         booleanParamNegativeTest(null);
     }
 
     @Test
-    public void nonBooleanValuesThrowAnException() {
+    void nonBooleanValuesThrowAnException() {
         booleanParamNegativeTest("foo");
     }
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/DateTimeParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/DateTimeParamTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class DateTimeParamTest {
     @Test
-    public void parsesDateTimes() {
+    void parsesDateTimes() {
         final DateTimeParam param = new DateTimeParam("2012-11-19");
 
         assertThat(param.get())

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/DurationParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/DurationParamTest.java
@@ -12,13 +12,13 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 public class DurationParamTest {
 
     @Test
-    public void parseDurationSeconds() {
+    void parseDurationSeconds() {
         assertThat(new DurationParam("10 seconds").get())
             .isEqualTo(Duration.seconds(10));
     }
 
     @Test
-    public void badValueThrowsException() {
+    void badValueThrowsException() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> new DurationParam("invalid", "param_name"))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(400))

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/InstantParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/InstantParamTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class InstantParamTest {
     @Test
-    public void parsesDateTimes() {
+    void parsesDateTimes() {
         final InstantParam param = new InstantParam("2012-11-19T00:00:00Z");
         Instant instant = LocalDateTime.of(2012, 11, 19, 0, 0)
             .toInstant(ZoneOffset.UTC);
@@ -23,7 +23,7 @@ public class InstantParamTest {
     }
 
     @Test
-    public void nullThrowsAnException() {
+    void nullThrowsAnException() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> new InstantParam(null, "myDate"))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(400))

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/IntParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/IntParamTest.java
@@ -10,12 +10,12 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class IntParamTest {
     @Test
-    public void anIntegerReturnsAnInteger() {
+    void anIntegerReturnsAnInteger() {
         assertThat(new IntParam("200").get()).isEqualTo(200);
     }
 
     @Test
-    public void nullThrowsAnException() {
+    void nullThrowsAnException() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> new IntParam(null))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(400))
@@ -25,7 +25,7 @@ public class IntParamTest {
     }
 
     @Test
-    public void emptyStringThrowsAnException() {
+    void emptyStringThrowsAnException() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> new IntParam(""))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(400))
@@ -35,7 +35,7 @@ public class IntParamTest {
     }
 
     @Test
-    public void aNonIntegerThrowsAnException() {
+    void aNonIntegerThrowsAnException() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> new IntParam("foo"))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(400))
@@ -45,7 +45,7 @@ public class IntParamTest {
     }
 
     @Test
-    public void aNonIntegerThrowsAnExceptionWithCustomName() {
+    void aNonIntegerThrowsAnExceptionWithCustomName() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> new IntParam("foo", "customName"))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(400))

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/LocalDateParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/LocalDateParamTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class LocalDateParamTest {
     @Test
-    public void parsesLocalDates() {
+    void parsesLocalDates() {
         final LocalDateParam param = new LocalDateParam("2012-11-20");
 
         assertThat(param.get())

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/LongParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/LongParamTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class LongParamTest {
     @Test
-    public void aLongReturnsALong() {
+    void aLongReturnsALong() {
         final LongParam param = new LongParam("200");
 
         assertThat(param.get())
@@ -18,7 +18,7 @@ public class LongParamTest {
     }
 
     @Test
-    public void nullThrowsAnException() {
+    void nullThrowsAnException() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> new LongParam(null))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(400))
@@ -28,7 +28,7 @@ public class LongParamTest {
     }
 
     @Test
-    public void emptyStringThrowsAnException() {
+    void emptyStringThrowsAnException() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> new LongParam(null))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(400))
@@ -38,7 +38,7 @@ public class LongParamTest {
     }
 
     @Test
-    public void aNonIntegerThrowsAnException() {
+    void aNonIntegerThrowsAnException() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> new LongParam("foo"))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(400))
@@ -48,7 +48,7 @@ public class LongParamTest {
     }
 
     @Test
-    public void aNonIntegerThrowsAnExceptionWithCustomName() {
+    void aNonIntegerThrowsAnExceptionWithCustomName() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> new LongParam("foo", "customName"))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(400))

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/NonEmptyStringParamProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/NonEmptyStringParamProviderTest.java
@@ -21,25 +21,25 @@ public class NonEmptyStringParamProviderTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void shouldReturnDefaultMessageWhenNonExistent() {
+    void shouldReturnDefaultMessageWhenNonExistent() {
         String response = target("/non-empty/string").request().get(String.class);
         assertThat(response).isEqualTo("Hello");
     }
 
     @Test
-    public void shouldReturnDefaultMessageWhenEmptyString() {
+    void shouldReturnDefaultMessageWhenEmptyString() {
         String response = target("/non-empty/string").queryParam("message", "").request().get(String.class);
         assertThat(response).isEqualTo("Hello");
     }
 
     @Test
-    public void shouldReturnDefaultMessageWhenNull() {
+    void shouldReturnDefaultMessageWhenNull() {
         String response = target("/non-empty/string").queryParam("message").request().get(String.class);
         assertThat(response).isEqualTo("Hello");
     }
 
     @Test
-    public void shouldReturnMessageWhenSpecified() {
+    void shouldReturnMessageWhenSpecified() {
         String response = target("/non-empty/string").queryParam("message", "Goodbye").request().get(String.class);
         assertThat(response).isEqualTo("Goodbye");
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/NonEmptyStringParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/NonEmptyStringParamTest.java
@@ -8,19 +8,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class NonEmptyStringParamTest {
     @Test
-    public void aBlankStringIsAnAbsentString() {
+    void aBlankStringIsAnAbsentString() {
         final NonEmptyStringParam param = new NonEmptyStringParam("");
         assertThat(param.get()).isEqualTo(Optional.empty());
     }
 
     @Test
-    public void aNullStringIsAnAbsentString() {
+    void aNullStringIsAnAbsentString() {
         final NonEmptyStringParam param = new NonEmptyStringParam(null);
         assertThat(param.get()).isEqualTo(Optional.empty());
     }
 
     @Test
-    public void aStringWithContentIsItself() {
+    void aStringWithContentIsItself() {
         final NonEmptyStringParam param = new NonEmptyStringParam("hello");
         assertThat(param.get()).isEqualTo(Optional.of("hello"));
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/SizeParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/SizeParamTest.java
@@ -12,14 +12,14 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 public class SizeParamTest {
 
     @Test
-    public void parseSizeKilobytes() {
+    void parseSizeKilobytes() {
         final SizeParam param = new SizeParam("10kb");
         assertThat(param.get())
             .isEqualTo(Size.kilobytes(10));
     }
 
     @Test
-    public void badValueThrowsException() {
+    void badValueThrowsException() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> new SizeParam("10 kelvins", "degrees"))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(400))

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/UUIDParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/UUIDParamTest.java
@@ -20,7 +20,7 @@ public class UUIDParamTest {
     }
 
     @Test
-    public void aUUIDStringReturnsAUUIDObject() {
+    void aUUIDStringReturnsAUUIDObject() {
         final String uuidString = "067e6162-3b6f-4ae2-a171-2470b63dff00";
         final UUID uuid = UUID.fromString(uuidString);
 
@@ -28,17 +28,17 @@ public class UUIDParamTest {
     }
 
     @Test
-    public void noSpaceUUID() {
+    void noSpaceUUID() {
         UuidParamNegativeTest("067e61623b6f4ae2a1712470b63dff00");
     }
 
     @Test
-    public void tooLongUUID() {
+    void tooLongUUID() {
         UuidParamNegativeTest("067e6162-3b6f-4ae2-a171-2470b63dff000");
     }
 
     @Test
-    public void aNonUUIDThrowsAnException() {
+    void aNonUUIDThrowsAnException() {
         UuidParamNegativeTest("foo");
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/sessions/FlashFactoryTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/sessions/FlashFactoryTest.java
@@ -40,7 +40,7 @@ public class FlashFactoryTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void passesInHttpSessions() throws Exception {
+    void passesInHttpSessions() throws Exception {
         Response firstResponse = target("/flash").request(MediaType.TEXT_PLAIN)
                 .post(Entity.entity("Mr. Peeps", MediaType.TEXT_PLAIN));
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/sessions/HttpSessionFactoryTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/sessions/HttpSessionFactoryTest.java
@@ -40,7 +40,7 @@ public class HttpSessionFactoryTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void passesInHttpSessions() throws Exception {
+    void passesInHttpSessions() throws Exception {
         Response firstResponse = target("/session/").request(MediaType.TEXT_PLAIN)
                 .post(Entity.entity("Mr. Peeps", MediaType.TEXT_PLAIN));
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/setup/JerseyEnvironmentTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/setup/JerseyEnvironmentTest.java
@@ -13,17 +13,17 @@ public class JerseyEnvironmentTest {
     private final JerseyEnvironment jerseyEnvironment = new JerseyEnvironment(holder, config);
 
     @Test
-    public void urlPatternEndsWithSlashStar() {
+    void urlPatternEndsWithSlashStar() {
         assertPatternEndsWithSlashStar("/missing/slash/star");
     }
 
     @Test
-    public void urlPatternEndsWithStar() {
+    void urlPatternEndsWithStar() {
         assertPatternEndsWithSlashStar("/missing/star/");
     }
 
     @Test
-    public void urlPatternSuffixNoop() {
+    void urlPatternSuffixNoop() {
         String slashStarPath = "/slash/star/*";
         jerseyEnvironment.setUrlPattern(slashStarPath);
         assertThat(jerseyEnvironment.getUrlPattern()).isEqualTo(slashStarPath);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
@@ -48,7 +48,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @BeforeEach
-    void setUp() throws Exception {
+    public void setUp() throws Exception {
         assumeThat(Locale.getDefault().getLanguage()).isEqualTo("en");
         super.setUp();
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
@@ -48,13 +48,13 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         assumeThat(Locale.getDefault().getLanguage()).isEqualTo("en");
         super.setUp();
     }
 
     @Test
-    public void postInvalidEntityIs422() {
+    void postInvalidEntityIs422() {
         final Response response = target("/valid/foo").request(MediaType.APPLICATION_JSON)
                 .post(Entity.entity("{}", MediaType.APPLICATION_JSON));
         assertThat(response.getStatus()).isEqualTo(422);
@@ -62,7 +62,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void postNullEntityIs422() {
+    void postNullEntityIs422() {
         final Response response = target("/valid/foo").request(MediaType.APPLICATION_JSON)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
         assertThat(response.getStatus()).isEqualTo(422);
@@ -72,7 +72,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void postInvalidatedEntityIs422() {
+    void postInvalidatedEntityIs422() {
         final Response response = target("/valid/fooValidated").request(MediaType.APPLICATION_JSON)
                 .post(Entity.entity("{}", MediaType.APPLICATION_JSON));
         assertThat(response.getStatus()).isEqualTo(422);
@@ -80,7 +80,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void postInvalidInterfaceEntityIs422() {
+    void postInvalidInterfaceEntityIs422() {
         final Response response = target("/valid2/repr").request(MediaType.APPLICATION_JSON)
             .post(Entity.entity("{\"name\": \"a\"}", MediaType.APPLICATION_JSON));
         assertThat(response.getStatus()).isEqualTo(400);
@@ -89,7 +89,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void returnInvalidEntityIs500() {
+    void returnInvalidEntityIs500() {
         final Response response = target("/valid/foo").request(MediaType.APPLICATION_JSON)
                 .post(Entity.entity("{ \"name\": \"Coda\" }", MediaType.APPLICATION_JSON));
         assertThat(response.getStatus()).isEqualTo(500);
@@ -98,7 +98,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void returnInvalidatedEntityIs500() {
+    void returnInvalidatedEntityIs500() {
         final Response response = target("/valid/fooValidated").request(MediaType.APPLICATION_JSON)
                 .post(Entity.entity("{ \"name\": \"Coda\" }", MediaType.APPLICATION_JSON));
         assertThat(response.getStatus()).isEqualTo(500);
@@ -107,7 +107,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidReturnIs500() {
+    void getInvalidReturnIs500() {
         // return value is too long and so will fail validation
         final Response response = target("/valid/bar")
                 .queryParam("name", "dropwizard").request().get();
@@ -118,7 +118,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidQueryParamsIs400() {
+    void getInvalidQueryParamsIs400() {
         // query parameter is too short and so will fail validation
         final Response response = target("/valid/bar")
                 .queryParam("name", "hi").request().get();
@@ -136,7 +136,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void cacheIsForParamNamesOnly() {
+    void cacheIsForParamNamesOnly() {
         // query parameter must not be null, and must be at least 3
         final Response response = target("/valid/fhqwhgads")
                 .queryParam("num", 2).request().get();
@@ -155,7 +155,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void postInvalidPrimitiveIs422() {
+    void postInvalidPrimitiveIs422() {
         // query parameter is too short and so will fail validation
         final Response response = target("/valid/simpleEntity")
                 .request().post(Entity.json("hi"));
@@ -167,7 +167,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidCustomTypeIs400() {
+    void getInvalidCustomTypeIs400() {
         // query parameter is too short and so will fail validation
         final Response response = target("/valid/barter")
                 .queryParam("name", "hi").request().get();
@@ -179,7 +179,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidBeanParamsIs400() {
+    void getInvalidBeanParamsIs400() {
         // bean parameter is too short and so will fail validation
         Response response = target("/valid/zoo")
                 .request().get();
@@ -192,7 +192,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidSubBeanParamsIs400() {
+    void getInvalidSubBeanParamsIs400() {
         final Response response = target("/valid/sub-zoo")
                 .queryParam("address", "42 Wallaby Way")
                 .request().get();
@@ -204,7 +204,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getGroupSubBeanParamsIs400() {
+    void getGroupSubBeanParamsIs400() {
         final Response response = target("/valid/sub-group-zoo")
             .queryParam("address", "42 WALLABY WAY")
             .queryParam("name", "Coda")
@@ -216,7 +216,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void postValidGroupsIs400() {
+    void postValidGroupsIs400() {
         final Response response = target("/valid/sub-valid-group-zoo")
             .queryParam("address", "42 WALLABY WAY")
             .queryParam("name", "Coda")
@@ -229,7 +229,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidatedBeanParamsIs400() {
+    void getInvalidatedBeanParamsIs400() {
         // bean parameter is too short and so will fail validation
         final Response response = target("/valid/zoo2")
                 .request().get();
@@ -241,7 +241,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidHeaderParamsIs400() {
+    void getInvalidHeaderParamsIs400() {
         final Response response = target("/valid/head")
                 .request().get();
         assertThat(response.getStatus()).isEqualTo(400);
@@ -251,7 +251,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidCookieParamsIs400() {
+    void getInvalidCookieParamsIs400() {
         final Response response = target("/valid/cooks")
                 .request().get();
         assertThat(response.getStatus()).isEqualTo(400);
@@ -261,7 +261,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidPathParamsIs400() {
+    void getInvalidPathParamsIs400() {
         final Response response = target("/valid/goods/11")
                 .request().get();
         assertThat(response.getStatus()).isEqualTo(400);
@@ -271,7 +271,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidFormParamsIs400() {
+    void getInvalidFormParamsIs400() {
         final Response response = target("/valid/form")
                 .request().post(Entity.form(new Form()));
         assertThat(response.getStatus()).isEqualTo(400);
@@ -281,7 +281,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void postInvalidMethodClassIs422() {
+    void postInvalidMethodClassIs422() {
         final Response response = target("/valid/nothing")
                 .request().post(Entity.entity("{}", MediaType.APPLICATION_JSON_TYPE));
         assertThat(response.getStatus()).isEqualTo(422);
@@ -291,7 +291,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidNestedReturnIs500() {
+    void getInvalidNestedReturnIs500() {
         final Response response = target("/valid/nested").request().get();
         assertThat(response.getStatus()).isEqualTo(500);
 
@@ -300,7 +300,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidNested2ReturnIs500() {
+    void getInvalidNested2ReturnIs500() {
         final Response response = target("/valid/nested2").request().get();
         assertThat(response.getStatus()).isEqualTo(500);
 
@@ -309,7 +309,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidContextIs400() {
+    void getInvalidContextIs400() {
         final Response response = target("/valid/context").request().get();
         assertThat(response.getStatus()).isEqualTo(400);
 
@@ -318,7 +318,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void getInvalidMatrixParamIs400() {
+    void getInvalidMatrixParamIs400() {
         final Response response = target("/valid/matrix")
                 .matrixParam("bob", "").request().get();
         assertThat(response.getStatus()).isEqualTo(400);
@@ -328,7 +328,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void functionWithSameNameReturnDifferentErrors() {
+    void functionWithSameNameReturnDifferentErrors() {
         // This test is to make sure that functions with the same name and
         // number of parameters (but different parameter types), don't return
         // the same validation error due to any caching effects
@@ -345,7 +345,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void paramsCanBeUnwrappedAndValidated() {
+    void paramsCanBeUnwrappedAndValidated() {
         final Response response = target("/valid/nullable-int-param")
                 .queryParam("num", 4)
                 .request()
@@ -356,7 +356,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void returnPartialValidatedRequestEntities() {
+    void returnPartialValidatedRequestEntities() {
         final Response response = target("/valid/validatedPartialExample")
                 .request().post(Entity.json("{\"id\":1}"));
 
@@ -366,7 +366,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void invalidNullPartialValidatedRequestEntities() {
+    void invalidNullPartialValidatedRequestEntities() {
         final Response response = target("/valid/validatedPartialExample")
             .request().post(Entity.json(null));
 
@@ -376,7 +376,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void invalidEntityExceptionForPartialValidatedRequestEntities() {
+    void invalidEntityExceptionForPartialValidatedRequestEntities() {
         final Response response = target("/valid/validatedPartialExampleBoth")
                 .request().post(Entity.json("{\"id\":1}"));
 
@@ -386,7 +386,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void invalidNullPartialBothValidatedRequestEntities() {
+    void invalidNullPartialBothValidatedRequestEntities() {
         final Response response = target("/valid/validatedPartialExampleBoth")
             .request().post(Entity.json(null));
 
@@ -396,7 +396,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void returnPartialBothValidatedRequestEntities() {
+    void returnPartialBothValidatedRequestEntities() {
         final Response response = target("/valid/validatedPartialExampleBoth")
                 .request().post(Entity.json("{\"id\":1,\"text\":\"hello Cemo\"}"));
 
@@ -408,7 +408,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void invalidEntityExceptionForInvalidRequestEntities() {
+    void invalidEntityExceptionForInvalidRequestEntities() {
         final Response response = target("/valid/validExample")
                 .request().post(Entity.json("{\"id\":-1}"));
 
@@ -418,7 +418,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void returnRequestEntities() {
+    void returnRequestEntities() {
         final Response response = target("/valid/validExample")
                 .request().post(Entity.json("{\"id\":1}"));
 
@@ -428,7 +428,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void returnRequestArrayEntities() {
+    void returnRequestArrayEntities() {
         final Response response = target("/valid/validExampleArray")
                 .request().post(Entity.json("[{\"id\":1}, {\"id\":2}]"));
 
@@ -443,7 +443,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void invalidRequestCollectionEntities() {
+    void invalidRequestCollectionEntities() {
         final Response response = target("/valid/validExampleCollection")
                 .request().post(Entity.json("[{\"id\":-1}, {\"id\":-2}]"));
 
@@ -454,7 +454,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void invalidRequestSingleCollectionEntities() {
+    void invalidRequestSingleCollectionEntities() {
         final Response response = target("/valid/validExampleCollection")
                 .request().post(Entity.json("[{\"id\":1}, {\"id\":-2}]"));
 
@@ -464,7 +464,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void returnRequestCollectionEntities() {
+    void returnRequestCollectionEntities() {
         final Response response = target("/valid/validExampleCollection")
                 .request().post(Entity.json("[{\"id\":1}, {\"id\":2}]"));
 
@@ -482,7 +482,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-         public void invalidRequestSetEntities() {
+         void invalidRequestSetEntities() {
         final Response response = target("/valid/validExampleSet")
                 .request().post(Entity.json("[{\"id\":1}, {\"id\":-2}]"));
         assertThat(response.getStatus()).isEqualTo(422);
@@ -491,7 +491,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void invalidRequestListEntities() {
+    void invalidRequestListEntities() {
         final Response response = target("/valid/validExampleList")
                 .request().post(Entity.json("[{\"id\":-1}, {\"id\":-2}]"));
         assertThat(response.getStatus()).isEqualTo(422);
@@ -501,7 +501,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void throwsAConstraintViolationExceptionForEmptyRequestEntities() {
+    void throwsAConstraintViolationExceptionForEmptyRequestEntities() {
         final Response response = target("/valid/validExample")
                 .request().post(Entity.json(null));
 
@@ -511,7 +511,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void returnsValidatedMapRequestEntities() {
+    void returnsValidatedMapRequestEntities() {
         final Response response = target("/valid/validExampleMap")
                 .request().post(Entity.json("{\"one\": {\"id\":1}, \"two\": {\"id\":2}}"));
 
@@ -524,7 +524,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void invalidMapRequestEntities() {
+    void invalidMapRequestEntities() {
         final Response response = target("/valid/validExampleMap")
                 .request().post(Entity.json("{\"one\": {\"id\":-1}, \"two\": {\"id\":-2}}"));
 
@@ -535,7 +535,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void returnsValidatedEmbeddedListEntities() {
+    void returnsValidatedEmbeddedListEntities() {
         final Response response = target("/valid/validExampleEmbeddedList")
                 .request().post(Entity.json("[ {\"examples\": [ {\"id\":1 } ] } ]"));
 
@@ -548,7 +548,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void invalidEmbeddedListEntities() {
+    void invalidEmbeddedListEntities() {
         final Response response = target("/valid/validExampleEmbeddedList")
                 .request().post(Entity.json("[ {\"examples\": [ {\"id\":1 } ] }, { } ]"));
 
@@ -558,7 +558,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void testInvalidFieldQueryParam() {
+    void testInvalidFieldQueryParam() {
         final Response response = target("/valid/bar")
             .queryParam("sort", "foo")
             .request()
@@ -570,7 +570,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void missingParameterMessageContainsParameterName() {
+    void missingParameterMessageContainsParameterName() {
         final Response response = target("/valid/paramValidation")
             .request()
             .get();
@@ -580,7 +580,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void emptyParameterMessageContainsParameterName() {
+    void emptyParameterMessageContainsParameterName() {
         final Response response = target("/valid/paramValidation")
             .queryParam("length", "")
             .request()
@@ -591,7 +591,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void maxMessageContainsParameterName() {
+    void maxMessageContainsParameterName() {
         final Response response = target("/valid/paramValidation")
             .queryParam("length", 50)
             .request()
@@ -602,7 +602,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void minMessageContainsParameterName() {
+    void minMessageContainsParameterName() {
         final Response response = target("/valid/paramValidation")
             .queryParam("length", 1)
             .request()
@@ -613,7 +613,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void paramClassPassesValidation() {
+    void paramClassPassesValidation() {
         final Response response = target("/valid/paramValidation")
             .queryParam("length", 3)
             .request()
@@ -622,7 +622,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void minCustomMessage() {
+    void minCustomMessage() {
         final Response response = target("/valid/messageValidation")
             .queryParam("length", 1)
             .request()
@@ -641,7 +641,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void notPresentEnumParameter() {
+    void notPresentEnumParameter() {
         final Response response = target("/valid/enumParam")
             .request()
             .get();
@@ -651,7 +651,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void invalidEnumParameter() {
+    void invalidEnumParameter() {
         final Response response = target("/valid/enumParam")
             .queryParam("choice", "invalid")
             .request()
@@ -662,7 +662,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void invalidBeanParamEnumParameter() {
+    void invalidBeanParamEnumParameter() {
         final Response response = target("/valid/zoo")
             .queryParam("choice", "invalid")
             .request().get();
@@ -672,7 +672,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void selfValidatingBeanParamInvalid() {
+    void selfValidatingBeanParamInvalid() {
         final Response response = target("/valid/selfValidatingBeanParam")
             .queryParam("answer", 100)
             .request()
@@ -684,7 +684,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void selfValidatingBeanParamSuccess() {
+    void selfValidatingBeanParamSuccess() {
         final Response response = target("/valid/selfValidatingBeanParam")
             .queryParam("answer", 42)
             .request()
@@ -696,7 +696,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void selfValidatingPayloadInvalid() {
+    void selfValidatingPayloadInvalid() {
         final Response response = target("/valid/selfValidatingPayload")
             .request()
             .post(Entity.json("{\"answer\":100}"));
@@ -707,7 +707,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void selfValidatingPayloadSuccess() {
+    void selfValidatingPayloadSuccess() {
         final String payload = "{\"answer\":42}";
 
         final Response response = target("/valid/selfValidatingPayload")
@@ -720,7 +720,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void longParam_fails_with_null() {
+    void longParam_fails_with_null() {
         final Response response = target("/valid/longParam")
                 .queryParam("num")
                 .request()
@@ -732,7 +732,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void longParam_fails_with_emptyString() {
+    void longParam_fails_with_emptyString() {
         final Response response = target("/valid/longParam")
                 .queryParam("num", "")
                 .request()
@@ -744,7 +744,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void longParam_fails_with_constraint_violation() {
+    void longParam_fails_with_constraint_violation() {
         final Response response = target("/valid/longParam")
                 .queryParam("num", 5)
                 .request()
@@ -756,7 +756,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void longParam_fails_with_string() {
+    void longParam_fails_with_string() {
         final Response response = target("/valid/longParam")
                 .queryParam("num", "string")
                 .request()
@@ -769,7 +769,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
 
 
     @Test
-    public void longParam_succeeds() {
+    void longParam_succeeds() {
         final Response response = target("/valid/longParam")
                 .queryParam("num", 42)
                 .request()
@@ -780,7 +780,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void longParamNotNull_fails_with_null() {
+    void longParamNotNull_fails_with_null() {
         final Response response = target("/valid/longParamNotNull")
                 .queryParam("num")
                 .request()
@@ -792,7 +792,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void longParamNotNull_fails_with_empty_string() {
+    void longParamNotNull_fails_with_empty_string() {
         final Response response = target("/valid/longParamNotNull")
                 .queryParam("num", "")
                 .request()
@@ -804,7 +804,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void longParamNotNull_fails_with_constraint_violation() {
+    void longParamNotNull_fails_with_constraint_violation() {
         final Response response = target("/valid/longParamNotNull")
                 .queryParam("num", 5)
                 .request()
@@ -816,7 +816,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void longParamNotNull_fails_with_string() {
+    void longParamNotNull_fails_with_string() {
         final Response response = target("/valid/longParamNotNull")
                 .queryParam("num", "test")
                 .request()
@@ -828,7 +828,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void longParamNotNull_succeeds() {
+    void longParamNotNull_succeeds() {
         final Response response = target("/valid/longParamNotNull")
                 .queryParam("num", 42)
                 .request()
@@ -839,7 +839,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void longParamWithDefault_succeeds_with_null() {
+    void longParamWithDefault_succeeds_with_null() {
         final Response response = target("/valid/longParamWithDefault")
                 .queryParam("num")
                 .request()
@@ -850,7 +850,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void longParamWithDefault_fails_with_empty_string() {
+    void longParamWithDefault_fails_with_empty_string() {
         final Response response = target("/valid/longParamWithDefault")
                 .queryParam("num", "")
                 .request()
@@ -861,7 +861,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void longParamWithDefault_fails_with_constraint_violation() {
+    void longParamWithDefault_fails_with_constraint_violation() {
         final Response response = target("/valid/longParamWithDefault")
                 .queryParam("num", 5)
                 .request()
@@ -873,7 +873,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void longParamWithDefault_fails_with_string() {
+    void longParamWithDefault_fails_with_string() {
         final Response response = target("/valid/longParamWithDefault")
                 .queryParam("num", "test")
                 .request()
@@ -885,7 +885,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void longParamWithDefault_succeeds() {
+    void longParamWithDefault_succeeds() {
         final Response response = target("/valid/longParamWithDefault")
                 .queryParam("num", 30)
                 .request()
@@ -896,7 +896,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void intParam_fails_with_null() {
+    void intParam_fails_with_null() {
         final Response response = target("/valid/intParam")
                 .queryParam("num")
                 .request()
@@ -908,7 +908,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void intParam_fails_with_emptyString() {
+    void intParam_fails_with_emptyString() {
         final Response response = target("/valid/intParam")
                 .queryParam("num", "")
                 .request()
@@ -920,7 +920,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void intParam_fails_with_constraint_violation() {
+    void intParam_fails_with_constraint_violation() {
         final Response response = target("/valid/intParam")
                 .queryParam("num", 5)
                 .request()
@@ -932,7 +932,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void intParam_fails_with_string() {
+    void intParam_fails_with_string() {
         final Response response = target("/valid/intParam")
                 .queryParam("num", "string")
                 .request()
@@ -945,7 +945,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
 
 
     @Test
-    public void intParam_succeeds() {
+    void intParam_succeeds() {
         final Response response = target("/valid/intParam")
                 .queryParam("num", 42)
                 .request()
@@ -956,7 +956,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void intParamNotNull_fails_with_null() {
+    void intParamNotNull_fails_with_null() {
         final Response response = target("/valid/intParamNotNull")
                 .queryParam("num")
                 .request()
@@ -968,7 +968,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void intParamNotNull_fails_with_empty_string() {
+    void intParamNotNull_fails_with_empty_string() {
         final Response response = target("/valid/intParamNotNull")
                 .queryParam("num", "")
                 .request()
@@ -980,7 +980,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void intParamNotNull_fails_with_constraint_violation() {
+    void intParamNotNull_fails_with_constraint_violation() {
         final Response response = target("/valid/intParamNotNull")
                 .queryParam("num", 5)
                 .request()
@@ -992,7 +992,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void intParamNotNull_fails_with_string() {
+    void intParamNotNull_fails_with_string() {
         final Response response = target("/valid/intParamNotNull")
                 .queryParam("num", "test")
                 .request()
@@ -1004,7 +1004,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void intParamNotNull_succeeds() {
+    void intParamNotNull_succeeds() {
         final Response response = target("/valid/intParamNotNull")
                 .queryParam("num", 42)
                 .request()
@@ -1015,7 +1015,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void intParamWithDefault_succeeds_with_null() {
+    void intParamWithDefault_succeeds_with_null() {
         final Response response = target("/valid/intParamWithDefault")
                 .queryParam("num")
                 .request()
@@ -1026,7 +1026,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void intParamWithDefault_fails_with_empty_string() {
+    void intParamWithDefault_fails_with_empty_string() {
         final Response response = target("/valid/intParamWithDefault")
                 .queryParam("num", "")
                 .request()
@@ -1037,7 +1037,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void intParamWithDefault_fails_with_constraint_violation() {
+    void intParamWithDefault_fails_with_constraint_violation() {
         final Response response = target("/valid/intParamWithDefault")
                 .queryParam("num", 5)
                 .request()
@@ -1049,7 +1049,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void intParamWithDefault_fails_with_string() {
+    void intParamWithDefault_fails_with_string() {
         final Response response = target("/valid/intParamWithDefault")
                 .queryParam("num", "test")
                 .request()
@@ -1061,7 +1061,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void intParamWithDefault_succeeds() {
+    void intParamWithDefault_succeeds() {
         final Response response = target("/valid/intParamWithDefault")
                 .queryParam("num", 30)
                 .request()
@@ -1072,7 +1072,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void intParamWithOptionalInside_fails_with_missing() {
+    void intParamWithOptionalInside_fails_with_missing() {
         final Response response = target("/valid/intParamWithOptionalInside")
                 .request()
                 .get();
@@ -1083,7 +1083,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void intParamWithOptionalInside_fails_with_empty_string() {
+    void intParamWithOptionalInside_fails_with_empty_string() {
         final Response response = target("/valid/intParamWithOptionalInside")
                 .queryParam("num", "")
                 .request()
@@ -1095,7 +1095,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void intParamWithOptionalInside_fails_with_constraint_violation() {
+    void intParamWithOptionalInside_fails_with_constraint_violation() {
         final Response response = target("/valid/intParamWithOptionalInside")
                 .queryParam("num", 5)
                 .request()
@@ -1107,7 +1107,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void intParamWithOptionalInside_fails_with_string() {
+    void intParamWithOptionalInside_fails_with_string() {
         final Response response = target("/valid/intParamWithOptionalInside")
                 .queryParam("num", "test")
                 .request()
@@ -1119,7 +1119,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void intParamWithOptionalInside_succeeds() {
+    void intParamWithOptionalInside_succeeds() {
         final Response response = target("/valid/intParamWithOptionalInside")
                 .queryParam("num", 30)
                 .request()
@@ -1130,7 +1130,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void optionalInt_succeeds_with_missing() {
+    void optionalInt_succeeds_with_missing() {
         final Response response = target("/valid/optionalInt")
                 .request()
                 .get();
@@ -1140,7 +1140,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void optionalInt_succeeds_with_empty_string() {
+    void optionalInt_succeeds_with_empty_string() {
         final Response response = target("/valid/optionalInt")
                 .queryParam("num", "")
                 .request()
@@ -1151,7 +1151,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void optionalInt_fails_with_constraint_violation() {
+    void optionalInt_fails_with_constraint_violation() {
         final Response response = target("/valid/optionalInt")
                 .queryParam("num", 5)
                 .request()
@@ -1163,7 +1163,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void optionalInt_fails_with_string() {
+    void optionalInt_fails_with_string() {
         final Response response = target("/valid/optionalInt")
                 .queryParam("num", "test")
                 .request()
@@ -1174,7 +1174,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void optionalInt_succeeds() {
+    void optionalInt_succeeds() {
         final Response response = target("/valid/optionalInt")
                 .queryParam("num", 30)
                 .request()
@@ -1186,7 +1186,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
 
 
     @Test
-    public void optionalIntWithDefault_succeeds_with_missing() {
+    void optionalIntWithDefault_succeeds_with_missing() {
         final Response response = target("/valid/optionalIntWithDefault")
                 .request()
                 .get();
@@ -1196,7 +1196,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void optionalIntWithDefault_succeeds_with_empty_string() {
+    void optionalIntWithDefault_succeeds_with_empty_string() {
         final Response response = target("/valid/optionalIntWithDefault")
                 .queryParam("num", "")
                 .request()
@@ -1207,7 +1207,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void optionalIntWithDefault_fails_with_constraint_violation() {
+    void optionalIntWithDefault_fails_with_constraint_violation() {
         final Response response = target("/valid/optionalIntWithDefault")
                 .queryParam("num", 5)
                 .request()
@@ -1219,7 +1219,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void optionalIntWithDefault_succeeds_with_string() {
+    void optionalIntWithDefault_succeeds_with_string() {
         final Response response = target("/valid/optionalIntWithDefault")
                 .queryParam("num", "test")
                 .request()
@@ -1230,7 +1230,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void optionalIntWithDefault_succeeds() {
+    void optionalIntWithDefault_succeeds() {
         final Response response = target("/valid/optionalIntWithDefault")
                 .queryParam("num", 30)
                 .request()
@@ -1241,7 +1241,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void optionalInteger_succeeds_with_missing() {
+    void optionalInteger_succeeds_with_missing() {
         final Response response = target("/valid/optionalInteger")
                 .request()
                 .get();
@@ -1251,7 +1251,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void optionalInteger_succeeds_with_empty_string() {
+    void optionalInteger_succeeds_with_empty_string() {
         final Response response = target("/valid/optionalInteger")
                 .queryParam("num", "")
                 .request()
@@ -1262,7 +1262,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void optionalInteger_fails_with_constraint_violation() {
+    void optionalInteger_fails_with_constraint_violation() {
         final Response response = target("/valid/optionalInteger")
                 .queryParam("num", 5)
                 .request()
@@ -1274,7 +1274,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void optionalInteger_fails_with_string() {
+    void optionalInteger_fails_with_string() {
         final Response response = target("/valid/optionalInteger")
                 .queryParam("num", "test")
                 .request()
@@ -1285,7 +1285,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void optionalInteger_succeeds() {
+    void optionalInteger_succeeds() {
         final Response response = target("/valid/optionalInteger")
                 .queryParam("num", 30)
                 .request()
@@ -1297,7 +1297,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
 
 
     @Test
-    public void optionalIntegerWithDefault_succeeds_with_missing() {
+    void optionalIntegerWithDefault_succeeds_with_missing() {
         final Response response = target("/valid/optionalIntegerWithDefault")
                 .request()
                 .get();
@@ -1307,7 +1307,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void optionalIntegerWithDefault_succeeds_with_empty_string() {
+    void optionalIntegerWithDefault_succeeds_with_empty_string() {
         final Response response = target("/valid/optionalIntegerWithDefault")
                 .queryParam("num", "")
                 .request()
@@ -1318,7 +1318,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void optionalIntegerWithDefault_fails_with_constraint_violation() {
+    void optionalIntegerWithDefault_fails_with_constraint_violation() {
         final Response response = target("/valid/optionalIntegerWithDefault")
                 .queryParam("num", 5)
                 .request()
@@ -1330,7 +1330,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void optionalIntegerWithDefault_fails_with_string() {
+    void optionalIntegerWithDefault_fails_with_string() {
         final Response response = target("/valid/optionalIntegerWithDefault")
                 .queryParam("num", "test")
                 .request()
@@ -1341,7 +1341,7 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    public void optionalIntegerWithDefault_succeeds() {
+    void optionalIntegerWithDefault_succeeds() {
         final Response response = target("/valid/optionalIntegerWithDefault")
                 .queryParam("num", 30)
                 .request()

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/FuzzyEnumParamConverterProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/FuzzyEnumParamConverterProviderTest.java
@@ -160,7 +160,7 @@ public class FuzzyEnumParamConverterProviderTest {
     }
 
     @Test
-    public void testFuzzyEnum() {
+    void testFuzzyEnum() {
         final ParamConverter<Fuzzy> converter = getConverter(Fuzzy.class);
         assertThat(converter.fromString(null)).isNull();
         assertThat(converter.fromString("A.1")).isSameAs(Fuzzy.A_1);
@@ -180,18 +180,18 @@ public class FuzzyEnumParamConverterProviderTest {
 
 
     @Test
-    public void testToString() {
+    void testToString() {
         final ParamConverter<WithToString> converter = getConverter(WithToString.class);
         assertThat(converter.toString(WithToString.A_1)).isEqualTo("<A_1>");
     }
 
     @Test
-    public void testNonEnum() {
+    void testNonEnum() {
         assertThat(paramConverterProvider.getConverter(Klass.class, null, new Annotation[] {})).isNull();
     }
 
     @Test
-    public void testEnumViaExplicitFromString() {
+    void testEnumViaExplicitFromString() {
         final ParamConverter<ExplicitFromString> converter = getConverter(ExplicitFromString.class);
         assertThat(converter.fromString("1")).isSameAs(ExplicitFromString.A);
         assertThat(converter.fromString("2")).isSameAs(ExplicitFromString.B);
@@ -203,7 +203,7 @@ public class FuzzyEnumParamConverterProviderTest {
     }
 
     @Test
-    public void testEnumViaExplicitFromStringThatThrowsWebApplicationException() {
+    void testEnumViaExplicitFromStringThatThrowsWebApplicationException() {
         final ParamConverter<ExplicitFromStringThrowsWebApplicationException> converter =
             getConverter(ExplicitFromStringThrowsWebApplicationException.class);
         final WebApplicationException throwable = catchThrowableOfType(() -> converter.fromString("3"), WebApplicationException.class);
@@ -214,7 +214,7 @@ public class FuzzyEnumParamConverterProviderTest {
     }
 
     @Test
-    public void testEnumViaExplicitFromStringThatThrowsOtherException() {
+    void testEnumViaExplicitFromStringThatThrowsOtherException() {
         final ParamConverter<ExplicitFromStringThrowsOtherException> converter =
             getConverter(ExplicitFromStringThrowsOtherException.class);
         final WebApplicationException throwable = catchThrowableOfType(() -> converter.fromString("1"), WebApplicationException.class);
@@ -225,7 +225,7 @@ public class FuzzyEnumParamConverterProviderTest {
     }
 
     @Test
-    public void testEnumViaExplicitFromStringNonStatic() {
+    void testEnumViaExplicitFromStringNonStatic() {
         final ParamConverter<ExplicitFromStringNonStatic> converter = getConverter(ExplicitFromStringNonStatic.class);
         final WebApplicationException throwable = catchThrowableOfType(() -> converter.fromString("1"), WebApplicationException.class);
         assertThat(throwable.getResponse())
@@ -238,7 +238,7 @@ public class FuzzyEnumParamConverterProviderTest {
     }
 
     @Test
-    public void testEnumViaExplicitFromStringPrivate() {
+    void testEnumViaExplicitFromStringPrivate() {
         final ParamConverter<ExplicitFromStringPrivate> converter = getConverter(ExplicitFromStringPrivate.class);
         final WebApplicationException throwable = catchThrowableOfType(() -> converter.fromString("1"), WebApplicationException.class);
         assertThat(throwable.getResponse())

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/JerseyViolationExceptionTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/JerseyViolationExceptionTest.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.mock;
 public class JerseyViolationExceptionTest {
 
     @Test
-    public void testAccessors() {
+    void testAccessors() {
         final Set<? extends ConstraintViolation<?>> violations = Collections.emptySet();
 
         @SuppressWarnings("unchecked")

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ParamValidatorUnwrapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ParamValidatorUnwrapperTest.java
@@ -30,14 +30,14 @@ public class ParamValidatorUnwrapperTest {
     private final Validator validator = Validators.newValidator();
 
     @Test
-    public void succeedsWithAllGoodData() {
+    void succeedsWithAllGoodData() {
         final Example example = new Example();
         final Set<ConstraintViolation<Example>> validate = validator.validate(example);
         assertThat(validate).isEmpty();
     }
 
     @Test
-    public void failsWithInvalidIntParam() {
+    void failsWithInvalidIntParam() {
         final Example example = new Example();
         example.inter = new IntParam("2");
         final Set<ConstraintViolation<Example>> validate = validator.validate(example);
@@ -46,7 +46,7 @@ public class ParamValidatorUnwrapperTest {
 
     @SuppressWarnings("NullAway")
     @Test
-    public void failsWithNullIntParam() {
+    void failsWithNullIntParam() {
         final Example example = new Example();
         example.inter = null;
         final Set<ConstraintViolation<Example>> validate = validator.validate(example);
@@ -55,7 +55,7 @@ public class ParamValidatorUnwrapperTest {
 
     @SuppressWarnings("NullAway")
     @Test
-    public void failsWithNullNonEmptyStringParam() {
+    void failsWithNullNonEmptyStringParam() {
         final Example example = new Example();
         example.name = null;
         final Set<ConstraintViolation<Example>> validate = validator.validate(example);
@@ -63,7 +63,7 @@ public class ParamValidatorUnwrapperTest {
     }
 
     @Test
-    public void failsWithInvalidNonEmptyStringParam() {
+    void failsWithInvalidNonEmptyStringParam() {
         final Example example = new Example();
         example.name = new NonEmptyStringParam("hello");
         final Set<ConstraintViolation<Example>> validate = validator.validate(example);
@@ -71,7 +71,7 @@ public class ParamValidatorUnwrapperTest {
     }
 
     @Test
-    public void failsWithEmptyNonEmptyStringParam() {
+    void failsWithEmptyNonEmptyStringParam() {
         final Example example = new Example();
         example.name = new NonEmptyStringParam("");
         final Set<ConstraintViolation<Example>> validate = validator.validate(example);

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/MutableServletContextHandlerTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/MutableServletContextHandlerTest.java
@@ -8,19 +8,19 @@ public class MutableServletContextHandlerTest {
     private final MutableServletContextHandler handler = new MutableServletContextHandler();
 
     @Test
-    public void defaultsToSessionsBeingDisabled() throws Exception {
+    void defaultsToSessionsBeingDisabled() throws Exception {
         assertThat(handler.isSessionsEnabled())
                 .isFalse();
     }
 
     @Test
-    public void defaultsToSecurityBeingDisabled() throws Exception {
+    void defaultsToSecurityBeingDisabled() throws Exception {
         assertThat(handler.isSecurityEnabled())
                 .isFalse();
     }
 
     @Test
-    public void canEnableSessionManagement() throws Exception {
+    void canEnableSessionManagement() throws Exception {
         handler.setSessionsEnabled(true);
 
         assertThat(handler.isSessionsEnabled())
@@ -31,7 +31,7 @@ public class MutableServletContextHandlerTest {
     }
 
     @Test
-    public void canDisableSessionManagement() throws Exception {
+    void canDisableSessionManagement() throws Exception {
         handler.setSessionsEnabled(true);
         handler.setSessionsEnabled(false);
 
@@ -43,7 +43,7 @@ public class MutableServletContextHandlerTest {
     }
 
     @Test
-    public void canEnableSecurity() throws Exception {
+    void canEnableSecurity() throws Exception {
         handler.setSecurityEnabled(true);
 
         assertThat(handler.isSessionsEnabled())
@@ -54,7 +54,7 @@ public class MutableServletContextHandlerTest {
     }
 
     @Test
-    public void canDisableSecurity() throws Exception {
+    void canDisableSecurity() throws Exception {
         handler.setSecurityEnabled(true);
         handler.setSecurityEnabled(false);
 

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NetUtilTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NetUtilTest.java
@@ -19,7 +19,7 @@ public class NetUtilTest {
      * Assuming Windows
      */
     @Test
-    public void testDefaultTcpBacklogForWindows() {
+    void testDefaultTcpBacklogForWindows() {
         assumeThat(System.getProperty(OS_NAME_PROPERTY)).contains("win");
         assumeThat(isTcpBacklogSettingReadable()).isFalse();
         assertThat(NetUtil.getTcpBacklog()).isEqualTo(NetUtil.DEFAULT_TCP_BACKLOG_WINDOWS);
@@ -29,7 +29,7 @@ public class NetUtilTest {
      * Assuming Mac (which does not have /proc)
      */
     @Test
-    public void testNonWindowsDefaultTcpBacklog() {
+    void testNonWindowsDefaultTcpBacklog() {
         assumeThat(System.getProperty(OS_NAME_PROPERTY)).contains("Mac OS X");
         assumeThat(isTcpBacklogSettingReadable()).isFalse();
         assertThat(NetUtil.getTcpBacklog()).isEqualTo(NetUtil.DEFAULT_TCP_BACKLOG_LINUX);
@@ -39,7 +39,7 @@ public class NetUtilTest {
      * Assuming Mac (which does not have /proc)
      */
     @Test
-    public void testNonWindowsSpecifiedTcpBacklog() {
+    void testNonWindowsSpecifiedTcpBacklog() {
         assumeThat(System.getProperty(OS_NAME_PROPERTY)).contains("Mac OS X");
         assumeThat(isTcpBacklogSettingReadable()).isFalse();
         assertThat(NetUtil.getTcpBacklog(100)).isEqualTo(100);
@@ -49,7 +49,7 @@ public class NetUtilTest {
      * Assuming Linux (which has /proc)
      */
     @Test
-    public void testOsSetting() {
+    void testOsSetting() {
         assumeThat(System.getProperty(OS_NAME_PROPERTY)).contains("Linux");
         assumeThat(isTcpBacklogSettingReadable()).isTrue();
         assertThat(NetUtil.getTcpBacklog(-1)).isNotEqualTo(-1);
@@ -59,7 +59,7 @@ public class NetUtilTest {
     }
 
     @Test
-    public void testAllLocalIps() throws Exception {
+    void testAllLocalIps() throws Exception {
         NetUtil.setLocalIpFilter((nif, adr) ->
             (adr != null) && !adr.isLoopbackAddress() && (nif.isPointToPoint() || !adr.isLinkLocalAddress()));
         final Collection<InetAddress> addresses = NetUtil.getAllLocalIPs();
@@ -68,7 +68,7 @@ public class NetUtilTest {
     }
 
     @Test
-    public void testLocalIpsWithLocalFilter() throws Exception {
+    void testLocalIpsWithLocalFilter() throws Exception {
         NetUtil.setLocalIpFilter((inf, adr) -> adr != null);
         final Collection<InetAddress> addresses = NetUtil.getAllLocalIPs();
         assertThat(addresses.size()).isGreaterThan(0);

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NonblockingServletHolderTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NonblockingServletHolderTest.java
@@ -28,20 +28,20 @@ public class NonblockingServletHolderTest {
     private final ServletResponse response = mock(ServletResponse.class);
 
     @Test
-    public void hasAServlet() throws Exception {
+    void hasAServlet() throws Exception {
         assertThat(holder.getServlet())
                 .isEqualTo(servlet);
     }
 
     @Test
-    public void servicesRequests() throws Exception {
+    void servicesRequests() throws Exception {
         holder.handle(baseRequest, request, response);
 
         verify(servlet).service(request, response);
     }
 
     @Test
-    public void servicesRequestHandleEofException() throws Exception {
+    void servicesRequestHandleEofException() throws Exception {
         doThrow(new EofException()).when(servlet).service(eq(request), eq(response));
         assertThatCode(() -> {
             holder.handle(baseRequest, request, response);
@@ -50,7 +50,7 @@ public class NonblockingServletHolderTest {
     }
 
     @Test
-    public void servicesRequestException() throws Exception {
+    void servicesRequestException() throws Exception {
         doThrow(new IOException()).when(servlet).service(eq(request), eq(response));
         assertThatExceptionOfType(IOException.class).isThrownBy(() -> {
             holder.handle(baseRequest, request, response);
@@ -58,7 +58,7 @@ public class NonblockingServletHolderTest {
     }
 
     @Test
-    public void temporarilyDisablesAsyncRequestsIfDisabled() throws Exception {
+    void temporarilyDisablesAsyncRequestsIfDisabled() throws Exception {
         holder.setAsyncSupported(false);
 
         holder.handle(baseRequest, request, response);
@@ -70,7 +70,7 @@ public class NonblockingServletHolderTest {
     }
 
     @Test
-    public void isEagerlyInitialized() throws Exception {
+    void isEagerlyInitialized() throws Exception {
         assertThat(holder.getInitOrder())
                 .isEqualTo(1);
     }

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/RoutingHandlerTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/RoutingHandlerTest.java
@@ -36,7 +36,7 @@ public class RoutingHandlerTest {
                                                                       handler2));
 
     @Test
-    public void startsAndStopsAllHandlers() throws Exception {
+    void startsAndStopsAllHandlers() throws Exception {
         handler1.setServer(mock(Server.class));
         handler2.setServer(mock(Server.class));
         handler.start();
@@ -56,7 +56,7 @@ public class RoutingHandlerTest {
     }
 
     @Test
-    public void routesRequestsToTheConnectorSpecificHandler() throws Exception {
+    void routesRequestsToTheConnectorSpecificHandler() throws Exception {
         final HttpChannel channel = mock(HttpChannel.class);
         when(channel.getConnector()).thenReturn(connector1);
 
@@ -72,7 +72,7 @@ public class RoutingHandlerTest {
     }
 
     @Test
-    public void withSessionHandler() throws Exception {
+    void withSessionHandler() throws Exception {
         final ContextHandler handler1 = new ContextHandler();
         final ServletContextHandler handler2 = new ServletContextHandler();
         final SessionHandler childHandler1 = new SessionHandler();
@@ -89,7 +89,7 @@ public class RoutingHandlerTest {
     }
 
     @Test
-    public void withoutSessionHandler() throws Exception {
+    void withoutSessionHandler() throws Exception {
         new Server().setHandler(handler);
 
         handler.start();

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/ServerPushFilterFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/ServerPushFilterFactoryTest.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.verify;
 public class ServerPushFilterFactoryTest {
 
     @Test
-    public void testLoadConfiguration() throws Exception {
+    void testLoadConfiguration() throws Exception {
         final ServerPushFilterFactory serverPush = new YamlConfigurationFactory<>(
                 ServerPushFilterFactory.class, BaseValidator.newValidator(),
                 Jackson.newObjectMapper(), "dw-server-push")
@@ -37,7 +37,7 @@ public class ServerPushFilterFactoryTest {
     }
 
     @Test
-    public void testDefaultConfiguration() {
+    void testDefaultConfiguration() {
         final ServerPushFilterFactory serverPush = new ServerPushFilterFactory();
         assertThat(serverPush.isEnabled()).isFalse();
         assertThat(serverPush.getAssociatePeriod()).isEqualTo(Duration.seconds(4));
@@ -47,7 +47,7 @@ public class ServerPushFilterFactoryTest {
     }
 
     @Test
-    public void testDontAddFilterByDefault() {
+    void testDontAddFilterByDefault() {
         final ServerPushFilterFactory serverPush = new ServerPushFilterFactory();
 
         ServletContextHandler servletContextHandler = mock(ServletContextHandler.class);
@@ -57,7 +57,7 @@ public class ServerPushFilterFactoryTest {
     }
 
     @Test
-    public void testAddFilter() {
+    void testAddFilter() {
         final ServerPushFilterFactory serverPush = new ServerPushFilterFactory();
         serverPush.setRefererHosts(Arrays.asList("dropwizard.io", "dropwizard.github.io"));
         serverPush.setRefererPorts(Arrays.asList(8444, 8445));
@@ -75,7 +75,7 @@ public class ServerPushFilterFactoryTest {
     }
 
     @Test
-    public void testRefererHostsAndPortsAreNotSet() {
+    void testRefererHostsAndPortsAreNotSet() {
         final ServerPushFilterFactory serverPush = new ServerPushFilterFactory();
         serverPush.setEnabled(true);
 

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/ZipExceptionHandlingInputStreamDelegateTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/ZipExceptionHandlingInputStreamDelegateTest.java
@@ -19,7 +19,7 @@ public class ZipExceptionHandlingInputStreamDelegateTest {
     private final ZipExceptionHandlingInputStream in = new ZipExceptionHandlingInputStream(delegate, "gzip");
 
     @Test
-    public void testReadBytes() throws Exception {
+    void testReadBytes() throws Exception {
         byte[] buffer = new byte[64];
 
         doReturn(buffer.length)
@@ -31,7 +31,7 @@ public class ZipExceptionHandlingInputStreamDelegateTest {
     }
 
     @Test
-    public void testReadByte() throws Exception {
+    void testReadByte() throws Exception {
         doReturn(42).when(delegate).read();
         assertEquals(42, in.read());
         verify(delegate).read();
@@ -39,7 +39,7 @@ public class ZipExceptionHandlingInputStreamDelegateTest {
     }
 
     @Test
-    public void testSkip() throws Exception {
+    void testSkip() throws Exception {
         doReturn(42L).when(delegate).skip(42L);
         assertEquals(42L, in.skip(42L));
         verify(delegate).skip(42L);
@@ -47,7 +47,7 @@ public class ZipExceptionHandlingInputStreamDelegateTest {
     }
 
     @Test
-    public void testAvailable() throws Exception {
+    void testAvailable() throws Exception {
         doReturn(42).when(delegate).available();
         assertEquals(42, in.available());
         verify(delegate).available();
@@ -55,21 +55,21 @@ public class ZipExceptionHandlingInputStreamDelegateTest {
     }
 
     @Test
-    public void testClose() throws Exception {
+    void testClose() throws Exception {
         in.close();
         verify(delegate).close();
         verifyNoMoreInteractions(delegate);
     }
 
     @Test
-    public void testMark() {
+    void testMark() {
         in.mark(42);
         verify(delegate).mark(42);
         verifyNoMoreInteractions(delegate);
     }
 
     @Test
-    public void testMarkSupported() {
+    void testMarkSupported() {
         doReturn(true).when(delegate).markSupported();
         assertTrue(in.markSupported());
         verify(delegate).markSupported();
@@ -77,7 +77,7 @@ public class ZipExceptionHandlingInputStreamDelegateTest {
     }
 
     @Test
-    public void testReset() throws Exception {
+    void testReset() throws Exception {
         doNothing().when(delegate).reset();
         in.reset();
         verify(delegate).reset();

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
@@ -54,7 +54,7 @@ public class LayoutIntegrationTests {
         ConsoleAppenderFactory.class, BaseValidator.newValidator(), objectMapper, "dw-json-log");
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         objectMapper.getSubtypeResolver().registerSubtypes(AccessJsonLayoutBaseFactory.class, EventJsonLayoutBaseFactory.class);
     }
 
@@ -64,7 +64,7 @@ public class LayoutIntegrationTests {
     }
 
     @Test
-    public void testDeserializeJson() throws Exception {
+    void testDeserializeJson() throws Exception {
         ConsoleAppenderFactory<ILoggingEvent> appenderFactory = getAppenderFactory("yaml/json-log.yml");
         DiscoverableLayoutFactory<?> layout = requireNonNull(appenderFactory.getLayout());
         assertThat(layout).isInstanceOf(EventJsonLayoutBaseFactory.class);
@@ -94,7 +94,7 @@ public class LayoutIntegrationTests {
     }
 
     @Test
-    public void testDeserializeAccessJson() throws Exception {
+    void testDeserializeAccessJson() throws Exception {
         ConsoleAppenderFactory<IAccessEvent> appenderFactory = getAppenderFactory("yaml/json-access-log.yml");
         DiscoverableLayoutFactory<?> layout = requireNonNull(appenderFactory.getLayout());
         assertThat(layout).isInstanceOf(AccessJsonLayoutBaseFactory.class);
@@ -122,7 +122,7 @@ public class LayoutIntegrationTests {
     }
 
     @Test
-    public void testLogJsonToConsole() throws Exception {
+    void testLogJsonToConsole() throws Exception {
         ConsoleAppenderFactory<ILoggingEvent> consoleAppenderFactory = getAppenderFactory("yaml/json-log-default.yml");
         DefaultLoggingFactory defaultLoggingFactory = new DefaultLoggingFactory();
         defaultLoggingFactory.setAppenders(Collections.singletonList(consoleAppenderFactory));
@@ -165,7 +165,7 @@ public class LayoutIntegrationTests {
     }
 
     @Test
-    public void testLogAccessJsonToConsole() throws Exception {
+    void testLogAccessJsonToConsole() throws Exception {
         ConsoleAppenderFactory<IAccessEvent> consoleAppenderFactory = getAppenderFactory("yaml/json-access-log-default.yml");
         // Use sys.err, because there are some other log configuration messages in std.out
         consoleAppenderFactory.setTarget(ConsoleAppenderFactory.ConsoleStream.STDERR);

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/AccessJsonLayoutTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/AccessJsonLayoutTest.java
@@ -49,7 +49,7 @@ public class AccessJsonLayoutTest {
         includes, Collections.emptyMap(), Collections.emptyMap());
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         requestHeaders = Maps.of(
                 "Host", "api.example.io",
                 "User-Agent", userAgent);
@@ -80,7 +80,7 @@ public class AccessJsonLayoutTest {
     }
 
     @Test
-    public void testProducesDefaultJsonMap() {
+    void testProducesDefaultJsonMap() {
         assertThat(accessJsonLayout.toJsonMap(event)).containsOnly(
             entry("timestamp", timestamp), entry("remoteUser", "john"),
             entry("method", "GET"), entry("uri", uri),
@@ -90,7 +90,7 @@ public class AccessJsonLayoutTest {
     }
 
     @Test
-    public void testDisableRemoteAddress() {
+    void testDisableRemoteAddress() {
         includes.remove(AccessAttribute.REMOTE_ADDRESS);
         accessJsonLayout.setIncludes(includes);
 
@@ -103,7 +103,7 @@ public class AccessJsonLayoutTest {
     }
 
     @Test
-    public void testDisableTimestamp() {
+    void testDisableTimestamp() {
         includes.remove(AccessAttribute.TIMESTAMP);
         accessJsonLayout.setIncludes(includes);
 
@@ -116,7 +116,7 @@ public class AccessJsonLayoutTest {
     }
 
     @Test
-    public void testEnableSpecificResponseHeader() {
+    void testEnableSpecificResponseHeader() {
         accessJsonLayout.setResponseHeaders(Collections.singleton("transfer-encoding"));
 
         assertThat(accessJsonLayout.toJsonMap(event)).containsOnly(
@@ -129,7 +129,7 @@ public class AccessJsonLayoutTest {
     }
 
     @Test
-    public void testEnableSpecificRequestHeader() {
+    void testEnableSpecificRequestHeader() {
         accessJsonLayout.setRequestHeaders(Collections.singleton("user-agent"));
 
         assertThat(accessJsonLayout.toJsonMap(event)).containsOnly(
@@ -142,7 +142,7 @@ public class AccessJsonLayoutTest {
     }
 
     @Test
-    public void testEnableEverything() {
+    void testEnableEverything() {
         accessJsonLayout.setIncludes(EnumSet.allOf(AccessAttribute.class));
         accessJsonLayout.setRequestHeaders(Sets.of("Host", "User-Agent"));
         accessJsonLayout.setResponseHeaders(Sets.of("Transfer-Encoding", "Content-Type"));
@@ -163,7 +163,7 @@ public class AccessJsonLayoutTest {
     }
 
     @Test
-    public void testAddAdditionalFields() {
+    void testAddAdditionalFields() {
         final Map<String, Object> additionalFields = Maps.of(
                 "serviceName", "user-service",
                 "serviceVersion", "1.2.3");
@@ -179,7 +179,7 @@ public class AccessJsonLayoutTest {
     }
 
     @Test
-    public void testCustomFieldNames() {
+    void testCustomFieldNames() {
         final Map<String, String> customFieldNames = Maps.of(
                 "remoteUser", "remote_user",
                 "userAgent", "user_agent",
@@ -196,7 +196,7 @@ public class AccessJsonLayoutTest {
     }
 
     @Test
-    public void testRequestAttributes() {
+    void testRequestAttributes() {
         final String attribute1 = "attribute1";
         final String attribute2 = "attribute2";
         final String attribute3 = "attribute3";
@@ -218,7 +218,7 @@ public class AccessJsonLayoutTest {
     }
 
     @Test
-    public void testRequestAttributesWithNull() {
+    void testRequestAttributesWithNull() {
         final String attribute1 = "attribute1";
         final String attribute2 = "attribute2";
         final String attribute3 = "attribute3";
@@ -239,7 +239,7 @@ public class AccessJsonLayoutTest {
     }
 
     @Test
-    public void testProducesCorrectJson() throws Exception {
+    void testProducesCorrectJson() throws Exception {
         JsonNode json = objectMapper.readTree(accessJsonLayout.doLayout(event));
         assertThat(json).isNotNull();
         assertThat(json.get("timestamp").asText()).isEqualTo(timestamp);

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/EventJsonLayoutTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/EventJsonLayoutTest.java
@@ -56,7 +56,7 @@ public class EventJsonLayoutTest {
     private EventJsonLayout eventJsonLayout;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         when(event.getTimeStamp()).thenReturn(1514906361000L);
         when(event.getLevel()).thenReturn(Level.INFO);
         when(event.getThreadName()).thenReturn("main");
@@ -89,14 +89,14 @@ public class EventJsonLayoutTest {
     }
 
     @Test
-    public void testProducesDefaultMap() {
+    void testProducesDefaultMap() {
         Map<String, Object> map = eventJsonLayout.toJsonMap(event);
         final HashMap<String, Object> expectedFields = new HashMap<>(defaultExpectedFields);
         assertThat(map).isEqualTo(expectedFields);
     }
 
     @Test
-    public void testLogsAnException() {
+    void testLogsAnException() {
         when(event.getThrowableProxy()).thenReturn(new ThrowableProxyVO());
         when(throwableProxyConverter.convert(event)).thenReturn("Boom!");
 
@@ -106,7 +106,7 @@ public class EventJsonLayoutTest {
     }
 
     @Test
-    public void testDisableTimestamp() {
+    void testDisableTimestamp() {
         EnumSet<EventAttribute> eventAttributes = EnumSet.copyOf(DEFAULT_EVENT_ATTRIBUTES);
         eventAttributes.remove(EventAttribute.TIMESTAMP);
         eventJsonLayout.setIncludes(eventAttributes);
@@ -117,7 +117,7 @@ public class EventJsonLayoutTest {
     }
 
     @Test
-    public void testLogVersion() {
+    void testLogVersion() {
         eventJsonLayout.setJsonProtocolVersion("1.2");
 
         final HashMap<String, Object> expectedFields = new HashMap<>(defaultExpectedFields);
@@ -126,7 +126,7 @@ public class EventJsonLayoutTest {
     }
 
     @Test
-    public void testReplaceFieldName() {
+    void testReplaceFieldName() {
         final Map<String, String> customFieldNames = Maps.of(
                 "timestamp", "@timestamp",
                 "message", "@message");
@@ -143,7 +143,7 @@ public class EventJsonLayoutTest {
     }
 
     @Test
-    public void testAddNewField() {
+    void testAddNewField() {
         final Map<String, Object> additionalFields = Maps.of(
                 "serviceName", "userService",
                 "serviceBuild", 207);
@@ -159,7 +159,7 @@ public class EventJsonLayoutTest {
     }
 
     @Test
-    public void testFilterMdc() {
+    void testFilterMdc() {
         final Set<String> includesMdcKeys = Sets.of("userId", "orderId");
         Map<String, Object> map = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter, DEFAULT_EVENT_ATTRIBUTES,
             Collections.emptyMap(), Collections.emptyMap(), includesMdcKeys, false)
@@ -174,7 +174,7 @@ public class EventJsonLayoutTest {
     }
 
     @Test
-    public void testFlattensMdcMap() {
+    void testFlattensMdcMap() {
         Map<String, Object> map = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter,
                 DEFAULT_EVENT_ATTRIBUTES, Collections.emptyMap(), Collections.emptyMap(), Collections.emptySet(), true)
                 .toJsonMap(event);
@@ -186,14 +186,14 @@ public class EventJsonLayoutTest {
     }
 
     @Test
-    public void testStartThrowableConverter() {
+    void testStartThrowableConverter() {
         eventJsonLayout.start();
 
         verify(throwableProxyConverter).start();
     }
 
     @Test
-    public void testStopThrowableConverter() {
+    void testStopThrowableConverter() {
         eventJsonLayout.stop();
 
         verify(throwableProxyConverter).stop();

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/ExceptionFormatTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/ExceptionFormatTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ExceptionFormatTest {
 
     @Test
-    public void testDefaults() {
+    void testDefaults() {
         ExceptionFormat ef = new ExceptionFormat();
         assertThat(ef.isRootFirst()).isTrue();
         assertThat(ef.getDepth()).isEqualTo("full");
@@ -15,7 +15,7 @@ public class ExceptionFormatTest {
     }
 
     @Test
-    public void testSetDepth() {
+    void testSetDepth() {
         ExceptionFormat ef = new ExceptionFormat();
         assertThat(ef.getDepth()).isEqualTo("full");
 

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/JsonFormatterTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/JsonFormatterTest.java
@@ -21,7 +21,7 @@ public class JsonFormatterTest {
     private final ObjectMapper objectMapper = Jackson.newObjectMapper();
 
     @Test
-    public void testNoPrettyPrintNoLineSeparator() throws IOException {
+    void testNoPrettyPrintNoLineSeparator() throws IOException {
         JsonFormatter formatter = new JsonFormatter(objectMapper, false, false);
 
         final JsonNode actual = objectMapper.readTree(formatter.toJson(map));
@@ -31,7 +31,7 @@ public class JsonFormatterTest {
 
 
     @Test
-    public void testNoPrettyPrintWithLineSeparator() throws IOException {
+    void testNoPrettyPrintWithLineSeparator() throws IOException {
         JsonFormatter formatter = new JsonFormatter(objectMapper, false, true);
 
         final String content = formatter.toJson(map);
@@ -42,7 +42,7 @@ public class JsonFormatterTest {
     }
 
     @Test
-    public void testPrettyPrintWithLineSeparator() {
+    void testPrettyPrintWithLineSeparator() {
         JsonFormatter formatter = new JsonFormatter(objectMapper, true, true);
         assertThat(formatter.toJson(map)).isEqualTo(String.format("{%n" +
                 "  \"hobbies\" : [ \"Reading\", \"Biking\", \"Snorkeling\" ],%n" +
@@ -51,7 +51,7 @@ public class JsonFormatterTest {
     }
 
     @Test
-    public void testPrettyPrintNoLineSeparator() {
+    void testPrettyPrintNoLineSeparator() {
         JsonFormatter formatter = new JsonFormatter(objectMapper, true, false);
         assertThat(formatter.toJson(map)).isEqualTo(String.format("{%n" +
                 "  \"hobbies\" : [ \"Reading\", \"Biking\", \"Snorkeling\" ],%n" +

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/MapBuilderTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/MapBuilderTest.java
@@ -16,53 +16,53 @@ public class MapBuilderTest {
     private String message = "Since the dawn of time...";
 
     @Test
-    public void testIncludeStringValue() {
+    void testIncludeStringValue() {
         assertThat(mapBuilder.add("message", true, message).build())
             .containsOnly(entry("message", message));
     }
 
     @Test
-    public void testDoNotIncludeStringValue() {
+    void testDoNotIncludeStringValue() {
         assertThat(mapBuilder.add("message", false, message).build()).isEmpty();
     }
 
     @Test
-    public void testDoNotIncludeNullStringValue() {
+    void testDoNotIncludeNullStringValue() {
         String value = null;
         assertThat(mapBuilder.add("message", true, value).build()).isEmpty();
     }
 
     @Test
-    public void testIncludeNumberValue() {
+    void testIncludeNumberValue() {
         assertThat(mapBuilder.addNumber("status", true, 200)
             .build()).containsOnly(entry("status", 200));
     }
 
     @Test
-    public void testIncludeMapValue() {
+    void testIncludeMapValue() {
         assertThat(mapBuilder.add("headers", true, Collections.singletonMap("userAgent", "Lynx/2.8.7"))
             .build()).containsOnly(entry("headers", Collections.singletonMap("userAgent", "Lynx/2.8.7")));
     }
 
     @Test
-    public void testDoNotIncludeEmptyMapValue() {
+    void testDoNotIncludeEmptyMapValue() {
         assertThat(mapBuilder.add("headers", true, Collections.emptyMap()).build()).isEmpty();
     }
 
     @Test
-    public void testDoNotIncludeNullNumberValue() {
+    void testDoNotIncludeNullNumberValue() {
         Double value = null;
         assertThat(mapBuilder.addNumber("status", true, value).build()).isEmpty();
     }
 
     @Test
-    public void testIncludeFormattedTimestamp() {
+    void testIncludeFormattedTimestamp() {
         assertThat(mapBuilder.addTimestamp("timestamp", true, 1514906361000L).build())
             .containsOnly(entry("timestamp", "2018-01-02T15:19:21.000+0000"));
     }
 
     @Test
-    public void testIncludeNotFormattedTimestamp() {
+    void testIncludeNotFormattedTimestamp() {
         assertThat(new MapBuilder(new TimestampFormatter(null, ZoneId.of("UTC")), Collections.emptyMap(),
             Collections.emptyMap(), size)
             .addTimestamp("timestamp", true, 1514906361000L)
@@ -70,52 +70,52 @@ public class MapBuilderTest {
     }
 
     @Test
-    public void testReplaceStringFieldName() {
+    void testReplaceStringFieldName() {
         assertThat(new MapBuilder(timestampFormatter, Collections.singletonMap("message", "@message"), Collections.emptyMap(), size)
             .add("message", true, message)
             .build()).containsOnly(entry("@message", message));
     }
 
     @Test
-    public void testReplaceNumberFieldName() {
+    void testReplaceNumberFieldName() {
         assertThat(new MapBuilder(timestampFormatter, Collections.singletonMap("status", "@status"), Collections.emptyMap(), size)
             .addNumber("status", true, 200)
             .build()).containsOnly(entry("@status", 200));
     }
 
     @Test
-    public void testAddAdditionalField() {
+    void testAddAdditionalField() {
         assertThat(new MapBuilder(timestampFormatter, Collections.emptyMap(), Collections.singletonMap("version", "1.8.3"), size)
             .add("message", true, message).build())
             .containsOnly(entry("message", message), entry("version", "1.8.3"));
     }
 
     @Test
-    public void testAddSupplier() {
+    void testAddSupplier() {
         assertThat(mapBuilder.add("message", true, () -> message).build())
             .containsOnly(entry("message", message));
     }
     @Test
-    public void testAddNumberSupplier() {
+    void testAddNumberSupplier() {
         assertThat(mapBuilder.addNumber("status", true, () -> 200)
             .build()).containsOnly(entry("status", 200));
     }
     @Test
-    public void testAddMapSupplier() {
+    void testAddMapSupplier() {
         assertThat(mapBuilder.addMap("headers", true, () -> Collections.singletonMap("userAgent", "Lynx/2.8.7"))
             .build()).containsOnly(entry("headers", Collections.singletonMap("userAgent", "Lynx/2.8.7")));
     }
 
     @Test
-    public void testAddSupplierNotInvoked() {
+    void testAddSupplierNotInvoked() {
         assertThat(mapBuilder.add("status", false, () -> {throw new RuntimeException();}).build()).isEmpty();
     }
     @Test
-    public void testAddNumberSupplierNotInvoked() {
+    void testAddNumberSupplierNotInvoked() {
         assertThat(mapBuilder.addNumber("status", false, () -> {throw new RuntimeException();}).build()).isEmpty();
     }
     @Test
-    public void testAddMapSupplierNotInvoked() {
+    void testAddMapSupplierNotInvoked() {
         assertThat(mapBuilder.addMap("status", false, () -> {throw new RuntimeException();}).build()).isEmpty();
     }
 }

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/TimestampFormatterTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/TimestampFormatterTest.java
@@ -11,21 +11,21 @@ public class TimestampFormatterTest {
     private final long timestamp = 1513956631000L;
 
     @Test
-    public void testFormatTimestampAsString() {
+    void testFormatTimestampAsString() {
         TimestampFormatter timestampFormatter = new TimestampFormatter("yyyy-MM-dd'T'HH:mm:ss.SSSZ",
             ZoneId.of("GMT+01:00"));
         assertThat(timestampFormatter.format(timestamp)).isEqualTo("2017-12-22T16:30:31.000+0100");
     }
 
     @Test
-    public void testFormatTimestampFromPredefinedFormat() {
+    void testFormatTimestampFromPredefinedFormat() {
         TimestampFormatter timestampFormatter = new TimestampFormatter("RFC_1123_DATE_TIME",
             ZoneId.of("GMT+01:00"));
         assertThat(timestampFormatter.format(timestamp)).isEqualTo("Fri, 22 Dec 2017 16:30:31 +0100");
     }
 
     @Test
-    public void testDoNotFormatTimestamp() {
+    void testDoNotFormatTimestamp() {
         TimestampFormatter timestampFormatter = new TimestampFormatter(null,
             ZoneId.of("GMT+01:00"));
         assertThat(timestampFormatter.format(timestamp)).isEqualTo(timestamp);

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/AutoCloseableManagerTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/AutoCloseableManagerTest.java
@@ -11,7 +11,7 @@ public class AutoCloseableManagerTest {
     private final AutoCloseableManager closeableManager = new AutoCloseableManager(this.managed);
 
     @Test
-    public void startsAndStops() throws Exception {
+    void startsAndStops() throws Exception {
         this.closeableManager.start();
         this.closeableManager.stop();
 

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/ExecutorServiceManagerTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/ExecutorServiceManagerTest.java
@@ -20,7 +20,7 @@ public class ExecutorServiceManagerTest {
     private final ExecutorService exec = mock(ExecutorService.class);
 
     @Test
-    public void testAccessors() {
+    void testAccessors() {
         // This test verifies the accessors behave as advertised for other unit
         // tests.
         final String poolName = this.getClass().getSimpleName();
@@ -33,7 +33,7 @@ public class ExecutorServiceManagerTest {
     }
 
     @Test
-    public void testManaged() throws Exception {
+    void testManaged() throws Exception {
         final String poolName = this.getClass().getSimpleName();
         when(this.exec.awaitTermination(anyLong(), any())).thenReturn(true);
 
@@ -50,7 +50,7 @@ public class ExecutorServiceManagerTest {
     }
 
     @Test
-    public void testManagedTimeout() throws Exception {
+    void testManagedTimeout() throws Exception {
         final String poolName = this.getClass().getSimpleName();
         when(this.exec.awaitTermination(anyLong(), any())).thenReturn(false);
 

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/JettyManagedTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/JettyManagedTest.java
@@ -11,7 +11,7 @@ public class JettyManagedTest {
     private final JettyManaged jettyManaged = new JettyManaged(managed);
 
     @Test
-    public void startsAndStops() throws Exception {
+    void startsAndStops() throws Exception {
         jettyManaged.start();
         jettyManaged.stop();
 

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/LifecycleEnvironmentTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/LifecycleEnvironmentTest.java
@@ -24,7 +24,7 @@ public class LifecycleEnvironmentTest {
     private final LifecycleEnvironment environment = new LifecycleEnvironment(new MetricRegistry());
 
     @Test
-    public void managesLifeCycleObjects() throws Exception {
+    void managesLifeCycleObjects() throws Exception {
         final LifeCycle lifeCycle = mock(LifeCycle.class);
         environment.manage(lifeCycle);
 
@@ -36,7 +36,7 @@ public class LifecycleEnvironmentTest {
     }
 
     @Test
-    public void managesManagedObjects() throws Exception {
+    void managesManagedObjects() throws Exception {
         final Managed managed = mock(Managed.class);
         environment.manage(managed);
 
@@ -54,7 +54,7 @@ public class LifecycleEnvironmentTest {
     }
 
     @Test
-    public void scheduledExecutorServiceBuildsDaemonThreads() throws ExecutionException, InterruptedException {
+    void scheduledExecutorServiceBuildsDaemonThreads() throws ExecutionException, InterruptedException {
         final ScheduledExecutorService executorService = environment.scheduledExecutorService("daemon-%d", true).build();
         final Future<Boolean> isDaemon = executorService.submit(() -> Thread.currentThread().isDaemon());
 
@@ -62,7 +62,7 @@ public class LifecycleEnvironmentTest {
     }
 
     @Test
-    public void scheduledExecutorServiceBuildsUserThreadsByDefault() throws ExecutionException, InterruptedException {
+    void scheduledExecutorServiceBuildsUserThreadsByDefault() throws ExecutionException, InterruptedException {
         final ScheduledExecutorService executorService = environment.scheduledExecutorService("user-%d").build();
         final Future<Boolean> isDaemon = executorService.submit(() -> Thread.currentThread().isDaemon());
 
@@ -70,7 +70,7 @@ public class LifecycleEnvironmentTest {
     }
 
     @Test
-    public void scheduledExecutorServiceThreadFactory() throws ExecutionException, InterruptedException {
+    void scheduledExecutorServiceThreadFactory() throws ExecutionException, InterruptedException {
         final String expectedName = "DropWizard ThreadFactory Test";
         final String expectedNamePattern = expectedName + "-%d";
 
@@ -83,7 +83,7 @@ public class LifecycleEnvironmentTest {
     }
 
     @Test
-    public void executorServiceThreadFactory() throws ExecutionException, InterruptedException {
+    void executorServiceThreadFactory() throws ExecutionException, InterruptedException {
         final String expectedName = "DropWizard ThreadFactory Test";
         final String expectedNamePattern = expectedName + "-%d";
 

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilderTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilderTest.java
@@ -35,7 +35,7 @@ public class ScheduledExecutorServiceBuilderTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         if (this.execTracker != null) {
             this.execTracker.shutdownNow();
 
@@ -53,7 +53,7 @@ public class ScheduledExecutorServiceBuilderTest {
     }
 
     @Test
-    public void testBasicInvocation() {
+    void testBasicInvocation() {
         final String poolName = this.getClass().getSimpleName();
 
         final ScheduledExecutorServiceBuilder test = new ScheduledExecutorServiceBuilder(this.le,
@@ -77,7 +77,7 @@ public class ScheduledExecutorServiceBuilderTest {
     }
 
     @Test
-    public void testRemoveOnCancelTrue() {
+    void testRemoveOnCancelTrue() {
         final String poolName = this.getClass().getSimpleName();
 
         final ScheduledExecutorServiceBuilder test = new ScheduledExecutorServiceBuilder(this.le,
@@ -100,7 +100,7 @@ public class ScheduledExecutorServiceBuilderTest {
     }
 
     @Test
-    public void testRemoveOnCancelFalse() {
+    void testRemoveOnCancelFalse() {
         final String poolName = this.getClass().getSimpleName();
 
         final ScheduledExecutorServiceBuilder test = new ScheduledExecutorServiceBuilder(this.le,
@@ -123,7 +123,7 @@ public class ScheduledExecutorServiceBuilderTest {
     }
 
     @Test
-    public void testPredefinedThreadFactory() {
+    void testPredefinedThreadFactory() {
         final ThreadFactory tfactory = mock(ThreadFactory.class);
         final String poolName = this.getClass().getSimpleName();
 

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/AppenderFactoryCustomLayoutTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/AppenderFactoryCustomLayoutTest.java
@@ -39,13 +39,13 @@ public class AppenderFactoryCustomLayoutTest {
     }
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         objectMapper.registerSubtypes(TestLayoutFactory.class);
         objectMapper.registerSubtypes(TestPatternLayoutFactory.class);
     }
 
     @Test
-    public void testLoadAppenderWithCustomLayout() throws Exception {
+    void testLoadAppenderWithCustomLayout() throws Exception {
         final ConsoleAppenderFactory<ILoggingEvent> appender = factory
             .build(loadResource("yaml/appender_with_custom_layout.yml"));
         assertThat(appender.getLayout()).isNotNull().isInstanceOf(TestLayoutFactory.class);
@@ -54,14 +54,14 @@ public class AppenderFactoryCustomLayoutTest {
     }
 
     @Test
-    public void testBuildAppenderWithCustomLayout() throws Exception {
+    void testBuildAppenderWithCustomLayout() throws Exception {
         ConsoleAppender<?> consoleAppender = buildAppender("yaml/appender_with_custom_layout.yml");
         LayoutWrappingEncoder<?> encoder = (LayoutWrappingEncoder<?>) consoleAppender.getEncoder();
         assertThat(encoder.getLayout()).isInstanceOf(TestLayoutFactory.TestLayout.class);
     }
 
     @Test
-    public void testBuildAppenderWithCustomPatternLayoutAndFormat() throws Exception {
+    void testBuildAppenderWithCustomPatternLayoutAndFormat() throws Exception {
         ConsoleAppender<?> consoleAppender = buildAppender("yaml/appender_with_custom_layout_and_format.yml");
         LayoutWrappingEncoder<?> encoder = (LayoutWrappingEncoder<?>) consoleAppender.getEncoder();
         TestPatternLayout layout = (TestPatternLayout) encoder.getLayout();

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/AppenderFactoryCustomTimeZone.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/AppenderFactoryCustomTimeZone.java
@@ -35,43 +35,43 @@ public class AppenderFactoryCustomTimeZone {
     }
 
     @Test
-    public void testLoadAppenderWithTimeZoneInFullFormat() throws Exception {
+    void testLoadAppenderWithTimeZoneInFullFormat() throws Exception {
         final ConsoleAppenderFactory<?> appender = factory.build(loadResource("yaml/appender_with_time_zone_in_full_format.yml"));
         assertThat(appender.getTimeZone().getID()).isEqualTo("America/Los_Angeles");
     }
 
     @Test
-    public void testLoadAppenderWithTimeZoneInCustomFormat() throws Exception {
+    void testLoadAppenderWithTimeZoneInCustomFormat() throws Exception {
         final ConsoleAppenderFactory<?> appender = factory.build(loadResource("yaml/appender_with_custom_time_zone_format.yml"));
         assertThat(appender.getTimeZone().getID()).isEqualTo("GMT-02:00");
     }
 
     @Test
-    public void testLoadAppenderWithNoTimeZone() throws Exception {
+    void testLoadAppenderWithNoTimeZone() throws Exception {
         final ConsoleAppenderFactory<?> appender = factory.build(loadResource("yaml/appender_with_no_time_zone.yml"));
         assertThat(appender.getTimeZone().getID()).isEqualTo("UTC");
     }
 
     @Test
-    public void testLoadAppenderWithUtcTimeZone() throws Exception {
+    void testLoadAppenderWithUtcTimeZone() throws Exception {
         final ConsoleAppenderFactory<?> appender = factory.build(loadResource("yaml/appender_with_utc_time_zone.yml"));
         assertThat(appender.getTimeZone().getID()).isEqualTo("UTC");
     }
 
     @Test
-    public void testLoadAppenderWithWrongTimeZone() throws Exception {
+    void testLoadAppenderWithWrongTimeZone() throws Exception {
         final ConsoleAppenderFactory<?> appender = factory.build(loadResource("yaml/appender_with_wrong_time_zone.yml"));
         assertThat(appender.getTimeZone().getID()).isEqualTo("GMT");
     }
 
     @Test
-    public void testLoadAppenderWithSystemTimeZone() throws Exception {
+    void testLoadAppenderWithSystemTimeZone() throws Exception {
         final ConsoleAppenderFactory<?> appender = factory.build(loadResource("yaml/appender_with_system_time_zone.yml"));
         assertThat(appender.getTimeZone()).isEqualTo(TimeZone.getDefault());
     }
 
     @Test
-    public void testBuildAppenderWithTimeZonePlaceholderInLogFormat() throws Exception {
+    void testBuildAppenderWithTimeZonePlaceholderInLogFormat() throws Exception {
         ConsoleAppender<?> consoleAppender = buildAppender("yaml/appender_with_time_zone_placeholder.yml");
         LayoutWrappingEncoder<?> encoder = (LayoutWrappingEncoder<?>) consoleAppender.getEncoder();
         PatternLayoutBase<?> layout = (PatternLayoutBase<?>) encoder.getLayout();

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/ConsoleAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/ConsoleAppenderFactoryTest.java
@@ -20,13 +20,13 @@ public class ConsoleAppenderFactoryTest {
     }
 
     @Test
-    public void isDiscoverable() throws Exception {
+    void isDiscoverable() throws Exception {
         assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
                 .contains(ConsoleAppenderFactory.class);
     }
 
     @Test
-    public void includesCallerData() {
+    void includesCallerData() {
         ConsoleAppenderFactory<ILoggingEvent> consoleAppenderFactory = new ConsoleAppenderFactory<>();
         AsyncAppender asyncAppender = (AsyncAppender) consoleAppenderFactory.build(new LoggerContext(), "test", new DropwizardLayoutFactory(), new NullLevelFilterFactory<>(), new AsyncLoggingEventAppenderFactory());
         assertThat(asyncAppender.isIncludeCallerData()).isFalse();
@@ -37,7 +37,7 @@ public class ConsoleAppenderFactoryTest {
     }
 
     @Test
-    public void appenderContextIsSet() throws Exception {
+    void appenderContextIsSet() throws Exception {
         final Logger root = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
         final ConsoleAppenderFactory<ILoggingEvent> appenderFactory = new ConsoleAppenderFactory<>();
         final Appender<ILoggingEvent> appender = appenderFactory.build(root.getLoggerContext(), "test", new DropwizardLayoutFactory(), new NullLevelFilterFactory<>(), new AsyncLoggingEventAppenderFactory());
@@ -46,7 +46,7 @@ public class ConsoleAppenderFactoryTest {
     }
 
     @Test
-    public void appenderNameIsSet() throws Exception {
+    void appenderNameIsSet() throws Exception {
         final Logger root = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
         final ConsoleAppenderFactory<ILoggingEvent> appenderFactory = new ConsoleAppenderFactory<>();
         final Appender<ILoggingEvent> appender = appenderFactory.build(root.getLoggerContext(), "test", new DropwizardLayoutFactory(), new NullLevelFilterFactory<>(), new AsyncLoggingEventAppenderFactory());
@@ -55,7 +55,7 @@ public class ConsoleAppenderFactoryTest {
     }
     
     @Test
-    public void isNeverBlock() throws Exception {
+    void isNeverBlock() throws Exception {
         ConsoleAppenderFactory<ILoggingEvent> consoleAppenderFactory = new ConsoleAppenderFactory<>();
         consoleAppenderFactory.setNeverBlock(true);
         AsyncAppender asyncAppender = (AsyncAppender) consoleAppenderFactory.build(new LoggerContext(), "test", new DropwizardLayoutFactory(), new NullLevelFilterFactory<>(), new AsyncLoggingEventAppenderFactory());
@@ -64,7 +64,7 @@ public class ConsoleAppenderFactoryTest {
     }
     
     @Test
-    public void isNotNeverBlock() throws Exception {
+    void isNotNeverBlock() throws Exception {
         ConsoleAppenderFactory<ILoggingEvent> consoleAppenderFactory = new ConsoleAppenderFactory<>();
         consoleAppenderFactory.setNeverBlock(false);
         AsyncAppender asyncAppender = (AsyncAppender) consoleAppenderFactory.build(new LoggerContext(), "test", new DropwizardLayoutFactory(), new NullLevelFilterFactory<>(), new AsyncLoggingEventAppenderFactory());
@@ -73,7 +73,7 @@ public class ConsoleAppenderFactoryTest {
     }
     
     @Test
-    public void defaultIsNotNeverBlock() throws Exception {
+    void defaultIsNotNeverBlock() throws Exception {
         ConsoleAppenderFactory<ILoggingEvent> consoleAppenderFactory = new ConsoleAppenderFactory<>();
         // default neverBlock
         AsyncAppender asyncAppender = (AsyncAppender) consoleAppenderFactory.build(new LoggerContext(), "test", new DropwizardLayoutFactory(), new NullLevelFilterFactory<>(), new AsyncLoggingEventAppenderFactory());

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/DefaultLoggingFactoryPrintErrorMessagesTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/DefaultLoggingFactoryPrintErrorMessagesTest.java
@@ -27,13 +27,13 @@ public class DefaultLoggingFactoryPrintErrorMessagesTest {
     private ByteArrayOutputStream output;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         output = new ByteArrayOutputStream();
         factory = new DefaultLoggingFactory(new LoggerContext(), new PrintStream(output));
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         factory.stop();
         factory.reset();
     }
@@ -58,21 +58,21 @@ public class DefaultLoggingFactoryPrintErrorMessagesTest {
     }
 
     @Test
-    public void testWhenUsingDefaultConstructor_SystemErrIsSet() throws Exception {
+    void testWhenUsingDefaultConstructor_SystemErrIsSet() throws Exception {
         PrintStream configurationErrorsStream = new DefaultLoggingFactory().getConfigurationErrorsStream();
 
         assertThat(configurationErrorsStream).isSameAs(System.err);
     }
 
     @Test
-    public void testWhenUsingDefaultConstructor_StaticILoggerFactoryIsSet() throws Exception {
+    void testWhenUsingDefaultConstructor_StaticILoggerFactoryIsSet() throws Exception {
         LoggerContext loggerContext = new DefaultLoggingFactory().getLoggerContext();
 
         assertThat(loggerContext).isSameAs(LoggerFactory.getILoggerFactory());
     }
 
     @Test
-    public void testWhenFileAppenderDoesNotHaveWritePermissionToFolder_PrintsErrorMessageToConsole(@TempDir Path tempDir) throws Exception {
+    void testWhenFileAppenderDoesNotHaveWritePermissionToFolder_PrintsErrorMessageToConsole(@TempDir Path tempDir) throws Exception {
         File folderWithoutWritePermission = tempDir.resolve("folder-without-write-permission").toFile();
         assumeTrue(folderWithoutWritePermission.mkdirs());
         assumeTrue(folderWithoutWritePermission.setWritable(false));
@@ -84,7 +84,7 @@ public class DefaultLoggingFactoryPrintErrorMessagesTest {
     }
 
     @Test
-    public void testWhenSettingUpLoggingWithValidConfiguration_NoErrorMessageIsPrintedToConsole(@TempDir Path tempDir) throws Exception {
+    void testWhenSettingUpLoggingWithValidConfiguration_NoErrorMessageIsPrintedToConsole(@TempDir Path tempDir) throws Exception {
         File folderWithWritePermission = tempDir.resolve("folder-with-write-permission").toFile();
         assumeTrue(folderWithWritePermission.mkdirs());
 
@@ -95,7 +95,7 @@ public class DefaultLoggingFactoryPrintErrorMessagesTest {
     }
 
     @Test
-    public void testLogbackStatusPrinterPrintStreamIsRestoredToSystemOut() throws Exception {
+    void testLogbackStatusPrinterPrintStreamIsRestoredToSystemOut() throws Exception {
         Field field = StatusPrinter.class.getDeclaredField("ps");
         field.setAccessible(true);
 

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/DefaultLoggingFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/DefaultLoggingFactoryTest.java
@@ -45,7 +45,7 @@ public class DefaultLoggingFactoryTest {
     private DefaultLoggingFactory config;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         objectMapper.getSubtypeResolver().registerSubtypes(ConsoleAppenderFactory.class,
                 FileAppenderFactory.class,
                 SyslogAppenderFactory.class);
@@ -54,12 +54,12 @@ public class DefaultLoggingFactoryTest {
     }
 
     @Test
-    public void hasADefaultLevel() {
+    void hasADefaultLevel() {
         assertThat(config.getLevel()).isEqualTo("INFO");
     }
 
     @Test
-    public void loggerLevelsCanBeOff() throws Exception {
+    void loggerLevelsCanBeOff() throws Exception {
         DefaultLoggingFactory config = null;
         try {
             config = factory.build(new File(Resources.getResource("yaml/logging_level_off.yml").toURI()));
@@ -83,7 +83,7 @@ public class DefaultLoggingFactoryTest {
     }
 
     @Test
-    public void canParseNewLoggerFormat() throws Exception {
+    void canParseNewLoggerFormat() throws Exception {
         final DefaultLoggingFactory config = factory.build(
                 new File(Resources.getResource("yaml/logging_advanced.yml").toURI()));
 
@@ -115,7 +115,7 @@ public class DefaultLoggingFactoryTest {
     }
 
     @Test
-    public void testConfigure(@TempDir Path tempDir) throws Exception {
+    void testConfigure(@TempDir Path tempDir) throws Exception {
         final StringSubstitutor substitutor = new StringSubstitutor(Maps.of(
                 "new_app", tempDir.resolve("example-new-app").toFile().getAbsolutePath(),
                 "new_app_not_additive", tempDir.resolve("example-new-app-not-additive").toFile().getAbsolutePath(),
@@ -162,7 +162,7 @@ public class DefaultLoggingFactoryTest {
     }
 
     @Test
-    public void testResetAppenders() throws Exception {
+    void testResetAppenders() throws Exception {
         final String configPath = Resources.getResource("yaml/logging.yml").getFile();
         final DefaultLoggingFactory config = factory.build(new FileConfigurationSourceProvider(), configPath);
         config.configure(new MetricRegistry(), "test-logger");
@@ -179,7 +179,7 @@ public class DefaultLoggingFactoryTest {
     }
 
     @Test
-    public void testToStringIsImplemented() {
+    void testToStringIsImplemented() {
         assertThat(config.toString()).startsWith(
                 "DefaultLoggingFactory{level=INFO, loggers={com.example.app=\"DEBUG\"}, appenders=");
     }

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/DropwizardLayoutTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/DropwizardLayoutTest.java
@@ -14,25 +14,25 @@ public class DropwizardLayoutTest {
     private final DropwizardLayout layout = new DropwizardLayout(context, timeZone);
 
     @Test
-    public void prefixesThrowables() throws Exception {
+    void prefixesThrowables() throws Exception {
         assertThat(layout.getDefaultConverterMap().get("ex"))
                 .isEqualTo(PrefixedThrowableProxyConverter.class.getName());
     }
 
     @Test
-    public void prefixesExtendedThrowables() throws Exception {
+    void prefixesExtendedThrowables() throws Exception {
         assertThat(layout.getDefaultConverterMap().get("xEx"))
                 .isEqualTo(PrefixedExtendedThrowableProxyConverter.class.getName());
     }
 
     @Test
-    public void hasAContext() throws Exception {
+    void hasAContext() throws Exception {
         assertThat(layout.getContext())
                 .isEqualTo(context);
     }
 
     @Test
-    public void hasAPatternWithATimeZoneAndExtendedThrowables() throws Exception {
+    void hasAPatternWithATimeZoneAndExtendedThrowables() throws Exception {
         assertThat(layout.getPattern())
                 .isEqualTo("%-5p [%d{ISO8601,UTC}] %c: %m%n%rEx");
     }

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/ExternalLoggingFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/ExternalLoggingFactoryTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ExternalLoggingFactoryTest {
 
     @Test
-    public void canBeDeserialized() throws Exception {
+    void canBeDeserialized() throws Exception {
         LoggingFactory externalRequestLogFactory = new YamlConfigurationFactory<>(LoggingFactory.class,
             BaseValidator.newValidator(), Jackson.newObjectMapper(), "dw")
             .build(new File(Resources.getResource("yaml/logging_external.yml").toURI()));
@@ -23,7 +23,7 @@ public class ExternalLoggingFactoryTest {
     }
 
     @Test
-    public void isDiscoverable() throws Exception {
+    void isDiscoverable() throws Exception {
         assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
             .contains(ExternalLoggingFactory.class);
     }

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/PrefixedExtendedThrowableProxyConverterTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/PrefixedExtendedThrowableProxyConverterTest.java
@@ -14,13 +14,13 @@ public class PrefixedExtendedThrowableProxyConverterTest {
     private final ThrowableProxy proxy = new ThrowableProxy(new IOException("noo"));
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         converter.setOptionList(Collections.singletonList("full"));
         converter.start();
     }
 
     @Test
-    public void prefixesExceptionsWithExclamationMarks() throws Exception {
+    void prefixesExceptionsWithExclamationMarks() throws Exception {
         assertThat(converter.throwableProxyToString(proxy))
                 .startsWith(String.format("! java.io.IOException: noo%n" +
                                                   "! at io.dropwizard.logging.PrefixedExtendedThrowableProxyConverterTest.<init>(PrefixedExtendedThrowableProxyConverterTest.java:14)%n"));

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/PrefixedRootCauseFirstThrowableProxyConverterTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/PrefixedRootCauseFirstThrowableProxyConverterTest.java
@@ -58,13 +58,13 @@ public class PrefixedRootCauseFirstThrowableProxyConverterTest {
     }
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         converter.setOptionList(Collections.singletonList("full"));
         converter.start();
     }
 
     @Test
-    public void prefixesExceptionsWithExclamationMarks()  {
+    void prefixesExceptionsWithExclamationMarks()  {
         final List<String> stackTrace = Arrays.stream(converter.throwableProxyToString(proxy).split(System.lineSeparator()))
                 .filter(s -> !Strings.isNullOrEmpty(s))
                 .collect(Collectors.toList());
@@ -75,7 +75,7 @@ public class PrefixedRootCauseFirstThrowableProxyConverterTest {
     }
 
     @Test
-    public void placesRootCauseIsFirst() {
+    void placesRootCauseIsFirst() {
         assertThat(converter.throwableProxyToString(proxy)).matches(Pattern.compile(".+" +
                 "java\\.net\\.SocketTimeoutException: Timed-out reading from socket.+" +
                 "java\\.io\\.IOException: Fairly general error doing some IO.+" +

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/PrefixedThrowableProxyConverterTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/PrefixedThrowableProxyConverterTest.java
@@ -14,13 +14,13 @@ public class PrefixedThrowableProxyConverterTest {
     private final ThrowableProxy proxy = new ThrowableProxy(new IOException("noo"));
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         converter.setOptionList(Collections.singletonList("full"));
         converter.start();
     }
 
     @Test
-    public void prefixesExceptionsWithExclamationMarks() throws Exception {
+    void prefixesExceptionsWithExclamationMarks() throws Exception {
         assertThat(converter.throwableProxyToString(proxy))
                 .startsWith(String.format("! java.io.IOException: noo%n" +
                                                   "! at io.dropwizard.logging.PrefixedThrowableProxyConverterTest.<init>(PrefixedThrowableProxyConverterTest.java:14)%n"));

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/SyslogAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/SyslogAppenderFactoryTest.java
@@ -25,25 +25,25 @@ public class SyslogAppenderFactoryTest {
     }
 
     @Test
-    public void isDiscoverable() throws Exception {
+    void isDiscoverable() throws Exception {
         assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
                 .contains(SyslogAppenderFactory.class);
     }
 
     @Test
-    public void defaultIncludesAppName() throws Exception {
+    void defaultIncludesAppName() throws Exception {
         assertThat(new SyslogAppenderFactory().getLogFormat())
                 .contains("%app");
     }
 
     @Test
-    public void defaultIncludesPid() throws Exception {
+    void defaultIncludesPid() throws Exception {
         assertThat(new SyslogAppenderFactory().getLogFormat())
                 .contains("%pid");
     }
 
     @Test
-    public void patternIncludesAppNameAndPid() throws Exception {
+    void patternIncludesAppNameAndPid() throws Exception {
         final AsyncAppender wrapper = (AsyncAppender) new SyslogAppenderFactory()
                 .build(new LoggerContext(), "MyApplication", new DropwizardLayoutFactory(), new NullLevelFilterFactory<>(), new AsyncLoggingEventAppenderFactory());
         assertThat(((SyslogAppender) wrapper.getAppender("syslog-appender")).getSuffixPattern())
@@ -51,7 +51,7 @@ public class SyslogAppenderFactoryTest {
     }
 
     @Test
-    public void stackTracePatternCanBeSet() throws Exception {
+    void stackTracePatternCanBeSet() throws Exception {
         final SyslogAppenderFactory syslogAppenderFactory = new SyslogAppenderFactory();
         syslogAppenderFactory.setStackTracePrefix("--->");
         final AsyncAppender wrapper = (AsyncAppender) syslogAppenderFactory
@@ -61,7 +61,7 @@ public class SyslogAppenderFactoryTest {
     }
 
     @Test
-    public void appenderContextIsSet() throws Exception {
+    void appenderContextIsSet() throws Exception {
         final Logger root = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
         final SyslogAppenderFactory appenderFactory = new SyslogAppenderFactory();
         final Appender<ILoggingEvent> appender = appenderFactory.build(root.getLoggerContext(), "test", new DropwizardLayoutFactory(),
@@ -71,7 +71,7 @@ public class SyslogAppenderFactoryTest {
     }
 
     @Test
-    public void appenderNameIsSet() throws Exception {
+    void appenderNameIsSet() throws Exception {
         final Logger root = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
         final SyslogAppenderFactory appenderFactory = new SyslogAppenderFactory();
         final Appender<ILoggingEvent> appender = appenderFactory.build(root.getLoggerContext(), "test", new DropwizardLayoutFactory(),
@@ -81,7 +81,7 @@ public class SyslogAppenderFactoryTest {
     }
 
     @Test
-    public void syslogFacilityTest() {
+    void syslogFacilityTest() {
         for (SyslogAppenderFactory.Facility facility : SyslogAppenderFactory.Facility.values()) {
             assertThatCode(() ->
                     SyslogAppender.facilityStringToint(facility.toString().toLowerCase(Locale.ENGLISH)))

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/TlsSocketAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/TlsSocketAppenderFactoryTest.java
@@ -34,7 +34,7 @@ public class TlsSocketAppenderFactoryTest {
         DefaultLoggingFactory.class, BaseValidator.newValidator(), objectMapper, "dw-ssl");
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         tcpServer.setUp();
         objectMapper.getSubtypeResolver().registerSubtypes(TcpSocketAppenderFactory.class);
     }
@@ -65,7 +65,7 @@ public class TlsSocketAppenderFactoryTest {
     }
 
     @Test
-    public void testTlsLogging() throws Exception {
+    void testTlsLogging() throws Exception {
         DefaultLoggingFactory loggingFactory = yamlConfigurationFactory.build(new SubstitutingSourceProvider(
             new ResourceConfigurationSourceProvider(), new StringSubstitutor(Maps.of(
             "tls.trust_store.path", resourcePath("stores/tls_client.jks").getAbsolutePath(),
@@ -85,7 +85,7 @@ public class TlsSocketAppenderFactoryTest {
     }
 
     @Test
-    public void testParseCustomConfiguration() throws Exception {
+    void testParseCustomConfiguration() throws Exception {
         DefaultLoggingFactory loggingFactory = yamlConfigurationFactory.build(
             resourcePath("yaml/logging-tls-custom.yml"));
         assertThat(loggingFactory.getAppenders()).hasSize(1);

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/UdpSocketAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/UdpSocketAppenderFactoryTest.java
@@ -34,7 +34,7 @@ public class UdpSocketAppenderFactoryTest {
     private final CountDownLatch countDownLatch = new CountDownLatch(messagesCount);
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         datagramSocket = new DatagramSocket(UDP_PORT);
         thread = new Thread(() -> {
             byte[] buffer = new byte[256];
@@ -54,13 +54,13 @@ public class UdpSocketAppenderFactoryTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         thread.interrupt();
         datagramSocket.close();
     }
 
     @Test
-    public void testSendLogsByTcp() throws Exception {
+    void testSendLogsByTcp() throws Exception {
         ObjectMapper objectMapper = Jackson.newObjectMapper();
         objectMapper.getSubtypeResolver().registerSubtypes(UdpSocketAppenderFactory.class);
 

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/socket/DropwizardUdpSocketAppenderTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/socket/DropwizardUdpSocketAppenderTest.java
@@ -26,7 +26,7 @@ public class DropwizardUdpSocketAppenderTest {
     private CountDownLatch countDownLatch = new CountDownLatch(1);
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         datagramSocket = new DatagramSocket();
         thread = new Thread(() -> {
             byte[] buffer = new byte[128];
@@ -49,14 +49,14 @@ public class DropwizardUdpSocketAppenderTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         datagramSocket.close();
         thread.interrupt();
         udpStreamAppender.stop();
     }
 
     @Test
-    public void testSendMessage() throws Exception {
+    void testSendMessage() throws Exception {
         udpStreamAppender.getOutputStream().write("Test message".getBytes(UTF_8));
 
         countDownLatch.await(5, TimeUnit.SECONDS);

--- a/dropwizard-metrics-graphite/src/test/java/io/dropwizard/metrics/graphite/GraphiteReporterFactoryTest.java
+++ b/dropwizard-metrics-graphite/src/test/java/io/dropwizard/metrics/graphite/GraphiteReporterFactoryTest.java
@@ -30,13 +30,13 @@ public class GraphiteReporterFactoryTest {
     };
 
     @Test
-    public void isDiscoverable() {
+    void isDiscoverable() {
         assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
             .contains(GraphiteReporterFactory.class);
     }
 
     @Test
-    public void createDefaultFactory() throws Exception {
+    void createDefaultFactory() throws Exception {
         final GraphiteReporterFactory factory = new YamlConfigurationFactory<>(GraphiteReporterFactory.class,
              BaseValidator.newValidator(), Jackson.newObjectMapper(), "dw")
             .build();
@@ -44,7 +44,7 @@ public class GraphiteReporterFactoryTest {
     }
 
     @Test
-    public void testNoAddressResolutionForGraphite() throws Exception {
+    void testNoAddressResolutionForGraphite() throws Exception {
         graphiteReporterFactory.build(new MetricRegistry());
 
         final ArgumentCaptor<Graphite> argument = ArgumentCaptor.forClass(Graphite.class);
@@ -57,7 +57,7 @@ public class GraphiteReporterFactoryTest {
     }
 
     @Test
-    public void testCorrectTransportForGraphiteUDP() throws Exception {
+    void testCorrectTransportForGraphiteUDP() throws Exception {
         graphiteReporterFactory.setTransport("udp");
         graphiteReporterFactory.build(new MetricRegistry());
 

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/ConsoleReporterFactoryTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/ConsoleReporterFactoryTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConsoleReporterFactoryTest {
     @Test
-    public void isDiscoverable() throws Exception {
+    void isDiscoverable() throws Exception {
         assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
                 .contains(ConsoleReporterFactory.class);
     }

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/CsvReporterFactoryTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/CsvReporterFactoryTest.java
@@ -23,20 +23,20 @@ public class CsvReporterFactoryTest {
                                            objectMapper, "dw");
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         objectMapper.getSubtypeResolver().registerSubtypes(ConsoleReporterFactory.class,
                                                            CsvReporterFactory.class,
                                                            Slf4jReporterFactory.class);
     }
 
     @Test
-    public void isDiscoverable() throws Exception {
+    void isDiscoverable() throws Exception {
         assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
                 .contains(CsvReporterFactory.class);
     }
 
     @Test
-    public void directoryCreatedOnStartup() throws Exception {
+    void directoryCreatedOnStartup() throws Exception {
         File dir = new File("metrics");
         dir.delete();
 

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/MetricsFactoryTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/MetricsFactoryTest.java
@@ -27,7 +27,7 @@ public class MetricsFactoryTest {
     private MetricsFactory config;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         objectMapper.getSubtypeResolver().registerSubtypes(ConsoleReporterFactory.class, CsvReporterFactory.class,
             Slf4jReporterFactory.class);
 
@@ -35,19 +35,19 @@ public class MetricsFactoryTest {
     }
 
     @Test
-    public void hasADefaultFrequency() throws Exception {
+    void hasADefaultFrequency() throws Exception {
         assertThat(config.getFrequency()).isEqualTo(Duration.seconds(10));
     }
 
     @Test
-    public void hasReporters() throws Exception {
+    void hasReporters() throws Exception {
         CsvReporterFactory csvReporter = new CsvReporterFactory();
         csvReporter.setFile(new File("metrics"));
         assertThat(config.getReporters()).hasSize(3);
     }
 
     @Test
-    public void canReadExcludedAndIncludedAttributes() {
+    void canReadExcludedAndIncludedAttributes() {
         assertThat(config.getReporters()).hasSize(3);
         final ReporterFactory reporterFactory = config.getReporters().get(0);
         assertThat(reporterFactory).isInstanceOf(ConsoleReporterFactory.class);
@@ -58,7 +58,7 @@ public class MetricsFactoryTest {
     }
 
     @Test
-    public void canReadDefaultExcludedAndIncludedAttributes() {
+    void canReadDefaultExcludedAndIncludedAttributes() {
         assertThat(config.getReporters()).hasSize(3);
         final ReporterFactory reporterFactory = config.getReporters().get(1);
         assertThat(reporterFactory).isInstanceOf(CsvReporterFactory.class);
@@ -68,12 +68,12 @@ public class MetricsFactoryTest {
     }
 
     @Test
-    public void reportOnStopFalseByDefault() {
+    void reportOnStopFalseByDefault() {
         assertThat(config.isReportOnStop()).isFalse();
     }
 
     @Test
-    public void reportOnStopCanBeTrue() throws Exception {
+    void reportOnStopCanBeTrue() throws Exception {
         config = factory.build(new File(Resources.getResource("yaml/metrics-report-on-stop.yml").toURI()));
         assertThat(config.isReportOnStop()).isTrue();
     }

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/ScheduledReporterManagerTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/ScheduledReporterManagerTest.java
@@ -10,7 +10,7 @@ import java.util.concurrent.TimeUnit;
 public class ScheduledReporterManagerTest {
 
     @Test
-    public void testStopWithoutReporting() throws Exception {
+    void testStopWithoutReporting() throws Exception {
         final boolean reportOnStop = false;
         ScheduledReporter mockReporter = Mockito.mock(ScheduledReporter.class);
         ScheduledReporterManager manager = new ScheduledReporterManager(mockReporter, Duration.minutes(5), reportOnStop);
@@ -24,7 +24,7 @@ public class ScheduledReporterManagerTest {
     }
 
     @Test
-    public void testStopWithReporting() throws Exception {
+    void testStopWithReporting() throws Exception {
         final boolean reportOnStop = true;
         ScheduledReporter mockReporter = Mockito.mock(ScheduledReporter.class);
         ScheduledReporterManager manager = new ScheduledReporterManager(mockReporter, Duration.minutes(5), reportOnStop);

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/Slf4jReporterFactoryTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/Slf4jReporterFactoryTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class Slf4jReporterFactoryTest {
     @Test
-    public void isDiscoverable() throws Exception {
+    void isDiscoverable() throws Exception {
         assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
                 .contains(Slf4jReporterFactory.class);
     }

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/CloseableLiquibaseTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/CloseableLiquibaseTest.java
@@ -17,7 +17,7 @@ public class CloseableLiquibaseTest {
     ManagedPooledDataSource dataSource;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         DataSourceFactory factory = new DataSourceFactory();
 
         factory.setDriverClass(org.h2.Driver.class.getName());
@@ -29,7 +29,7 @@ public class CloseableLiquibaseTest {
     }
 
     @Test
-    public void testWhenClosingAllConnectionsInPoolIsReleased() throws Exception {
+    void testWhenClosingAllConnectionsInPoolIsReleased() throws Exception {
 
         ConnectionPool pool = dataSource.getPool();
         assertThat(pool.getActive()).isEqualTo(1);

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbCalculateChecksumCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbCalculateChecksumCommandTest.java
@@ -21,7 +21,7 @@ public class DbCalculateChecksumCommandTest extends AbstractMigrationTest {
         TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations.xml");
 
     @Test
-    public void testRun() throws Exception {
+    void testRun() throws Exception {
         final AtomicBoolean checkSumVerified = new AtomicBoolean();
         migrateCommand.setCheckSumConsumer(checkSum -> {
             assertThat(checkSum).isEqualTo(CheckSum.parse("8:0f3683b37321ccfb1694a044986de4d9"));
@@ -35,7 +35,7 @@ public class DbCalculateChecksumCommandTest extends AbstractMigrationTest {
     }
 
     @Test
-    public void testHelpPage() throws Exception {
+    void testHelpPage() throws Exception {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         createSubparser(migrateCommand).printHelp(new PrintWriter(new OutputStreamWriter(out, UTF_8), true));
         assertThat(out.toString(UTF_8)).isEqualTo(String.format(

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbClearChecksumsCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbClearChecksumsCommandTest.java
@@ -20,14 +20,14 @@ public class DbClearChecksumsCommandTest extends AbstractMigrationTest {
         TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations.xml");
 
     @Test
-    public void testRun() throws Exception {
+    void testRun() throws Exception {
         final Liquibase liquibase = Mockito.mock(Liquibase.class);
         clearChecksums.run(new Namespace(Collections.emptyMap()), liquibase);
         Mockito.verify(liquibase).clearCheckSums();
     }
 
     @Test
-    public void testHelpPage() throws Exception {
+    void testHelpPage() throws Exception {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         createSubparser(clearChecksums).printHelp(new PrintWriter(new OutputStreamWriter(out, UTF_8), true));
         assertThat(out.toString(UTF_8)).isEqualTo(String.format(

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDumpCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDumpCommandTest.java
@@ -48,7 +48,7 @@ public class DbDumpCommandTest extends AbstractMigrationTest {
     }
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         final String existedDbPath = new File(Resources.getResource("test-db.mv.db").toURI()).getAbsolutePath();
         final String existedDbUrl = "jdbc:h2:" + existedDbPath.substring(0, existedDbPath.length() - ".mv.db".length());
         existedDbConf = createConfiguration(existedDbUrl);
@@ -56,7 +56,7 @@ public class DbDumpCommandTest extends AbstractMigrationTest {
     }
 
     @Test
-    public void testDumpSchema() throws Exception {
+    void testDumpSchema() throws Exception {
         dumpCommand.run(null, new Namespace(ATTRIBUTE_NAMES.stream()
             .collect(Collectors.toMap(a -> a, b -> true))), existedDbConf);
 
@@ -65,7 +65,7 @@ public class DbDumpCommandTest extends AbstractMigrationTest {
     }
 
     @Test
-    public void testDumpSchemaAndData() throws Exception {
+    void testDumpSchemaAndData() throws Exception {
         dumpCommand.run(null, new Namespace(Stream.concat(ATTRIBUTE_NAMES.stream(), Stream.of("data"))
             .collect(Collectors.toMap(a -> a, b -> true))), existedDbConf);
 
@@ -75,7 +75,7 @@ public class DbDumpCommandTest extends AbstractMigrationTest {
     }
 
     @Test
-    public void testDumpOnlyData() throws Exception {
+    void testDumpOnlyData() throws Exception {
         dumpCommand.run(null, new Namespace(Collections.singletonMap("data", true)), existedDbConf);
 
         final Element changeSet = getFirstElement(toXmlDocument(baos).getDocumentElement(), "changeSet");
@@ -83,7 +83,7 @@ public class DbDumpCommandTest extends AbstractMigrationTest {
     }
 
     @Test
-    public void testWriteToFile() throws Exception {
+    void testWriteToFile() throws Exception {
         final File file = File.createTempFile("migration", ".xml");
         dumpCommand.run(null, new Namespace(Collections.singletonMap("output", file.getAbsolutePath())), existedDbConf);
         // Check that file is exist, and has some XML content (no reason to make a full-blown XML assertion)
@@ -92,7 +92,7 @@ public class DbDumpCommandTest extends AbstractMigrationTest {
     }
 
     @Test
-    public void testHelpPage() throws Exception {
+    void testHelpPage() throws Exception {
         createSubparser(dumpCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
         assertThat(baos.toString(UTF_8)).isEqualTo(String.format(
                 "usage: db dump [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbGenerateDocsCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbGenerateDocsCommandTest.java
@@ -20,14 +20,14 @@ public class DbGenerateDocsCommandTest extends AbstractMigrationTest {
         TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations.xml");
 
     @Test
-    public void testRun() throws Exception {
+    void testRun() throws Exception {
         Liquibase liquibase = Mockito.mock(Liquibase.class);
         generateDocsCommand.run(new Namespace(Collections.singletonMap("output", Collections.singletonList("/tmp/docs"))), liquibase);
         Mockito.verify(liquibase).generateDocumentation("/tmp/docs");
     }
 
     @Test
-    public void testHelpPage() throws Exception {
+    void testHelpPage() throws Exception {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         createSubparser(generateDocsCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
         assertThat(baos.toString(UTF_8)).isEqualTo(String.format(

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbLocksCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbLocksCommandTest.java
@@ -22,7 +22,7 @@ public class DbLocksCommandTest extends AbstractMigrationTest {
         TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations.xml");
 
     @Test
-    public void testRelease() throws Exception {
+    void testRelease() throws Exception {
         // We can't create locks in the database, so use mocks
         final Liquibase liquibase = Mockito.mock(Liquibase.class);
         locksCommand.run(new Namespace(Maps.of("list", false, "release", true)), liquibase);
@@ -30,7 +30,7 @@ public class DbLocksCommandTest extends AbstractMigrationTest {
     }
 
     @Test
-    public void testListLocks() throws Exception {
+    void testListLocks() throws Exception {
         final PrintStream printStream = new PrintStream(new ByteArrayOutputStream());
         locksCommand.setPrintStream(printStream);
 
@@ -41,7 +41,7 @@ public class DbLocksCommandTest extends AbstractMigrationTest {
     }
 
     @Test
-    public void testFailsWhenNoListOrRelease() throws Exception {
+    void testFailsWhenNoListOrRelease() throws Exception {
         final Liquibase liquibase = Mockito.mock(Liquibase.class);
         assertThatExceptionOfType(IllegalArgumentException.class)
             .isThrownBy(() -> locksCommand.run(new Namespace(Maps.of("list", false, "release", false)),
@@ -50,7 +50,7 @@ public class DbLocksCommandTest extends AbstractMigrationTest {
     }
 
     @Test
-    public void testFailsWhenBothListAndRelease() throws Exception {
+    void testFailsWhenBothListAndRelease() throws Exception {
         final Liquibase liquibase = Mockito.mock(Liquibase.class);
         assertThatExceptionOfType(IllegalArgumentException.class)
             .isThrownBy(() -> locksCommand.run(new Namespace(Maps.of("list", true, "release", true)),
@@ -59,7 +59,7 @@ public class DbLocksCommandTest extends AbstractMigrationTest {
     }
 
     @Test
-    public void testPrintHelp() throws Exception {
+    void testPrintHelp() throws Exception {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         createSubparser(locksCommand).printHelp(new PrintWriter(new OutputStreamWriter(out, UTF_8), true));
         assertThat(out.toString(UTF_8)).isEqualTo(String.format(

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbPrepareRollbackCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbPrepareRollbackCommandTest.java
@@ -22,13 +22,13 @@ public class DbPrepareRollbackCommandTest extends AbstractMigrationTest {
     private TestMigrationConfiguration conf;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         final String databaseUrl = getDatabaseUrl();
         conf = createConfiguration(databaseUrl);
     }
 
     @Test
-    public void testRun() throws Exception {
+    void testRun() throws Exception {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         prepareRollbackCommand.setOutputStream(new PrintStream(baos));
         prepareRollbackCommand.run(null, new Namespace(Collections.emptyMap()), conf);
@@ -38,7 +38,7 @@ public class DbPrepareRollbackCommandTest extends AbstractMigrationTest {
     }
 
     @Test
-    public void testPrepareOnlyChange() throws Exception {
+    void testPrepareOnlyChange() throws Exception {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         prepareRollbackCommand.setOutputStream(new PrintStream(baos));
         prepareRollbackCommand.run(null, new Namespace(Collections.singletonMap("count", 1)), conf);
@@ -46,7 +46,7 @@ public class DbPrepareRollbackCommandTest extends AbstractMigrationTest {
     }
 
     @Test
-    public void testPrintHelp() throws Exception {
+    void testPrintHelp() throws Exception {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         createSubparser(prepareRollbackCommand).printHelp(new PrintWriter(new OutputStreamWriter(out, UTF_8), true));
         assertThat(out.toString(UTF_8)).isEqualTo(String.format(

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbStatusCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbStatusCommandTest.java
@@ -24,14 +24,14 @@ public class DbStatusCommandTest extends AbstractMigrationTest {
     private TestMigrationConfiguration conf;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         conf = createConfiguration(getDatabaseUrl());
 
         statusCommand.setOutputStream(new PrintStream(baos));
     }
 
     @Test
-    public void testRunOnMigratedDb() throws Exception {
+    void testRunOnMigratedDb() throws Exception {
         final String existedDbPath = new File(Resources.getResource("test-db.mv.db").toURI()).getAbsolutePath();
         final String existedDbUrl = "jdbc:h2:" + existedDbPath.substring(0, existedDbPath.length() - ".mv.db".length());
         final TestMigrationConfiguration existedDbConf = createConfiguration(existedDbUrl);
@@ -41,14 +41,14 @@ public class DbStatusCommandTest extends AbstractMigrationTest {
     }
 
     @Test
-    public void testRun() throws Exception {
+    void testRun() throws Exception {
         statusCommand.run(null, new Namespace(Collections.emptyMap()), conf);
         assertThat(baos.toString(UTF_8)).matches(
                 "3 change sets have not been applied to \\S+" + System.lineSeparator());
     }
 
     @Test
-    public void testVerbose() throws Exception {
+    void testVerbose() throws Exception {
         statusCommand.run(null, new Namespace(Collections.singletonMap("verbose", true)), conf);
         assertThat(baos.toString(UTF_8)).matches(
                 "3 change sets have not been applied to \\S+" + System.lineSeparator() +
@@ -58,7 +58,7 @@ public class DbStatusCommandTest extends AbstractMigrationTest {
     }
 
     @Test
-    public void testPrintHelp() throws Exception {
+    void testPrintHelp() throws Exception {
         createSubparser(statusCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
         assertThat(baos.toString(UTF_8)).isEqualTo(String.format(
                 "usage: db status [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbTagCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbTagCommandTest.java
@@ -19,7 +19,7 @@ public class DbTagCommandTest extends AbstractMigrationTest {
         new TestMigrationDatabaseConfiguration(), TestMigrationConfiguration.class, migrationsFileName);
 
     @Test
-    public void testRun() throws Exception {
+    void testRun() throws Exception {
         // Migrate some DDL changes
         final TestMigrationConfiguration conf = createConfiguration(getDatabaseUrl());
         final DbMigrateCommand<TestMigrationConfiguration> dbMigrateCommand = new DbMigrateCommand<>(
@@ -37,7 +37,7 @@ public class DbTagCommandTest extends AbstractMigrationTest {
     }
 
     @Test
-    public void testPrintHelp() throws Exception {
+    void testPrintHelp() throws Exception {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         createSubparser(dbTagCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
         assertThat(baos.toString(UTF_8)).isEqualTo(String.format(

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbTestCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbTestCommandTest.java
@@ -18,7 +18,7 @@ public class DbTestCommandTest extends AbstractMigrationTest {
         new TestMigrationDatabaseConfiguration(), TestMigrationConfiguration.class, "migrations-ddl.xml");
 
     @Test
-    public void testRun() throws Exception {
+    void testRun() throws Exception {
         // Apply and rollback some DDL changes
         final TestMigrationConfiguration conf = createConfiguration(getDatabaseUrl());
         dbTestCommand.run(null, new Namespace(Collections.emptyMap()), conf);
@@ -27,7 +27,7 @@ public class DbTestCommandTest extends AbstractMigrationTest {
     }
 
     @Test
-    public void testPrintHelp() throws Exception {
+    void testPrintHelp() throws Exception {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         createSubparser(dbTestCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
         assertThat(baos.toString(UTF_8)).isEqualTo(String.format(

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/ExternalRequestLogFactoryTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/ExternalRequestLogFactoryTest.java
@@ -19,7 +19,7 @@ public class ExternalRequestLogFactoryTest {
     }
 
     @Test
-    public void canBeDeserialized() throws Exception {
+    void canBeDeserialized() throws Exception {
         RequestLogFactory<?> externalRequestLogFactory = new YamlConfigurationFactory<>(RequestLogFactory.class,
             BaseValidator.newValidator(), Jackson.newObjectMapper(), "dw")
             .build(new File(Resources.getResource("yaml/externalRequestLog.yml").toURI()));
@@ -29,7 +29,7 @@ public class ExternalRequestLogFactoryTest {
     }
 
     @Test
-    public void isDiscoverable() throws Exception {
+    void isDiscoverable() throws Exception {
         assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
             .contains(ExternalRequestLogFactory.class);
     }

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/LogbackAccessRequestLogTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/LogbackAccessRequestLogTest.java
@@ -29,7 +29,7 @@ public class LogbackAccessRequestLogTest {
     private final HttpChannelState channelState = mock(HttpChannelState.class);
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         when(channelState.isInitial()).thenReturn(true);
 
         when(request.getRemoteAddr()).thenReturn("10.0.0.1");
@@ -48,12 +48,12 @@ public class LogbackAccessRequestLogTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         requestLog.stop();
     }
 
     @Test
-    public void logsRequestsToTheAppender() {
+    void logsRequestsToTheAppender() {
         final IAccessEvent event = logAndCapture();
 
         assertThat(event.getRemoteAddr()).isEqualTo("10.0.0.1");

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/RequestLogFactoryTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/RequestLogFactoryTest.java
@@ -20,7 +20,7 @@ public class RequestLogFactoryTest {
     private LogbackAccessRequestLogFactory logbackAccessRequestLogFactory;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         final ObjectMapper objectMapper = Jackson.newObjectMapper();
         objectMapper.getSubtypeResolver().registerSubtypes(ConsoleAppenderFactory.class,
                                                            FileAppenderFactory.class,
@@ -32,7 +32,7 @@ public class RequestLogFactoryTest {
     }
 
     @Test
-    public void fileAppenderFactoryIsSet() {
+    void fileAppenderFactoryIsSet() {
         assertThat(logbackAccessRequestLogFactory).isNotNull();
         assertThat(logbackAccessRequestLogFactory.getAppenders()).isNotNull();
         assertThat(logbackAccessRequestLogFactory.getAppenders().size()).isEqualTo(1);
@@ -41,7 +41,7 @@ public class RequestLogFactoryTest {
     }
 
     @Test
-    public void isDiscoverable() throws Exception {
+    void isDiscoverable() throws Exception {
         assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
             .contains(LogbackAccessRequestLogFactory.class);
     }

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/filter/UriFilterFactoryTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/filter/UriFilterFactoryTest.java
@@ -26,7 +26,7 @@ public class UriFilterFactoryTest {
     }
 
     @Test
-    public void shouldDenyLogsForConfiguredUri() {
+    void shouldDenyLogsForConfiguredUri() {
         final String path = "/health-check";
         filterFactory.setUris(Collections.singleton(path));
         final Filter filter = filterFactory.build();
@@ -39,7 +39,7 @@ public class UriFilterFactoryTest {
     }
 
     @Test
-    public void shouldNotDenyUnconfiguredUriLogs() {
+    void shouldNotDenyUnconfiguredUriLogs() {
         filterFactory.setUris(Collections.emptySet());
         final Filter filter = filterFactory.build();
 
@@ -51,7 +51,7 @@ public class UriFilterFactoryTest {
     }
 
     @Test
-    public void shouldDenyLogsForAdditionalConfiguredUris() {
+    void shouldDenyLogsForAdditionalConfiguredUris() {
         final Set<String> paths = new HashSet<>();
         paths.add("/health-check");
         paths.add("/sys/health");
@@ -67,7 +67,7 @@ public class UriFilterFactoryTest {
     }
 
     @Test
-    public void isDiscoverable() {
+    void isDiscoverable() {
         assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes()).contains(UriFilterFactory.class);
     }
 }

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/layout/LogbackAccessRequestLayoutTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/layout/LogbackAccessRequestLayoutTest.java
@@ -15,18 +15,18 @@ public class LogbackAccessRequestLayoutTest {
     final LogbackAccessRequestLayout layout = new LogbackAccessRequestLayout(context, timeZone);
 
     @Test
-    public void outputPatternAsHeaderIsFalse() {
+    void outputPatternAsHeaderIsFalse() {
         assertThat(layout.isOutputPatternAsHeader()).isFalse();
     }
 
     @Test
-    public void hasAContext() throws Exception {
+    void hasAContext() throws Exception {
         assertThat(layout.getContext())
             .isEqualTo(context);
     }
 
     @Test
-    public void hasAPatternWithATimeZone() throws Exception {
+    void hasAPatternWithATimeZone() throws Exception {
         assertThat(layout.getPattern())
             .isEqualTo("%h %l %u [%t{dd/MMM/yyyy:HH:mm:ss Z,UTC}] \"%r\" %s %b \"%i{Referer}\" \"%i{User-Agent}\" %D");
     }

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/layout/SafeRequestParameterConverterTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/layout/SafeRequestParameterConverterTest.java
@@ -20,7 +20,7 @@ public class SafeRequestParameterConverterTest {
     private AccessEvent accessEvent;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         accessEvent = new AccessEvent(httpServletRequest, Mockito.mock(HttpServletResponse.class),
             Mockito.mock(ServerAdapter.class));
 
@@ -29,12 +29,12 @@ public class SafeRequestParameterConverterTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         safeRequestParameterConverter.stop();
     }
 
     @Test
-    public void testConvertOneParameter() throws Exception {
+    void testConvertOneParameter() throws Exception {
         Mockito.when(httpServletRequest.getParameterValues("name")).thenReturn(new String[]{"Alice"});
         Mockito.when(httpServletRequest.getParameterNames())
                 .thenReturn(Collections.enumeration(Collections.singleton("name")));
@@ -49,7 +49,7 @@ public class SafeRequestParameterConverterTest {
     }
 
     @Test
-    public void testConvertSeveralParameters() throws Exception {
+    void testConvertSeveralParameters() throws Exception {
         Mockito.when(httpServletRequest.getParameterValues("name")).thenReturn(new String[]{"Alice", "Bob"});
         Mockito.when(httpServletRequest.getParameterNames())
                 .thenReturn(Collections.enumeration(Collections.singleton("name")));

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/old/DropwizardSlf4jRequestLogWriterTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/old/DropwizardSlf4jRequestLogWriterTest.java
@@ -38,7 +38,7 @@ public class DropwizardSlf4jRequestLogWriterTest {
     private final HttpChannelState channelState = mock(HttpChannelState.class);
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         when(channelState.isInitial()).thenReturn(true);
 
         when(request.getRemoteHost()).thenReturn("10.0.0.1");
@@ -58,12 +58,12 @@ public class DropwizardSlf4jRequestLogWriterTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         slf4jRequestLog.stop();
     }
 
     @Test
-    public void logsRequestsToTheAppenders() throws Exception {
+    void logsRequestsToTheAppenders() throws Exception {
         final String requestLine = "1, 2 buckle my shoe";
         slf4jRequestLog.write(requestLine);
         final ArgumentCaptor<ILoggingEvent> captor = ArgumentCaptor.forClass(ILoggingEvent.class);

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/old/LogbackClassicRequestLogFactoryTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/old/LogbackClassicRequestLogFactoryTest.java
@@ -42,7 +42,7 @@ public class LogbackClassicRequestLogFactoryTest {
     private RequestLogFactory<?> requestLog;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         final ObjectMapper objectMapper = Jackson.newObjectMapper();
         objectMapper.getSubtypeResolver().registerSubtypes(ConsoleAppenderFactory.class, FileAppenderFactory.class,
             SyslogAppenderFactory.class);
@@ -52,7 +52,7 @@ public class LogbackClassicRequestLogFactoryTest {
     }
 
     @Test
-    public void testDeserialized() {
+    void testDeserialized() {
         LogbackClassicRequestLogFactory classicRequestLogFactory = (LogbackClassicRequestLogFactory) requestLog;
         assertThat(classicRequestLogFactory.getTimeZone()).isEqualTo(TimeZone.getTimeZone("Europe/Amsterdam"));
         assertThat(classicRequestLogFactory.getAppenders()).hasSize(3).extractingResultOf("getClass").contains(
@@ -61,7 +61,7 @@ public class LogbackClassicRequestLogFactoryTest {
     }
 
     @Test
-    public void testLogFormat() throws Exception {
+    void testLogFormat() throws Exception {
         final LogbackClassicRequestLogFactory factory = new LogbackClassicRequestLogFactory();
 
         @SuppressWarnings("unchecked")
@@ -112,7 +112,7 @@ public class LogbackClassicRequestLogFactoryTest {
     }
 
     @Test
-    public void isDiscoverable() throws Exception {
+    void isDiscoverable() throws Exception {
         assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
             .contains(LogbackClassicRequestLogFactory.class);
     }

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/CacheBustingFilterTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/CacheBustingFilterTest.java
@@ -21,7 +21,7 @@ public class CacheBustingFilterTest {
     private final CacheBustingFilter filter = new CacheBustingFilter();
 
     @Test
-    public void passesThroughNonHttpRequests() throws Exception {
+    void passesThroughNonHttpRequests() throws Exception {
         final ServletRequest req = mock(ServletRequest.class);
         final ServletResponse res = mock(ServletResponse.class);
 
@@ -32,7 +32,7 @@ public class CacheBustingFilterTest {
     }
 
     @Test
-    public void setsACacheHeaderOnTheResponse() throws Exception {
+    void setsACacheHeaderOnTheResponse() throws Exception {
         filter.doFilter(request, response, chain);
 
         final InOrder inOrder = inOrder(response, chain);

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/ServletsTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/ServletsTest.java
@@ -14,20 +14,20 @@ public class ServletsTest {
     private final HttpServletRequest fullRequest = mock(HttpServletRequest.class);
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         when(request.getRequestURI()).thenReturn("/one/two");
         when(fullRequest.getRequestURI()).thenReturn("/one/two");
         when(fullRequest.getQueryString()).thenReturn("one=two&three=four");
     }
 
     @Test
-    public void formatsBasicURIs() throws Exception {
+    void formatsBasicURIs() throws Exception {
         assertThat(Servlets.getFullUrl(request))
                 .isEqualTo("/one/two");
     }
 
     @Test
-    public void formatsFullURIs() throws Exception {
+    void formatsFullURIs() throws Exception {
         assertThat(Servlets.getFullUrl(fullRequest))
                 .isEqualTo("/one/two?one=two&three=four");
     }

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/SlowRequestFilterTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/SlowRequestFilterTest.java
@@ -28,7 +28,7 @@ public class SlowRequestFilterTest {
     private SlowRequestFilter slowRequestFilter = new SlowRequestFilter(Duration.milliseconds(500));
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         slowRequestFilter.init(filterConfig);
         slowRequestFilter.setLogger(logger);
         slowRequestFilter.setCurrentTimeProvider(() -> 1510330244000000L);
@@ -38,12 +38,12 @@ public class SlowRequestFilterTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         slowRequestFilter.destroy();
     }
 
     @Test
-    public void logsSlowRequests() throws Exception {
+    void logsSlowRequests() throws Exception {
         doAnswer(invocationOnMock -> {
             slowRequestFilter.setCurrentTimeProvider(() -> 1510330745000000L);
             return null;
@@ -55,7 +55,7 @@ public class SlowRequestFilterTest {
     }
 
     @Test
-    public void doesNotLogFastRequests() throws Exception {
+    void doesNotLogFastRequests() throws Exception {
         doAnswer(invocationOnMock -> {
             slowRequestFilter.setCurrentTimeProvider(() -> 1510330743000000L);
             return null;

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/ThreadNameFilterTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/ThreadNameFilterTest.java
@@ -28,17 +28,17 @@ public class ThreadNameFilterTest {
     private ThreadNameFilter threadNameFilter = new ThreadNameFilter();
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         threadNameFilter.init(filterConfig);
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         threadNameFilter.destroy();
     }
 
     @Test
-    public void setsThreadNameInChain() throws Exception {
+    void setsThreadNameInChain() throws Exception {
         when(request.getMethod()).thenReturn("GET");
         when(request.getRequestURI()).thenReturn("/some/path");
 

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/assets/AssetServletTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/assets/AssetServletTest.java
@@ -107,14 +107,14 @@ public class AssetServletTest {
     }
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         request.setMethod("GET");
         request.setURI(DUMMY_SERVLET + "example.txt");
         request.setVersion(HttpVersion.HTTP_1_0);
     }
 
     @Test
-    public void servesFilesMappedToRoot() throws Exception {
+    void servesFilesMappedToRoot() throws Exception {
         request.setURI(ROOT_SERVLET + "assets/example.txt");
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request.generate()));
         assertThat(response.getStatus())
@@ -124,7 +124,7 @@ public class AssetServletTest {
     }
 
     @Test
-    public void servesCharset() throws Exception {
+    void servesCharset() throws Exception {
         request.setURI(DUMMY_SERVLET + "example.txt");
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request.generate()));
         assertThat(response.getStatus())
@@ -141,7 +141,7 @@ public class AssetServletTest {
     }
 
     @Test
-    public void servesFilesFromRootsWithSameName() throws Exception {
+    void servesFilesFromRootsWithSameName() throws Exception {
         request.setURI(DUMMY_SERVLET + "example2.txt");
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request.generate()));
         assertThat(response.getStatus())
@@ -151,7 +151,7 @@ public class AssetServletTest {
     }
 
     @Test
-    public void servesFilesWithA200() throws Exception {
+    void servesFilesWithA200() throws Exception {
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request.generate()));
         assertThat(response.getStatus())
                 .isEqualTo(200);
@@ -160,7 +160,7 @@ public class AssetServletTest {
     }
 
     @Test
-    public void throws404IfTheAssetIsMissing() throws Exception {
+    void throws404IfTheAssetIsMissing() throws Exception {
         request.setURI(DUMMY_SERVLET + "doesnotexist.txt");
 
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request.generate()));
@@ -169,7 +169,7 @@ public class AssetServletTest {
     }
 
     @Test
-    public void consistentlyAssignsETags() throws Exception {
+    void consistentlyAssignsETags() throws Exception {
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request.generate()));
         final String firstEtag = response.get(HttpHeader.ETAG);
 
@@ -198,7 +198,7 @@ public class AssetServletTest {
     }
 
     @Test
-    public void assignsDifferentETagsForDifferentFiles() throws Exception {
+    void assignsDifferentETagsForDifferentFiles() throws Exception {
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request.generate()));
         final String firstEtag = response.get(HttpHeader.ETAG);
 
@@ -213,7 +213,7 @@ public class AssetServletTest {
     }
 
     @Test
-    public void supportsIfNoneMatchRequests() throws Exception {
+    void supportsIfNoneMatchRequests() throws Exception {
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request.generate()));
         final String correctEtag = response.get(HttpHeader.ETAG);
 
@@ -232,7 +232,7 @@ public class AssetServletTest {
     }
 
     @Test
-    public void consistentlyAssignsLastModifiedTimes() throws Exception {
+    void consistentlyAssignsLastModifiedTimes() throws Exception {
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request.generate()));
         final long firstLastModifiedTime = response.getDateField(HttpHeader.LAST_MODIFIED.asString());
 
@@ -244,7 +244,7 @@ public class AssetServletTest {
     }
 
     @Test
-    public void supportsByteRangeForMedia() throws Exception {
+    void supportsByteRangeForMedia() throws Exception {
         request.setURI(ROOT_SERVLET + "assets/foo.mp4");
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request
                 .generate()));
@@ -259,7 +259,7 @@ public class AssetServletTest {
     }
 
     @Test
-    public void supportsFullByteRange() throws Exception {
+    void supportsFullByteRange() throws Exception {
         request.setURI(ROOT_SERVLET + "assets/example.txt");
         request.setHeader(HttpHeader.RANGE.asString(), "bytes=0-");
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request
@@ -272,7 +272,7 @@ public class AssetServletTest {
     }
 
     @Test
-    public void supportsCentralByteRange() throws Exception {
+    void supportsCentralByteRange() throws Exception {
         request.setURI(ROOT_SERVLET + "assets/example.txt");
         request.setHeader(HttpHeader.RANGE.asString(), "bytes=4-8");
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request
@@ -286,7 +286,7 @@ public class AssetServletTest {
     }
 
     @Test
-    public void supportsFinalByteRange() throws Exception {
+    void supportsFinalByteRange() throws Exception {
         request.setURI(ROOT_SERVLET + "assets/example.txt");
         request.setHeader(HttpHeader.RANGE.asString(), "bytes=10-10");
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request
@@ -310,7 +310,7 @@ public class AssetServletTest {
     }
 
     @Test
-    public void rejectsInvalidByteRanges() throws Exception {
+    void rejectsInvalidByteRanges() throws Exception {
         request.setURI(ROOT_SERVLET + "assets/example.txt");
         request.setHeader(HttpHeader.RANGE.asString(), "bytes=test");
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request
@@ -334,7 +334,7 @@ public class AssetServletTest {
     }
 
     @Test
-    public void supportsMultipleByteRanges() throws Exception {
+    void supportsMultipleByteRanges() throws Exception {
         request.setURI(ROOT_SERVLET + "assets/example.txt");
         request.setHeader(HttpHeader.RANGE.asString(), "bytes=0-0,-1");
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request
@@ -358,7 +358,7 @@ public class AssetServletTest {
     }
 
     @Test
-    public void supportsIfRangeMatchRequests() throws Exception {
+    void supportsIfRangeMatchRequests() throws Exception {
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request
                 .generate()));
         final String correctEtag = response.get(HttpHeader.ETAG);
@@ -380,7 +380,7 @@ public class AssetServletTest {
     }
 
     @Test
-    public void supportsIfModifiedSinceRequests() throws Exception {
+    void supportsIfModifiedSinceRequests() throws Exception {
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request.generate()));
         final long lastModifiedTime = response.getDateField(HttpHeader.LAST_MODIFIED.asString());
 
@@ -407,7 +407,7 @@ public class AssetServletTest {
     }
 
     @Test
-    public void guessesMimeTypes() throws Exception {
+    void guessesMimeTypes() throws Exception {
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request.generate()));
         assertThat(response.getStatus())
                 .isEqualTo(200);
@@ -416,7 +416,7 @@ public class AssetServletTest {
     }
 
     @Test
-    public void defaultsToHtml() throws Exception {
+    void defaultsToHtml() throws Exception {
         request.setURI(DUMMY_SERVLET + "foo.bar");
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request.generate()));
         assertThat(response.getStatus())
@@ -426,7 +426,7 @@ public class AssetServletTest {
     }
 
     @Test
-    public void defaultsToHtmlIfNotOverridden() throws Exception {
+    void defaultsToHtmlIfNotOverridden() throws Exception {
         request.setURI(NOMEDIATYPE_SERVLET + "foo.bar");
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request.generate()));
         assertThat(response.getStatus())
@@ -436,7 +436,7 @@ public class AssetServletTest {
     }
 
     @Test
-    public void servesWithDefaultMediaType() throws Exception {
+    void servesWithDefaultMediaType() throws Exception {
         request.setURI(MEDIATYPE_SERVLET + "foo.bar");
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request.generate()));
         assertThat(response.getStatus())
@@ -446,7 +446,7 @@ public class AssetServletTest {
     }
 
     @Test
-    public void servesIndexFilesByDefault() throws Exception {
+    void servesIndexFilesByDefault() throws Exception {
         // Root directory listing:
         request.setURI(DUMMY_SERVLET);
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request.generate()));
@@ -473,7 +473,7 @@ public class AssetServletTest {
     }
 
     @Test
-    public void throwsA404IfNoIndexFileIsDefined() throws Exception {
+    void throwsA404IfNoIndexFileIsDefined() throws Exception {
         // Root directory listing:
         request.setURI(NOINDEX_SERVLET + '/');
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request.generate()));
@@ -494,7 +494,7 @@ public class AssetServletTest {
     }
 
     @Test
-    public void doesNotAllowOverridingUrls() throws Exception {
+    void doesNotAllowOverridingUrls() throws Exception {
         request.setURI(DUMMY_SERVLET + "file:/etc/passwd");
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request.generate()));
         assertThat(response.getStatus())
@@ -502,7 +502,7 @@ public class AssetServletTest {
     }
 
     @Test
-    public void doesNotAllowOverridingPaths() throws Exception {
+    void doesNotAllowOverridingPaths() throws Exception {
         request.setURI(DUMMY_SERVLET + "/etc/passwd");
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request.generate()));
         assertThat(response.getStatus())
@@ -510,7 +510,7 @@ public class AssetServletTest {
     }
 
     @Test
-    public void allowsEncodedAssetNames() throws Exception {
+    void allowsEncodedAssetNames() throws Exception {
         request.setURI(DUMMY_SERVLET + "encoded%20example.txt");
         response = HttpTester.parseResponse(SERVLET_TESTER.getResponses(request.generate()));
         assertThat(response.getStatus())

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/assets/ByteRangeTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/assets/ByteRangeTest.java
@@ -9,42 +9,42 @@ public class ByteRangeTest {
     private static final int RESOURCE_LENGTH = 10000;
 
     @Test
-    public void firstBytes() {
+    void firstBytes() {
         final ByteRange actual = ByteRange.parse("0-499", RESOURCE_LENGTH);
         assertThat(actual.getStart()).isEqualTo(0);
         assertThat(actual.getEnd()).isEqualTo(499);
     }
 
     @Test
-    public void secondBytes() {
+    void secondBytes() {
         final ByteRange actual = ByteRange.parse("500-999", RESOURCE_LENGTH);
         assertThat(actual.getStart()).isEqualTo(500);
         assertThat(actual.getEnd()).isEqualTo(999);
     }
 
     @Test
-    public void finalBytes() {
+    void finalBytes() {
         final ByteRange actual = ByteRange.parse("-500", RESOURCE_LENGTH);
         assertThat(actual.getStart()).isEqualTo(9500);
         assertThat(actual.getEnd()).isEqualTo(9999);
     }
 
     @Test
-    public void noEndBytes() {
+    void noEndBytes() {
         final ByteRange actual = ByteRange.parse("9500-", RESOURCE_LENGTH);
         assertThat(actual.getStart()).isEqualTo(9500);
         assertThat(actual.getEnd()).isEqualTo(9999);
     }
 
     @Test
-    public void startBytes() {
+    void startBytes() {
         final ByteRange actual = ByteRange.parse("9500", RESOURCE_LENGTH);
         assertThat(actual.getStart()).isEqualTo(9500);
         assertThat(actual.getEnd()).isEqualTo(9999);
     }
 
     @Test
-    public void tooManyBytes() {
+    void tooManyBytes() {
         final ByteRange actual = ByteRange.parse("9000-20000", RESOURCE_LENGTH);
         assertThat(actual.getStart()).isEqualTo(9000);
         assertThat(actual.getEnd()).isEqualTo(9999);

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/GarbageCollectionTaskTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/GarbageCollectionTaskTest.java
@@ -19,14 +19,14 @@ public class GarbageCollectionTaskTest {
     private final GarbageCollectionTask task = new GarbageCollectionTask(runtime);
 
     @Test
-    public void runsOnceWithNoParameters() throws Exception {
+    void runsOnceWithNoParameters() throws Exception {
         task.execute(Collections.emptyMap(), output);
 
         verify(runtime, times(1)).gc();
     }
 
     @Test
-    public void usesTheFirstRunsParameter() throws Exception {
+    void usesTheFirstRunsParameter() throws Exception {
         final Map<String, List<String>> parameters = Collections.singletonMap("runs", Arrays.asList("3", "2"));
         task.execute(parameters, output);
 
@@ -34,7 +34,7 @@ public class GarbageCollectionTaskTest {
     }
 
     @Test
-    public void defaultsToOneRunIfTheQueryParamDoesNotParse() throws Exception {
+    void defaultsToOneRunIfTheQueryParamDoesNotParse() throws Exception {
         task.execute(Collections.singletonMap("runs", Collections.singletonList("$")), output);
 
         verify(runtime, times(1)).gc();

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/LogConfigurationTaskTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/LogConfigurationTaskTest.java
@@ -28,7 +28,7 @@ public class LogConfigurationTaskTest {
     private final LogConfigurationTask task = new LogConfigurationTask(loggerContext);
 
     @Test
-    public void configuresSpecificLevelForALogger() throws Exception {
+    void configuresSpecificLevelForALogger() throws Exception {
 
         // given
         Level twoEffectiveBefore = logger2.getEffectiveLevel();
@@ -47,7 +47,7 @@ public class LogConfigurationTaskTest {
     }
 
     @Test
-    public void configuresSpecificLevelForALoggerForADuration() throws Exception {
+    void configuresSpecificLevelForALoggerForADuration() throws Exception {
 
         // given
         long millis = 2000;
@@ -70,7 +70,7 @@ public class LogConfigurationTaskTest {
     }
 
     @Test
-    public void configuresDefaultLevelForALogger() throws Exception {
+    void configuresDefaultLevelForALogger() throws Exception {
         // given
         Level oneEffectiveBefore = logger1.getEffectiveLevel();
         Level twoEffectiveBefore = logger2.getEffectiveLevel();
@@ -88,7 +88,7 @@ public class LogConfigurationTaskTest {
     }
 
     @Test
-    public void configuresLevelForMultipleLoggers() throws Exception {
+    void configuresLevelForMultipleLoggers() throws Exception {
         // given
         Map<String, List<String>> parameters = Maps.of(
                 "logger", Arrays.asList("logger.one", "logger.two"),

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/PostBodyTaskTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/PostBodyTaskTest.java
@@ -21,7 +21,7 @@ public class PostBodyTaskTest {
 
     @SuppressWarnings("deprecation")
     @Test
-    public void throwsExceptionWhenCallingExecuteWithoutThePostBody() throws Exception {
+    void throwsExceptionWhenCallingExecuteWithoutThePostBody() throws Exception {
         assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() ->
                 task.execute(Collections.emptyMap(), new PrintWriter(new OutputStreamWriter(System.out, UTF_8))));
     }

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/TaskTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/TaskTest.java
@@ -18,7 +18,7 @@ public class TaskTest {
     };
 
     @Test
-    public void hasAName() throws Exception {
+    void hasAName() throws Exception {
         assertThat(task.getName())
                 .isEqualTo("test");
     }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/GzipDefaultVaryBehaviourTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/GzipDefaultVaryBehaviourTest.java
@@ -22,7 +22,7 @@ public class GzipDefaultVaryBehaviourTest {
             new DropwizardAppRule<>(TestApplication.class, resourceFilePath("gzip-vary-test-config.yaml"));
 
     @Test
-    public void testDefaultVaryHeader() {
+    void testDefaultVaryHeader() {
         final Response clientResponse = RULE.client().target(
             "http://localhost:" + RULE.getLocalPort() + "/test").request().header(ACCEPT_ENCODING, "gzip").get();
 

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResourceExceptionMapperTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResourceExceptionMapperTest.java
@@ -35,7 +35,7 @@ public class PersonResourceExceptionMapperTest {
         .build();
 
     @Test
-    public void testDefaultConstraintViolation() {
+    void testDefaultConstraintViolation() {
         assertThat(RESOURCES.target("/person/blah/index")
             .queryParam("ind", -1).request()
             .get().readEntity(String.class))
@@ -43,7 +43,7 @@ public class PersonResourceExceptionMapperTest {
     }
 
     @Test
-    public void testDefaultJsonProcessingMapper() {
+    void testDefaultJsonProcessingMapper() {
         assertThat(RESOURCES.target("/person/blah/runtime-exception")
             .request()
             .post(Entity.json("{ \"he: \"ho\"}"))
@@ -52,7 +52,7 @@ public class PersonResourceExceptionMapperTest {
     }
 
     @Test
-    public void testDefaultExceptionMapper() {
+    void testDefaultExceptionMapper() {
         assertThat(RESOURCES.target("/person/blah/runtime-exception")
             .request()
             .post(Entity.json("{}"))
@@ -61,7 +61,7 @@ public class PersonResourceExceptionMapperTest {
     }
 
     @Test
-    public void testDefaultEofExceptionMapper() {
+    void testDefaultEofExceptionMapper() {
         assertThat(RESOURCES.target("/person/blah/eof-exception")
             .request()
             .get().readEntity(String.class))

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestRuleTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestRuleTest.java
@@ -54,7 +54,7 @@ public class ResourceTestRuleTest {
     }
 
     @Test
-    public void testGetPerson() {
+    void testGetPerson() {
         assertThat(resourceTestRule.target("/person/blah").request()
                 .get(Person.class))
                 .isEqualTo(person);
@@ -62,14 +62,14 @@ public class ResourceTestRuleTest {
     }
 
     @Test
-    public void testGetImmutableListOfPersons() {
+    void testGetImmutableListOfPersons() {
         assertThat(resourceTestRule.target("/person/blah/list").request()
                 .get(new GenericType<List<Person>>() {
                 })).isEqualTo(Collections.singletonList(person));
     }
 
     @Test
-    public void testGetPersonWithQueryParam() {
+    void testGetPersonWithQueryParam() {
         // Test to ensure that the dropwizard validator is registered so that
         // it can validate the "ind" IntParam.
         assertThat(resourceTestRule.target("/person/blah/index")
@@ -80,7 +80,7 @@ public class ResourceTestRuleTest {
     }
 
     @Test
-    public void testDefaultConstraintViolation() {
+    void testDefaultConstraintViolation() {
         assertThat(resourceTestRule.target("/person/blah/index")
                 .queryParam("ind", -1).request()
                 .get().readEntity(String.class))
@@ -88,7 +88,7 @@ public class ResourceTestRuleTest {
     }
 
     @Test
-    public void testDefaultJsonProcessingMapper() {
+    void testDefaultJsonProcessingMapper() {
         assertThat(resourceTestRule.target("/person/blah/runtime-exception")
                 .request()
                 .post(Entity.json("{ \"he: \"ho\"}"))
@@ -97,7 +97,7 @@ public class ResourceTestRuleTest {
     }
 
     @Test
-    public void testDefaultExceptionMapper() {
+    void testDefaultExceptionMapper() {
         assertThat(resourceTestRule.target("/person/blah/runtime-exception")
                 .request()
                 .post(Entity.json("{}"))
@@ -106,7 +106,7 @@ public class ResourceTestRuleTest {
     }
 
     @Test
-    public void testDefaultEofExceptionMapper() {
+    void testDefaultEofExceptionMapper() {
         assertThat(resourceTestRule.target("/person/blah/eof-exception")
                 .request()
                 .get().getStatus())
@@ -114,7 +114,7 @@ public class ResourceTestRuleTest {
     }
 
     @Test
-    public void testValidationGroupsException() {
+    void testValidationGroupsException() {
         final Response resp = resourceTestRule.target("/person/blah/validation-groups-exception")
                 .request()
                 .post(Entity.json("{}"));
@@ -125,7 +125,7 @@ public class ResourceTestRuleTest {
     }
 
     @Test
-    public void testCustomClientConfiguration() {
+    void testCustomClientConfiguration() {
         assertThat(resourceTestRule.client().getConfiguration().isRegistered(DummyExceptionMapper.class)).isTrue();
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestRuleWithGrizzlyTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestRuleWithGrizzlyTest.java
@@ -26,14 +26,14 @@ public class ResourceTestRuleWithGrizzlyTest {
             .build();
 
     @Test
-    public void testResource() {
+    void testResource() {
         assertThat(resourceTestRule.target("test").request()
                 .get(String.class))
                 .isEqualTo("test");
     }
 
     @Test
-    public void testExceptionMapper() {
+    void testExceptionMapper() {
         final Response resp = resourceTestRule.target("test").request()
                 .post(Entity.json(""));
         assertThat(resp.getStatus()).isEqualTo(500);
@@ -41,7 +41,7 @@ public class ResourceTestRuleWithGrizzlyTest {
     }
 
     @Test
-    public void testClientSupportsPatchMethod() {
+    void testClientSupportsPatchMethod() {
         final String resp = resourceTestRule.target("test")
             .request()
             .method("PATCH", Entity.text("Patch is working"), String.class);

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestRuleWithoutLoggingBootstrapTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestRuleWithoutLoggingBootstrapTest.java
@@ -15,7 +15,7 @@ public class ResourceTestRuleWithoutLoggingBootstrapTest {
             .build();
 
     @Test
-    public void testResource() {
+    void testResource() {
         assertThat(resourceTestRule.target("test").request()
                 .get(String.class))
                 .isEqualTo("Default message");

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DAOTestRuleConfigTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DAOTestRuleConfigTest.java
@@ -25,7 +25,7 @@ public class DAOTestRuleConfigTest {
         .build();
 
     @Test
-    public void explicitConfigCreatesSessionFactory() {
+    void explicitConfigCreatesSessionFactory() {
         // it yields a valid SessionFactory instance
         final SessionFactory sessionFactory = database.getSessionFactory();
         assertThat(sessionFactory).isNotNull();

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DAOTestRuleTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DAOTestRuleTest.java
@@ -18,21 +18,21 @@ public class DAOTestRuleTest {
     public final DAOTestRule daoTestRule = DAOTestRule.newBuilder().addEntityClass(TestEntity.class).build();
 
     @Test
-    public void ruleCreatedSessionFactory() {
+    void ruleCreatedSessionFactory() {
         final SessionFactory sessionFactory = daoTestRule.getSessionFactory();
 
         assertThat(sessionFactory).isNotNull();
     }
 
     @Test
-    public void ruleCanOpenTransaction() {
+    void ruleCanOpenTransaction() {
         final Long id = daoTestRule.inTransaction(() -> persist(new TestEntity("description")).getId());
 
         assertThat(id).isNotNull();
     }
 
     @Test
-    public void ruleCanRoundtrip() {
+    void ruleCanRoundtrip() {
         final Long id = daoTestRule.inTransaction(() -> persist(new TestEntity("description")).getId());
 
         final TestEntity testEntity = get(id);
@@ -42,13 +42,13 @@ public class DAOTestRuleTest {
     }
 
     @Test
-    public void transactionThrowsExceptionAsExpected() {
+    void transactionThrowsExceptionAsExpected() {
         assertThatExceptionOfType(ConstraintViolationException.class).isThrownBy(()->
             daoTestRule.inTransaction(() -> persist(new TestEntity(null))));
     }
 
     @Test
-    public void rollsBackTransaction() {
+    void rollsBackTransaction() {
         // given a successfully persisted entity
         final TestEntity testEntity = new TestEntity("description");
         daoTestRule.inTransaction(() -> persist(testEntity));

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DAOTestRuleWithoutLoggingBootstrapTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DAOTestRuleWithoutLoggingBootstrapTest.java
@@ -16,7 +16,7 @@ public class DAOTestRuleWithoutLoggingBootstrapTest {
             .build();
 
     @Test
-    public void ruleCreatedSessionFactory() {
+    void ruleCreatedSessionFactory() {
         final SessionFactory sessionFactory = daoTestRule.getSessionFactory();
 
         assertThat(sessionFactory).isNotNull();

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleConfigOverrideTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleConfigOverrideTest.java
@@ -20,7 +20,7 @@ public class DropwizardAppRuleConfigOverrideTest {
             config("extra", () -> "supplied again"));
 
     @Test
-    public void supportsConfigAttributeOverrides() {
+    void supportsConfigAttributeOverrides() {
         final String content = RULE.client().target("http://localhost:" + RULE.getLocalPort() + "/test")
             .request().get(String.class);
 
@@ -28,7 +28,7 @@ public class DropwizardAppRuleConfigOverrideTest {
     }
 
     @Test
-    public void supportsSuppliedConfigAttributeOverrides() throws Exception {
+    void supportsSuppliedConfigAttributeOverrides() throws Exception {
         assertThat(System.getProperty("app-rule.extra")).isEqualTo("supplied");
         assertThat(System.getProperty("dw.extra")).isEqualTo("supplied again");
     }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleReentrantTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleReentrantTest.java
@@ -26,7 +26,7 @@ public class DropwizardAppRuleReentrantTest {
     private Description description = mock(Description.class);
 
     @Test
-    public void testReentrantRuleStartsApplicationOnlyOnce() throws Throwable {
+    void testReentrantRuleStartsApplicationOnlyOnce() throws Throwable {
         @SuppressWarnings("deprecation")
         DropwizardAppRule<TestConfiguration> dropwizardAppRule = new DropwizardAppRule<>(testSupport);
 

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleResetConfigOverrideTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleResetConfigOverrideTest.java
@@ -17,7 +17,7 @@ public class DropwizardAppRuleResetConfigOverrideTest {
         config("app-rule-reset", "message", "A new way to say Hooray!"));
 
     @Test
-    public void test2() throws Exception {
+    void test2() throws Exception {
         dropwizardAppRule.before();
         assertThat(System.getProperty("app-rule-reset.message")).isEqualTo("A new way to say Hooray!");
         assertThat(System.getProperty("app-rule-reset.extra")).isNull();

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleTest.java
@@ -20,7 +20,7 @@ public class DropwizardAppRuleTest {
         new DropwizardAppRule<>(DropwizardTestApplication.class, resourceFilePath("test-config.yaml"));
 
     @Test
-    public void canGetExpectedResourceOverHttp() {
+    void canGetExpectedResourceOverHttp() {
         final String content = ClientBuilder.newClient().target(
             "http://localhost:" + RULE.getLocalPort() + "/test").request().get(String.class);
 
@@ -28,25 +28,25 @@ public class DropwizardAppRuleTest {
     }
 
     @Test
-    public void returnsConfiguration() {
+    void returnsConfiguration() {
         final TestConfiguration config = RULE.getConfiguration();
         assertThat(config.getMessage()).isEqualTo("Yes, it's here");
     }
 
     @Test
-    public void returnsApplication() {
+    void returnsApplication() {
         final DropwizardTestApplication application = RULE.getApplication();
         assertThat(application).isNotNull();
     }
 
     @Test
-    public void returnsEnvironment() {
+    void returnsEnvironment() {
         final Environment environment = RULE.getEnvironment();
         assertThat(environment.getName()).isEqualTo("DropwizardTestApplication");
     }
 
     @Test
-    public void canPerformAdminTask() {
+    void canPerformAdminTask() {
         final String response
             = RULE.client().target("http://localhost:"
             + RULE.getAdminPort() + "/tasks/hello?name=test_user")
@@ -57,7 +57,7 @@ public class DropwizardAppRuleTest {
     }
 
     @Test
-    public void canPerformAdminTaskWithPostBody() {
+    void canPerformAdminTaskWithPostBody() {
         final String response
             = RULE.client().target("http://localhost:"
             + RULE.getAdminPort() + "/tasks/echo")
@@ -68,7 +68,7 @@ public class DropwizardAppRuleTest {
     }
 
     @Test
-    public void clientUsesJacksonMapperFromEnvironment() {
+    void clientUsesJacksonMapperFromEnvironment() {
         assertThat(RULE.client().target("http://localhost:" + RULE.getLocalPort() + "/message")
             .request()
             .get(DropwizardTestApplication.MessageView.class).getMessage())
@@ -76,7 +76,7 @@ public class DropwizardAppRuleTest {
     }
 
     @Test
-    public void clientSupportsPatchMethod() {
+    void clientSupportsPatchMethod() {
         assertThat(RULE.client().target("http://localhost:" + RULE.getLocalPort() + "/echoPatch")
             .request()
             .method("PATCH", Entity.text("Patch is working"), String.class))

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleWithExplicitTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleWithExplicitTest.java
@@ -39,7 +39,7 @@ public class DropwizardAppRuleWithExplicitTest {
 
 
     @Test
-    public void runWithExplicitConfig() {
+    void runWithExplicitConfig() {
         Map<String, String> response = RULE.client().target("http://localhost:" + RULE.getLocalPort() + "/test")
             .request()
             .get(new GenericType<Map<String, String>>() {

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleWithoutConfigTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleWithoutConfigTest.java
@@ -27,7 +27,7 @@ public class DropwizardAppRuleWithoutConfigTest {
         ConfigOverride.config("server.adminConnectors[0].port", "0"));
 
     @Test
-    public void runWithoutConfigFile() {
+    void runWithoutConfigFile() {
         Map<String, String> response = RULE.client().target("http://localhost:" + RULE.getLocalPort() + "/test")
             .request()
             .get(new GenericType<Map<String, String>>() {

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardClientRuleTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardClientRuleTest.java
@@ -21,13 +21,13 @@ public class DropwizardClientRuleTest {
     public static final DropwizardClientRule RULE_WITH_CLASS = new DropwizardClientRule(TestResource.class);
 
     @Test
-    public void shouldGetStringBodyFromDropWizard() throws IOException {
+    void shouldGetStringBodyFromDropWizard() throws IOException {
         final URL url = new URL(RULE_WITH_INSTANCE.baseUri() + "/test");
         assertThat("foo").isEqualTo(Resources.toString(url, StandardCharsets.UTF_8));
     }
 
     @Test
-    public void shouldGetDefaultStringBodyFromDropWizard() throws IOException {
+    void shouldGetDefaultStringBodyFromDropWizard() throws IOException {
         final URL url = new URL(RULE_WITH_CLASS.baseUri() + "/test");
         assertThat(Resources.toString(url, StandardCharsets.UTF_8)).isEqualTo(TestResource.DEFAULT_MESSAGE);
     }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/LogbackExcludedTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/LogbackExcludedTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.fail;
 public class LogbackExcludedTest {
 
     @Test
-    public void testLogbackExcludedClassNotFound() throws Exception {
+    void testLogbackExcludedClassNotFound() throws Exception {
         testBuildConfigurationMetadata(className -> {
             if (className.startsWith("ch.qos.logback.")) {
                 throw new ClassNotFoundException();
@@ -34,7 +34,7 @@ public class LogbackExcludedTest {
     }
 
     @Test
-    public void testLogbackExcludedNoClassDef() throws Exception {
+    void testLogbackExcludedNoClassDef() throws Exception {
         testBuildConfigurationMetadata(className -> {
             if (className.startsWith("ch.qos.logback.")) {
                 throw new NoClassDefFoundError();
@@ -43,7 +43,7 @@ public class LogbackExcludedTest {
     }
 
     @Test
-    public void testPropagatedException() throws Exception {
+    void testPropagatedException() throws Exception {
         AtomicReference<RuntimeException> thrown = new AtomicReference<>();
         try {
             testBuildConfigurationMetadata(className -> {

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/ResourceExtensionMocksTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/ResourceExtensionMocksTest.java
@@ -29,7 +29,7 @@ class ResourceExtensionMocksTest {
     }
 
     @Test
-    public void accessingMockPersonSucceeds() {
+    void accessingMockPersonSucceeds() {
         when(mockPerson.getName()).thenReturn("Person-Name");
 
         final String resp = resources.target("test/name").request().get(String.class);

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/ResourceExtensionWithJettyTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/ResourceExtensionWithJettyTest.java
@@ -22,7 +22,7 @@ class ResourceExtensionWithJettyTest {
             .build();
 
     @Test
-    public void testClientSupportsPatchMethod() {
+    void testClientSupportsPatchMethod() {
         final String resp = resources.target("test")
                 .request()
                 .method("PATCH", Entity.text("Patch is working"), String.class);

--- a/dropwizard-util/src/test/java/io/dropwizard/util/ByteStreamsTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/ByteStreamsTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ByteStreamsTest {
 
     @Test
-    public void testToByteArray() throws IOException {
+    void testToByteArray() throws IOException {
         byte[] input = new byte[4010];
         for (int i = 0; i < 4010; i++) {
             input[i] = 0x1A;

--- a/dropwizard-util/src/test/java/io/dropwizard/util/CharStreamsTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/CharStreamsTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class CharStreamsTest {
 
     @Test
-    public void testToString() throws IOException {
+    void testToString() throws IOException {
         StringBuilder builder = new StringBuilder(4100);
         for (int i = 0; i < 4100; i++) {
              builder.append("a");

--- a/dropwizard-util/src/test/java/io/dropwizard/util/DurationTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/DurationTest.java
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 
 public class DurationTest {
     @Test
-    public void convertsDays() throws Exception {
+    void convertsDays() throws Exception {
         assertThat(Duration.days(2).toDays())
             .isEqualTo(2);
         assertThat(Duration.days(2).toHours())
@@ -23,43 +23,43 @@ public class DurationTest {
     }
 
     @Test
-    public void convertsHours() throws Exception {
+    void convertsHours() throws Exception {
         assertThat(Duration.hours(2).toMinutes())
             .isEqualTo(120);
     }
 
     @Test
-    public void convertsMinutes() throws Exception {
+    void convertsMinutes() throws Exception {
         assertThat(Duration.minutes(3).toSeconds())
             .isEqualTo(180);
     }
 
     @Test
-    public void convertsSeconds() throws Exception {
+    void convertsSeconds() throws Exception {
         assertThat(Duration.seconds(2).toMilliseconds())
             .isEqualTo(2000);
     }
 
     @Test
-    public void convertsMilliseconds() throws Exception {
+    void convertsMilliseconds() throws Exception {
         assertThat(Duration.milliseconds(2).toMicroseconds())
             .isEqualTo(2000);
     }
 
     @Test
-    public void convertsMicroseconds() throws Exception {
+    void convertsMicroseconds() throws Exception {
         assertThat(Duration.microseconds(2).toNanoseconds())
             .isEqualTo(2000);
     }
 
     @Test
-    public void convertsNanoseconds() throws Exception {
+    void convertsNanoseconds() throws Exception {
         assertThat(Duration.nanoseconds(2).toNanoseconds())
             .isEqualTo(2);
     }
 
     @Test
-    public void parsesDays() throws Exception {
+    void parsesDays() throws Exception {
         assertThat(Duration.parse("1d"))
             .isEqualTo(Duration.days(1));
 
@@ -71,7 +71,7 @@ public class DurationTest {
     }
 
     @Test
-    public void parsesHours() throws Exception {
+    void parsesHours() throws Exception {
         assertThat(Duration.parse("1h"))
             .isEqualTo(Duration.hours(1));
 
@@ -83,7 +83,7 @@ public class DurationTest {
     }
 
     @Test
-    public void parsesMinutes() throws Exception {
+    void parsesMinutes() throws Exception {
         assertThat(Duration.parse("1m"))
             .isEqualTo(Duration.minutes(1));
 
@@ -101,7 +101,7 @@ public class DurationTest {
     }
 
     @Test
-    public void parsesSeconds() throws Exception {
+    void parsesSeconds() throws Exception {
         assertThat(Duration.parse("1s"))
             .isEqualTo(Duration.seconds(1));
 
@@ -113,7 +113,7 @@ public class DurationTest {
     }
 
     @Test
-    public void parsesMilliseconds() throws Exception {
+    void parsesMilliseconds() throws Exception {
         assertThat(Duration.parse("1ms"))
             .isEqualTo(Duration.milliseconds(1));
 
@@ -125,7 +125,7 @@ public class DurationTest {
     }
 
     @Test
-    public void parsesMicroseconds() throws Exception {
+    void parsesMicroseconds() throws Exception {
         assertThat(Duration.parse("1us"))
             .isEqualTo(Duration.microseconds(1));
 
@@ -137,7 +137,7 @@ public class DurationTest {
     }
 
     @Test
-    public void parsesNanoseconds() throws Exception {
+    void parsesNanoseconds() throws Exception {
         assertThat(Duration.parse("1ns"))
             .isEqualTo(Duration.nanoseconds(1));
 
@@ -149,28 +149,28 @@ public class DurationTest {
     }
 
     @Test
-    public void parseDurationWithWhiteSpaces() {
+    void parseDurationWithWhiteSpaces() {
         assertThat(Duration.parse("5   seconds"))
             .isEqualTo(Duration.seconds(5));
     }
 
     @Test
-    public void unableParseWrongDurationCount() {
+    void unableParseWrongDurationCount() {
         assertThatIllegalArgumentException().isThrownBy(() -> Duration.parse("five seconds"));
     }
 
     @Test
-    public void unableParseWrongDurationTimeUnit() {
+    void unableParseWrongDurationTimeUnit() {
         assertThatIllegalArgumentException().isThrownBy(() -> Duration.parse("1gs"));
     }
 
     @Test
-    public void unableParseWrongDurationFormat() {
+    void unableParseWrongDurationFormat() {
         assertThatIllegalArgumentException().isThrownBy(() -> Duration.parse("1 milli second"));
     }
 
     @Test
-    public void isHumanReadable() throws Exception {
+    void isHumanReadable() throws Exception {
         assertThat(Duration.microseconds(1).toString())
             .isEqualTo("1 microsecond");
 
@@ -179,19 +179,19 @@ public class DurationTest {
     }
 
     @Test
-    public void hasAQuantity() throws Exception {
+    void hasAQuantity() throws Exception {
         assertThat(Duration.microseconds(12).getQuantity())
             .isEqualTo(12);
     }
 
     @Test
-    public void hasAUnit() throws Exception {
+    void hasAUnit() throws Exception {
         assertThat(Duration.microseconds(1).getUnit())
             .isEqualTo(TimeUnit.MICROSECONDS);
     }
 
     @Test
-    public void isComparable() throws Exception {
+    void isComparable() throws Exception {
         // both zero
         assertThat(Duration.nanoseconds(0).compareTo(Duration.nanoseconds(0))).isEqualTo(0);
         assertThat(Duration.nanoseconds(0).compareTo(Duration.microseconds(0))).isEqualTo(0);
@@ -816,7 +816,7 @@ public class DurationTest {
     }
 
     @Test
-    public void serializesCorrectlyWithJackson() throws IOException {
+    void serializesCorrectlyWithJackson() throws IOException {
         final ObjectMapper mapper = new ObjectMapper();
 
         assertThat(mapper.writeValueAsString(Duration.nanoseconds(0L))).isEqualTo("\"0 nanoseconds\"");
@@ -843,7 +843,7 @@ public class DurationTest {
     }
 
     @Test
-    public void deserializesCorrectlyWithJackson() throws IOException {
+    void deserializesCorrectlyWithJackson() throws IOException {
         final ObjectMapper mapper = new ObjectMapper();
 
         assertThat(mapper.readValue("\"0 nanoseconds\"", Duration.class)).isEqualTo(Duration.nanoseconds(0L));

--- a/dropwizard-util/src/test/java/io/dropwizard/util/JarLocationTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/JarLocationTest.java
@@ -8,13 +8,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class JarLocationTest {
     @Test
-    public void isHumanReadable() throws Exception {
+    void isHumanReadable() throws Exception {
         assertThat(new JarLocation(JarLocationTest.class).toString())
                 .isEqualTo("project.jar");
     }
 
     @Test
-    public void hasAVersion() throws Exception {
+    void hasAVersion() throws Exception {
         assertThat(new JarLocation(JarLocationTest.class).getVersion())
                 .isEqualTo(Optional.empty());
     }

--- a/dropwizard-util/src/test/java/io/dropwizard/util/MapsTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/MapsTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MapsTest {
 
     @Test
-    public void of2KeyValuePairs() {
+    void of2KeyValuePairs() {
         final Map map = Maps.of(1, 60, 2, 61);
         final HashMap hashMap = new HashMap();
         hashMap.put(1, 60);
@@ -20,7 +20,7 @@ public class MapsTest {
     }
 
     @Test
-    public void of3KeyValuePairs() {
+    void of3KeyValuePairs() {
         final Map map = Maps.of(1, 60, 2, 61, 3, 62);
         final HashMap hashMap = new HashMap();
         hashMap.put(1, 60);
@@ -31,7 +31,7 @@ public class MapsTest {
     }
 
     @Test
-    public void of4KeyValuePairs() {
+    void of4KeyValuePairs() {
         final Map map = Maps.of(1, 60, 2, 61, 3, 62, 4, 63);
         final HashMap hashMap = new HashMap();
         hashMap.put(1, 60);
@@ -43,7 +43,7 @@ public class MapsTest {
     }
 
     @Test
-    public void of5KeyValuePairs() {
+    void of5KeyValuePairs() {
         final Map map = Maps.of(1, 60, 2, 61, 3, 62, 4, 63, 5, 64);
         final HashMap hashMap = new HashMap();
         hashMap.put(1, 60);

--- a/dropwizard-util/src/test/java/io/dropwizard/util/OptionalsTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/OptionalsTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OptionalsTest {
     @Test
-    public void testFromGuavaOptional() throws Exception {
+    void testFromGuavaOptional() throws Exception {
         assertFalse(Optionals.fromGuavaOptional(com.google.common.base.Optional.absent()).isPresent());
         assertTrue(Optionals.fromGuavaOptional(com.google.common.base.Optional.of("Foo")).isPresent());
         assertEquals(
@@ -18,7 +18,7 @@ public class OptionalsTest {
     }
 
     @Test
-    public void testToGuavaOptional() throws Exception {
+    void testToGuavaOptional() throws Exception {
         assertFalse(Optionals.toGuavaOptional(java.util.Optional.empty()).isPresent());
         assertTrue(Optionals.toGuavaOptional(java.util.Optional.of("Foo")).isPresent());
         assertEquals(

--- a/dropwizard-util/src/test/java/io/dropwizard/util/SetsTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/SetsTest.java
@@ -11,28 +11,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SetsTest {
 
     @Test
-    public void of2Elements() {
+    void of2Elements() {
         final Set set = Sets.of(1, 2);
 
         assertThat(set).isEqualTo(new HashSet(Arrays.asList(1, 2)));
     }
 
     @Test
-    public void of3Elements() {
+    void of3Elements() {
         final Set set = Sets.of(1, 2, 1);
 
         assertThat(set).isEqualTo(new HashSet(Arrays.asList(1, 2)));
     }
 
     @Test
-    public void of4Elements() {
+    void of4Elements() {
         final Set set = Sets.of(1, 2, 1, 1);
 
         assertThat(set).isEqualTo(new HashSet(Arrays.asList(1, 2)));
     }
 
     @Test
-    public void of5Elements() {
+    void of5Elements() {
         final Set set = Sets.of(1, 1, 2, 3, 3);
 
         assertThat(set).isEqualTo(new HashSet(Arrays.asList(1, 2, 3)));

--- a/dropwizard-util/src/test/java/io/dropwizard/util/StringsTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/StringsTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 public class StringsTest {
 
   @Test
-  public void emptyToNull() {
+  void emptyToNull() {
       assertThat(Strings.emptyToNull("A"))
           .isEqualTo("A");
       assertThat(Strings.emptyToNull("")).isNull();
@@ -16,21 +16,21 @@ public class StringsTest {
   }
 
   @Test
-  public void isNullOrEmpty() {
+  void isNullOrEmpty() {
       assertThat(Strings.isNullOrEmpty("A")).isFalse();
       assertThat(Strings.isNullOrEmpty("")).isTrue();
       assertThat(Strings.isNullOrEmpty(null)).isTrue();
   }
 
   @Test
-  public void nullToEmpty() {
+  void nullToEmpty() {
       assertThat(Strings.nullToEmpty("")).isEqualTo("");
       assertThat(Strings.nullToEmpty(null)).isEqualTo("");
       assertThat(Strings.nullToEmpty("foo")).isEqualTo("foo");
   }
 
   @Test
-  public void repeatExceptions() {
+  void repeatExceptions() {
     assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> Strings.repeat("", -2_147_483_647))
         .withMessage("invalid count: -2147483647" );
     assertThatExceptionOfType(ArrayIndexOutOfBoundsException.class).isThrownBy(() -> Strings.repeat("00000000", 319_979_524))
@@ -39,7 +39,7 @@ public class StringsTest {
 
 
   @Test
-  public void repeat() {
+  void repeat() {
       assertThat(Strings.repeat("", 0)).isEqualTo("");
       assertThat(Strings.repeat("0", 6)).isEqualTo("000000");
   }

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/DurationValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/DurationValidatorTest.java
@@ -73,7 +73,7 @@ public class DurationValidatorTest {
     private final Validator validator = BaseValidator.newValidator();
 
     @Test
-    public void returnsASetOfErrorsForAnObject() throws Exception {
+    void returnsASetOfErrorsForAnObject() throws Exception {
         assumeTrue("en".equals(Locale.getDefault().getLanguage()),
                 "This test executes when the defined language is English ('en'). If not, it is skipped.");
 
@@ -94,7 +94,7 @@ public class DurationValidatorTest {
     }
 
     @Test
-    public void returnsAnEmptySetForAValidObject() throws Exception {
+    void returnsAnEmptySetForAValidObject() throws Exception {
         final Example example = new Example();
         example.setTooBig(Duration.seconds(10));
         example.setTooBigExclusive(Duration.seconds(29));

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/MethodValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/MethodValidatorTest.java
@@ -35,7 +35,7 @@ public class MethodValidatorTest {
     private final Validator validator = BaseValidator.newValidator();
 
     @Test
-    public void complainsAboutMethodsWhichReturnFalse() throws Exception {
+    void complainsAboutMethodsWhichReturnFalse() throws Exception {
         final Collection<String> errors =
                 ConstraintViolations.format(validator.validate(new Example()));
 

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/OneOfValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/OneOfValidatorTest.java
@@ -31,13 +31,13 @@ public class OneOfValidatorTest {
     private final Validator validator = BaseValidator.newValidator();
 
     @Test
-    public void allowsExactElements() throws Exception {
+    void allowsExactElements() throws Exception {
         assertThat(format(validator.validate(new Example())))
                 .isEmpty();
     }
 
     @Test
-    public void doesNotAllowOtherElements() throws Exception {
+    void doesNotAllowOtherElements() throws Exception {
         assumeTrue("en".equals(Locale.getDefault().getLanguage()),
                 "This test executes when the defined language is English ('en'). If not, it is skipped.");
 
@@ -49,7 +49,7 @@ public class OneOfValidatorTest {
     }
 
     @Test
-    public void doesNotAllowBadElementsInList() {
+    void doesNotAllowBadElementsInList() {
         final Example example = new Example();
         example.basicList = Collections.singletonList("four");
 
@@ -58,7 +58,7 @@ public class OneOfValidatorTest {
     }
 
     @Test
-    public void optionallyIgnoresCase() throws Exception {
+    void optionallyIgnoresCase() throws Exception {
         final Example example = new Example();
         example.caseInsensitive = "ONE";
 
@@ -67,7 +67,7 @@ public class OneOfValidatorTest {
     }
 
     @Test
-    public void optionallyIgnoresWhitespace() throws Exception {
+    void optionallyIgnoresWhitespace() throws Exception {
         final Example example = new Example();
         example.whitespaceInsensitive = "   one  ";
 

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/PortRangeValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/PortRangeValidatorTest.java
@@ -30,12 +30,12 @@ public class PortRangeValidatorTest {
     private final Example example = new Example();
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         assumeThat(Locale.getDefault().getLanguage()).isEqualTo("en");
     }
 
     @Test
-    public void acceptsNonPrivilegedPorts() throws Exception {
+    void acceptsNonPrivilegedPorts() throws Exception {
         example.port = 2048;
 
         assertThat(validator.validate(example))
@@ -43,7 +43,7 @@ public class PortRangeValidatorTest {
     }
 
     @Test
-    public void acceptsDynamicPorts() throws Exception {
+    void acceptsDynamicPorts() throws Exception {
         example.port = 0;
 
         assertThat(validator.validate(example))
@@ -51,7 +51,7 @@ public class PortRangeValidatorTest {
     }
 
     @Test
-    public void rejectsNegativePorts() throws Exception {
+    void rejectsNegativePorts() throws Exception {
         example.port = -1;
 
         assertThat(ConstraintViolations.format(validator.validate(example)))
@@ -59,7 +59,7 @@ public class PortRangeValidatorTest {
     }
 
     @Test
-    public void allowsForCustomMinimumPorts() throws Exception {
+    void allowsForCustomMinimumPorts() throws Exception {
         example.otherPort = 8080;
 
         assertThat(ConstraintViolations.format(validator.validate(example)))
@@ -67,7 +67,7 @@ public class PortRangeValidatorTest {
     }
 
     @Test
-    public void allowsForCustomMaximumPorts() throws Exception {
+    void allowsForCustomMaximumPorts() throws Exception {
         example.otherPort = 16000;
 
         assertThat(ConstraintViolations.format(validator.validate(example)))
@@ -75,7 +75,7 @@ public class PortRangeValidatorTest {
     }
 
     @Test
-    public void rejectsInvalidPortsInList() {
+    void rejectsInvalidPortsInList() {
         example.ports = Collections.singletonList(-1);
         assertThat(ConstraintViolations.format(validator.validate(example)))
             .containsOnly("ports[0].<list element> must be between 1 and 65535");

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/SelfValidationTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/SelfValidationTest.java
@@ -193,7 +193,7 @@ public class SelfValidationTest {
     private final Validator validator = BaseValidator.newValidator();
 
     @Test
-    public void failingExample() {
+    void failingExample() {
         assertThat(ConstraintViolations.format(validator.validate(new FailingExample())))
                 .containsExactlyInAnyOrder(FAILED_RESULT);
         assertThat(TestLoggerFactory.getAllLoggingEvents())
@@ -201,7 +201,7 @@ public class SelfValidationTest {
     }
 
     @Test
-    public void subClassExample() {
+    void subClassExample() {
         assertThat(ConstraintViolations.format(validator.validate(new SubclassExample())))
                 .containsExactlyInAnyOrder(
                         FAILED_RESULT,
@@ -212,7 +212,7 @@ public class SelfValidationTest {
     }
 
     @Test
-    public void annotatedSubClassExample() {
+    void annotatedSubClassExample() {
         assertThat(ConstraintViolations.format(validator.validate(new AnnotatedSubclassExample())))
                 .containsExactlyInAnyOrder(
                         FAILED_RESULT,
@@ -223,7 +223,7 @@ public class SelfValidationTest {
     }
 
     @Test
-    public void overridingSubClassExample() {
+    void overridingSubClassExample() {
         assertThat(ConstraintViolations.format(validator.validate(new OverridingExample())))
                 .isEmpty();
         assertThat(TestLoggerFactory.getAllLoggingEvents())
@@ -231,7 +231,7 @@ public class SelfValidationTest {
     }
 
     @Test
-    public void correctExample() {
+    void correctExample() {
         assertThat(ConstraintViolations.format(validator.validate(new CorrectExample())))
                 .isEmpty();
         assertThat(TestLoggerFactory.getAllLoggingEvents())
@@ -239,7 +239,7 @@ public class SelfValidationTest {
     }
 
     @Test
-    public void multipleTestingOfSameClass() {
+    void multipleTestingOfSameClass() {
         assertThat(ConstraintViolations.format(validator.validate(new CorrectExample())))
                 .isEmpty();
         assertThat(ConstraintViolations.format(validator.validate(new CorrectExample())))
@@ -249,7 +249,7 @@ public class SelfValidationTest {
     }
 
     @Test
-    public void testDirectContextUsage() {
+    void testDirectContextUsage() {
         assertThat(ConstraintViolations.format(validator.validate(new DirectContextExample())))
                 .containsExactlyInAnyOrder(FAILED_RESULT);
         assertThat(TestLoggerFactory.getAllLoggingEvents())
@@ -257,7 +257,7 @@ public class SelfValidationTest {
     }
 
     @Test
-    public void complexExample() {
+    void complexExample() {
         assertThat(ConstraintViolations.format(validator.validate(new ComplexExample())))
                 .containsExactly(
                         " failed1",
@@ -269,7 +269,7 @@ public class SelfValidationTest {
     }
 
     @Test
-    public void invalidExample() throws Exception {
+    void invalidExample() throws Exception {
         assertThat(ConstraintViolations.format(validator.validate(new InvalidExample())))
                 .isEmpty();
         assertThat(TestLoggerFactory.getAllLoggingEvents())
@@ -294,7 +294,7 @@ public class SelfValidationTest {
     }
 
     @Test
-    public void giveWarningIfNoValidationMethods() {
+    void giveWarningIfNoValidationMethods() {
         assertThat(ConstraintViolations.format(validator.validate(new NoValidations())))
                 .isEmpty();
         assertThat(TestLoggerFactory.getAllLoggingEvents())
@@ -309,7 +309,7 @@ public class SelfValidationTest {
     }
 
     @Test
-    public void violationMessagesAreEscapedByDefault() {
+    void violationMessagesAreEscapedByDefault() {
         assertThat(ConstraintViolations.format(validator.validate(new InjectionExample()))).containsExactly(
                 " $\\A{1+1}",
                 " ${'value'}",
@@ -322,7 +322,7 @@ public class SelfValidationTest {
     }
 
     @Test
-    public void violationMessagesAreInterpolatedIfEscapingDisabled() {
+    void violationMessagesAreInterpolatedIfEscapingDisabled() {
         assertThat(ConstraintViolations.format(validator.validate(new EscapingDisabledExample()))).containsExactly(
                 " $\\A{1+1}",
                 " TEST",
@@ -335,7 +335,7 @@ public class SelfValidationTest {
     }
 
     @Test
-    public void messageParametersExample() {
+    void messageParametersExample() {
         assertThat(ConstraintViolations.format(validator.validate(new MessageParametersExample()))).containsExactly(
                 " Mixed value VALUE",
                 " Nested ${'nested'}",

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/SizeValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/SizeValidatorTest.java
@@ -60,7 +60,7 @@ public class SizeValidatorTest {
     private final Validator validator = BaseValidator.newValidator();
 
     @Test
-    public void returnsASetOfErrorsForAnObject() throws Exception {
+    void returnsASetOfErrorsForAnObject() throws Exception {
         assumeTrue("en".equals(Locale.getDefault().getLanguage()),
                 "This test executes when the defined language is English ('en'). If not, it is skipped.");
 
@@ -75,7 +75,7 @@ public class SizeValidatorTest {
     }
 
     @Test
-    public void returnsAnEmptySetForAValidObject() throws Exception {
+    void returnsAnEmptySetForAValidObject() throws Exception {
         final Example example = new Example();
         example.setTooBig(Size.bytes(10));
         example.setTooSmall(Size.megabytes(10));

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/selfvalidating/SelfValidatingValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/selfvalidating/SelfValidatingValidatorTest.java
@@ -20,14 +20,14 @@ public class SelfValidatingValidatorTest {
     private SelfValidatingValidator selfValidatingValidator = new SelfValidatingValidator();
 
     @Test
-    public void validObjectHasNoViolations() throws Exception {
+    void validObjectHasNoViolations() throws Exception {
         final Validator validator = BaseValidator.newValidator();
         final Set<ConstraintViolation<ValidExample>> violations = validator.validate(new ValidExample(1));
         assertThat(violations).isEmpty();
     }
 
     @Test
-    public void invalidObjectHasViolations() throws Exception {
+    void invalidObjectHasViolations() throws Exception {
         final Validator validator = BaseValidator.newValidator();
         final Set<ConstraintViolation<ValidExample>> violations = validator.validate(new ValidExample(-1));
         assertThat(violations)
@@ -36,28 +36,28 @@ public class SelfValidatingValidatorTest {
     }
 
     @Test
-    public void correctMethod() throws Exception {
+    void correctMethod() throws Exception {
         assertThat(selfValidatingValidator.isMethodCorrect(
                 getMethod("validateCorrect", ViolationCollector.class)))
                 .isTrue();
     }
 
     @Test
-    public void voidIsNotAccepted() throws Exception {
+    void voidIsNotAccepted() throws Exception {
         assertThat(selfValidatingValidator.isMethodCorrect(
                 getMethod("validateFailReturn", ViolationCollector.class)))
                 .isFalse();
     }
 
     @Test
-    public void privateIsNotAccepted() throws Exception {
+    void privateIsNotAccepted() throws Exception {
         assertThat(selfValidatingValidator.isMethodCorrect(
                 getMethod("validateFailPrivate", ViolationCollector.class)))
                 .isFalse();
     }
 
     @Test
-    public void additionalParametersAreNotAccepted() throws Exception {
+    void additionalParametersAreNotAccepted() throws Exception {
         assertThat(selfValidatingValidator.isMethodCorrect(
                 getMethod("validateFailAdditionalParameters", ViolationCollector.class, int.class)))
                 .isFalse();

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/valuehandling/GuavaOptionalValueExtractorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/valuehandling/GuavaOptionalValueExtractorTest.java
@@ -33,14 +33,14 @@ public class GuavaOptionalValueExtractorTest {
             .getValidator();
 
     @Test
-    public void succeedsWhenAbsent() {
+    void succeedsWhenAbsent() {
         Example example = new Example();
         Set<ConstraintViolation<Example>> violations = validator.validate(example);
         assertThat(violations).isEmpty();
     }
 
     @Test
-    public void failsWhenFailingConstraint() {
+    void failsWhenFailingConstraint() {
         Example example = new Example();
         example.three = Optional.of(2);
         Set<ConstraintViolation<Example>> violations = validator.validate(example);
@@ -48,7 +48,7 @@ public class GuavaOptionalValueExtractorTest {
     }
 
     @Test
-    public void succeedsWhenConstraintsMet() {
+    void succeedsWhenConstraintsMet() {
         Example example = new Example();
         example.three = Optional.of(10);
         Set<ConstraintViolation<Example>> violations = validator.validate(example);
@@ -56,7 +56,7 @@ public class GuavaOptionalValueExtractorTest {
     }
 
     @Test
-    public void notNullFailsWhenAbsent() {
+    void notNullFailsWhenAbsent() {
         Example example = new Example();
         example.notNull = Optional.absent();
         Set<ConstraintViolation<Example>> violations = validator.validate(example);

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/valuehandling/OptionalValidatedValueUnwrapperTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/valuehandling/OptionalValidatedValueUnwrapperTest.java
@@ -35,14 +35,14 @@ public class OptionalValidatedValueUnwrapperTest {
             .getValidator();
 
     @Test
-    public void succeedsWhenAbsent() {
+    void succeedsWhenAbsent() {
         Example example = new Example();
         Set<ConstraintViolation<Example>> violations = validator.validate(example);
         assertThat(violations).isEmpty();
     }
 
     @Test
-    public void failsWhenFailingConstraint() {
+    void failsWhenFailingConstraint() {
         Example example = new Example();
         example.three = Optional.of(2);
         Set<ConstraintViolation<Example>> violations = validator.validate(example);
@@ -50,7 +50,7 @@ public class OptionalValidatedValueUnwrapperTest {
     }
 
     @Test
-    public void succeedsWhenConstraintsMet() {
+    void succeedsWhenConstraintsMet() {
         Example example = new Example();
         example.three = Optional.of(10);
         Set<ConstraintViolation<Example>> violations = validator.validate(example);
@@ -58,7 +58,7 @@ public class OptionalValidatedValueUnwrapperTest {
     }
 
     @Test
-    public void notNullFailsWhenAbsent() {
+    void notNullFailsWhenAbsent() {
         Example example = new Example();
         example.notNull = Optional.empty();
         Set<ConstraintViolation<Example>> violations = validator.validate(example);

--- a/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/FreemarkerViewRendererTest.java
+++ b/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/FreemarkerViewRendererTest.java
@@ -71,13 +71,13 @@ public class FreemarkerViewRendererTest extends JerseyTest {
 
     @Override
     @BeforeEach
-    void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
     }
 
     @Override
     @AfterEach
-    void tearDown() throws Exception {
+    public void tearDown() throws Exception {
         super.tearDown();
     }
 

--- a/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/FreemarkerViewRendererTest.java
+++ b/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/FreemarkerViewRendererTest.java
@@ -71,13 +71,13 @@ public class FreemarkerViewRendererTest extends JerseyTest {
 
     @Override
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         super.setUp();
     }
 
     @Override
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         super.tearDown();
     }
 
@@ -92,21 +92,21 @@ public class FreemarkerViewRendererTest extends JerseyTest {
     }
 
     @Test
-    public void rendersViewsWithAbsoluteTemplatePaths() {
+    void rendersViewsWithAbsoluteTemplatePaths() {
         final String response = target("/test/absolute")
                 .request().get(String.class);
         assertThat(response).isEqualTo("Woop woop. yay\n");
     }
 
     @Test
-    public void rendersViewsWithRelativeTemplatePaths() {
+    void rendersViewsWithRelativeTemplatePaths() {
         final String response = target("/test/relative")
                 .request().get(String.class);
         assertThat(response).isEqualTo("Ok.\n");
     }
 
     @Test
-    public void returnsA500ForViewsWithBadTemplatePaths() {
+    void returnsA500ForViewsWithBadTemplatePaths() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> target("/test/bad").request().get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(500))
@@ -125,7 +125,7 @@ public class FreemarkerViewRendererTest extends JerseyTest {
     }
 
     @Test
-    public void rendersViewsUsingUnsafeInputWithAutoEscapingEnabled() {
+    void rendersViewsUsingUnsafeInputWithAutoEscapingEnabled() {
         final String unsafe = "<script>alert(\"hello\")</script>";
         final Response response = target("/test/auto-escaping")
             .request().post(Entity.form(new Form("input", unsafe)));

--- a/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/MultipleContentTypeTest.java
+++ b/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/MultipleContentTypeTest.java
@@ -40,13 +40,13 @@ public class MultipleContentTypeTest extends JerseyTest {
 
     @Override
     @BeforeEach
-    void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
     }
 
     @Override
     @AfterEach
-    void tearDown() throws Exception {
+    public void tearDown() throws Exception {
         super.tearDown();
     }
 

--- a/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/MultipleContentTypeTest.java
+++ b/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/MultipleContentTypeTest.java
@@ -40,13 +40,13 @@ public class MultipleContentTypeTest extends JerseyTest {
 
     @Override
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         super.setUp();
     }
 
     @Override
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         super.tearDown();
     }
 
@@ -60,7 +60,7 @@ public class MultipleContentTypeTest extends JerseyTest {
     }
 
     @Test
-    public void testJsonContentType() {
+    void testJsonContentType() {
         final Response response = target("/").request().accept(MediaType.APPLICATION_JSON_TYPE).get();
 
         assertThat(response.getStatus()).isEqualTo(200);
@@ -68,7 +68,7 @@ public class MultipleContentTypeTest extends JerseyTest {
     }
 
     @Test
-    public void testHtmlContentType() {
+    void testHtmlContentType() {
         final Response response = target("/").request().accept(MediaType.TEXT_HTML_TYPE).get();
 
         assertThat(response.getStatus()).isEqualTo(200);
@@ -79,7 +79,7 @@ public class MultipleContentTypeTest extends JerseyTest {
     }
 
     @Test
-    public void testOnlyJsonContentType() {
+    void testOnlyJsonContentType() {
         final Response response = target("/json").request().accept(MediaType.APPLICATION_JSON_TYPE).get();
 
         assertThat(response.getStatus()).isEqualTo(200);
@@ -87,7 +87,7 @@ public class MultipleContentTypeTest extends JerseyTest {
     }
 
     @Test
-    public void testOnlyHtmlContentType() {
+    void testOnlyHtmlContentType() {
         final Response response = target("/html").request().accept(MediaType.TEXT_HTML_TYPE).get();
 
         assertThat(response.getStatus()).isEqualTo(200);

--- a/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererFileSystemTest.java
+++ b/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererFileSystemTest.java
@@ -64,13 +64,13 @@ public class MustacheViewRendererFileSystemTest extends JerseyTest {
 
     @Override
     @BeforeEach
-    void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
     }
 
     @Override
     @AfterEach
-    void tearDown() throws Exception {
+    public void tearDown() throws Exception {
         super.tearDown();
     }
 

--- a/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererFileSystemTest.java
+++ b/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererFileSystemTest.java
@@ -64,13 +64,13 @@ public class MustacheViewRendererFileSystemTest extends JerseyTest {
 
     @Override
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         super.setUp();
     }
 
     @Override
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         super.tearDown();
     }
 
@@ -86,19 +86,19 @@ public class MustacheViewRendererFileSystemTest extends JerseyTest {
     }
 
     @Test
-    public void rendersViewsWithAbsoluteTemplatePaths() {
+    void rendersViewsWithAbsoluteTemplatePaths() {
         final String response = target("/test/absolute").request().get(String.class);
         assertThat(response).isEqualTo("Woop woop. yay\n");
     }
 
     @Test
-    public void rendersViewsWithRelativeTemplatePaths() {
+    void rendersViewsWithRelativeTemplatePaths() {
         final String response = target("/test/relative").request().get(String.class);
         assertThat(response).isEqualTo("Ok.\n");
     }
 
     @Test
-    public void returnsA500ForViewsWithBadTemplatePaths() {
+    void returnsA500ForViewsWithBadTemplatePaths() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> target("/test/bad").request().get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(500))
@@ -107,7 +107,7 @@ public class MustacheViewRendererFileSystemTest extends JerseyTest {
     }
 
     @Test
-    public void returnsA500ForViewsThatCantCompile() {
+    void returnsA500ForViewsThatCantCompile() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> target("/test/error").request().get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(500))

--- a/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererTest.java
+++ b/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererTest.java
@@ -58,13 +58,13 @@ public class MustacheViewRendererTest extends JerseyTest {
 
     @Override
     @BeforeEach
-    void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
     }
 
     @Override
     @AfterEach
-    void tearDown() throws Exception {
+    public void tearDown() throws Exception {
         super.tearDown();
     }
 

--- a/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererTest.java
+++ b/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererTest.java
@@ -58,13 +58,13 @@ public class MustacheViewRendererTest extends JerseyTest {
 
     @Override
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         super.setUp();
     }
 
     @Override
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         super.tearDown();
     }
 
@@ -79,19 +79,19 @@ public class MustacheViewRendererTest extends JerseyTest {
     }
 
     @Test
-    public void rendersViewsWithAbsoluteTemplatePaths() throws Exception {
+    void rendersViewsWithAbsoluteTemplatePaths() throws Exception {
         final String response = target("/test/absolute").request().get(String.class);
         assertThat(response).isEqualTo("Woop woop. yay\n");
     }
 
     @Test
-    public void rendersViewsWithRelativeTemplatePaths() throws Exception {
+    void rendersViewsWithRelativeTemplatePaths() throws Exception {
         final String response = target("/test/relative").request().get(String.class);
         assertThat(response).isEqualTo("Ok.\n");
     }
 
     @Test
-    public void returnsA500ForViewsWithBadTemplatePaths() throws Exception {
+    void returnsA500ForViewsWithBadTemplatePaths() throws Exception {
         try {
             target("/test/bad").request().get(String.class);
             failBecauseExceptionWasNotThrown(WebApplicationException.class);
@@ -105,7 +105,7 @@ public class MustacheViewRendererTest extends JerseyTest {
     }
 
     @Test
-    public void returnsA500ForViewsThatCantCompile() throws Exception {
+    void returnsA500ForViewsThatCantCompile() throws Exception {
         try {
             target("/test/error").request().get(String.class);
             failBecauseExceptionWasNotThrown(WebApplicationException.class);
@@ -119,14 +119,14 @@ public class MustacheViewRendererTest extends JerseyTest {
     }
 
     @Test
-    public void cacheByDefault() {
+    void cacheByDefault() {
         MustacheViewRenderer mustacheViewRenderer = new MustacheViewRenderer();
         mustacheViewRenderer.configure(Collections.emptyMap());
         assertThat(mustacheViewRenderer.isUseCache()).isTrue();
     }
 
     @Test
-    public void canDisableCache() {
+    void canDisableCache() {
         MustacheViewRenderer mustacheViewRenderer = new MustacheViewRenderer();
         mustacheViewRenderer.configure(Collections.singletonMap("cache", "false"));
         assertThat(mustacheViewRenderer.isUseCache()).isFalse();

--- a/dropwizard-views/src/test/java/io/dropwizard/views/ViewBundleTest.java
+++ b/dropwizard-views/src/test/java/io/dropwizard/views/ViewBundleTest.java
@@ -42,19 +42,19 @@ public class ViewBundleTest {
     }
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         when(environment.jersey()).thenReturn(jerseyEnvironment);
     }
 
     @Test
-    public void addsTheViewMessageBodyWriterToTheEnvironment() throws Exception {
+    void addsTheViewMessageBodyWriterToTheEnvironment() throws Exception {
         new ViewBundle<>().run(new MyConfiguration(), environment);
 
         verify(jerseyEnvironment).register(any(ViewMessageBodyWriter.class));
     }
 
     @Test
-    public void addsTheViewMessageBodyWriterWithSingleViewRendererToTheEnvironment() throws Exception {
+    void addsTheViewMessageBodyWriterWithSingleViewRendererToTheEnvironment() throws Exception {
         final String configurationKey = "freemarker";
         final String testKey = "testKey";
         final Map<String, String> freeMarkerConfig = Collections.singletonMap(testKey, "yes");

--- a/dropwizard-views/src/test/java/io/dropwizard/views/ViewMessageBodyWriterTest.java
+++ b/dropwizard-views/src/test/java/io/dropwizard/views/ViewMessageBodyWriterTest.java
@@ -39,7 +39,7 @@ public class ViewMessageBodyWriterTest {
     public Timer.Context timerContext = mock(Timer.Context.class);
 
     @Test
-    public void writeToShouldUseValidRenderer() throws IOException {
+    void writeToShouldUseValidRenderer() throws IOException {
         final ViewRenderer renderable = mock(ViewRenderer.class);
         final ViewRenderer nonRenderable = mock(ViewRenderer.class);
         final Locale locale = new Locale("en-US");
@@ -65,7 +65,7 @@ public class ViewMessageBodyWriterTest {
     }
 
     @Test
-    public void writeToShouldThrowWhenNoValidRendererFound() {
+    void writeToShouldThrowWhenNoValidRendererFound() {
         final ViewMessageBodyWriter writer = new ViewMessageBodyWriter(metricRegistry, Collections.emptyList());
 
         when(metricRegistry.timer(anyString())).thenReturn(timer);
@@ -80,7 +80,7 @@ public class ViewMessageBodyWriterTest {
     }
 
     @Test
-    public void writeToShouldHandleViewRenderingExceptions() throws IOException {
+    void writeToShouldHandleViewRenderingExceptions() throws IOException {
         final ViewRenderer renderer = mock(ViewRenderer.class);
         final Locale locale = new Locale("en-US");
         final ViewRenderException exception = new ViewRenderException("oops");
@@ -104,7 +104,7 @@ public class ViewMessageBodyWriterTest {
     }
 
     @Test
-    public void detectLocaleShouldHandleBadlyFormedHeader() {
+    void detectLocaleShouldHandleBadlyFormedHeader() {
         when(headers.getAcceptableLanguages()).thenThrow(HeaderValueException.class);
 
         final ViewMessageBodyWriter writer = new ViewMessageBodyWriter(metricRegistry, Collections.emptyList());
@@ -115,7 +115,7 @@ public class ViewMessageBodyWriterTest {
     }
 
     @Test
-    public void detectLocaleShouldReturnDefaultLocaleWhenHeaderNotSpecified() {
+    void detectLocaleShouldReturnDefaultLocaleWhenHeaderNotSpecified() {
         // We call the real methods to make sure that 'getAcceptableLanguages' returns a locale with a wildcard
         // (which is their default value). This also validates that 'detectLocale' skips wildcard languages.
         when(headers.getAcceptableLanguages()).thenCallRealMethod();
@@ -129,7 +129,7 @@ public class ViewMessageBodyWriterTest {
     }
 
     @Test
-    public void detectLocaleShouldReturnCorrectLocale() {
+    void detectLocaleShouldReturnCorrectLocale() {
         final Locale fakeLocale = new Locale("en-US");
         when(headers.getAcceptableLanguages()).thenReturn(Collections.singletonList(fakeLocale));
 

--- a/dropwizard-views/src/test/java/io/dropwizard/views/ViewTest.java
+++ b/dropwizard-views/src/test/java/io/dropwizard/views/ViewTest.java
@@ -9,7 +9,7 @@ public class ViewTest {
     };
 
     @Test
-    public void hasATemplate() throws Exception {
+    void hasATemplate() throws Exception {
         assertThat(view.getTemplateName())
                 .isEqualTo("/blah.tmp");
     }


### PR DESCRIPTION
JUnit 5 no longer requires this.

Generated via:

    sed -i '/@\(Test\|BeforeEach\|AfterEach\)/{n;s/public void/void/}' \
        $(git grep -lF '@Test' */src/test/)

Sadly, Jersey's `JerseyTest` base class declares its `BeforeEach`/`AfterEach` methods public so we have to follow suit there.