### PR TITLE
Support "purging" the GitHub workflow cache

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,16 +30,16 @@ jobs:
       if: runner.os != 'Windows'
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-maven-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-maven-
+          ${{ runner.os }}-maven-${{ secrets.CACHE_VERSION }}-
     - uses: actions/cache@v2.1.4
       if: runner.os == 'Windows'
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**\pom.xml') }}
+        key: ${{ runner.os }}-maven-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**\pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-maven-
+          ${{ runner.os }}-maven-${{ secrets.CACHE_VERSION }}-
     - name: Cache SonarCloud packages
       uses: actions/cache@v2.1.4
       if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,9 @@ jobs:
     - uses: actions/cache@v2.1.4
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-maven-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-maven-
+          ${{ runner.os }}-maven-${{ secrets.CACHE_VERSION }}-
     - name: Build and Deploy
       run: ./mvnw -B -V -ntp -Pjakarta-apis -DperformRelease=true deploy
       env:


### PR DESCRIPTION
The `CACHE_VERSION` repository secret can be used to "purge" the caches created by the `actions/cache` action.

Using the current date for `CACHE_VERSION` and a random suffix should suffice, for example `2021-03-17-cache`.

Refs https://github.com/actions/cache/issues/2
Refs https://stackoverflow.com/a/64819132