### PR TITLE
Allow unknown properties by default in YAML config

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -1961,11 +1961,6 @@ You can change this behavior by configuring Dropwizard's object mapper:
         bootstrap.getObjectMapper().enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }
 
-.. note::
-
-    The YAML configuration parser will fail on unknown properties regardless of the object mapper
-    configuration.
-
 
 Streaming Output
 ----------------

--- a/dropwizard-client/src/test/java/io/dropwizard/client/proxy/HttpClientConfigurationTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/proxy/HttpClientConfigurationTest.java
@@ -1,5 +1,6 @@
 package io.dropwizard.client.proxy;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.client.HttpClientConfiguration;
 import io.dropwizard.configuration.ConfigurationParsingException;
@@ -29,7 +30,8 @@ public class HttpClientConfigurationTest {
             .create(
                 HttpClientConfiguration.class,
                 Validators.newValidator(),
-                objectMapper, "dw"
+                objectMapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES),
+                "dw"
             ).build(new File(Resources.getResource(configLocation).toURI()));
     }
 

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/DefaultConfigurationFactoryFactory.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/DefaultConfigurationFactoryFactory.java
@@ -21,14 +21,13 @@ public class DefaultConfigurationFactoryFactory<T> implements ConfigurationFacto
 
     /**
      * Provides additional configuration for the {@link ObjectMapper} used to read
-     * the configuration. By default {@link DeserializationFeature#FAIL_ON_UNKNOWN_PROPERTIES}
-     * is enabled to protect against misconfiguration.
+     * the configuration.
      *
      * @param objectMapper template to be configured
      * @return configured object mapper
      */
     protected ObjectMapper configureObjectMapper(ObjectMapper objectMapper) {
-        return objectMapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        return objectMapper;
     }
 
 }


### PR DESCRIPTION
###### Problem:

Currently, the JSON configuration parser allows unknown properties by default (but can be configured to not allow them), but for some reason, the YAML configuration parser behaves differently. From the [current dropwizard docs](https://github.com/dropwizard/dropwizard/blob/98dd6a5c2b568dd33f768bd65f53991870c76409/docs/source/manual/core.rst#unknown-properties):

> The YAML configuration parser will fail on unknown properties regardless of the object mapper configuration.

In the [issue](https://github.com/dropwizard/dropwizard/issues/2567) & [PR](https://github.com/dropwizard/dropwizard/pull/2570) that changed the default for JSON configs to allow unknown properties, I couldn't find any explanation for why YAML behavior was not similarly updated.

Allowing unknown properties by default are desirable in YAML config files for the same [reasons listed for allowing them by default in JSON config files](https://github.com/dropwizard/dropwizard/issues/2567#issue-382545846):

> * Most, if not all, Dropwizard projects that I’ve seen disables it.
> * It follows Postel’s law (be conservative in what you send, be liberal in what you accept).
> * All other JSON libraries that I know allows unknown properties by default: GSON, the json package in Go and Json.NET. Spring Boot (which uses Jackson) also disables it by default.

###### Solution:

Makes YAML config file behavior consistent with that of JSON

###### Result:

By default, an unknown property in a `config.yml` file will no longer cause an exception to be thrown when loaded.