### PR TITLE
Add anchor to note on config overrides to allow direct links

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -197,7 +197,7 @@ and would output an error message describing the issues.
 Once your application has parsed the YAML file and constructed its ``Configuration`` instance,
 Dropwizard then calls your ``Application`` subclass to initialize your application's ``Environment``.
 
-.. note::
+.. note:: :name: config-override
 
     You can override configuration settings by passing special Java system properties when starting
     your application. Overrides must start with prefix ``dw.``, followed by the path to the


### PR DESCRIPTION
###### Problem:

Provide a link directly to the section in the docs on overriding configuration via system properties.

###### Solution:

Add an anchor to the note in the docs on overriding configs via system properties.