### PR TITLE
AssetServlet: Use MIME type of index file for directory requests

### DIFF
--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/assets/AssetServlet.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/assets/AssetServlet.java
@@ -237,7 +237,9 @@ public class AssetServlet extends HttpServlet {
             resp.setDateHeader(LAST_MODIFIED, cachedAsset.getLastModifiedTime());
             resp.setHeader(ETAG, cachedAsset.getETag());
 
-            final String mediaType = Optional.ofNullable(req.getServletContext().getMimeType(req.getRequestURI()))
+            final String requestUri = req.getRequestURI();
+            final String mediaType = Optional.ofNullable(req.getServletContext().getMimeType(
+                    indexFile != null && requestUri.endsWith("/") ? requestUri + indexFile : requestUri))
                     .orElse(defaultMediaType);
             if (mediaType.startsWith("video") || mediaType.startsWith("audio") || usingRanges) {
                 resp.addHeader(ACCEPT_RANGES, "bytes");


### PR DESCRIPTION
With this change the extension of the index file is used do determine the content type of responses of requests to directories.

Background: I have written a filter which uses a servlet extending `AssetServlet` to serve static resources at the same path level as Jersey resources (for example, it’s possible to have dynamic Jersey resources at `/someResource` while also serving static content at paths like `/`, `/robots.txt` and `/favicon.ico`). Currently the servlet replaces the `HttpServletRequest` with a [proxy](https://docs.oracle.com/en/java/javase/16/docs/api/java.base/java/lang/reflect/Proxy.html) which replaces the return value of `getRequestURI()` with the URI of the index file if the real request URI ends with `/`. This change eliminates the need for the (somewhat ugly) proxy.

If desired, I could provide the code for the filter and servlet in another pull request.