### PR TITLE
Add more test assertions

### DIFF
--- a/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckSchedulerTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckSchedulerTest.java
@@ -10,6 +10,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.AdditionalMatchers.or;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -171,6 +172,7 @@ public class HealthCheckSchedulerTest {
     public void unscheduleShouldDoNothingIfNoCheckScheduled() {
         final String name = "test";
 
-        scheduler.unschedule(name);
+        assertThatCode(() -> scheduler.unschedule(name))
+            .doesNotThrowAnyException();;
     }
 }

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/AbstractHttp2Test.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/AbstractHttp2Test.java
@@ -53,13 +53,13 @@ class AbstractHttp2Test {
         sslContextFactory.stop();
     }
 
-    protected static void assertResponse(ContentResponse response, HttpVersion httpVersion) {
+    static void assertResponse(ContentResponse response, HttpVersion httpVersion) {
         assertThat(response.getVersion()).isEqualTo(httpVersion);
         assertThat(response.getStatus()).isEqualTo(200);
         assertThat(response.getContentAsString()).isEqualTo(FakeApplication.HELLO_WORLD);
     }
 
-    protected void performManyAsyncRequests(HttpClient client, String url) throws InterruptedException {
+    static boolean performManyAsyncRequests(HttpClient client, String url) throws InterruptedException {
         final int amount = 100;
         final CountDownLatch latch = new CountDownLatch(amount);
         for (int i = 0; i < amount; i++) {
@@ -75,6 +75,6 @@ class AbstractHttp2Test {
                     });
         }
 
-        assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
+        return latch.await(30, TimeUnit.SECONDS);
     }
 }

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2CIntegrationTest.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2CIntegrationTest.java
@@ -14,6 +14,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @ExtendWith(DropwizardExtensionsSupport.class)
 class Http2CIntegrationTest extends AbstractHttp2Test {
 
@@ -41,16 +43,17 @@ class Http2CIntegrationTest extends AbstractHttp2Test {
 
     @Test
     void testHttp1() throws Exception {
-        assertResponse(http1Client.GET("http://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_1_1);
+        AbstractHttp2Test.assertResponse(http1Client.GET("http://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_1_1);
     }
 
     @Test
     void testHttp2c() throws Exception {
-        assertResponse(http2Client.GET("http://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_2);
+        AbstractHttp2Test.assertResponse(http2Client.GET("http://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_2);
     }
 
     @Test
     void testHttp2cManyRequests() throws Exception {
-        performManyAsyncRequests(http2Client, "http://localhost:" + appRule.getLocalPort() + "/api/test");
+        assertThat(AbstractHttp2Test.performManyAsyncRequests(http2Client, "http://localhost:" + appRule.getLocalPort() + "/api/test"))
+            .isTrue();
     }
 }

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2IntegrationTest.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2IntegrationTest.java
@@ -9,6 +9,8 @@ import org.eclipse.jetty.http.HttpVersion;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @ExtendWith(DropwizardExtensionsSupport.class)
 class Http2IntegrationTest extends AbstractHttp2Test {
 
@@ -23,16 +25,17 @@ class Http2IntegrationTest extends AbstractHttp2Test {
 
     @Test
     void testHttp1() throws Exception {
-        assertResponse(http1Client.GET("https://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_1_1);
+        AbstractHttp2Test.assertResponse(http1Client.GET("https://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_1_1);
     }
 
     @Test
     void testHttp2() throws Exception {
-        assertResponse(http2Client.GET("https://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_2);
+        AbstractHttp2Test.assertResponse(http2Client.GET("https://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_2);
     }
 
     @Test
     void testHttp2ManyRequests() throws Exception {
-        performManyAsyncRequests(http2Client, "https://localhost:" + appRule.getLocalPort() + "/api/test");
+        assertThat(AbstractHttp2Test.performManyAsyncRequests(http2Client, "https://localhost:" + appRule.getLocalPort() + "/api/test"))
+            .isTrue();
     }
 }


### PR DESCRIPTION
###### Problem:
Sonar is currently listing 9 'Blocker' code smells. They're mostly pretty spurious, but some are about test methods which lack assertions, which are mostly easy to fix.

###### Solution:
Where a test is testing that no exception is thrown (`HealthCheckSchedulerTest`), use `assertThatCode().doesNotThrowAnyException()` to be explicit about what is being tested.

In `dropwizard-http2`, `AbstractHttp2Test` has a helper method `performManyAsyncRequests` which is called by both `Http2IntegrationTest` and `Http2CIntegrationTest`. It contains embedded assertions about each requests and also a final assertion that all requests completed within a reasonable time.

Move that final assertion to the caller by returning a boolean. Also make the helper `static` and call it as a class method rather than instance method.

###### Result:
The number of 'Blocker' code smells in Sonar should reduce from 9 to 6.