### PR TITLE
Remove public modifiers from dropwizard-auth tests

### DIFF
--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthFilterTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/AuthFilterTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class AuthFilterTest {
+class AuthFilterTest {
 
     @Test
     void isSecureShouldStayTheSame() throws Exception {

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/CachingAuthorizerTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/CachingAuthorizerTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class CachingAuthorizerTest {
+class CachingAuthorizerTest {
     @SuppressWarnings("unchecked")
     private final Authorizer<Principal> underlying = mock(Authorizer.class);
     private final CachingAuthorizer<Principal> cached = new CachingAuthorizer<>(

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/OptionalAuthFilterOrderingTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/OptionalAuthFilterOrderingTest.java
@@ -24,7 +24,7 @@ import javax.ws.rs.container.DynamicFeature;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
-public class OptionalAuthFilterOrderingTest extends JerseyTest {
+class OptionalAuthFilterOrderingTest extends JerseyTest {
 
     @Override
     @BeforeEach

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/BasicCredentialsTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/basic/BasicCredentialsTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BasicCredentialsTest {
+class BasicCredentialsTest {
     private final BasicCredentials credentials = new BasicCredentials("u", "p");
 
     @Test
@@ -19,7 +19,7 @@ public class BasicCredentialsTest {
 
     @Test
     @SuppressWarnings({ "ObjectEqualsNull", "LiteralAsArgToStringEquals" })
-    public void hasAWorkingEqualsMethod() {
+    void hasAWorkingEqualsMethod() {
         assertThat(credentials)
             .isEqualTo(credentials)
             .isEqualTo(new BasicCredentials("u", "p"))

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/chained/ChainedAuthProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/chained/ChainedAuthProviderTest.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ChainedAuthProviderTest extends AuthBaseTest<ChainedAuthProviderTest.ChainedAuthTestResourceConfig> {
+class ChainedAuthProviderTest extends AuthBaseTest<ChainedAuthProviderTest.ChainedAuthTestResourceConfig> {
     private static final String BEARER_USER = "A12B3C4D";
     public static class ChainedAuthTestResourceConfig extends DropwizardResourceConfig {
 

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/oauth/OAuthProviderTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/oauth/OAuthProviderTest.java
@@ -13,7 +13,7 @@ import javax.ws.rs.container.ContainerRequestFilter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class OAuthProviderTest extends AuthBaseTest<OAuthProviderTest.OAuthTestResourceConfig> {
+class OAuthProviderTest extends AuthBaseTest<OAuthProviderTest.OAuthTestResourceConfig> {
     public static class OAuthTestResourceConfig extends AbstractAuthResourceConfig {
         public OAuthTestResourceConfig() {
             register(AuthResource.class);

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/NoAuthPolymorphicPrincipalEntityTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/NoAuthPolymorphicPrincipalEntityTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Testing that principal entity is not affected by authentication logic and can be injected as any other entity.
  */
-public class NoAuthPolymorphicPrincipalEntityTest extends JerseyTest {
+class NoAuthPolymorphicPrincipalEntityTest extends JerseyTest {
 
     static {
         BootstrapLogging.bootstrap();

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/NoAuthPrincipalEntityTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/NoAuthPrincipalEntityTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Testing that principal entity is not affected by authentication logic and can be injected as any other entity.
  */
-public class NoAuthPrincipalEntityTest extends JerseyTest {
+class NoAuthPrincipalEntityTest extends JerseyTest {
 
     static {
         BootstrapLogging.bootstrap();

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/PolymorphicPrincipalEntityTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/PolymorphicPrincipalEntityTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 /**
  * Testing that polymorphic principal entity injection works.
  */
-public class PolymorphicPrincipalEntityTest extends JerseyTest {
+class PolymorphicPrincipalEntityTest extends JerseyTest {
     private static final String JSON_USERNAME = "good-guy";
     private static final String NULL_USERNAME = "bad-guy";
     private static final String JSON_USERNAME_ENCODED_TOKEN = "Z29vZC1ndXk6c2VjcmV0";


### PR DESCRIPTION
This is no longer needed since JUnit 5