### PR TITLE
Use surefire plugin in archetype compatible with JUnit 5

### DIFF
--- a/dropwizard-archetypes/java-simple/src/main/resources/archetype-resources/pom.xml
+++ b/dropwizard-archetypes/java-simple/src/main/resources/archetype-resources/pom.xml
@@ -111,6 +111,10 @@
                 </configuration>
             </plugin>
             <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+            <plugin>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.2.1</version>
                 <executions>


### PR DESCRIPTION
###### Problem:
When using the archetype to create a new project based on Dropwizard, it uses a version of surefire that is not yet compatible with JUnit 5. This causes problems because unexpectedly no tests are being run when the project is being built with Maven. Since testing examples in the docs use JUnit 5 I think it should be supported out of the box with the need to adjust your `pom.xml`

###### Solution:
Added a plugin declaration for surefire 2.22.2 to the template for the `pom.xml`

###### Result:
New projects created using the archetype automatically run JUnit 5 tests.
