### PR TITLE
Improve dropwizard-migrations tests

### DIFF
--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/AbstractMigrationTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/AbstractMigrationTest.java
@@ -14,8 +14,6 @@ public class AbstractMigrationTest {
         SqlGeneratorFactory.getInstance().unregister(AddColumnGeneratorSQLite.class);
     }
 
-    protected static final String UTF_8 = "UTF-8";
-
     protected static Subparser createSubparser(AbstractLiquibaseCommand<?> command) {
         final Subparser subparser = ArgumentParsers.newFor("db")
             .terminalWidthDetection(false)

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/AbstractMigrationTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/AbstractMigrationTest.java
@@ -5,7 +5,9 @@ import liquibase.sqlgenerator.SqlGeneratorFactory;
 import liquibase.sqlgenerator.core.AddColumnGeneratorSQLite;
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.Subparser;
+import org.jdbi.v3.core.Handle;
 
+import java.sql.SQLException;
 import java.util.UUID;
 
 public class AbstractMigrationTest {
@@ -35,5 +37,13 @@ public class AbstractMigrationTest {
 
     protected static String getDatabaseUrl() {
         return "jdbc:h2:mem:" + UUID.randomUUID() + ";db_close_delay=-1";
+    }
+
+    protected boolean tableExists(final Handle handle, final String tableName) throws SQLException {
+        return handle.getConnection().getMetaData().getTables(null, null, tableName, null).next();
+    }
+
+    protected boolean columnExists(final Handle handle, final String tableName, final String columnName) throws SQLException {
+        return handle.getConnection().getMetaData().getColumns(null, null, tableName, columnName).next();
     }
 }

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbCalculateChecksumCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbCalculateChecksumCommandTest.java
@@ -12,12 +12,13 @@ import java.io.PrintWriter;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
 public class DbCalculateChecksumCommandTest extends AbstractMigrationTest {
 
-    private DbCalculateChecksumCommand<TestMigrationConfiguration> migrateCommand = new DbCalculateChecksumCommand<>(
+    private final DbCalculateChecksumCommand<TestMigrationConfiguration> migrateCommand = new DbCalculateChecksumCommand<>(
         TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations.xml");
 
     @Test
@@ -38,7 +39,7 @@ public class DbCalculateChecksumCommandTest extends AbstractMigrationTest {
     void testHelpPage() throws Exception {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         createSubparser(migrateCommand).printHelp(new PrintWriter(new OutputStreamWriter(out, UTF_8), true));
-        assertThat(out.toString(UTF_8)).isEqualTo(String.format(
+        assertThat(out.toString(UTF_8.name())).isEqualTo(String.format(
             "usage: db calculate-checksum [-h] [--migrations MIGRATIONS-FILE]%n" +
                 "          [--catalog CATALOG] [--schema SCHEMA] [file] id author%n" +
                 "%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbClearChecksumsCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbClearChecksumsCommandTest.java
@@ -11,12 +11,13 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.util.Collections;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
 public class DbClearChecksumsCommandTest extends AbstractMigrationTest {
 
-    private DbClearChecksumsCommand<TestMigrationConfiguration> clearChecksums = new DbClearChecksumsCommand<>(
+    private final DbClearChecksumsCommand<TestMigrationConfiguration> clearChecksums = new DbClearChecksumsCommand<>(
         TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations.xml");
 
     @Test
@@ -30,7 +31,7 @@ public class DbClearChecksumsCommandTest extends AbstractMigrationTest {
     void testHelpPage() throws Exception {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         createSubparser(clearChecksums).printHelp(new PrintWriter(new OutputStreamWriter(out, UTF_8), true));
-        assertThat(out.toString(UTF_8)).isEqualTo(String.format(
+        assertThat(out.toString(UTF_8.name())).isEqualTo(String.format(
             "usage: db clear-checksums [-h] [--migrations MIGRATIONS-FILE]%n" +
                 "          [--catalog CATALOG] [--schema SCHEMA] [file]%n" +
                 "%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbCommandTest.java
@@ -11,6 +11,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.util.Collections;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
@@ -36,7 +37,7 @@ class DbCommandTest extends AbstractMigrationTest {
     void testPrintHelp() throws Exception {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         createSubparser(dbCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
-        assertThat(baos.toString(UTF_8)).isEqualTo(String.format(
+        assertThat(baos.toString(UTF_8.name())).isEqualTo(String.format(
             "usage: db db [-h]%n" +
                 "          {calculate-checksum,clear-checksums,drop-all,dump,fast-forward,generate-docs,locks,migrate,prepare-rollback,rollback,status,tag,test}%n" +
                 "          ...%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDropAllCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDropAllCommandTest.java
@@ -11,12 +11,13 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.util.Collections;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
 class DbDropAllCommandTest extends AbstractMigrationTest {
 
-    private DbDropAllCommand<TestMigrationConfiguration> dropAllCommand = new DbDropAllCommand<>(
+    private final DbDropAllCommand<TestMigrationConfiguration> dropAllCommand = new DbDropAllCommand<>(
         TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations.xml");
 
     @Test
@@ -42,7 +43,7 @@ class DbDropAllCommandTest extends AbstractMigrationTest {
     void testHelpPage() throws Exception {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         createSubparser(dropAllCommand).printHelp(new PrintWriter(new OutputStreamWriter(out, UTF_8), true));
-        assertThat(out.toString(UTF_8)).isEqualTo(String.format(
+        assertThat(out.toString(UTF_8.name())).isEqualTo(String.format(
             "usage: db drop-all [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
                 "          [--schema SCHEMA] --confirm-delete-everything [file]%n" +
                 "%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDropAllCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDropAllCommandTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.sql.SQLException;
 import java.util.Collections;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -30,12 +31,17 @@ class DbDropAllCommandTest extends AbstractMigrationTest {
             TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations.xml")
             .run(null, new Namespace(Collections.emptyMap()), conf);
 
+        try (Handle handle = Jdbi.create(databaseUrl, "sa", "").open()) {
+            assertThat(tableExists(handle, "PERSONS"))
+                .isTrue();
+        }
+
         // Drop it
         dropAllCommand.run(null, new Namespace(Collections.emptyMap()), conf);
 
-        // After we dropped data and schema, we should be able to create the "persons" table again
         try (Handle handle = Jdbi.create(databaseUrl, "sa", "").open()) {
-            handle.execute("create table persons(id int, name varchar(255))");
+            assertThat(tableExists(handle, "PERSONS"))
+                .isFalse();
         }
     }
 

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDumpCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDumpCommandTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
@@ -94,7 +95,7 @@ public class DbDumpCommandTest extends AbstractMigrationTest {
     @Test
     void testHelpPage() throws Exception {
         createSubparser(dumpCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
-        assertThat(baos.toString(UTF_8)).isEqualTo(String.format(
+        assertThat(baos.toString(UTF_8.name())).isEqualTo(String.format(
                 "usage: db dump [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
                         "          [--schema SCHEMA] [-o OUTPUT] [--tables] [--ignore-tables]%n" +
                         "          [--columns] [--ignore-columns] [--views] [--ignore-views]%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbFastForwardCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbFastForwardCommandTest.java
@@ -15,13 +15,14 @@ import java.io.PrintWriter;
 import java.util.Collections;
 import java.util.regex.Pattern;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
 class DbFastForwardCommandTest extends AbstractMigrationTest {
 
     private static final Pattern NEWLINE_PATTERN = Pattern.compile(System.lineSeparator());
-    private DbFastForwardCommand<TestMigrationConfiguration> fastForwardCommand = new DbFastForwardCommand<>(
+    private final DbFastForwardCommand<TestMigrationConfiguration> fastForwardCommand = new DbFastForwardCommand<>(
         TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations.xml");
     private TestMigrationConfiguration conf;
 
@@ -91,7 +92,7 @@ class DbFastForwardCommandTest extends AbstractMigrationTest {
         // Fast-forward one change
         fastForwardCommand.run(null, new Namespace(Maps.of("all", false, "dry-run", true)), conf);
 
-        assertThat(NEWLINE_PATTERN.splitAsStream(baos.toString(UTF_8))
+        assertThat(NEWLINE_PATTERN.splitAsStream(baos.toString(UTF_8.name()))
             .filter(s -> s.startsWith("INSERT INTO PUBLIC.DATABASECHANGELOG (")))
             .hasSize(1);
     }
@@ -104,7 +105,7 @@ class DbFastForwardCommandTest extends AbstractMigrationTest {
         // Fast-forward 3 changes
         fastForwardCommand.run(null, new Namespace(Maps.of("all", true, "dry-run", true)), conf);
 
-        assertThat(NEWLINE_PATTERN.splitAsStream(baos.toString(UTF_8))
+        assertThat(NEWLINE_PATTERN.splitAsStream(baos.toString(UTF_8.name()))
             .filter(s -> s.startsWith("INSERT INTO PUBLIC.DATABASECHANGELOG (")))
             .hasSize(3);
     }
@@ -113,7 +114,7 @@ class DbFastForwardCommandTest extends AbstractMigrationTest {
     void testPrintHelp() throws Exception {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         createSubparser(fastForwardCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
-        assertThat(baos.toString(UTF_8)).isEqualTo(String.format(
+        assertThat(baos.toString(UTF_8.name())).isEqualTo(String.format(
             "usage: db fast-forward [-h] [--migrations MIGRATIONS-FILE]%n" +
                 "          [--catalog CATALOG] [--schema SCHEMA] [-n] [-a] [-i CONTEXTS]%n" +
                 "          [file]%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbGenerateDocsCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbGenerateDocsCommandTest.java
@@ -11,12 +11,13 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.util.Collections;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
 public class DbGenerateDocsCommandTest extends AbstractMigrationTest {
 
-    private DbGenerateDocsCommand<TestMigrationConfiguration> generateDocsCommand = new DbGenerateDocsCommand<>(
+    private final DbGenerateDocsCommand<TestMigrationConfiguration> generateDocsCommand = new DbGenerateDocsCommand<>(
         TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations.xml");
 
     @Test
@@ -30,7 +31,7 @@ public class DbGenerateDocsCommandTest extends AbstractMigrationTest {
     void testHelpPage() throws Exception {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         createSubparser(generateDocsCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
-        assertThat(baos.toString(UTF_8)).isEqualTo(String.format(
+        assertThat(baos.toString(UTF_8.name())).isEqualTo(String.format(
             "usage: db generate-docs [-h] [--migrations MIGRATIONS-FILE]%n" +
                 "          [--catalog CATALOG] [--schema SCHEMA] [file] output%n" +
                 "%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbLocksCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbLocksCommandTest.java
@@ -12,13 +12,14 @@ import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @NotThreadSafe
 public class DbLocksCommandTest extends AbstractMigrationTest {
 
-    private DbLocksCommand<TestMigrationConfiguration> locksCommand = new DbLocksCommand<>(
+    private final DbLocksCommand<TestMigrationConfiguration> locksCommand = new DbLocksCommand<>(
         TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations.xml");
 
     @Test
@@ -41,7 +42,7 @@ public class DbLocksCommandTest extends AbstractMigrationTest {
     }
 
     @Test
-    void testFailsWhenNoListOrRelease() throws Exception {
+    void testFailsWhenNoListOrRelease() {
         final Liquibase liquibase = Mockito.mock(Liquibase.class);
         assertThatExceptionOfType(IllegalArgumentException.class)
             .isThrownBy(() -> locksCommand.run(new Namespace(Maps.of("list", false, "release", false)),
@@ -50,7 +51,7 @@ public class DbLocksCommandTest extends AbstractMigrationTest {
     }
 
     @Test
-    void testFailsWhenBothListAndRelease() throws Exception {
+    void testFailsWhenBothListAndRelease() {
         final Liquibase liquibase = Mockito.mock(Liquibase.class);
         assertThatExceptionOfType(IllegalArgumentException.class)
             .isThrownBy(() -> locksCommand.run(new Namespace(Maps.of("list", true, "release", true)),
@@ -62,7 +63,7 @@ public class DbLocksCommandTest extends AbstractMigrationTest {
     void testPrintHelp() throws Exception {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         createSubparser(locksCommand).printHelp(new PrintWriter(new OutputStreamWriter(out, UTF_8), true));
-        assertThat(out.toString(UTF_8)).isEqualTo(String.format(
+        assertThat(out.toString(UTF_8.name())).isEqualTo(String.format(
             "usage: db locks [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
                 "          [--schema SCHEMA] [-l] [-r] [file]%n" +
                 "%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbLocksCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbLocksCommandTest.java
@@ -13,8 +13,7 @@ import java.io.PrintStream;
 import java.io.PrintWriter;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.*;
 
 @NotThreadSafe
 public class DbLocksCommandTest extends AbstractMigrationTest {
@@ -44,7 +43,7 @@ public class DbLocksCommandTest extends AbstractMigrationTest {
     @Test
     void testFailsWhenNoListOrRelease() {
         final Liquibase liquibase = Mockito.mock(Liquibase.class);
-        assertThatExceptionOfType(IllegalArgumentException.class)
+        assertThatIllegalArgumentException()
             .isThrownBy(() -> locksCommand.run(new Namespace(Maps.of("list", false, "release", false)),
                 liquibase))
             .withMessage("Must specify either --list or --force-release");
@@ -53,7 +52,7 @@ public class DbLocksCommandTest extends AbstractMigrationTest {
     @Test
     void testFailsWhenBothListAndRelease() {
         final Liquibase liquibase = Mockito.mock(Liquibase.class);
-        assertThatExceptionOfType(IllegalArgumentException.class)
+        assertThatIllegalArgumentException()
             .isThrownBy(() -> locksCommand.run(new Namespace(Maps.of("list", true, "release", true)),
                 liquibase))
             .withMessage("Must specify either --list or --force-release");

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCommandTest.java
@@ -18,12 +18,13 @@ import java.io.PrintWriter;
 import java.util.Collections;
 import java.util.Map;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
 class DbMigrateCommandTest extends AbstractMigrationTest {
 
-    private DbMigrateCommand<TestMigrationConfiguration> migrateCommand = new DbMigrateCommand<>(
+    private final DbMigrateCommand<TestMigrationConfiguration> migrateCommand = new DbMigrateCommand<>(
         TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations.xml");
     private TestMigrationConfiguration conf;
     private String databaseUrl;
@@ -60,7 +61,7 @@ class DbMigrateCommandTest extends AbstractMigrationTest {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         migrateCommand.setOutputStream(new PrintStream(baos));
         migrateCommand.run(null, new Namespace(Collections.singletonMap("dry-run", true)), conf);
-        assertThat(baos.toString(UTF_8)).startsWith(String.format(
+        assertThat(baos.toString(UTF_8.name())).startsWith(String.format(
                 "-- *********************************************************************%n" +
                 "-- Update Database Script%n" +
                 "-- *********************************************************************%n"));
@@ -78,7 +79,7 @@ class DbMigrateCommandTest extends AbstractMigrationTest {
 
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         subparser.printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
-        assertThat(baos.toString(UTF_8)).isEqualTo(String.format(
+        assertThat(baos.toString(UTF_8.name())).isEqualTo(String.format(
                         "usage: db migrate [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
                         "          [--schema SCHEMA] [-n] [-c COUNT] [-i CONTEXTS] [file]%n" +
                         "%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCustomSchemaTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCustomSchemaTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @NotThreadSafe
 class DbMigrateCustomSchemaTest extends AbstractMigrationTest {
 
-    private DbMigrateCommand<TestMigrationConfiguration> migrateCommand = new DbMigrateCommand<>(
+    private final DbMigrateCommand<TestMigrationConfiguration> migrateCommand = new DbMigrateCommand<>(
         TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations-custom-schema.xml");
     private TestMigrationConfiguration conf;
     private String databaseUrl;
@@ -35,7 +35,7 @@ class DbMigrateCustomSchemaTest extends AbstractMigrationTest {
                 .select("select * from " + schemaName + ".persons")
                 .mapToMap())
                 .hasSize(1)
-                .containsExactly(Maps.<String, Object>of("id", 1, "name", "Bill Smith", "email", "bill@smith.me"))
+                .containsExactly(Maps.of("id", 1, "name", "Bill Smith", "email", "bill@smith.me"))
         );
     }
 

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateDifferentFileCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateDifferentFileCommandTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @NotThreadSafe
 class DbMigrateDifferentFileCommandTest extends AbstractMigrationTest {
 
-    private DbMigrateCommand<TestMigrationConfiguration> migrateCommand = new DbMigrateCommand<>(
+    private final DbMigrateCommand<TestMigrationConfiguration> migrateCommand = new DbMigrateCommand<>(
         TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations-ddl.xml");
     private TestMigrationConfiguration conf;
     private String databaseUrl;

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateDifferentFileCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateDifferentFileCommandTest.java
@@ -5,14 +5,12 @@ import net.jcip.annotations.NotThreadSafe;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
-import org.jdbi.v3.core.result.ResultIterable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.Collections;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,8 +32,8 @@ class DbMigrateDifferentFileCommandTest extends AbstractMigrationTest {
     void testRun() throws Exception {
         migrateCommand.run(null, new Namespace(Collections.emptyMap()), conf);
         try (Handle handle = Jdbi.create(databaseUrl, "sa", "").open()) {
-            final ResultIterable<Map<String, Object>> rows = handle.select("select * from persons").mapToMap();
-            assertThat(rows).isEmpty();
+            assertThat(handle.select("select * from persons").mapToMap())
+                .isEmpty();
         }
     }
 
@@ -46,7 +44,8 @@ class DbMigrateDifferentFileCommandTest extends AbstractMigrationTest {
             .getAbsolutePath();
         migrateCommand.run(null, new Namespace(Collections.singletonMap("migrations-file", migrationsPath)), conf);
         try (Handle handle = Jdbi.create(databaseUrl, "sa", "").open()) {
-            assertThat(handle.select("select * from persons").mapToMap()).hasSize(1);
+            assertThat(handle.select("select * from persons").mapToMap())
+                .hasSize(1);
         }
     }
 

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbPrepareRollbackCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbPrepareRollbackCommandTest.java
@@ -11,6 +11,7 @@ import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.util.Collections;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
@@ -22,7 +23,7 @@ public class DbPrepareRollbackCommandTest extends AbstractMigrationTest {
     private TestMigrationConfiguration conf;
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         final String databaseUrl = getDatabaseUrl();
         conf = createConfiguration(databaseUrl);
     }
@@ -32,7 +33,7 @@ public class DbPrepareRollbackCommandTest extends AbstractMigrationTest {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         prepareRollbackCommand.setOutputStream(new PrintStream(baos));
         prepareRollbackCommand.run(null, new Namespace(Collections.emptyMap()), conf);
-        assertThat(baos.toString(UTF_8))
+        assertThat(baos.toString(UTF_8.name()))
             .contains("ALTER TABLE PUBLIC.persons DROP COLUMN email;")
             .contains("DROP TABLE PUBLIC.persons;");
     }
@@ -42,14 +43,14 @@ public class DbPrepareRollbackCommandTest extends AbstractMigrationTest {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         prepareRollbackCommand.setOutputStream(new PrintStream(baos));
         prepareRollbackCommand.run(null, new Namespace(Collections.singletonMap("count", 1)), conf);
-        assertThat(baos.toString(UTF_8)).contains("DROP TABLE PUBLIC.persons;");
+        assertThat(baos.toString(UTF_8.name())).contains("DROP TABLE PUBLIC.persons;");
     }
 
     @Test
     void testPrintHelp() throws Exception {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         createSubparser(prepareRollbackCommand).printHelp(new PrintWriter(new OutputStreamWriter(out, UTF_8), true));
-        assertThat(out.toString(UTF_8)).isEqualTo(String.format(
+        assertThat(out.toString(UTF_8.name())).isEqualTo(String.format(
             "usage: db prepare-rollback [-h] [--migrations MIGRATIONS-FILE]%n" +
                 "          [--catalog CATALOG] [--schema SCHEMA] [-c COUNT] [-i CONTEXTS]%n" +
                 "          [file]%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbRollbackCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbRollbackCommandTest.java
@@ -14,6 +14,7 @@ import java.io.PrintWriter;
 import java.util.Collections;
 import java.util.Date;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
@@ -55,7 +56,7 @@ class DbRollbackCommandTest extends AbstractMigrationTest {
         // Print out the change that rollbacks the second change
         rollbackCommand.setOutputStream(new PrintStream(baos, true));
         rollbackCommand.run(null, new Namespace(Maps.of("count", 1, "dry-run", true)), conf);
-        assertThat(baos.toString(UTF_8))
+        assertThat(baos.toString(UTF_8.name()))
             .containsIgnoringCase("ALTER TABLE PUBLIC.persons DROP COLUMN email;");
     }
 
@@ -85,7 +86,7 @@ class DbRollbackCommandTest extends AbstractMigrationTest {
                 "date", new Date(migrationDate - 1000),
                 "dry-run", true)),
                 conf);
-        assertThat(baos.toString(UTF_8))
+        assertThat(baos.toString(UTF_8.name()))
             .containsIgnoringCase("ALTER TABLE PUBLIC.persons DROP COLUMN email;")
             .containsIgnoringCase("DROP TABLE PUBLIC.persons;");
     }
@@ -126,14 +127,14 @@ class DbRollbackCommandTest extends AbstractMigrationTest {
         // Print out the rollback script for the second change
         rollbackCommand.setOutputStream(new PrintStream(baos, true));
         rollbackCommand.run(null, new Namespace(Maps.of("tag", "v1", "dry-run", true)), conf);
-        assertThat(baos.toString(UTF_8))
+        assertThat(baos.toString(UTF_8.name()))
             .containsIgnoringCase("ALTER TABLE PUBLIC.persons DROP COLUMN email;");
     }
 
     @Test
     void testPrintHelp() throws Exception {
         createSubparser(rollbackCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
-        assertThat(baos.toString(UTF_8)).isEqualTo(String.format(
+        assertThat(baos.toString(UTF_8.name())).isEqualTo(String.format(
             "usage: db rollback [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
             "          [--schema SCHEMA] [-n] [-t TAG] [-d DATE] [-c COUNT]%n" +
             "          [-i CONTEXTS] [file]%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbStatusCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbStatusCommandTest.java
@@ -13,6 +13,7 @@ import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.util.Collections;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
@@ -37,20 +38,20 @@ public class DbStatusCommandTest extends AbstractMigrationTest {
         final TestMigrationConfiguration existedDbConf = createConfiguration(existedDbUrl);
 
         statusCommand.run(null, new Namespace(Collections.emptyMap()), existedDbConf);
-        assertThat(baos.toString(UTF_8)).matches("\\S+ is up to date" + System.lineSeparator());
+        assertThat(baos.toString(UTF_8.name())).matches("\\S+ is up to date" + System.lineSeparator());
     }
 
     @Test
     void testRun() throws Exception {
         statusCommand.run(null, new Namespace(Collections.emptyMap()), conf);
-        assertThat(baos.toString(UTF_8)).matches(
+        assertThat(baos.toString(UTF_8.name())).matches(
                 "3 change sets have not been applied to \\S+" + System.lineSeparator());
     }
 
     @Test
     void testVerbose() throws Exception {
         statusCommand.run(null, new Namespace(Collections.singletonMap("verbose", true)), conf);
-        assertThat(baos.toString(UTF_8)).matches(
+        assertThat(baos.toString(UTF_8.name())).matches(
                 "3 change sets have not been applied to \\S+" + System.lineSeparator() +
                         "\\s*migrations\\.xml::1::db_dev"  + System.lineSeparator() +
                         "\\s*migrations\\.xml::2::db_dev"  + System.lineSeparator() +
@@ -60,7 +61,7 @@ public class DbStatusCommandTest extends AbstractMigrationTest {
     @Test
     void testPrintHelp() throws Exception {
         createSubparser(statusCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
-        assertThat(baos.toString(UTF_8)).isEqualTo(String.format(
+        assertThat(baos.toString(UTF_8.name())).isEqualTo(String.format(
                 "usage: db status [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
                         "          [--schema SCHEMA] [-v] [-i CONTEXTS] [file]%n" +
                         "%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbTagCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbTagCommandTest.java
@@ -9,6 +9,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.util.Collections;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
@@ -40,7 +41,7 @@ public class DbTagCommandTest extends AbstractMigrationTest {
     void testPrintHelp() throws Exception {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         createSubparser(dbTagCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
-        assertThat(baos.toString(UTF_8)).isEqualTo(String.format(
+        assertThat(baos.toString(UTF_8.name())).isEqualTo(String.format(
             "usage: db tag [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
             "          [--schema SCHEMA] [file] tag-name%n" +
             "%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbTestCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbTestCommandTest.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 @NotThreadSafe
 public class DbTestCommandTest extends AbstractMigrationTest {
@@ -22,9 +23,8 @@ public class DbTestCommandTest extends AbstractMigrationTest {
     void testRun() throws Exception {
         // Apply and rollback some DDL changes
         final TestMigrationConfiguration conf = createConfiguration(getDatabaseUrl());
-        dbTestCommand.run(null, new Namespace(Collections.emptyMap()), conf);
-
-        // No exception, the test passed
+        assertThatNoException()
+            .isThrownBy(() -> dbTestCommand.run(null, new Namespace(Collections.emptyMap()), conf));
     }
 
     @Test

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbTestCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbTestCommandTest.java
@@ -9,6 +9,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.util.Collections;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
@@ -30,7 +31,7 @@ public class DbTestCommandTest extends AbstractMigrationTest {
     void testPrintHelp() throws Exception {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         createSubparser(dbTestCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
-        assertThat(baos.toString(UTF_8)).isEqualTo(String.format(
+        assertThat(baos.toString(UTF_8.name())).isEqualTo(String.format(
             "usage: db test [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
                 "          [--schema SCHEMA] [-i CONTEXTS] [file]%n" +
                 "%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/TestMigrationConfiguration.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/TestMigrationConfiguration.java
@@ -5,7 +5,7 @@ import io.dropwizard.db.DataSourceFactory;
 
 public class TestMigrationConfiguration extends Configuration {
 
-    private DataSourceFactory dataSource;
+    private final DataSourceFactory dataSource;
 
     public TestMigrationConfiguration(DataSourceFactory dataSource) {
         this.dataSource = dataSource;


### PR DESCRIPTION
###### Problem:
There are some opportunities to improve the `dropwizard-migrations` tests.

- Some fields could be made `final`
- The UTF-8 character set was referenced via a shared string when `StandardCharsets` could be used instead.
- In some cases we were using the ability to create something (e.g. a table) as a proxy for  detecting whether the table existed or not.

###### Solution:
- Make fields `final` which can be.
- Switch to using `StandardCharsets`.
- Test for existence of database entities directly rather than using the ability to create them as a proxy.

###### Result:
Tests should be a bit more precise and Sonar should complain a bit less.