### PR TITLE
Bump Dropwizard Metrics from 4.1.21 to 4.1.22

### DIFF
--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -56,7 +56,7 @@
         <liquibase-slf4j.version>2.0.0</liquibase-slf4j.version>
         <logback-throttling-appender.version>1.1.0</logback-throttling-appender.version>
         <logback.version>1.2.3</logback.version>
-        <metrics4.version>4.1.21</metrics4.version>
+        <metrics4.version>4.1.22</metrics4.version>
         <mustache-compiler.version>0.9.7</mustache-compiler.version>
         <nullaway.version>0.9.1</nullaway.version>
         <slf4j.version>1.7.30</slf4j.version>


### PR DESCRIPTION
Release notes:
https://github.com/dropwizard/metrics/releases/tag/v4.1.22