### PR TITLE
Remove Apache httpclient from dropwizard-e2e

### DIFF
--- a/dropwizard-e2e/pom.xml
+++ b/dropwizard-e2e/pom.xml
@@ -102,10 +102,6 @@
             <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-io</artifactId>
         </dependency>

--- a/dropwizard-e2e/src/test/java/com/example/sslreload/SslReloadAppTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/sslreload/SslReloadAppTest.java
@@ -7,7 +7,6 @@ import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.util.CharStreams;
 import io.dropwizard.util.Resources;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -16,6 +15,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 import java.io.IOException;
@@ -24,7 +24,6 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,12 +33,12 @@ public class SslReloadAppTest {
 
     private static final X509TrustManager TRUST_ALL = new X509TrustManager() {
         @Override
-        public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+        public void checkClientTrusted(X509Certificate[] x509Certificates, String s) {
 
         }
 
         @Override
-        public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+        public void checkServerTrusted(X509Certificate[] x509Certificates, String s) {
 
         }
 
@@ -143,7 +142,7 @@ public class SslReloadAppTest {
         final SSLContext sslCtx = SSLContext.getInstance("TLS");
         sslCtx.init(null, new TrustManager[]{TRUST_ALL}, null);
 
-        conn.setHostnameVerifier(new NoopHostnameVerifier());
+        conn.setHostnameVerifier((String s, SSLSession sslSession) -> true);
         conn.setSSLSocketFactory(sslCtx.getSocketFactory());
 
         // Make it a POST


### PR DESCRIPTION
This was only used for the `NoopHostnameVerifier` in `SslReloadAppTest`, but since it's a functional interface we can replace it with a lambda expression.

With this removal, `dropwizard-client` is the only module which depends on `httpclient` directly.