### PR TITLE
Add method to `AbstractDAO` to get `NamedQuery` in a type-safe manner

### DIFF
--- a/docs/source/manual/hibernate.rst
+++ b/docs/source/manual/hibernate.rst
@@ -123,7 +123,6 @@ contains type-safe wrappers for most of ``SessionFactory``'s common operations:
             return persist(person).getId();
         }
 
-        @SuppressWarnings("unchecked")
         public List<Person> findAll() {
             return list(namedTypedQuery("com.example.helloworld.core.Person.findAll"));
         }

--- a/docs/source/manual/hibernate.rst
+++ b/docs/source/manual/hibernate.rst
@@ -125,7 +125,7 @@ contains type-safe wrappers for most of ``SessionFactory``'s common operations:
 
         @SuppressWarnings("unchecked")
         public List<Person> findAll() {
-            return list((Query<Person>) namedQuery("com.example.helloworld.core.Person.findAll"));
+            return list(namedTypedQuery("com.example.helloworld.core.Person.findAll"));
         }
     }
 

--- a/docs/source/manual/hibernate.rst
+++ b/docs/source/manual/hibernate.rst
@@ -106,7 +106,7 @@ Data Access Objects
 -------------------
 
 Dropwizard comes with ``AbstractDAO``, a minimal template for entity-specific DAO classes. It
-contains type-safe wrappers for most of ``SessionFactory``'s common operations:
+contains type-safe wrappers for ``SessionFactory``'s common operations:
 
 .. code-block:: java
 

--- a/dropwizard-example/src/main/java/com/example/helloworld/db/PersonDAO.java
+++ b/dropwizard-example/src/main/java/com/example/helloworld/db/PersonDAO.java
@@ -4,7 +4,6 @@ import com.example.helloworld.core.Person;
 import io.dropwizard.hibernate.AbstractDAO;
 
 import org.hibernate.SessionFactory;
-import org.hibernate.query.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -22,8 +21,7 @@ public class PersonDAO extends AbstractDAO<Person> {
         return persist(person);
     }
 
-    @SuppressWarnings("unchecked")
     public List<Person> findAll() {
-        return list((Query<Person>) namedQuery("com.example.helloworld.core.Person.findAll"));
+        return list(namedTypedQuery("com.example.helloworld.core.Person.findAll"));
     }
 }

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/AbstractDAO.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/AbstractDAO.java
@@ -81,7 +81,7 @@ public class AbstractDAO<E> {
      *
      * @param queryName the name of the query
      * @return the named query
-     * @see Session#createNamedQuery(String)
+     * @see Session#createNamedQuery(String, Class)
      */
     protected Query<E> namedTypedQuery(String queryName) throws HibernateException {
         return currentSession().createNamedQuery(queryName, getEntityClass());

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/AbstractDAO.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/AbstractDAO.java
@@ -82,6 +82,7 @@ public class AbstractDAO<E> {
      * @param queryName the name of the query
      * @return the named query
      * @see Session#createNamedQuery(String, Class)
+     * @since 2.0.22
      */
     protected Query<E> namedTypedQuery(String queryName) throws HibernateException {
         return currentSession().createNamedQuery(queryName, getEntityClass());

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/AbstractDAO.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/AbstractDAO.java
@@ -77,6 +77,17 @@ public class AbstractDAO<E> {
     }
 
     /**
+     * Returns a named and type-safe {@link Query}.
+     *
+     * @param queryName the name of the query
+     * @return the named query
+     * @see Session#createNamedQuery(String)
+     */
+    protected Query<E> namedTypedQuery(String queryName) throws HibernateException {
+        return currentSession().createNamedQuery(queryName, getEntityClass());
+    }
+
+    /**
      * Returns a typed {@link Query<E>}
      *
      * @param queryString HQL query

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/AbstractDAOTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/AbstractDAOTest.java
@@ -49,6 +49,11 @@ public class AbstractDAOTest {
         }
 
         @Override
+        protected Query<String> namedTypedQuery(String queryName) throws HibernateException {
+            return super.namedTypedQuery(queryName);
+        }
+
+        @Override
         public Class<String> getEntityClass() {
             return super.getEntityClass();
         }
@@ -107,6 +112,7 @@ public class AbstractDAOTest {
         when(session.getCriteriaBuilder()).thenReturn(criteriaBuilder);
         when(session.getNamedQuery(anyString())).thenReturn(query);
         when(session.createQuery(anyString(), same(String.class))).thenReturn(query);
+        when(session.createNamedQuery(anyString(), same(String.class))).thenReturn(query);
     }
 
     @Test
@@ -127,6 +133,14 @@ public class AbstractDAOTest {
                 .isEqualTo(query);
 
         verify(session).getNamedQuery("query-name");
+    }
+
+    @Test
+    void getsNamedTypedQueries() throws Exception {
+        assertThat(dao.namedTypedQuery("query-name"))
+            .isEqualTo(query);
+
+        verify(session).createNamedQuery("query-name", String.class);
     }
 
     @Test


### PR DESCRIPTION
###### Problem:
`AbstractDAO` offers a way to easily get named queries but does so in a way that requires casting the returned `Query` to the correct type.

###### Solution:
Added a method to `AbstractDAO` which returns a named query in a type-safe way, `namedTypedQuery(String)`. This methods uses `Session#createNamedQuery(String, Class)` internally where the generic type is retrieved via `AbstractDAO#getEntityClass()`.

I hope I followed all conventions of this project. Please let me know if you would like me to change anything.
