### PR TITLE
Support using custom AuthorizationContext

### DIFF
--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthorizationContext.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthorizationContext.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 import javax.ws.rs.container.ContainerRequestContext;
 
-class AuthorizationContext<P extends Principal> {
+public abstract class AuthorizationContext<P extends Principal> {
     private final P principal;
     private final String role;
     private final @Nullable

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthorizationContext.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthorizationContext.java
@@ -12,21 +12,21 @@ public abstract class AuthorizationContext<P extends Principal> {
     private final @Nullable
     ContainerRequestContext requestContext;
 
-    AuthorizationContext(P principal, String role, @Nullable ContainerRequestContext requestContext) {
+    protected AuthorizationContext(P principal, String role, @Nullable ContainerRequestContext requestContext) {
         this.principal = principal;
         this.role = role;
         this.requestContext = requestContext;
     }
 
-    P getPrincipal() {
+    protected P getPrincipal() {
         return principal;
     }
 
-    String getRole() {
+    protected String getRole() {
         return role;
     }
 
-    @Nullable ContainerRequestContext getRequestContext() {
+    @Nullable protected ContainerRequestContext getRequestContext() {
         return requestContext;
     }
 

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/Authorizer.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/Authorizer.java
@@ -41,6 +41,7 @@ public interface Authorizer<P extends Principal> {
      * @param role           a user role
      * @param requestContext a request context.
      * @return {@link AuthorizationContext} object, to be used in {@link CachingAuthorizer}.
+     * @since 2.1
      */
     default AuthorizationContext<P> getAuthorizationContext(P principal, String role, @Nullable ContainerRequestContext requestContext) {
         return new DefaultAuthorizationContext<>(principal, role, requestContext);

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/Authorizer.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/Authorizer.java
@@ -34,4 +34,15 @@ public interface Authorizer<P extends Principal> {
     default boolean authorize(P principal, String role, @Nullable ContainerRequestContext requestContext) {
         return authorize(principal, role);
     }
+
+    /**
+     * Returns an {@link AuthorizationContext} object, to be used in {@link CachingAuthorizer} as cache key.
+     * @param principal      a {@link Principal} object, representing a user
+     * @param role           a user role
+     * @param requestContext a request context.
+     * @return {@link AuthorizationContext} object, to be used in {@link CachingAuthorizer}.
+     */
+    default AuthorizationContext<P> getAuthorizationContext(P principal, String role, @Nullable ContainerRequestContext requestContext) {
+        return new DefaultAuthorizationContext<>(principal, role, requestContext);
+    }
 }

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/CachingAuthorizer.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/CachingAuthorizer.java
@@ -112,7 +112,7 @@ public class CachingAuthorizer<P extends Principal> implements Authorizer<P> {
     @Override
     public boolean authorize(P principal, String role, @Nullable ContainerRequestContext requestContext) {
         try (Timer.Context context = getsTimer.time()) {
-            final AuthorizationContext<P> cacheKey = new AuthorizationContext<>(principal, role, requestContext);
+            final AuthorizationContext<P> cacheKey = getAuthorizationContext(principal, role, requestContext);
             final Boolean result = cache.get(cacheKey);
             return result == null ? false : result;
         } catch (CompletionException e) {
@@ -127,6 +127,11 @@ public class CachingAuthorizer<P extends Principal> implements Authorizer<P> {
         }
     }
 
+    @Override
+    public AuthorizationContext<P> getAuthorizationContext(P principal, String role, @Nullable ContainerRequestContext requestContext) {
+        return underlying.getAuthorizationContext(principal, role, requestContext);
+    }
+
     /**
      * Discards any cached role associations for the given principal and role.
      *
@@ -135,7 +140,7 @@ public class CachingAuthorizer<P extends Principal> implements Authorizer<P> {
      * @param requestContext
      */
     public void invalidate(P principal, String role, ContainerRequestContext requestContext) {
-        cache.invalidate(new AuthorizationContext<>(principal, role, requestContext));
+        cache.invalidate(getAuthorizationContext(principal, role, requestContext));
     }
 
     /**

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/DefaultAuthorizationContext.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/DefaultAuthorizationContext.java
@@ -5,6 +5,13 @@ import java.security.Principal;
 import javax.annotation.Nullable;
 import javax.ws.rs.container.ContainerRequestContext;
 
+/**
+ * The default implementation of {@link AuthorizationContext},
+ * which uses a {@link Principal}, a role and a {@link ContainerRequestContext} to
+ * temporarily cache principals' role associations.
+ *
+ * @param <P> the type of principals
+ */
 public class DefaultAuthorizationContext<P extends Principal> extends AuthorizationContext<P> {
     DefaultAuthorizationContext(P principal, String role, @Nullable ContainerRequestContext requestContext) {
         super(principal, role, requestContext);

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/DefaultAuthorizationContext.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/DefaultAuthorizationContext.java
@@ -1,0 +1,12 @@
+package io.dropwizard.auth;
+
+import java.security.Principal;
+
+import javax.annotation.Nullable;
+import javax.ws.rs.container.ContainerRequestContext;
+
+public class DefaultAuthorizationContext<P extends Principal> extends AuthorizationContext<P> {
+    DefaultAuthorizationContext(P principal, String role, @Nullable ContainerRequestContext requestContext) {
+        super(principal, role, requestContext);
+    }
+}

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/CachingAuthorizerTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/CachingAuthorizerTest.java
@@ -13,6 +13,7 @@ import java.security.Principal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -33,10 +34,14 @@ public class CachingAuthorizerTest {
     private final Principal principal2 = new PrincipalImpl("principal2");
     private final String role = "popular_kids";
     private final ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
+    private final AuthorizationContext<Principal> authorizationContext = new DefaultAuthorizationContext<>(principal, role, requestContext);
+    private final AuthorizationContext<Principal> authorizationContext2 = new DefaultAuthorizationContext<>(principal2, role, requestContext);
 
     @BeforeEach
     public void setUp() throws Exception {
         when(underlying.authorize(any(), anyString(), any())).thenReturn(true);
+        when(underlying.getAuthorizationContext(eq(principal), anyString(), any())).thenReturn(authorizationContext);
+        when(underlying.getAuthorizationContext(eq(principal2), anyString(), any())).thenReturn(authorizationContext2);
     }
 
     @Test


### PR DESCRIPTION
###### Problem:

This address issue #3714, where `ContainerRequestContext ` is too unique and increases drastically the chance of cache misses.

###### Solution:

This solve the problem by allowing an authorizer to return a custom `AuthorizationContext` used by `CachingAuthorizer`.

###### Result:

The existing behaviour is unchanged, but if you'd wish to be able to increase your cache hit you can return make your `Authorizer` return a custom `AuthorizationContext` that will be unique for the attributes/fields you need to authorize a request.