### PR TITLE
Add typed exceptions to authentication.

### DIFF
--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthorizationException.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthorizationException.java
@@ -1,0 +1,10 @@
+package io.dropwizard.auth;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+public class AuthorizationException extends WebApplicationException {
+    public AuthorizationException(Response response) {
+        super(response);
+    }
+}

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/basic/BasicCredentialAuthFilter.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/basic/BasicCredentialAuthFilter.java
@@ -2,6 +2,7 @@ package io.dropwizard.auth.basic;
 
 import io.dropwizard.auth.AuthFilter;
 import io.dropwizard.auth.Authenticator;
+import io.dropwizard.auth.AuthorizationException;
 
 import javax.annotation.Nullable;
 import javax.annotation.Priority;
@@ -26,7 +27,7 @@ public class BasicCredentialAuthFilter<P extends Principal> extends AuthFilter<B
         final BasicCredentials credentials =
                 getCredentials(requestContext.getHeaders().getFirst(HttpHeaders.AUTHORIZATION));
         if (!authenticate(requestContext, credentials, SecurityContext.BASIC_AUTH)) {
-            throw new WebApplicationException(unauthorizedHandler.buildResponse(prefix, realm));
+            throw new AuthorizationException(unauthorizedHandler.buildResponse(prefix, realm));
         }
     }
 

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/oauth/OAuthCredentialAuthFilter.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/oauth/OAuthCredentialAuthFilter.java
@@ -2,6 +2,7 @@ package io.dropwizard.auth.oauth;
 
 import io.dropwizard.auth.AuthFilter;
 import io.dropwizard.auth.Authenticator;
+import io.dropwizard.auth.AuthorizationException;
 
 import javax.annotation.Nullable;
 import javax.annotation.Priority;
@@ -36,7 +37,7 @@ public class OAuthCredentialAuthFilter<P extends Principal> extends AuthFilter<S
         }
 
         if (!authenticate(requestContext, credentials, SecurityContext.BASIC_AUTH)) {
-            throw new WebApplicationException(unauthorizedHandler.buildResponse(prefix, realm));
+            throw new AuthorizationException(unauthorizedHandler.buildResponse(prefix, realm));
         }
     }
 


### PR DESCRIPTION
###### Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->

I want authentication exceptions to have a custom error page - which requires them to be handled by my custom exception mapper. This can be done so long as the `Response` in the `WebApplicationException` doesn't have an entity, so I need to provide a custom `UnauthorizedHandler`. The only issue is that I cannot tell which exceptions are from the Dropwizard Auth package.

[Though to be fair, looking for 401 `UNAUTHORIZED` code is a reasonable workaround]

###### Solution:
<!-- Describe the modifications you've done. -->
Ensure all exceptions thrown by the authentication package extend a specific type.


###### Result:
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->
I'm now able to build custom web pages correctly in my exception mapper.


