### PR TITLE
Remove 'public' modifiers from tests

### DIFF
--- a/dropwizard-client/src/test/java/io/dropwizard/client/ConfiguredCloseableHttpClientTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/ConfiguredCloseableHttpClientTest.java
@@ -8,7 +8,7 @@ import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ConfiguredCloseableHttpClientTest {
+class ConfiguredCloseableHttpClientTest {
     private ConfiguredCloseableHttpClient configuredClient;
 
     private CloseableHttpClient closeableHttpClientMock = Mockito.mock(CloseableHttpClient.class);

--- a/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-public class DropwizardApacheConnectorTest {
+class DropwizardApacheConnectorTest {
 
     private static final int SLEEP_TIME_IN_MILLIS = 1000;
     private static final int DEFAULT_CONNECT_TIMEOUT_IN_MILLIS = 500;

--- a/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactoryTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactoryTest.java
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.bouncycastle.jce.provider.BouncyCastleProvider.PROVIDER_NAME;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-public class DropwizardSSLConnectionSocketFactoryTest {
+class DropwizardSSLConnectionSocketFactoryTest {
     private TlsConfiguration tlsConfiguration;
     private JerseyClientConfiguration jerseyClientConfiguration;
 

--- a/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
@@ -84,7 +84,7 @@ class AnotherHttpClientBuilder extends org.apache.http.impl.client.HttpClientBui
     }
 }
 
-public class HttpClientBuilderTest {
+class HttpClientBuilderTest {
     static class CustomRequestExecutor extends HttpRequestExecutor {
     }
 

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
@@ -73,7 +73,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class JerseyClientBuilderTest {
+class JerseyClientBuilderTest {
     private final MetricRegistry metricRegistry = new MetricRegistry();
     private final JerseyClientBuilder builder = new JerseyClientBuilder(metricRegistry);
     private final LifecycleEnvironment lifecycleEnvironment = spy(new LifecycleEnvironment(metricRegistry));
@@ -234,7 +234,7 @@ public class JerseyClientBuilderTest {
 
     @Test
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public void usesAnExecutorServiceFromTheEnvironment() {
+    void usesAnExecutorServiceFromTheEnvironment() {
         final JerseyClientConfiguration configuration = new JerseyClientConfiguration();
         configuration.setMinThreads(7);
         configuration.setMaxThreads(532);

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientConfigurationTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientConfigurationTest.java
@@ -10,7 +10,7 @@ import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class JerseyClientConfigurationTest {
+class JerseyClientConfigurationTest {
 
     @Test
     void testBasicJerseyClient() throws Exception {

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientIntegrationTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientIntegrationTest.java
@@ -44,7 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Integration test of {@link org.glassfish.jersey.client.JerseyClient}
  * with {@link io.dropwizard.client.DropwizardApacheConnector}
  */
-public class JerseyClientIntegrationTest {
+class JerseyClientIntegrationTest {
 
     private static final String TRANSFER_ENCODING = "Transfer-Encoding";
     private static final String CHUNKED = "chunked";

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyIgnoreRequestUserAgentHeaderFilterTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyIgnoreRequestUserAgentHeaderFilterTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.Executors;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-public class JerseyIgnoreRequestUserAgentHeaderFilterTest {
+class JerseyIgnoreRequestUserAgentHeaderFilterTest {
     public static final DropwizardAppExtension<Configuration> APP_RULE =
             new DropwizardAppExtension<>(TestApplication.class, Resources.getResource("yaml/jerseyIgnoreRequestUserAgentHeaderFilterTest.yml").getPath());
 

--- a/dropwizard-client/src/test/java/io/dropwizard/client/proxy/HttpClientConfigurationTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/proxy/HttpClientConfigurationTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 
-public class HttpClientConfigurationTest {
+class HttpClientConfigurationTest {
 
     private final ObjectMapper objectMapper = Jackson.newObjectMapper();
     private HttpClientConfiguration configuration = new HttpClientConfiguration();

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryFactoryTest.java
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 
-public class ConfigurationFactoryFactoryTest {
+class ConfigurationFactoryFactoryTest {
 
     private final ConfigurationFactoryFactory<Example> factoryFactory = new DefaultConfigurationFactoryFactory<>();
     private final Validator validator = BaseValidator.newValidator();

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationMetadataTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationMetadataTest.java
@@ -137,7 +137,7 @@ class ConfigurationMetadataTest {
 
     @ParameterizedTest
     @MethodSource("provideArgsForShouldDiscoverAllFields")
-    public void shouldDiscoverAllFields(String name, boolean isPrimitive,
+    void shouldDiscoverAllFields(String name, boolean isPrimitive,
                                         boolean isCollectionOrArrayType,
                                         Class<?> klass) {
         final ConfigurationMetadata metadata = new ConfigurationMetadata(
@@ -171,7 +171,7 @@ class ConfigurationMetadataTest {
 
     @ParameterizedTest
     @MethodSource("provideArgsForIsCollectionOfStringsShouldWork")
-    public void isCollectionOfStringsShouldWork(String name, boolean isCollectionOfStrings) {
+    void isCollectionOfStringsShouldWork(String name, boolean isCollectionOfStrings) {
         final ConfigurationMetadata metadata = new ConfigurationMetadata(
                 Jackson.newObjectMapper(), ExampleConfiguration.class);
 

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationValidationExceptionTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationValidationExceptionTest.java
@@ -14,7 +14,7 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
-public class ConfigurationValidationExceptionTest {
+class ConfigurationValidationExceptionTest {
     private static class Example {
         @NotNull
         @Nullable // Weird combination, but Hibernate Validator is not good with the compile nullable checks

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/EnvironmentVariableLookupTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/EnvironmentVariableLookupTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
-public class EnvironmentVariableLookupTest {
+class EnvironmentVariableLookupTest {
     @Test
     void lookupThrowsExceptionInStrictMode() {
         assumeThat(System.getenv("nope")).isNull();

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/EnvironmentVariableSubstitutorTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/EnvironmentVariableSubstitutorTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 
 import org.junit.jupiter.api.Test;
 
-public class EnvironmentVariableSubstitutorTest {
+class EnvironmentVariableSubstitutorTest {
 
     @Test
     void defaultConstructorDisablesSubstitutionInVariables() {

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/FileConfigurationSourceProviderTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/FileConfigurationSourceProviderTest.java
@@ -9,7 +9,7 @@ import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class FileConfigurationSourceProviderTest {
+class FileConfigurationSourceProviderTest {
     private final ConfigurationSourceProvider provider = new FileConfigurationSourceProvider();
 
     @Test

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/JsonConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/JsonConfigurationFactoryTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class JsonConfigurationFactoryTest extends BaseConfigurationFactoryTest {
+class JsonConfigurationFactoryTest extends BaseConfigurationFactoryTest {
 
     private File commentFile;
 

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/LevenshteinComparatorTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/LevenshteinComparatorTest.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
-public class LevenshteinComparatorTest {
+class LevenshteinComparatorTest {
     private final ConfigurationParsingException.Builder.LevenshteinComparator c = new ConfigurationParsingException.Builder.LevenshteinComparator("base");
 
     /**

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ResourceConfigurationSourceProviderTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ResourceConfigurationSourceProviderTest.java
@@ -9,7 +9,7 @@ import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ResourceConfigurationSourceProviderTest {
+class ResourceConfigurationSourceProviderTest {
     private final ConfigurationSourceProvider provider = new ResourceConfigurationSourceProvider();
 
     @Test

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/SubstitutingSourceProviderTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/SubstitutingSourceProviderTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class SubstitutingSourceProviderTest {
+class SubstitutingSourceProviderTest {
     @Test
     void shouldSubstituteCorrectly() throws IOException {
         StringLookup dummyLookup = (x) -> "baz";

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/UrlConfigurationSourceProviderTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/UrlConfigurationSourceProviderTest.java
@@ -9,7 +9,7 @@ import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class UrlConfigurationSourceProviderTest {
+class UrlConfigurationSourceProviderTest {
     private final ConfigurationSourceProvider provider = new UrlConfigurationSourceProvider();
 
     @Test

--- a/dropwizard-core/src/test/java/io/dropwizard/ApplicationTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/ApplicationTest.java
@@ -8,7 +8,7 @@ import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ApplicationTest {
+class ApplicationTest {
     private static class FakeConfiguration extends Configuration {
     }
 

--- a/dropwizard-core/src/test/java/io/dropwizard/BundleTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/BundleTest.java
@@ -11,7 +11,7 @@ import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BundleTest {
+class BundleTest {
     @Test
     void deprecatedBundleWillBeInitializedAndRun() throws Exception {
         final DeprecatedBundle deprecatedBundle = new DeprecatedBundle();

--- a/dropwizard-core/src/test/java/io/dropwizard/ConfigurationTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/ConfigurationTest.java
@@ -12,7 +12,7 @@ import java.util.stream.StreamSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ConfigurationTest {
+class ConfigurationTest {
     private final Configuration configuration = new Configuration();
 
     @Test

--- a/dropwizard-core/src/test/java/io/dropwizard/cli/CheckCommandTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/cli/CheckCommandTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 
-public class CheckCommandTest {
+class CheckCommandTest {
     private static class MyApplication extends Application<Configuration> {
         @Override
         public void run(Configuration configuration, Environment environment) throws Exception {

--- a/dropwizard-core/src/test/java/io/dropwizard/cli/ConfiguredCommandTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/cli/ConfiguredCommandTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 
-public class ConfiguredCommandTest {
+class ConfiguredCommandTest {
     private static class TestCommand extends ConfiguredCommand<Configuration> {
         protected TestCommand() {
             super("test", "test");

--- a/dropwizard-core/src/test/java/io/dropwizard/cli/InheritedServerCommandTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/cli/InheritedServerCommandTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class InheritedServerCommandTest {
+class InheritedServerCommandTest {
     private static class ApiCommand extends ServerCommand<Configuration> {
 
         protected ApiCommand(final Application<Configuration> application) {

--- a/dropwizard-core/src/test/java/io/dropwizard/cli/ServerCommandTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/cli/ServerCommandTest.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class ServerCommandTest {
+class ServerCommandTest {
     private static class MyApplication extends Application<Configuration> {
         @Override
         public void run(Configuration configuration, Environment environment) throws Exception {

--- a/dropwizard-core/src/test/java/io/dropwizard/server/AbstractServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/AbstractServerFactoryTest.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.when;
  *     <li>Default value defined by {@link DropwizardResourceConfig#urlPattern}</li>
  * </ol>
  */
-public class AbstractServerFactoryTest {
+class AbstractServerFactoryTest {
 
     private final JerseyContainerHolder holder = mock(JerseyContainerHolder.class);
     private final DropwizardResourceConfig config = new DropwizardResourceConfig();

--- a/dropwizard-core/src/test/java/io/dropwizard/setup/BootstrapTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/setup/BootstrapTest.java
@@ -19,7 +19,7 @@ import javax.validation.ValidatorFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BootstrapTest {
+class BootstrapTest {
     private final Application<Configuration> application = new Application<Configuration>() {
         @Override
         public void run(Configuration configuration, Environment environment) throws Exception {

--- a/dropwizard-core/src/test/java/io/dropwizard/validation/InjectValidatorFeatureTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/validation/InjectValidatorFeatureTest.java
@@ -23,7 +23,7 @@ import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class InjectValidatorFeatureTest {
+class InjectValidatorFeatureTest {
 
     private final Application<Configuration> application = new Application<Configuration>() {
         @Override

--- a/dropwizard-db/src/test/java/io/dropwizard/db/ManagedPooledDataSourceTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/ManagedPooledDataSourceTest.java
@@ -8,7 +8,7 @@ import java.sql.SQLFeatureNotSupportedException;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class ManagedPooledDataSourceTest {
+class ManagedPooledDataSourceTest {
     private final PoolProperties config = new PoolProperties();
     private final MetricRegistry metricRegistry = new MetricRegistry();
     private final ManagedPooledDataSource dataSource = new ManagedPooledDataSource(config, metricRegistry);

--- a/dropwizard-db/src/test/java/io/dropwizard/db/TimeBoundHealthCheckTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/TimeBoundHealthCheckTest.java
@@ -16,11 +16,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class TimeBoundHealthCheckTest {
+class TimeBoundHealthCheckTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testCheck() throws InterruptedException, ExecutionException, TimeoutException {
+    void testCheck() throws InterruptedException, ExecutionException, TimeoutException {
         final ExecutorService executorService = mock(ExecutorService.class);
         final Duration duration = mock(Duration.class);
         when(duration.getQuantity()).thenReturn(5L);

--- a/dropwizard-example/src/test/java/com/example/helloworld/db/PersonDAOIntegrationTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/db/PersonDAOIntegrationTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 @Testcontainers(disabledWithoutDocker = true)
 @ExtendWith(DropwizardExtensionsSupport.class)
 @DisabledForJreRange(min = JRE.JAVA_16)
-public class PersonDAOIntegrationTest {
+class PersonDAOIntegrationTest {
     @Container
     private static final MySQLContainer<?> MY_SQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0.24"));
 

--- a/dropwizard-example/src/test/java/com/example/helloworld/resources/PeopleResourceTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/resources/PeopleResourceTest.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.when;
  * Unit tests for {@link PeopleResource}.
  */
 @ExtendWith(DropwizardExtensionsSupport.class)
-public class PeopleResourceTest {
+class PeopleResourceTest {
     private static final PersonDAO PERSON_DAO = mock(PersonDAO.class);
     public static final ResourceExtension RESOURCES = ResourceExtension.builder()
             .addResource(new PeopleResource(PERSON_DAO))

--- a/dropwizard-example/src/test/java/com/example/helloworld/resources/ProtectedClassResourceTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/resources/ProtectedClassResourceTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-public final class ProtectedClassResourceTest {
+final class ProtectedClassResourceTest {
 
     private static final BasicCredentialAuthFilter<User> BASIC_AUTH_HANDLER =
         new BasicCredentialAuthFilter.Builder<User>()

--- a/dropwizard-health/src/test/java/io/dropwizard/health/DefaultHealthFactoryTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/DefaultHealthFactoryTest.java
@@ -14,14 +14,14 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DefaultHealthFactoryTest {
+class DefaultHealthFactoryTest {
     private final ObjectMapper objectMapper = Jackson.newObjectMapper();
     private final Validator validator = Validators.newValidator();
     private final YamlConfigurationFactory<DefaultHealthFactory> configFactory =
         new YamlConfigurationFactory<>(DefaultHealthFactory.class, validator, objectMapper, "dw");
 
     @Test
-    public void shouldBuildHealthFactoryFromYaml() throws Exception {
+    void shouldBuildHealthFactoryFromYaml() throws Exception {
         final File yml = new File(Resources.getResource("yml/health.yml").toURI());
         final DefaultHealthFactory healthFactory = configFactory.build(yml);
 

--- a/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckConfigValidatorTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckConfigValidatorTest.java
@@ -26,20 +26,20 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
-public class HealthCheckConfigValidatorTest {
+class HealthCheckConfigValidatorTest {
 
     @Mock
     private Appender<ILoggingEvent> mockLogAppender;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) LoggerFactory
             .getLogger(HealthCheckConfigValidator.class);
         logger.addAppender(mockLogAppender);
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) LoggerFactory
             .getLogger(HealthCheckConfigValidator.class);
         logger.detachAppender(mockLogAppender);
@@ -47,7 +47,7 @@ public class HealthCheckConfigValidatorTest {
     }
 
     @Test
-    public void startValidationsShouldSucceedWhenNoHealthChecksConfigured() throws Exception {
+    void startValidationsShouldSucceedWhenNoHealthChecksConfigured() throws Exception {
         // given
         List<HealthCheckConfiguration> configs = ImmutableList.of();
         HealthCheckRegistry registry = new HealthCheckRegistry();
@@ -61,7 +61,7 @@ public class HealthCheckConfigValidatorTest {
     }
 
     @Test
-    public void startValidationsShouldSucceedForConfiguredAndRegisteredHealthCheck() throws Exception {
+    void startValidationsShouldSucceedForConfiguredAndRegisteredHealthCheck() throws Exception {
         // given
         HealthCheckConfiguration check1 = new HealthCheckConfiguration();
         check1.setName("check-1");
@@ -81,7 +81,7 @@ public class HealthCheckConfigValidatorTest {
     }
 
     @Test
-    public void startValidationsShouldSucceedButLogWhenNotAllHealthChecksAreConfigured() throws Exception {
+    void startValidationsShouldSucceedButLogWhenNotAllHealthChecksAreConfigured() throws Exception {
         // given
         ArgumentCaptor<LoggingEvent> captor = ArgumentCaptor.forClass(LoggingEvent.class);
         HealthCheckConfiguration check1 = new HealthCheckConfiguration();
@@ -109,7 +109,7 @@ public class HealthCheckConfigValidatorTest {
     }
 
     @Test
-    public void startValidationsShouldFailIfAHealthCheckConfiguredButNotRegistered() throws Exception {
+    void startValidationsShouldFailIfAHealthCheckConfiguredButNotRegistered() throws Exception {
         // given
         ArgumentCaptor<LoggingEvent> captor = ArgumentCaptor.forClass(LoggingEvent.class);
         HealthCheckConfiguration check1 = new HealthCheckConfiguration();

--- a/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckConfigurationTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckConfigurationTest.java
@@ -12,14 +12,14 @@ import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class HealthCheckConfigurationTest {
+class HealthCheckConfigurationTest {
     private final ObjectMapper objectMapper = Jackson.newObjectMapper();
     private final Validator validator = Validators.newValidator();
     private final YamlConfigurationFactory<HealthCheckConfiguration> configFactory =
         new YamlConfigurationFactory<>(HealthCheckConfiguration.class, validator, objectMapper, "dw");
 
     @Test
-    public void shouldBuildHealthCheckConfigurationFromYaml() throws Exception {
+    void shouldBuildHealthCheckConfigurationFromYaml() throws Exception {
         final File yml = new File(Resources.getResource("yml/healthCheck.yml").toURI());
         final HealthCheckConfiguration healthCheckConfig = configFactory.build(yml);
 

--- a/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckManagerTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckManagerTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class HealthCheckManagerTest {
+class HealthCheckManagerTest {
     private static final String NAME = "test";
     private static final String NAME_2 = "test2";
     private static final HealthCheckType READY = HealthCheckType.READY;
@@ -39,7 +39,7 @@ public class HealthCheckManagerTest {
     private HealthCheckScheduler scheduler;
 
     @Test
-    public void shouldIgnoreUnconfiguredAddedHealthChecks() {
+    void shouldIgnoreUnconfiguredAddedHealthChecks() {
         // given
         final HealthCheckManager manager = new HealthCheckManager(Collections.emptyList(), scheduler,
             new MetricRegistry(), SHUTDOWN_WAIT, true, Collections.emptyList());
@@ -52,7 +52,7 @@ public class HealthCheckManagerTest {
     }
 
     @Test
-    public void shouldScheduleHealthCheckWhenConfiguredHealthCheckAdded() {
+    void shouldScheduleHealthCheckWhenConfiguredHealthCheckAdded() {
         // given
         final HealthCheckConfiguration config = new HealthCheckConfiguration();
         config.setName(NAME);
@@ -69,7 +69,7 @@ public class HealthCheckManagerTest {
     }
 
     @Test
-    public void shouldUnscheduleTaskWhenHealthCheckRemoved() {
+    void shouldUnscheduleTaskWhenHealthCheckRemoved() {
         // given
         final ScheduledHealthCheck healthCheck = mock(ScheduledHealthCheck.class);
         final HealthCheckManager manager = new HealthCheckManager(Collections.emptyList(), scheduler,
@@ -84,7 +84,7 @@ public class HealthCheckManagerTest {
     }
 
     @Test
-    public void shouldDoNothingWhenStateChangesForUnconfiguredHealthCheck() {
+    void shouldDoNothingWhenStateChangesForUnconfiguredHealthCheck() {
         // given
         final HealthCheckManager manager = new HealthCheckManager(Collections.emptyList(), scheduler,
             new MetricRegistry(), SHUTDOWN_WAIT, true, Collections.emptyList());
@@ -97,7 +97,7 @@ public class HealthCheckManagerTest {
     }
 
     @Test
-    public void shouldReportUnhealthyWhenInitialOverallStateIsFalse() {
+    void shouldReportUnhealthyWhenInitialOverallStateIsFalse() {
         // given
         final HealthCheckConfiguration config = new HealthCheckConfiguration();
         config.setName(NAME);
@@ -126,7 +126,7 @@ public class HealthCheckManagerTest {
     }
 
     @Test
-    public void shouldMarkServerUnhealthyWhenCriticalHealthCheckFails() {
+    void shouldMarkServerUnhealthyWhenCriticalHealthCheckFails() {
         // given
         final HealthCheckConfiguration config = new HealthCheckConfiguration();
         config.setName(NAME);
@@ -154,7 +154,7 @@ public class HealthCheckManagerTest {
     }
 
     @Test
-    public void shouldMarkServerNotAliveAndUnhealthyWhenCriticalAliveCheckFails() {
+    void shouldMarkServerNotAliveAndUnhealthyWhenCriticalAliveCheckFails() {
         // given
         final HealthCheckConfiguration config = new HealthCheckConfiguration();
         config.setName(NAME);
@@ -182,7 +182,7 @@ public class HealthCheckManagerTest {
     }
 
     @Test
-    public void shouldMarkServerHealthyWhenCriticalHealthCheckRecovers() {
+    void shouldMarkServerHealthyWhenCriticalHealthCheckRecovers() {
         // given
         final HealthCheckConfiguration config = new HealthCheckConfiguration();
         config.setName(NAME);
@@ -227,7 +227,7 @@ public class HealthCheckManagerTest {
     }
 
     @Test
-    public void shouldNotChangeServerStateWhenNonCriticalHealthCheckFails() {
+    void shouldNotChangeServerStateWhenNonCriticalHealthCheckFails() {
         // given
         final HealthCheckConfiguration config = new HealthCheckConfiguration();
         config.setName(NAME);
@@ -249,7 +249,7 @@ public class HealthCheckManagerTest {
     }
 
     @Test
-    public void shouldNotChangeServerStateWhenNonCriticalHealthCheckRecovers() {
+    void shouldNotChangeServerStateWhenNonCriticalHealthCheckRecovers() {
         // given
         final HealthCheckConfiguration nonCriticalConfig = new HealthCheckConfiguration();
         nonCriticalConfig.setName(NAME);
@@ -311,7 +311,7 @@ public class HealthCheckManagerTest {
     }
 
     @Test
-    public void shouldRecordNumberOfHealthyAndUnhealthyHealthChecks() {
+    void shouldRecordNumberOfHealthyAndUnhealthyHealthChecks() {
         // given
         final Schedule schedule = new Schedule();
         final HealthCheckConfiguration nonCriticalConfig = new HealthCheckConfiguration();
@@ -377,7 +377,7 @@ public class HealthCheckManagerTest {
     }
 
     @Test
-    public void shouldContinueScheduledCheckingWhileDelayingShutdown() throws Exception {
+    void shouldContinueScheduledCheckingWhileDelayingShutdown() throws Exception {
         // given
         final int checkIntervalMillis = 10;
         final int shutdownWaitTimeMillis = 50;

--- a/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckSchedulerTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckSchedulerTest.java
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class HealthCheckSchedulerTest {
+class HealthCheckSchedulerTest {
 
     @Mock
     private ScheduledExecutorService executor;
@@ -27,12 +27,12 @@ public class HealthCheckSchedulerTest {
     private HealthCheckScheduler scheduler;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         this.scheduler = new HealthCheckScheduler(executor);
     }
 
     @Test
-    public void shouldScheduleCheckForNotAlreadyScheduledHealthyDependency() {
+    void shouldScheduleCheckForNotAlreadyScheduledHealthyDependency() {
         final String name = "test";
         final Schedule schedule = new Schedule();
 
@@ -51,7 +51,7 @@ public class HealthCheckSchedulerTest {
     }
 
     @Test
-    public void shouldScheduleCheckForNotAlreadyScheduledUnhealthyDependency() {
+    void shouldScheduleCheckForNotAlreadyScheduledUnhealthyDependency() {
         final String name = "test";
         final Schedule schedule = new Schedule();
 
@@ -72,7 +72,7 @@ public class HealthCheckSchedulerTest {
     }
 
     @Test
-    public void shouldRescheduleCheckForHealthyDependency() {
+    void shouldRescheduleCheckForHealthyDependency() {
         final String name = "test";
         final Schedule schedule = new Schedule();
         final ScheduledFuture future = mock(ScheduledFuture.class);
@@ -105,7 +105,7 @@ public class HealthCheckSchedulerTest {
     }
 
     @Test
-    public void shouldRescheduleCheckForUnhealthyDependency() {
+    void shouldRescheduleCheckForUnhealthyDependency() {
         final String name = "test";
         final Schedule schedule = new Schedule();
         final ScheduledFuture future = mock(ScheduledFuture.class);
@@ -138,7 +138,7 @@ public class HealthCheckSchedulerTest {
     }
 
     @Test
-    public void shouldUnscheduleExistingCheck() {
+    void shouldUnscheduleExistingCheck() {
         final String name = "test";
         final Schedule schedule = new Schedule();
         final ScheduledFuture future = mock(ScheduledFuture.class);
@@ -169,7 +169,7 @@ public class HealthCheckSchedulerTest {
     }
 
     @Test
-    public void unscheduleShouldDoNothingIfNoCheckScheduled() {
+    void unscheduleShouldDoNothingIfNoCheckScheduled() {
         final String name = "test";
 
         assertThatCode(() -> scheduler.unschedule(name))

--- a/dropwizard-health/src/test/java/io/dropwizard/health/ScheduleTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/ScheduleTest.java
@@ -12,14 +12,14 @@ import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ScheduleTest {
+class ScheduleTest {
     private final ObjectMapper objectMapper = Jackson.newObjectMapper();
     private final Validator validator = Validators.newValidator();
     private final YamlConfigurationFactory<Schedule> configFactory =
         new YamlConfigurationFactory<>(Schedule.class, validator, objectMapper, "dw");
 
     @Test
-    public void shouldBuildAScheduleFromYaml() throws Exception {
+    void shouldBuildAScheduleFromYaml() throws Exception {
         final File yml = new File(Resources.getResource("yml/schedule.yml").toURI());
         final Schedule schedule = configFactory.build(yml);
 

--- a/dropwizard-health/src/test/java/io/dropwizard/health/ScheduledHealthCheckTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/ScheduledHealthCheckTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class ScheduledHealthCheckTest {
+class ScheduledHealthCheckTest {
     private static final HealthStateListener LISTENER = new HealthStateListener() {
         @Override
         public void onHealthyCheck(String healthCheckName) {
@@ -33,7 +33,7 @@ public class ScheduledHealthCheckTest {
     private Schedule schedule;
 
     @Test
-    public void healthyCheckShouldResultInSuccess() {
+    void healthyCheckShouldResultInSuccess() {
         when(schedule.getSuccessAttempts()).thenReturn(1);
         when(schedule.getFailureAttempts()).thenReturn(1);
 
@@ -55,7 +55,7 @@ public class ScheduledHealthCheckTest {
     }
 
     @Test
-    public void unhealthyCheckShouldResultInFail() {
+    void unhealthyCheckShouldResultInFail() {
         when(schedule.getSuccessAttempts()).thenReturn(1);
         when(schedule.getFailureAttempts()).thenReturn(1);
 

--- a/dropwizard-health/src/test/java/io/dropwizard/health/StateTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/StateTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-public class StateTest {
+class StateTest {
     private static final String NAME = "test";
 
     private final AtomicBoolean didStateChange = new AtomicBoolean(false);
@@ -33,12 +33,12 @@ public class StateTest {
     private HealthStateListener listenerMock;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         didStateChange.set(false);
     }
 
     @Test
-    public void singleFailureShouldNotChangeStateIfThresholdNotExceeded() {
+    void singleFailureShouldNotChangeStateIfThresholdNotExceeded() {
         final State state = new State(NAME, 2, 1, true, listener);
         state.failure();
 
@@ -47,7 +47,7 @@ public class StateTest {
     }
 
     @Test
-    public void singleFailureShouldChangeStateIfThresholdExceeded() {
+    void singleFailureShouldChangeStateIfThresholdExceeded() {
         final State state = new State(NAME, 1, 1, true, listener);
         assertThat(state.getHealthy().get()).isTrue();
 
@@ -58,7 +58,7 @@ public class StateTest {
     }
 
     @Test
-    public void singleSuccessShouldNotChangeStateIfThresholdNotExceeded() {
+    void singleSuccessShouldNotChangeStateIfThresholdNotExceeded() {
         final State state = new State(NAME, 1, 2, false, listener);
         assertThat(state.getHealthy().get()).isFalse();
 
@@ -69,7 +69,7 @@ public class StateTest {
     }
 
     @Test
-    public void singleSuccessShouldChangeStateIfThresholdExceeded() {
+    void singleSuccessShouldChangeStateIfThresholdExceeded() {
         final State state = new State(NAME, 1, 1, false, listener);
         assertThat(state.getHealthy().get()).isFalse();
 
@@ -80,7 +80,7 @@ public class StateTest {
     }
 
     @Test
-    public void failureFollowedByRecoveryShouldAllowAStateChangeToUnhealthyAfterAnotherFailureOccurs() {
+    void failureFollowedByRecoveryShouldAllowAStateChangeToUnhealthyAfterAnotherFailureOccurs() {
         final State state = new State(NAME, 1, 1, true, listener);
 
         state.failure();
@@ -104,7 +104,7 @@ public class StateTest {
     }
 
     @Test
-    public void successFollowedByFailureShouldAllowAStateChangeToHealthyAfterAnotherSuccessOccurs() {
+    void successFollowedByFailureShouldAllowAStateChangeToHealthyAfterAnotherSuccessOccurs() {
         final State state = new State(NAME, 1, 1, false, listener);
         assertThat(state.getHealthy().get()).isFalse();
 
@@ -129,7 +129,7 @@ public class StateTest {
     }
 
     @Test
-    public void dependencyFailingThenRecoveringTriggersStateChangeEventsCorrectly() {
+    void dependencyFailingThenRecoveringTriggersStateChangeEventsCorrectly() {
         // given
         final State state = new State(NAME, 3, 2, true, listenerMock);
 

--- a/dropwizard-health/src/test/java/io/dropwizard/health/check/http/HttpHealthCheckTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/check/http/HttpHealthCheckTest.java
@@ -11,7 +11,7 @@ import java.net.InetSocketAddress;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class HttpHealthCheckTest {
+class HttpHealthCheckTest {
     private static final String SUCCESS_PATH = "/ping";
     private static final String FAIL_PATH = "/fail";
     private static final String TIMEOUT_PATH = "/timeout";
@@ -30,7 +30,7 @@ public class HttpHealthCheckTest {
     }
 
     @Test
-    public void httpHealthCheckShouldConsiderA200ResponseHealthy() {
+    void httpHealthCheckShouldConsiderA200ResponseHealthy() {
         httpServer.createContext(SUCCESS_PATH, httpExchange -> {
             try {
                 httpExchange.sendResponseHeaders(200, 0);
@@ -45,7 +45,7 @@ public class HttpHealthCheckTest {
     }
 
     @Test
-    public void httpHealthCheckShouldConsiderA500ResponseUnhealthy() {
+    void httpHealthCheckShouldConsiderA500ResponseUnhealthy() {
         httpServer.createContext(FAIL_PATH, httpExchange -> {
             try {
                 httpExchange.sendResponseHeaders(500, 0);
@@ -60,7 +60,7 @@ public class HttpHealthCheckTest {
     }
 
     @Test
-    public void httpHealthCheckShouldConsiderATimeoutUnhealthy() {
+    void httpHealthCheckShouldConsiderATimeoutUnhealthy() {
         httpServer.createContext(TIMEOUT_PATH, httpExchange -> {
             try {
                 Thread.sleep(HttpHealthCheck.DEFAULT_TIMEOUT.toMillis() * 2);

--- a/dropwizard-health/src/test/java/io/dropwizard/health/check/tcp/TcpHealthCheckTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/check/tcp/TcpHealthCheckTest.java
@@ -16,23 +16,23 @@ import java.util.concurrent.TimeUnit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class TcpHealthCheckTest {
+class TcpHealthCheckTest {
     private ServerSocket serverSocket;
     private TcpHealthCheck tcpHealthCheck;
 
     @BeforeEach
-    public void setUp() throws IOException {
+    void setUp() throws IOException {
         serverSocket = new ServerSocket(0);
         tcpHealthCheck = new TcpHealthCheck("127.0.0.1", serverSocket.getLocalPort());
     }
 
     @AfterEach
-    public void tearDown() throws IOException {
+    void tearDown() throws IOException {
         serverSocket.close();
     }
 
     @Test
-    public void tcpHealthCheckShouldReturnHealthyIfCanConnect() throws IOException {
+    void tcpHealthCheckShouldReturnHealthyIfCanConnect() throws IOException {
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
         executorService.submit(() -> serverSocket.accept());
         assertThat(tcpHealthCheck.check().isHealthy())
@@ -40,13 +40,13 @@ public class TcpHealthCheckTest {
     }
 
     @Test
-    public void tcpHealthCheckShouldReturnUnhealthyIfCannotConnect() throws IOException {
+    void tcpHealthCheckShouldReturnUnhealthyIfCannotConnect() throws IOException {
         serverSocket.close();
         assertThrows(ConnectException.class, () -> tcpHealthCheck.check());
     }
 
     @Test
-    public void tcpHealthCheckShouldReturnUnhealthyIfCannotConnectWithinConfiguredTimeout() throws IOException {
+    void tcpHealthCheckShouldReturnUnhealthyIfCannotConnectWithinConfiguredTimeout() throws IOException {
         final int port = serverSocket.getLocalPort();
         serverSocket.setReuseAddress(true);
         serverSocket.close();

--- a/dropwizard-health/src/test/java/io/dropwizard/health/response/ServletHealthResponderFactoryTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/response/ServletHealthResponderFactoryTest.java
@@ -36,7 +36,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class ServletHealthResponderFactoryTest {
+class ServletHealthResponderFactoryTest {
     private static final String NAME = "tests";
     private static final String HEALTH_CHECK_URI = "/health-check";
     private static final HealthResponse SUCCESS = new HealthResponse(true, "healthy", MediaType.TEXT_PLAIN,

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/AbstractDAOTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/AbstractDAOTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("deprecation")
-public class AbstractDAOTest {
+class AbstractDAOTest {
     private static class MockDAO extends AbstractDAO<String> {
         MockDAO(SessionFactory factory) {
             super(factory);

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/HibernateBundleTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/HibernateBundleTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class HibernateBundleTest {
+class HibernateBundleTest {
     private final DataSourceFactory dbConfig = new DataSourceFactory();
     private final List<Class<?>> entities = Collections.singletonList(Person.class);
     private final SessionFactoryFactory factory = mock(SessionFactoryFactory.class);

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
@@ -41,7 +41,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class JerseyIntegrationTest extends JerseyTest {
+class JerseyIntegrationTest extends JerseyTest {
     static {
         BootstrapLogging.bootstrap();
     }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/ScanningHibernateBundleTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/ScanningHibernateBundleTest.java
@@ -7,7 +7,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-public class ScanningHibernateBundleTest {
+class ScanningHibernateBundleTest {
 
     @Test
     void testFindEntityClassesFromDirectory() {

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryFactoryTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryFactoryTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class SessionFactoryFactoryTest {
+class SessionFactoryFactoryTest {
     static {
         BootstrapLogging.bootstrap();
     }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryHealthCheckTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryHealthCheckTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("HibernateResourceOpenedButNotSafelyClosed")
-public class SessionFactoryHealthCheckTest {
+class SessionFactoryHealthCheckTest {
     private final SessionFactory factory = mock(SessionFactory.class);
 
     @Test

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryManagerTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SessionFactoryManagerTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class SessionFactoryManagerTest {
+class SessionFactoryManagerTest {
     private final SessionFactory factory = mock(SessionFactory.class);
     private final ManagedDataSource dataSource = mock(ManagedDataSource.class);
     private final SessionFactoryManager manager = new SessionFactoryManager(factory, dataSource);

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkApplicationListenerTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkApplicationListenerTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("HibernateResourceOpenedButNotSafelyClosed")
-public class UnitOfWorkApplicationListenerTest {
+class UnitOfWorkApplicationListenerTest {
     private final SessionFactory sessionFactory = mock(SessionFactory.class);
     private final SessionFactory analyticsSessionFactory = mock(SessionFactory.class);
     private final UnitOfWorkApplicationListener listener = new UnitOfWorkApplicationListener();

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class UnitOfWorkAwareProxyFactoryTest {
+class UnitOfWorkAwareProxyFactoryTest {
 
     static {
         BootstrapLogging.bootstrap();

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class UnitOfWorkTest {
+class UnitOfWorkTest {
     private static class Example {
         @UnitOfWork
         public void example() {


### PR DESCRIPTION
This is no longer needed since JUnit 5