### PR TITLE
Properly support HTTP/1.1 in Http2ConnectorFactory

### DIFF
--- a/dropwizard-http2/pom.xml
+++ b/dropwizard-http2/pom.xml
@@ -91,10 +91,6 @@
             <groupId>org.eclipse.jetty.http2</groupId>
             <artifactId>http2-server</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-client</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2ConnectorFactory.java
+++ b/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2ConnectorFactory.java
@@ -57,13 +57,6 @@ import java.util.Collections;
  */
 @JsonTypeName("h2")
 public class Http2ConnectorFactory extends HttpsConnectorFactory {
-
-    /**
-     * Supported protocols
-     */
-    private static final String H2 = "h2";
-    private static final String H2_17 = "h2-17";
-    private static final String HTTP_1_1 = "http/1.1";
     private static final String HTTP2_DEFAULT_CIPHER = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
 
     @Min(100)
@@ -108,8 +101,8 @@ public class Http2ConnectorFactory extends HttpsConnectorFactory {
         http2.setMaxConcurrentStreams(maxConcurrentStreams);
         http2.setInitialStreamRecvWindow(initialStreamRecvWindow);
 
-        final NegotiatingServerConnectionFactory alpn = new ALPNServerConnectionFactory(H2, H2_17);
-        alpn.setDefaultProtocol(HTTP_1_1); // Speak HTTP 1.1 over TLS if negotiation fails
+        final NegotiatingServerConnectionFactory alpn = new ALPNServerConnectionFactory();
+        alpn.setDefaultProtocol("http/1.1"); // Speak HTTP 1.1 over TLS if negotiation fails
 
         final SslContextFactory sslContextFactory = configureSslContextFactory(new SslContextFactory.Server());
         sslContextFactory.addLifeCycleListener(logSslInfoOnStart(sslContextFactory));
@@ -122,8 +115,8 @@ public class Http2ConnectorFactory extends HttpsConnectorFactory {
         final SslConnectionFactory sslConnectionFactory = new SslConnectionFactory(sslContextFactory, "alpn");
 
         return buildConnector(server, new ScheduledExecutorScheduler(), buildBufferPool(), name, threadPool,
-                new Jetty93InstrumentedConnectionFactory(sslConnectionFactory, metrics.timer(httpConnections())),
-                alpn, http2, http1);
+            new Jetty93InstrumentedConnectionFactory(sslConnectionFactory, metrics.timer(httpConnections())),
+            alpn, http2, http1);
     }
 
     void checkSupportedCipherSuites() {

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2CIntegrationTest.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2CIntegrationTest.java
@@ -5,63 +5,52 @@ import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http2.client.HTTP2Client;
 import org.eclipse.jetty.http2.client.HTTP2ClientConnectionFactory;
 import org.eclipse.jetty.http2.client.http.HttpClientTransportOverHTTP2;
-import org.glassfish.jersey.client.JerseyClient;
-import org.glassfish.jersey.client.JerseyClientBuilder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ExtendWith(DropwizardExtensionsSupport.class)
-public class Http2CIntegrationTest  extends AbstractHttp2Test {
+class Http2CIntegrationTest extends AbstractHttp2Test {
 
-    public DropwizardAppExtension<Configuration> appRule = new DropwizardAppExtension<>(
+    final DropwizardAppExtension<Configuration> appRule = new DropwizardAppExtension<>(
             FakeApplication.class, ResourceHelpers.resourceFilePath("test-http2c.yml"));
 
     @BeforeEach
     @Override
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         final HTTP2Client http2Client = new HTTP2Client();
         http2Client.setClientConnectionFactory(new HTTP2ClientConnectionFactory()); // No need for ALPN
-        client = new HttpClient(new HttpClientTransportOverHTTP2(http2Client), null);
-        client.start();
+        this.http2Client = new HttpClient(new HttpClientTransportOverHTTP2(http2Client), null);
+        this.http2Client.start();
+
+        this.http1Client = new HttpClient();
+        this.http1Client.start();
     }
 
     @AfterEach
     @Override
-    public void tearDown() throws Exception {
-        client.stop();
+    void tearDown() throws Exception {
+        http2Client.stop();
+        http1Client.stop();
     }
 
     @Test
-    void testHttp11() {
-        final String hostname = "127.0.0.1";
-        final int port = appRule.getLocalPort();
-        final JerseyClient http11Client = new JerseyClientBuilder().build();
-        final Response response = http11Client.target("http://" + hostname + ":" + port + "/api/test")
-                .request()
-                .get();
-        assertThat(response.getHeaderString(HttpHeaders.CONTENT_TYPE)).isEqualTo(MediaType.APPLICATION_JSON);
-        assertThat(response.readEntity(String.class)).isEqualTo(FakeApplication.HELLO_WORLD);
-        http11Client.close();
+    void testHttp1() throws Exception {
+        assertResponse(http1Client.GET("http://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_1_1);
     }
 
     @Test
     void testHttp2c() throws Exception {
-        assertResponse(client.GET("http://localhost:" + appRule.getLocalPort() + "/api/test"));
+        assertResponse(http2Client.GET("http://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_2);
     }
 
     @Test
     void testHttp2cManyRequests() throws Exception {
-        performManyAsyncRequests(client, "http://localhost:" + appRule.getLocalPort() + "/api/test");
+        performManyAsyncRequests(http2Client, "http://localhost:" + appRule.getLocalPort() + "/api/test");
     }
 }

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2ConnectorFactoryTest.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2ConnectorFactoryTest.java
@@ -8,9 +8,9 @@ import java.util.Collections;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
-public class Http2ConnectorFactoryTest {
+class Http2ConnectorFactoryTest {
 
-    private Http2ConnectorFactory http2ConnectorFactory = new Http2ConnectorFactory();
+    private final Http2ConnectorFactory http2ConnectorFactory = new Http2ConnectorFactory();
 
     @Test
     void testSetDefaultHttp2Cipher() {
@@ -35,7 +35,7 @@ public class Http2ConnectorFactoryTest {
     void testThrowExceptionIfDefaultCipherIsNotSet() {
         http2ConnectorFactory.setSupportedCipherSuites(Collections.singletonList("TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"));
 
-        assertThatIllegalArgumentException().isThrownBy(() -> http2ConnectorFactory.checkSupportedCipherSuites())
+        assertThatIllegalArgumentException().isThrownBy(http2ConnectorFactory::checkSupportedCipherSuites)
             .withMessage("HTTP/2 server configuration must include cipher: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
     }
 }

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2IntegrationTest.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2IntegrationTest.java
@@ -5,54 +5,34 @@ import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
-import org.glassfish.jersey.client.JerseyClient;
-import org.glassfish.jersey.client.JerseyClientBuilder;
-import org.junit.Rule;
+import org.eclipse.jetty.http.HttpVersion;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ExtendWith(DropwizardExtensionsSupport.class)
-public class Http2IntegrationTest extends AbstractHttp2Test {
+class Http2IntegrationTest extends AbstractHttp2Test {
 
-    @Rule
-    public final DropwizardAppExtension<Configuration> appRule = new DropwizardAppExtension<>(
-            FakeApplication.class, ResourceHelpers.resourceFilePath("test-http2.yml"),
-            Optional.of("tls_http2"),
-            ConfigOverride.config("tls_http2", "server.connector.keyStorePath",
-                    ResourceHelpers.resourceFilePath("stores/http2_server.jks")),
-            ConfigOverride.config("tls_http2", "server.connector.trustStorePath",
-                    ResourceHelpers.resourceFilePath("stores/http2_client.jts"))
+    final DropwizardAppExtension<Configuration> appRule = new DropwizardAppExtension<>(
+        FakeApplication.class, ResourceHelpers.resourceFilePath("test-http2.yml"),
+        "tls_http2",
+        ConfigOverride.config("tls_http2", "server.connector.keyStorePath",
+            ResourceHelpers.resourceFilePath("stores/http2_server.jks")),
+        ConfigOverride.config("tls_http2", "server.connector.trustStorePath",
+            ResourceHelpers.resourceFilePath("stores/http2_client.jts"))
     );
 
     @Test
-    void testHttp11() throws Exception {
-        final String hostname = "localhost";
-        final int port = appRule.getLocalPort();
-        final JerseyClient http11Client = new JerseyClientBuilder()
-                .sslContext(sslContextFactory.getSslContext())
-                .build();
-        final Response response = http11Client.target("https://" + hostname + ":" + port + "/api/test")
-                .request()
-                .get();
-        assertThat(response.getHeaderString(HttpHeaders.CONTENT_TYPE)).isEqualTo(MediaType.APPLICATION_JSON);
-        assertThat(response.readEntity(String.class)).isEqualTo(FakeApplication.HELLO_WORLD);
-        http11Client.close();
+    void testHttp1() throws Exception {
+        assertResponse(http1Client.GET("https://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_1_1);
     }
 
     @Test
     void testHttp2() throws Exception {
-        assertResponse(client.GET("https://localhost:" + appRule.getLocalPort() + "/api/test"));
+        assertResponse(http2Client.GET("https://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_2);
     }
 
     @Test
     void testHttp2ManyRequests() throws Exception {
-        performManyAsyncRequests(client, "https://localhost:" + appRule.getLocalPort() + "/api/test");
+        performManyAsyncRequests(http2Client, "https://localhost:" + appRule.getLocalPort() + "/api/test");
     }
 }

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2WithConscrypt.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2WithConscrypt.java
@@ -4,11 +4,11 @@ import io.dropwizard.Configuration;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.conscrypt.OpenSSLProvider;
+import org.eclipse.jetty.http.HttpVersion;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.security.Security;
-import java.util.Optional;
 
 import static io.dropwizard.testing.ConfigOverride.config;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
@@ -21,16 +21,21 @@ class Http2WithConscrypt extends AbstractHttp2Test {
     }
 
     private static final String PREFIX = "tls_conscrypt";
-    private static final DropwizardAppExtension<Configuration> appRule = new DropwizardAppExtension<>(
+    final DropwizardAppExtension<Configuration> appRule = new DropwizardAppExtension<>(
         FakeApplication.class, resourceFilePath("test-http2-with-conscrypt.yml"),
-        Optional.of(PREFIX),
+        PREFIX,
         config(PREFIX, "server.connector.keyStorePath", resourceFilePath("stores/http2_server.jks")),
         config(PREFIX, "server.connector.trustStorePath", resourceFilePath("stores/http2_client.jts"))
     );
 
     @Test
+    void testHttp1WithCustomCipher() throws Exception {
+        assertResponse(http1Client.GET("https://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_1_1);
+    }
+
+    @Test
     void testHttp2WithCustomCipher() throws Exception {
-        assertResponse(client.GET("https://localhost:" + appRule.getLocalPort() + "/api/test"));
+        assertResponse(http2Client.GET("https://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_2);
     }
 
 }

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2WithCustomCipherTest.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2WithCustomCipherTest.java
@@ -3,31 +3,31 @@ package io.dropwizard.http2;
 import io.dropwizard.Configuration;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
-import org.junit.Rule;
+import org.eclipse.jetty.http.HttpVersion;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-
-import java.util.Optional;
 
 import static io.dropwizard.testing.ConfigOverride.config;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-public class Http2WithCustomCipherTest extends AbstractHttp2Test {
-
+class Http2WithCustomCipherTest extends AbstractHttp2Test {
     private static final String PREFIX = "tls_custom_http2";
 
-    @Rule
-    public final DropwizardAppExtension<Configuration> appRule = new DropwizardAppExtension<>(
+    final DropwizardAppExtension<Configuration> appRule = new DropwizardAppExtension<>(
         FakeApplication.class, resourceFilePath("test-http2-with-custom-cipher.yml"),
-        Optional.of(PREFIX),
+        PREFIX,
         config(PREFIX, "server.connector.keyStorePath", resourceFilePath("stores/http2_server.jks")),
         config(PREFIX, "server.connector.trustStorePath", resourceFilePath("stores/http2_client.jts"))
     );
 
     @Test
-    void testHttp2WithCustomCipher() throws Exception {
-        assertResponse(client.GET("https://localhost:" + appRule.getLocalPort() + "/api/test"));
+    void testHttp1WithCustomCipher() throws Exception {
+        assertResponse(http1Client.GET("https://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_1_1);
     }
 
+    @Test
+    void testHttp2WithCustomCipher() throws Exception {
+        assertResponse(http2Client.GET("https://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_2);
+    }
 }


### PR DESCRIPTION
The HTTP/1.1 protocol wasn't added to the ALPNServerConnectionFactory constructor which prevented using HTTP/1.1 when ALPN was being used.

Directly using HTTP/1.1 without ALPN was still possible.

Fixes #3776
Refs https://github.com/eclipse/jetty.project/issues/6058