### PR TITLE
Remove unnecessary eq() Mockito references

### DIFF
--- a/dropwizard-core/src/test/java/io/dropwizard/validation/InjectValidatorFeatureTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/validation/InjectValidatorFeatureTest.java
@@ -20,7 +20,6 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.AdditionalAnswers.delegatesTo;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -85,7 +84,7 @@ public class InjectValidatorFeatureTest {
         Validator validator = validatorFactory.getValidator();
         validator.validate(new Bean(1));
 
-        verify(mockedFactory).getInstance(eq(MinValidatorForInteger.class));
+        verify(mockedFactory).getInstance(MinValidatorForInteger.class);
     }
 
     static class Bean {

--- a/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckSchedulerTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckSchedulerTest.java
@@ -40,14 +40,14 @@ public class HealthCheckSchedulerTest {
         when(check.getName()).thenReturn(name);
         when(check.getSchedule()).thenReturn(schedule);
 
-        when(executor.scheduleWithFixedDelay(eq(check), eq(schedule.getCheckInterval().toMilliseconds()),
-            eq(schedule.getCheckInterval().toMilliseconds()), eq(TimeUnit.MILLISECONDS)))
+        when(executor.scheduleWithFixedDelay(check, schedule.getCheckInterval().toMilliseconds(),
+            schedule.getCheckInterval().toMilliseconds(), TimeUnit.MILLISECONDS))
             .thenReturn(mock(ScheduledFuture.class));
 
         scheduler.schedule(check, true);
 
-        verify(executor).scheduleWithFixedDelay(eq(check), eq(schedule.getCheckInterval().toMilliseconds()),
-            eq(schedule.getCheckInterval().toMilliseconds()), eq(TimeUnit.MILLISECONDS));
+        verify(executor).scheduleWithFixedDelay(check, schedule.getCheckInterval().toMilliseconds(),
+            schedule.getCheckInterval().toMilliseconds(), TimeUnit.MILLISECONDS);
     }
 
     @Test
@@ -61,14 +61,14 @@ public class HealthCheckSchedulerTest {
         when(check.getSchedule())
             .thenReturn(schedule);
 
-        when(executor.scheduleWithFixedDelay(eq(check), eq(schedule.getDowntimeInterval().toMilliseconds()),
-            eq(schedule.getDowntimeInterval().toMilliseconds()), eq(TimeUnit.MILLISECONDS)))
+        when(executor.scheduleWithFixedDelay(check, schedule.getDowntimeInterval().toMilliseconds(),
+            schedule.getDowntimeInterval().toMilliseconds(), TimeUnit.MILLISECONDS))
             .thenReturn(mock(ScheduledFuture.class));
 
         scheduler.schedule(check, false);
 
-        verify(executor).scheduleWithFixedDelay(eq(check), eq(schedule.getDowntimeInterval().toMilliseconds()),
-            eq(schedule.getDowntimeInterval().toMilliseconds()), eq(TimeUnit.MILLISECONDS));
+        verify(executor).scheduleWithFixedDelay(check, schedule.getDowntimeInterval().toMilliseconds(),
+            schedule.getDowntimeInterval().toMilliseconds(), TimeUnit.MILLISECONDS);
     }
 
     @Test
@@ -160,10 +160,10 @@ public class HealthCheckSchedulerTest {
         scheduler.unschedule(name);
 
         verify(executor).scheduleWithFixedDelay(
-            eq(check),
-            eq(schedule.getCheckInterval().toMilliseconds()),
-            eq(schedule.getCheckInterval().toMilliseconds()),
-            eq(TimeUnit.MILLISECONDS));
+            check,
+            schedule.getCheckInterval().toMilliseconds(),
+            schedule.getCheckInterval().toMilliseconds(),
+            TimeUnit.MILLISECONDS);
 
         verify(future).cancel(true);
     }

--- a/dropwizard-health/src/test/java/io/dropwizard/health/response/ServletHealthResponderFactoryTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/response/ServletHealthResponderFactoryTest.java
@@ -99,7 +99,7 @@ public class ServletHealthResponderFactoryTest {
 
         // when
         // succeed first, fail second
-        when(healthResponseProvider.healthResponse(eq(Collections.emptyMap()))).thenReturn(SUCCESS, FAIL);
+        when(healthResponseProvider.healthResponse(Collections.emptyMap())).thenReturn(SUCCESS, FAIL);
         HealthResponderFactory factory = configFactory.build(yml);
         factory.configure(NAME, Collections.singletonList(HEALTH_CHECK_URI), healthResponseProvider, health, jersey,
             servlets, mapper);
@@ -121,7 +121,7 @@ public class ServletHealthResponderFactoryTest {
 
         // when
         // succeed first, fail second
-        when(healthResponseProvider.healthResponse(eq(Collections.emptyMap()))).thenReturn(SUCCESS, FAIL);
+        when(healthResponseProvider.healthResponse(Collections.emptyMap())).thenReturn(SUCCESS, FAIL);
         HealthResponderFactory factory = configFactory.build(yml);
         factory.configure(NAME, Collections.singletonList(HEALTH_CHECK_URI), healthResponseProvider, health, jersey,
             servlets, mapper);
@@ -144,7 +144,7 @@ public class ServletHealthResponderFactoryTest {
     private void setupServletStubbing() {
         when(servlets.addServlet(eq(NAME + SERVLET_SUFFIX), servletCaptor.capture()))
             .thenReturn(servletRegistration);
-        when(servletRegistration.addMapping(eq(HEALTH_CHECK_URI)))
+        when(servletRegistration.addMapping(HEALTH_CHECK_URI))
             .thenReturn(Collections.singleton(HEALTH_CHECK_URI));
     }
 }

--- a/dropwizard-health/src/test/java/io/dropwizard/health/response/ServletHealthResponderTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/response/ServletHealthResponderTest.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -61,7 +60,7 @@ class ServletHealthResponderTest {
             "no-store");
 
         // when
-        when(healthResponseProvider.healthResponse(eq(Collections.emptyMap()))).thenReturn(SUCCESS);
+        when(healthResponseProvider.healthResponse(Collections.emptyMap())).thenReturn(SUCCESS);
         servletTester.addServlet(new ServletHolder(servletHealthResponder), HEALTH_CHECK_URI);
         servletTester.start();
         final HttpTester.Response response = executeRequest(request);
@@ -78,7 +77,7 @@ class ServletHealthResponderTest {
             "no-store");
 
         // when
-        when(healthResponseProvider.healthResponse(eq(Collections.emptyMap()))).thenReturn(SUCCESS);
+        when(healthResponseProvider.healthResponse(Collections.emptyMap())).thenReturn(SUCCESS);
         servletTester.addServlet(new ServletHolder(servletHealthResponder), HEALTH_CHECK_URI);
         servletTester.start();
         final HttpTester.Response response = executeRequest(request);
@@ -97,7 +96,7 @@ class ServletHealthResponderTest {
             "no-store");
 
         // when
-        when(healthResponseProvider.healthResponse(eq(Collections.emptyMap()))).thenReturn(FAIL);
+        when(healthResponseProvider.healthResponse(Collections.emptyMap())).thenReturn(FAIL);
         servletTester.addServlet(new ServletHolder(servletHealthResponder), HEALTH_CHECK_URI);
         servletTester.start();
         final HttpTester.Response response = executeRequest(request);
@@ -124,7 +123,7 @@ class ServletHealthResponderTest {
         queryParams.put(nameQueryParam, ImmutableList.of(name, anotherName));
 
         // when
-        when(healthResponseProvider.healthResponse(eq(queryParams))).thenReturn(SUCCESS);
+        when(healthResponseProvider.healthResponse(queryParams)).thenReturn(SUCCESS);
         servletTester.addServlet(new ServletHolder(servletHealthResponder), HEALTH_CHECK_URI);
         servletTester.start();
         final String uri = String.format("%s?%s=%s&%s=%s&%s=%s", HEALTH_CHECK_URI, typeQueryParam, type, nameQueryParam,

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/AllowedMethodsFilterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/AllowedMethodsFilterTest.java
@@ -26,7 +26,6 @@ import java.util.Collections;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -125,6 +124,6 @@ public class AllowedMethodsFilterTest extends AbstractJerseyTest {
     void disallowedMethodCausesMethodNotAllowedResponse() throws IOException, ServletException {
         when(request.getMethod()).thenReturn("TRACE");
         filter.doFilter(request, response, chain);
-        verify(response).sendError(eq(DISALLOWED_STATUS_CODE));
+        verify(response).sendError(DISALLOWED_STATUS_CODE);
     }
 }

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NonblockingServletHolderTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NonblockingServletHolderTest.java
@@ -13,7 +13,6 @@ import javax.servlet.ServletResponse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -42,7 +41,7 @@ public class NonblockingServletHolderTest {
 
     @Test
     void servicesRequestHandleEofException() throws Exception {
-        doThrow(new EofException()).when(servlet).service(eq(request), eq(response));
+        doThrow(new EofException()).when(servlet).service(request, response);
         assertThatCode(() -> {
             holder.handle(baseRequest, request, response);
         }).doesNotThrowAnyException();
@@ -51,7 +50,7 @@ public class NonblockingServletHolderTest {
 
     @Test
     void servicesRequestException() throws Exception {
-        doThrow(new IOException()).when(servlet).service(eq(request), eq(response));
+        doThrow(new IOException()).when(servlet).service(request, response);
         assertThatExceptionOfType(IOException.class).isThrownBy(() -> {
             holder.handle(baseRequest, request, response);
         });

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/AccessJsonLayoutTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/AccessJsonLayoutTest.java
@@ -19,7 +19,6 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 public class AccessJsonLayoutTest {
@@ -207,9 +206,9 @@ public class AccessJsonLayoutTest {
                 attribute2, "value2",
                 attribute3, "value3");
 
-        when(event.getAttribute(eq(attribute1))).thenReturn(attributes.get(attribute1));
-        when(event.getAttribute(eq(attribute2))).thenReturn(attributes.get(attribute2));
-        when(event.getAttribute(eq(attribute3))).thenReturn(attributes.get(attribute3));
+        when(event.getAttribute(attribute1)).thenReturn(attributes.get(attribute1));
+        when(event.getAttribute(attribute2)).thenReturn(attributes.get(attribute2));
+        when(event.getAttribute(attribute3)).thenReturn(attributes.get(attribute3));
 
         accessJsonLayout.setRequestAttributes(attributes.keySet());
         assertThat(accessJsonLayout.toJsonMap(event))
@@ -235,9 +234,9 @@ public class AccessJsonLayoutTest {
                 attribute1, "value1",
                 attribute2, "value2");
 
-        when(event.getAttribute(eq(attribute1))).thenReturn(attributes.get(attribute1));
-        when(event.getAttribute(eq(attribute2))).thenReturn(attributes.get(attribute2));
-        when(event.getAttribute(eq(attribute3))).thenReturn(null);
+        when(event.getAttribute(attribute1)).thenReturn(attributes.get(attribute1));
+        when(event.getAttribute(attribute2)).thenReturn(attributes.get(attribute2));
+        when(event.getAttribute(attribute3)).thenReturn(null);
 
         accessJsonLayout.setRequestAttributes(Sets.of(attribute1, attribute2, attribute3));
         assertThat(accessJsonLayout.toJsonMap(event))

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/ScheduledReporterManagerTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/ScheduledReporterManagerTest.java
@@ -3,39 +3,42 @@ package io.dropwizard.metrics;
 import com.codahale.metrics.ScheduledReporter;
 import io.dropwizard.util.Duration;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class ScheduledReporterManagerTest {
 
     @Test
     void testStopWithoutReporting() throws Exception {
         final boolean reportOnStop = false;
-        ScheduledReporter mockReporter = Mockito.mock(ScheduledReporter.class);
+        ScheduledReporter mockReporter = mock(ScheduledReporter.class);
         ScheduledReporterManager manager = new ScheduledReporterManager(mockReporter, Duration.minutes(5), reportOnStop);
 
         manager.start();
         manager.stop();
 
-        Mockito.verify(mockReporter).start(Mockito.eq(5L), Mockito.eq(TimeUnit.MINUTES));
-        Mockito.verify(mockReporter).stop();
-        Mockito.verifyNoMoreInteractions(mockReporter);
+        verify(mockReporter).start(5L, TimeUnit.MINUTES);
+        verify(mockReporter).stop();
+        verifyNoMoreInteractions(mockReporter);
     }
 
     @Test
     void testStopWithReporting() throws Exception {
         final boolean reportOnStop = true;
-        ScheduledReporter mockReporter = Mockito.mock(ScheduledReporter.class);
+        ScheduledReporter mockReporter = mock(ScheduledReporter.class);
         ScheduledReporterManager manager = new ScheduledReporterManager(mockReporter, Duration.minutes(5), reportOnStop);
 
         manager.start();
         manager.stop();
 
-        Mockito.verify(mockReporter).start(Mockito.eq(5L), Mockito.eq(TimeUnit.MINUTES));
-        Mockito.verify(mockReporter).report();
-        Mockito.verify(mockReporter).stop();
-        Mockito.verifyNoMoreInteractions(mockReporter);
+        verify(mockReporter).start(5L, TimeUnit.MINUTES);
+        verify(mockReporter).report();
+        verify(mockReporter).stop();
+        verifyNoMoreInteractions(mockReporter);
     }
 
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestRuleTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/ResourceTestRuleTest.java
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -50,7 +49,7 @@ public class ResourceTestRuleTest {
 
     @Before
     public void setup() {
-        when(peopleStore.fetchPerson(eq("blah"))).thenReturn(person);
+        when(peopleStore.fetchPerson("blah")).thenReturn(person);
     }
 
     @Test


### PR DESCRIPTION
This isn't needed as equality is the default matcher type. Picked up by Sonar.