### PR TITLE
Remove explicit scope in dropwizard-dependencies

### DIFF
--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -162,7 +162,6 @@
                 <groupId>jakarta.activation</groupId>
                 <artifactId>jakarta.activation-api</artifactId>
                 <version>${activation-api.version}</version>
-                <scope>runtime</scope>
             </dependency>
             <dependency>
                 <groupId>jakarta.annotation</groupId>
@@ -173,7 +172,6 @@
                 <groupId>jakarta.xml.bind</groupId>
                 <artifactId>jakarta.xml.bind-api</artifactId>
                 <version>${jaxb-api.version}</version>
-                <scope>runtime</scope>
             </dependency>
             <dependency>
                 <groupId>jakarta.servlet</groupId>

--- a/dropwizard-hibernate/pom.xml
+++ b/dropwizard-hibernate/pom.xml
@@ -125,10 +125,12 @@
         <dependency>
             <groupId>jakarta.activation</groupId>
             <artifactId>jakarta.activation-api</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/dropwizard-testing/pom.xml
+++ b/dropwizard-testing/pom.xml
@@ -214,10 +214,12 @@
         <dependency>
             <groupId>jakarta.activation</groupId>
             <artifactId>jakarta.activation-api</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>


### PR DESCRIPTION
Dependencies declared in a BOM shouldn't have scopes pre-defined.

Fixes #3769