### PR TITLE
Ensure FileAppenderFactoryTest works within its temporary directories

### DIFF
--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
@@ -86,21 +86,23 @@ class FileAppenderFactoryTest {
     }
 
     @Test
-    void testAppenderIsStarted(@TempDir Path tempDir) throws Exception {
-        FileAppenderFactory<ILoggingEvent> fileAppenderFactory = new FileAppenderFactory<ILoggingEvent>();
-        fileAppenderFactory.setCurrentLogFilename("application.log");
+    void testAppenderIsStarted(@TempDir Path tempDir) {
+        FileAppenderFactory<ILoggingEvent> fileAppenderFactory = new FileAppenderFactory<>();
+        fileAppenderFactory.setCurrentLogFilename(tempDir.resolve("application.log").toString());
         fileAppenderFactory.setArchive(true);
         fileAppenderFactory.setArchivedFileCount(20);
         fileAppenderFactory.setArchivedLogFilenamePattern("application-%i.log");
         fileAppenderFactory.setMaxFileSize(DataSize.megabytes(500));
         fileAppenderFactory.setImmediateFlush(false);
         fileAppenderFactory.setThreshold("ERROR");
-        Appender appender = fileAppenderFactory.build(new LoggerContext(),
+        Appender<ILoggingEvent> appender = fileAppenderFactory.build(new LoggerContext(),
             "test-app",
             new DropwizardLayoutFactory(),
             new NullLevelFilterFactory<>(),
             new AsyncLoggingEventAppenderFactory());
         assertThat(appender.isStarted()).isTrue();
+        appender.stop();
+        assertThat(appender.isStarted()).isFalse();
     }
 
     @Test

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
@@ -40,7 +40,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class FileAppenderFactoryTest {
 
@@ -52,7 +52,7 @@ class FileAppenderFactoryTest {
     private final Validator validator = BaseValidator.newValidator();
 
     @Test
-    void isDiscoverable() throws Exception {
+    void isDiscoverable() {
         assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
                 .contains(FileAppenderFactory.class);
     }
@@ -70,7 +70,7 @@ class FileAppenderFactoryTest {
     }
 
     @Test
-    void isRolling(@TempDir Path tempDir) throws Exception {
+    void isRolling(@TempDir Path tempDir) {
         // the method we want to test is protected, so we need to override it so we can see it
         FileAppenderFactory<ILoggingEvent> fileAppenderFactory = new FileAppenderFactory<ILoggingEvent>() {
             @Override
@@ -284,7 +284,7 @@ class FileAppenderFactoryTest {
     }
 
     @Test
-    void defaultIsNotNeverBlock() throws Exception {
+    void defaultIsNotNeverBlock() {
         FileAppenderFactory<ILoggingEvent> fileAppenderFactory = new FileAppenderFactory<>();
         fileAppenderFactory.setArchive(false);
         // default neverBlock
@@ -387,10 +387,10 @@ class FileAppenderFactoryTest {
     void invalidUseOfTotalSizeCap() {
         final YamlConfigurationFactory<FileAppenderFactory> factory =
             new YamlConfigurationFactory<>(FileAppenderFactory.class, validator, mapper, "dw");
-        assertThatThrownBy(() ->
-            factory.build(new File(Resources.getResource("yaml/appender_file_cap_invalid.yaml").getFile()))
-        ).isExactlyInstanceOf(ConfigurationValidationException.class)
-            .hasMessageContaining("totalSizeCap has no effect when using maxFileSize and an archivedLogFilenamePattern " +
+
+        assertThatExceptionOfType(ConfigurationValidationException.class)
+            .isThrownBy(() -> factory.build(new File(Resources.getResource("yaml/appender_file_cap_invalid.yaml").getFile())))
+            .withMessageContaining("totalSizeCap has no effect when using maxFileSize and an archivedLogFilenamePattern " +
                 "without %d, as archivedFileCount implicitly controls the total size cap");
     }
 }


### PR DESCRIPTION
Ensure these tests use the temporary directory provided by JUnit for their log files.

Stop the appender before finishing the test so that open file handles won't upset Windows.

Slip in a couple of cleanups whilst we're here.