### PR TITLE
Be stricter when parsing 'Range' headers

### DIFF
--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/assets/ByteRange.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/assets/ByteRange.java
@@ -3,6 +3,7 @@ package io.dropwizard.servlets.assets;
 import io.dropwizard.util.Strings;
 
 import javax.annotation.concurrent.Immutable;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -29,17 +30,18 @@ public final class ByteRange {
 
     public static ByteRange parse(final String byteRange,
                                   final int resourceLength) {
+        final String asciiString = new String(byteRange.getBytes(), StandardCharsets.US_ASCII);
         // missing separator
         if (!byteRange.contains("-")) {
-            final int start = Integer.parseInt(byteRange);
+            final int start = Integer.parseInt(asciiString);
             return new ByteRange(start, resourceLength - 1);
         }
         // negative range
         if (byteRange.indexOf("-") == 0) {
-            final int start = Integer.parseInt(byteRange);
+            final int start = Integer.parseInt(asciiString);
             return new ByteRange(resourceLength + start, resourceLength - 1);
         }
-        final List<String> parts = Arrays.stream(byteRange.split("-", -1))
+        final List<String> parts = Arrays.stream(asciiString.split("-", -1))
                 .map(String::trim)
                 .filter(s -> !Strings.isNullOrEmpty(s))
                 .collect(Collectors.toList());

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/assets/ByteRangeTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/assets/ByteRangeTest.java
@@ -2,6 +2,7 @@ package io.dropwizard.servlets.assets;
 
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ByteRangeTest {
@@ -48,5 +49,11 @@ public class ByteRangeTest {
         final ByteRange actual = ByteRange.parse("9000-20000", RESOURCE_LENGTH);
         assertThat(actual.getStart()).isEqualTo(9000);
         assertThat(actual.getEnd()).isEqualTo(9999);
+    }
+
+    @Test
+    public void nonASCIIDisallowed() {
+        assertThatExceptionOfType(NumberFormatException.class)
+            .isThrownBy(() -> ByteRange.parse("០-០", RESOURCE_LENGTH));
     }
 }


### PR DESCRIPTION
###### Problem:
`AssetsServlet` will accept a `Range:` header which isn't RFC-compliant due to the behaviour of `Integer.parseInt` 

`Integer.parseInt()` will gladly accept non-ASCII representations of digits, but RFC7233 specifies that only ASCII 0-9 are valid digits in a `Range` header.

I initially thought this might have some security implications, but I've decided either I'm lacking in creativity or it's just a regular minor bug.

###### Solution:
Treat the header value as ASCII when parsing.

###### Result:
Requests with an invalid `Range` header will be rejected.