### PR TITLE
Replace Jackson Afterburner with Blackbird

### DIFF
--- a/dropwizard-jackson/pom.xml
+++ b/dropwizard-jackson/pom.xml
@@ -55,7 +55,7 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>jackson-module-afterburner</artifactId>
+            <artifactId>jackson-module-blackbird</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
@@ -8,9 +8,8 @@ import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
+import com.fasterxml.jackson.module.blackbird.BlackbirdModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
-import io.dropwizard.util.JavaVersion;
 
 import javax.annotation.Nullable;
 
@@ -61,9 +60,7 @@ public class Jackson {
         mapper.registerModule(new GuavaExtrasModule());
         mapper.registerModule(new CaffeineModule());
         mapper.registerModule(new JodaModule());
-        if (JavaVersion.isJava8()) {
-            mapper.registerModule(new AfterburnerModule());
-        }
+        mapper.registerModule(new BlackbirdModule());
         mapper.registerModule(new FuzzyEnumModule());
         mapper.registerModule(new ParameterNamesModule());
         mapper.registerModule(new Jdk8Module());


### PR DESCRIPTION
Instead of going to great lengths trying to accommodate users Java 8 and 9+, let's use this opportunity to give them a nudge in the right direction and upgrade their JVM. 😉 

Since the Jackson Blackbird module is working with Java 8 and later, there shouldn't be a big performance impact for anyone according to the benchmarks mentioned in the Blackbird documentation.

https://github.com/FasterXML/jackson-modules-base/blob/jackson-modules-base-2.12.2/blackbird/README.md
https://cowtowncoder.medium.com/jackson-2-12-features-eee9456fec75#ec83

Closes #3652
Closes #3674