### PR TITLE
Refactored test to use parameterization

### DIFF
--- a/dropwizard-assets/src/test/java/io/dropwizard/assets/AssetsBundleTest.java
+++ b/dropwizard-assets/src/test/java/io/dropwizard/assets/AssetsBundleTest.java
@@ -8,6 +8,8 @@ import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Resources;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
 
 import javax.servlet.ServletRegistration;
@@ -84,34 +86,25 @@ class AssetsBundleTest {
                 .isEqualTo("/what");
     }
 
-    @Test
-    void canSupportDifferentAssetsBundleName() {
-        runBundle(new AssetsBundle("/json", "/what/new", "index.txt", "customAsset1"), "customAsset1");
 
+    @ParameterizedTest
+    @CsvSource({
+        "customAsset1, /what/new",
+        "customAsset2, /what/old"
+    })
+    void canSupportDifferentAssetsBundleName(String asset, String path) {
+        runBundle(new AssetsBundle("/json", path, "index.txt", asset), asset);
         assertThat(servletPath)
-                .isEqualTo("/what/new/*");
+            .isEqualTo(path + "/*");
 
         assertThat(servlet.getIndexFile())
-                .isEqualTo("index.txt");
+            .isEqualTo("index.txt");
 
         assertThat(servlet.getResourceURL())
-                .isEqualTo(normalize("json"));
+            .isEqualTo(normalize("json"));
 
         assertThat(servlet.getUriPath())
-                .isEqualTo("/what/new");
-
-        runBundle(new AssetsBundle("/json", "/what/old", "index.txt", "customAsset2"), "customAsset2");
-        assertThat(servletPath)
-                .isEqualTo("/what/old/*");
-
-        assertThat(servlet.getIndexFile())
-                .isEqualTo("index.txt");
-
-        assertThat(servlet.getResourceURL())
-                .isEqualTo(normalize("json"));
-
-        assertThat(servlet.getUriPath())
-                .isEqualTo("/what/old");
+            .isEqualTo(path);
     }
 
     @Test


### PR DESCRIPTION
###### Problem:
(1) A test method with many individual assertions stops being executed on the first failed assertion, which prevents the remaining ones' execution.
(2) Classes containing test methods with repeated test code steps, typically, parts that set up test fixtures, generate additional effort in case of test maintenance.

###### Solution:
Parameterized tests make it possible to run a test multiple times, with different arguments, as individual and independent tests. In this refactoring, no original assertion parameter was changed.
