### PR TITLE
Appease Sonar in dropwizard-benchmarks

### DIFF
--- a/dropwizard-benchmarks/src/main/java/io/dropwizard/benchmarks/jersey/DropwizardResourceConfigBenchmark.java
+++ b/dropwizard-benchmarks/src/main/java/io/dropwizard/benchmarks/jersey/DropwizardResourceConfigBenchmark.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Benchmark)
 public class DropwizardResourceConfigBenchmark {
 
-    private DropwizardResourceConfig dropwizardResourceConfig = DropwizardResourceConfig.forTesting();
+    private final DropwizardResourceConfig dropwizardResourceConfig = DropwizardResourceConfig.forTesting();
 
     @Setup
     public void setUp() throws Exception {
@@ -92,11 +92,13 @@ public class DropwizardResourceConfigBenchmark {
         @DELETE
         @Path("{id}")
         public void delete(@PathParam("id") String id) {
+            // stub implementation
         }
 
         @PUT
         @Path("{id}")
         public void update(@PathParam("id") String id, String asset) {
+            // stub implementation
         }
     }
 
@@ -107,24 +109,28 @@ public class DropwizardResourceConfigBenchmark {
         @Path("{assetId}/clusters/{code}/start")
         public void start(@PathParam("assetId") String assetId,
                                       @PathParam("code") String code) {
+            // stub implementation
         }
 
         @POST
         @Path("{assetId}/clusters/{code}/complete")
         public void complete(@PathParam("assetId") String assetId,
                                          @PathParam("code") String code) {
+            // stub implementation
         }
 
         @POST
         @Path("{assetId}/clusters/{code}/abort")
         public void abort(@PathParam("assetId") String assetId,
                                       @PathParam("code") String code) {
+            // stub implementation
         }
 
         @POST
         @Path("{assetId}/clusters/{code}/delete")
         public void delete(@PathParam("assetId") String assetId,
                                        @PathParam("code") String code) {
+            // stub implementation
         }
 
         @GET
@@ -157,6 +163,7 @@ public class DropwizardResourceConfigBenchmark {
         @DELETE
         @Path("{code}")
         public void delete(@PathParam("code") String code) {
+            // stub implementation
         }
     }
 }

--- a/dropwizard-benchmarks/src/main/java/io/dropwizard/benchmarks/jersey/SelfValidatingBenchmark.java
+++ b/dropwizard-benchmarks/src/main/java/io/dropwizard/benchmarks/jersey/SelfValidatingBenchmark.java
@@ -55,10 +55,12 @@ public class SelfValidatingBenchmark {
     public static class SelfValidatingMethodUser {
         @SelfValidation
         public void validateValid1(ViolationCollector collector) {
+            // stub implementation
         }
 
         @SelfValidation
         public void validateValid2(ViolationCollector collector) {
+            // stub implementation
         }
 
         @SelfValidation


### PR DESCRIPTION
Sonar isn't a fan of empty methods, considering them a critical issue. Add a comment to persuade it that things are OK.

I don't really like doing this, but having Sonar scream "critical" isn't great either. Is there a better way? Sonar currently complains about 64 things it deems critical and this will resolve 9 of them.