### PR TITLE
Exclude TLSv1.1 in `HttpsConnectorFactoryTest`

### DIFF
--- a/dropwizard-example/src/test/java/com/example/helloworld/DockerIntegrationTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/DockerIntegrationTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
@@ -33,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisabledForJreRange(min = JRE.JAVA_16)
 public class DockerIntegrationTest {
     @Container
-    private static final MySQLContainer<?> MY_SQL_CONTAINER = new MySQLContainer<>();
+    private static final MySQLContainer<?> MY_SQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0.24"));
 
     private static final String CONFIG_PATH = ResourceHelpers.resourceFilePath("test-docker-example.yml");
 
@@ -41,8 +42,9 @@ public class DockerIntegrationTest {
             HelloWorldApplication.class, CONFIG_PATH,
             ConfigOverride.config("database.url", MY_SQL_CONTAINER::getJdbcUrl),
             ConfigOverride.config("database.user", MY_SQL_CONTAINER::getUsername),
-            ConfigOverride.config("database.password", MY_SQL_CONTAINER::getPassword)
-            );
+            ConfigOverride.config("database.password", MY_SQL_CONTAINER::getPassword),
+            ConfigOverride.config("database.properties.enabledTLSProtocols", "TLSv1.1,TLSv1.2,TLSv1.3")
+    );
 
     @BeforeAll
     public static void migrateDb() throws Exception {

--- a/dropwizard-example/src/test/java/com/example/helloworld/db/PersonDAOIntegrationTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/db/PersonDAOIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.example.helloworld.db;
 
 import com.example.helloworld.core.Person;
+import com.mysql.cj.conf.PropertyKey;
 import io.dropwizard.testing.junit5.DAOTestExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.hibernate.cfg.AvailableSettings;
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
 import java.util.List;
 import java.util.Optional;
@@ -26,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 @DisabledForJreRange(min = JRE.JAVA_16)
 public class PersonDAOIntegrationTest {
     @Container
-    private static final MySQLContainer<?> MY_SQL_CONTAINER = new MySQLContainer<>();
+    private static final MySQLContainer<?> MY_SQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0.24"));
 
     public DAOTestExtension daoTestRule = DAOTestExtension.newBuilder()
             .customizeConfiguration(c -> c.setProperty(AvailableSettings.DIALECT, MySQL57Dialect.class.getName()))
@@ -34,6 +36,7 @@ public class PersonDAOIntegrationTest {
             .setUrl(MY_SQL_CONTAINER.getJdbcUrl())
             .setUsername(MY_SQL_CONTAINER.getUsername())
             .setPassword(MY_SQL_CONTAINER.getPassword())
+            .setProperty(PropertyKey.enabledTLSProtocols.getKeyName(), "TLSv1.1,TLSv1.2,TLSv1.3")
             .addEntityClass(Person.class)
             .build();
 

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
@@ -152,7 +152,7 @@ class HttpsConnectorFactoryTest {
         sslContextFactory.start();
         try {
             assertThat(sslContextFactory.newSSLEngine().getEnabledProtocols())
-                    .contains("TLSv1.1", "TLSv1.2")
+                    .contains("TLSv1.2")
                     .doesNotContain("SSLv3", "TLSv1");
         } finally {
             sslContextFactory.stop();


### PR DESCRIPTION
The latest versions of Java 8 and 11 don't support TLSv1.1 anymore.

```
JDK-8256490: Disable TLS 1.0 and 1.1
====================================
TLS 1.0 and 1.1 are versions of the TLS protocol that are no longer
considered secure and have been superseded by more secure and modern
versions (TLS 1.2 and 1.3).

These versions have now been disabled by default. If you encounter
issues, you can, at your own risk, re-enable the versions by removing
"TLSv1" and/or "TLSv1.1" from the `jdk.tls.disabledAlgorithms`
security property in the `java.security` configuration file.
```

https://mail.openjdk.java.net/pipermail/jdk8u-dev/2021-April/013680.html
https://mail.openjdk.java.net/pipermail/jdk-updates-dev/2021-April/005860.html