### PR TITLE
Make jUnit 4 test methods public

### DIFF
--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/GzipDefaultVaryBehaviourTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/GzipDefaultVaryBehaviourTest.java
@@ -22,7 +22,7 @@ public class GzipDefaultVaryBehaviourTest {
             new DropwizardAppRule<>(TestApplication.class, resourceFilePath("gzip-vary-test-config.yaml"));
 
     @Test
-    void testDefaultVaryHeader() {
+    public void testDefaultVaryHeader() {
         final Response clientResponse = RULE.client().target(
             "http://localhost:" + RULE.getLocalPort() + "/test").request().header(ACCEPT_ENCODING, "gzip").get();
 

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResourceExceptionMapperTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResourceExceptionMapperTest.java
@@ -35,7 +35,7 @@ public class PersonResourceExceptionMapperTest {
         .build();
 
     @Test
-    void testDefaultConstraintViolation() {
+    public void testDefaultConstraintViolation() {
         assertThat(RESOURCES.target("/person/blah/index")
             .queryParam("ind", -1).request()
             .get().readEntity(String.class))
@@ -43,7 +43,7 @@ public class PersonResourceExceptionMapperTest {
     }
 
     @Test
-    void testDefaultJsonProcessingMapper() {
+    public void testDefaultJsonProcessingMapper() {
         assertThat(RESOURCES.target("/person/blah/runtime-exception")
             .request()
             .post(Entity.json("{ \"he: \"ho\"}"))
@@ -52,7 +52,7 @@ public class PersonResourceExceptionMapperTest {
     }
 
     @Test
-    void testDefaultExceptionMapper() {
+    public void testDefaultExceptionMapper() {
         assertThat(RESOURCES.target("/person/blah/runtime-exception")
             .request()
             .post(Entity.json("{}"))
@@ -61,7 +61,7 @@ public class PersonResourceExceptionMapperTest {
     }
 
     @Test
-    void testDefaultEofExceptionMapper() {
+    public void testDefaultEofExceptionMapper() {
         assertThat(RESOURCES.target("/person/blah/eof-exception")
             .request()
             .get().readEntity(String.class))

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestRuleTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestRuleTest.java
@@ -54,7 +54,7 @@ public class ResourceTestRuleTest {
     }
 
     @Test
-    void testGetPerson() {
+    public void testGetPerson() {
         assertThat(resourceTestRule.target("/person/blah").request()
                 .get(Person.class))
                 .isEqualTo(person);
@@ -62,14 +62,14 @@ public class ResourceTestRuleTest {
     }
 
     @Test
-    void testGetImmutableListOfPersons() {
+    public void testGetImmutableListOfPersons() {
         assertThat(resourceTestRule.target("/person/blah/list").request()
                 .get(new GenericType<List<Person>>() {
                 })).isEqualTo(Collections.singletonList(person));
     }
 
     @Test
-    void testGetPersonWithQueryParam() {
+    public void testGetPersonWithQueryParam() {
         // Test to ensure that the dropwizard validator is registered so that
         // it can validate the "ind" IntParam.
         assertThat(resourceTestRule.target("/person/blah/index")
@@ -80,7 +80,7 @@ public class ResourceTestRuleTest {
     }
 
     @Test
-    void testDefaultConstraintViolation() {
+    public void testDefaultConstraintViolation() {
         assertThat(resourceTestRule.target("/person/blah/index")
                 .queryParam("ind", -1).request()
                 .get().readEntity(String.class))
@@ -88,7 +88,7 @@ public class ResourceTestRuleTest {
     }
 
     @Test
-    void testDefaultJsonProcessingMapper() {
+    public void testDefaultJsonProcessingMapper() {
         assertThat(resourceTestRule.target("/person/blah/runtime-exception")
                 .request()
                 .post(Entity.json("{ \"he: \"ho\"}"))
@@ -97,7 +97,7 @@ public class ResourceTestRuleTest {
     }
 
     @Test
-    void testDefaultExceptionMapper() {
+    public void testDefaultExceptionMapper() {
         assertThat(resourceTestRule.target("/person/blah/runtime-exception")
                 .request()
                 .post(Entity.json("{}"))
@@ -106,7 +106,7 @@ public class ResourceTestRuleTest {
     }
 
     @Test
-    void testDefaultEofExceptionMapper() {
+    public void testDefaultEofExceptionMapper() {
         assertThat(resourceTestRule.target("/person/blah/eof-exception")
                 .request()
                 .get().getStatus())
@@ -114,7 +114,7 @@ public class ResourceTestRuleTest {
     }
 
     @Test
-    void testValidationGroupsException() {
+    public void testValidationGroupsException() {
         final Response resp = resourceTestRule.target("/person/blah/validation-groups-exception")
                 .request()
                 .post(Entity.json("{}"));
@@ -125,7 +125,7 @@ public class ResourceTestRuleTest {
     }
 
     @Test
-    void testCustomClientConfiguration() {
+    public void testCustomClientConfiguration() {
         assertThat(resourceTestRule.client().getConfiguration().isRegistered(DummyExceptionMapper.class)).isTrue();
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestRuleWithGrizzlyTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestRuleWithGrizzlyTest.java
@@ -26,14 +26,14 @@ public class ResourceTestRuleWithGrizzlyTest {
             .build();
 
     @Test
-    void testResource() {
+    public void testResource() {
         assertThat(resourceTestRule.target("test").request()
                 .get(String.class))
                 .isEqualTo("test");
     }
 
     @Test
-    void testExceptionMapper() {
+    public void testExceptionMapper() {
         final Response resp = resourceTestRule.target("test").request()
                 .post(Entity.json(""));
         assertThat(resp.getStatus()).isEqualTo(500);
@@ -41,7 +41,7 @@ public class ResourceTestRuleWithGrizzlyTest {
     }
 
     @Test
-    void testClientSupportsPatchMethod() {
+    public void testClientSupportsPatchMethod() {
         final String resp = resourceTestRule.target("test")
             .request()
             .method("PATCH", Entity.text("Patch is working"), String.class);

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestRuleWithoutLoggingBootstrapTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestRuleWithoutLoggingBootstrapTest.java
@@ -15,7 +15,7 @@ public class ResourceTestRuleWithoutLoggingBootstrapTest {
             .build();
 
     @Test
-    void testResource() {
+    public void testResource() {
         assertThat(resourceTestRule.target("test").request()
                 .get(String.class))
                 .isEqualTo("Default message");

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DAOTestRuleConfigTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DAOTestRuleConfigTest.java
@@ -25,7 +25,7 @@ public class DAOTestRuleConfigTest {
         .build();
 
     @Test
-    void explicitConfigCreatesSessionFactory() {
+    public void explicitConfigCreatesSessionFactory() {
         // it yields a valid SessionFactory instance
         final SessionFactory sessionFactory = database.getSessionFactory();
         assertThat(sessionFactory).isNotNull();

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DAOTestRuleTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DAOTestRuleTest.java
@@ -18,21 +18,21 @@ public class DAOTestRuleTest {
     public final DAOTestRule daoTestRule = DAOTestRule.newBuilder().addEntityClass(TestEntity.class).build();
 
     @Test
-    void ruleCreatedSessionFactory() {
+    public void ruleCreatedSessionFactory() {
         final SessionFactory sessionFactory = daoTestRule.getSessionFactory();
 
         assertThat(sessionFactory).isNotNull();
     }
 
     @Test
-    void ruleCanOpenTransaction() {
+    public void ruleCanOpenTransaction() {
         final Long id = daoTestRule.inTransaction(() -> persist(new TestEntity("description")).getId());
 
         assertThat(id).isNotNull();
     }
 
     @Test
-    void ruleCanRoundtrip() {
+    public void ruleCanRoundtrip() {
         final Long id = daoTestRule.inTransaction(() -> persist(new TestEntity("description")).getId());
 
         final TestEntity testEntity = get(id);
@@ -42,13 +42,13 @@ public class DAOTestRuleTest {
     }
 
     @Test
-    void transactionThrowsExceptionAsExpected() {
+    public void transactionThrowsExceptionAsExpected() {
         assertThatExceptionOfType(ConstraintViolationException.class).isThrownBy(()->
             daoTestRule.inTransaction(() -> persist(new TestEntity(null))));
     }
 
     @Test
-    void rollsBackTransaction() {
+    public void rollsBackTransaction() {
         // given a successfully persisted entity
         final TestEntity testEntity = new TestEntity("description");
         daoTestRule.inTransaction(() -> persist(testEntity));

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DAOTestRuleWithoutLoggingBootstrapTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DAOTestRuleWithoutLoggingBootstrapTest.java
@@ -16,7 +16,7 @@ public class DAOTestRuleWithoutLoggingBootstrapTest {
             .build();
 
     @Test
-    void ruleCreatedSessionFactory() {
+    public void ruleCreatedSessionFactory() {
         final SessionFactory sessionFactory = daoTestRule.getSessionFactory();
 
         assertThat(sessionFactory).isNotNull();

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleConfigOverrideTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleConfigOverrideTest.java
@@ -20,7 +20,7 @@ public class DropwizardAppRuleConfigOverrideTest {
             config("extra", () -> "supplied again"));
 
     @Test
-    void supportsConfigAttributeOverrides() {
+    public void supportsConfigAttributeOverrides() {
         final String content = RULE.client().target("http://localhost:" + RULE.getLocalPort() + "/test")
             .request().get(String.class);
 
@@ -28,7 +28,7 @@ public class DropwizardAppRuleConfigOverrideTest {
     }
 
     @Test
-    void supportsSuppliedConfigAttributeOverrides() throws Exception {
+    public void supportsSuppliedConfigAttributeOverrides() throws Exception {
         assertThat(System.getProperty("app-rule.extra")).isEqualTo("supplied");
         assertThat(System.getProperty("dw.extra")).isEqualTo("supplied again");
     }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleReentrantTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleReentrantTest.java
@@ -26,7 +26,7 @@ public class DropwizardAppRuleReentrantTest {
     private Description description = mock(Description.class);
 
     @Test
-    void testReentrantRuleStartsApplicationOnlyOnce() throws Throwable {
+    public void testReentrantRuleStartsApplicationOnlyOnce() throws Throwable {
         @SuppressWarnings("deprecation")
         DropwizardAppRule<TestConfiguration> dropwizardAppRule = new DropwizardAppRule<>(testSupport);
 

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleResetConfigOverrideTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleResetConfigOverrideTest.java
@@ -17,7 +17,7 @@ public class DropwizardAppRuleResetConfigOverrideTest {
         config("app-rule-reset", "message", "A new way to say Hooray!"));
 
     @Test
-    void test2() throws Exception {
+    public void test2() throws Exception {
         dropwizardAppRule.before();
         assertThat(System.getProperty("app-rule-reset.message")).isEqualTo("A new way to say Hooray!");
         assertThat(System.getProperty("app-rule-reset.extra")).isNull();

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleTest.java
@@ -20,7 +20,7 @@ public class DropwizardAppRuleTest {
         new DropwizardAppRule<>(DropwizardTestApplication.class, resourceFilePath("test-config.yaml"));
 
     @Test
-    void canGetExpectedResourceOverHttp() {
+    public void canGetExpectedResourceOverHttp() {
         final String content = ClientBuilder.newClient().target(
             "http://localhost:" + RULE.getLocalPort() + "/test").request().get(String.class);
 
@@ -28,25 +28,25 @@ public class DropwizardAppRuleTest {
     }
 
     @Test
-    void returnsConfiguration() {
+    public void returnsConfiguration() {
         final TestConfiguration config = RULE.getConfiguration();
         assertThat(config.getMessage()).isEqualTo("Yes, it's here");
     }
 
     @Test
-    void returnsApplication() {
+    public void returnsApplication() {
         final DropwizardTestApplication application = RULE.getApplication();
         assertThat(application).isNotNull();
     }
 
     @Test
-    void returnsEnvironment() {
+    public void returnsEnvironment() {
         final Environment environment = RULE.getEnvironment();
         assertThat(environment.getName()).isEqualTo("DropwizardTestApplication");
     }
 
     @Test
-    void canPerformAdminTask() {
+    public void canPerformAdminTask() {
         final String response
             = RULE.client().target("http://localhost:"
             + RULE.getAdminPort() + "/tasks/hello?name=test_user")
@@ -57,7 +57,7 @@ public class DropwizardAppRuleTest {
     }
 
     @Test
-    void canPerformAdminTaskWithPostBody() {
+    public void canPerformAdminTaskWithPostBody() {
         final String response
             = RULE.client().target("http://localhost:"
             + RULE.getAdminPort() + "/tasks/echo")
@@ -68,7 +68,7 @@ public class DropwizardAppRuleTest {
     }
 
     @Test
-    void clientUsesJacksonMapperFromEnvironment() {
+    public void clientUsesJacksonMapperFromEnvironment() {
         assertThat(RULE.client().target("http://localhost:" + RULE.getLocalPort() + "/message")
             .request()
             .get(DropwizardTestApplication.MessageView.class).getMessage())
@@ -76,7 +76,7 @@ public class DropwizardAppRuleTest {
     }
 
     @Test
-    void clientSupportsPatchMethod() {
+    public void clientSupportsPatchMethod() {
         assertThat(RULE.client().target("http://localhost:" + RULE.getLocalPort() + "/echoPatch")
             .request()
             .method("PATCH", Entity.text("Patch is working"), String.class))

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleWithExplicitTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleWithExplicitTest.java
@@ -39,7 +39,7 @@ public class DropwizardAppRuleWithExplicitTest {
 
 
     @Test
-    void runWithExplicitConfig() {
+    public void runWithExplicitConfig() {
         Map<String, String> response = RULE.client().target("http://localhost:" + RULE.getLocalPort() + "/test")
             .request()
             .get(new GenericType<Map<String, String>>() {

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleWithoutConfigTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleWithoutConfigTest.java
@@ -27,7 +27,7 @@ public class DropwizardAppRuleWithoutConfigTest {
         ConfigOverride.config("server.adminConnectors[0].port", "0"));
 
     @Test
-    void runWithoutConfigFile() {
+    public void runWithoutConfigFile() {
         Map<String, String> response = RULE.client().target("http://localhost:" + RULE.getLocalPort() + "/test")
             .request()
             .get(new GenericType<Map<String, String>>() {

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardClientRuleTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardClientRuleTest.java
@@ -21,13 +21,13 @@ public class DropwizardClientRuleTest {
     public static final DropwizardClientRule RULE_WITH_CLASS = new DropwizardClientRule(TestResource.class);
 
     @Test
-    void shouldGetStringBodyFromDropWizard() throws IOException {
+    public void shouldGetStringBodyFromDropWizard() throws IOException {
         final URL url = new URL(RULE_WITH_INSTANCE.baseUri() + "/test");
         assertThat("foo").isEqualTo(Resources.toString(url, StandardCharsets.UTF_8));
     }
 
     @Test
-    void shouldGetDefaultStringBodyFromDropWizard() throws IOException {
+    public void shouldGetDefaultStringBodyFromDropWizard() throws IOException {
         final URL url = new URL(RULE_WITH_CLASS.baseUri() + "/test");
         assertThat(Resources.toString(url, StandardCharsets.UTF_8)).isEqualTo(TestResource.DEFAULT_MESSAGE);
     }


### PR DESCRIPTION
This is a regression from f17aea0e7669b6182330151697022b1d44fde8bd - not all tests are jUnit 5. jUnit 4 test methods should be made public.