### PR TITLE
Skip POM signature verification

### DIFF
--- a/dropwizard-parent/pom.xml
+++ b/dropwizard-parent/pom.xml
@@ -24,6 +24,7 @@
         <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
 
         <pgpverify.keyserver>hkps://hkps.pool.sks-keyservers.net;hkps://keyserver.ubuntu.com</pgpverify.keyserver>
+        <pgpverify.verifyPomFiles>false</pgpverify.verifyPomFiles>
 
         <surefire.argLine>-Duser.language=en -Duser.region=US -Duser.timezone=UTC</surefire.argLine>
         <argLine>${surefire.argLine}</argLine>


### PR DESCRIPTION
The signature verification of our dependencies is often running into problem, so let's skip POM signature verification for now.

The actual artifacts (JARs) are still verified.