### PR TITLE
Link to example application source code from docs

### DIFF
--- a/docs/source/manual/example.rst
+++ b/docs/source/manual/example.rst
@@ -6,7 +6,7 @@ Dropwizard Example, Step by Step
 
 .. highlight:: text
 
-.. rubric:: The ``dropwizard-example`` module provides you with a working Dropwizard Example Application.
+.. rubric:: The ``dropwizard-example`` module provides you with a working `Dropwizard Example Application <https://github.com/dropwizard/dropwizard/tree/master/dropwizard-example>`_.
 
 * Preconditions
 


### PR DESCRIPTION
###### Problem:
Documentation [Dropwizard Example, Step by Step](https://www.dropwizard.io/en/latest/manual/example.html>) makes mention of the example project, but does not supply a link. New users, such as; myself, are left to search for the source code.

While most users will likely enter through [Getting Started](https://www.dropwizard.io/en/latest/getting-started.html), which has a link to the source code, users entering by way of the the example page mentioned above could use the link as well.

###### Solution:
Added link to documentation

###### Result:
Users can link directly to the mentioned example application's source code from the [Dropwizard Example, Step by Step](https://www.dropwizard.io/en/latest/manual/example.html>) page.
