### PR TITLE
Mark more test classes as non-public

### DIFF
--- a/dropwizard-client/src/test/java/io/dropwizard/client/proxy/NonProxyListProxyRoutePlannerTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/proxy/NonProxyListProxyRoutePlannerTest.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-public class NonProxyListProxyRoutePlannerTest {
+class NonProxyListProxyRoutePlannerTest {
 
     private HttpHost proxy = new HttpHost("192.168.52.15");
     private NonProxyListProxyRoutePlanner routePlanner = new NonProxyListProxyRoutePlanner(proxy,

--- a/dropwizard-example/src/test/java/com/example/helloworld/db/PersonDAOTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/db/PersonDAOTest.java
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-public class PersonDAOTest {
+class PersonDAOTest {
 
     public DAOTestExtension daoTestRule = DAOTestExtension.newBuilder()
         .addEntityClass(Person.class)

--- a/dropwizard-example/src/test/java/com/example/helloworld/resources/PersonResourceTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/resources/PersonResourceTest.java
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.*;
  * Unit tests for {@link PersonResource}.
  */
 @ExtendWith(DropwizardExtensionsSupport.class)
-public class PersonResourceTest {
+class PersonResourceTest {
     private static final PersonDAO DAO = mock(PersonDAO.class);
     public static final ResourceExtension RULE = ResourceExtension.builder()
             .addResource(new PersonResource(DAO))

--- a/dropwizard-example/src/test/java/com/example/helloworld/resources/ProtectedResourceTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/resources/ProtectedResourceTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-public class ProtectedResourceTest {
+class ProtectedResourceTest {
     private static final BasicCredentialAuthFilter<User> BASIC_AUTH_HANDLER =
             new BasicCredentialAuthFilter.Builder<User>()
                     .setAuthenticator(new ExampleAuthenticator())

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/CaffeineModuleTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/CaffeineModuleTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CaffeineModuleTest {
+class CaffeineModuleTest {
     private final ObjectMapper mapper = new ObjectMapper().registerModule(new CaffeineModule());
 
     @Test

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/DiscoverableSubtypeResolverTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/DiscoverableSubtypeResolverTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DiscoverableSubtypeResolverTest {
+class DiscoverableSubtypeResolverTest {
     private final ObjectMapper mapper = new ObjectMapper();
     private final DiscoverableSubtypeResolver resolver = new DiscoverableSubtypeResolver(ExampleTag.class);
 

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/FuzzyEnumModuleTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/FuzzyEnumModuleTest.java
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class FuzzyEnumModuleTest {
+class FuzzyEnumModuleTest {
     private final ObjectMapper mapper = new ObjectMapper();
 
     private enum EnumWithLowercase {

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/GuavaExtrasModuleTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/GuavaExtrasModuleTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class GuavaExtrasModuleTest {
+class GuavaExtrasModuleTest {
     private final ObjectMapper mapper = new ObjectMapper();
 
     @BeforeEach

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonDeserializationOfBigNumbersToDurationTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonDeserializationOfBigNumbersToDurationTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertTimeout;
 
 
-public class JacksonDeserializationOfBigNumbersToDurationTest {
+class JacksonDeserializationOfBigNumbersToDurationTest {
 
     private final ObjectMapper objectMapper = Jackson.newObjectMapper();
 

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonDeserializationOfBigNumbersToInstantTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonDeserializationOfBigNumbersToInstantTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertTimeout;
 
-public class JacksonDeserializationOfBigNumbersToInstantTest {
+class JacksonDeserializationOfBigNumbersToInstantTest {
 
     private final ObjectMapper objectMapper = Jackson.newObjectMapper();
 

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonTest.java
@@ -13,7 +13,7 @@ import java.nio.file.Paths;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 
-public class JacksonTest {
+class JacksonTest {
     @Test
     void objectMapperUsesGivenCustomJsonFactory() {
         JsonFactory factory = Mockito.mock(JsonFactory.class);

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/ParanamerModuleTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/ParanamerModuleTest.java
@@ -11,7 +11,7 @@ import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ParanamerModuleTest {
+class ParanamerModuleTest {
     private final ObjectMapper mapper = new ObjectMapper();
 
     @BeforeEach

--- a/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/JdbiFactoryTest.java
+++ b/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/JdbiFactoryTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
-public class JdbiFactoryTest {
+class JdbiFactoryTest {
     @Test
     void testBuild() {
         final Environment environment = mock(Environment.class);

--- a/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/NamePrependingTemplateEngineTest.java
+++ b/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/NamePrependingTemplateEngineTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class NamePrependingTemplateEngineTest {
+class NamePrependingTemplateEngineTest {
     private static final String TEMPLATE = UUID.randomUUID().toString();
     private static final String ORIGINAL_RENDERED = UUID.randomUUID().toString();
 

--- a/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/bundles/JdbiExceptionsBundleTest.java
+++ b/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/bundles/JdbiExceptionsBundleTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class JdbiExceptionsBundleTest {
+class JdbiExceptionsBundleTest {
 
     @Test
     void test() {

--- a/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/jersey/LoggingJdbiExceptionMapperTest.java
+++ b/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/jersey/LoggingJdbiExceptionMapperTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-public class LoggingJdbiExceptionMapperTest {
+class LoggingJdbiExceptionMapperTest {
     private LoggingJdbiExceptionMapper jdbiExceptionMapper;
     private Logger logger;
 

--- a/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/jersey/LoggingSQLExceptionMapperTest.java
+++ b/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/jersey/LoggingSQLExceptionMapperTest.java
@@ -8,7 +8,7 @@ import java.sql.SQLException;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class LoggingSQLExceptionMapperTest {
+class LoggingSQLExceptionMapperTest {
     @Test
     void testLogException() throws Exception {
         Logger logger = mock(Logger.class);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/AsyncServletTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/AsyncServletTest.java
@@ -9,7 +9,7 @@ import javax.ws.rs.core.Response;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class AsyncServletTest extends AbstractJerseyTest {
+class AsyncServletTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
@@ -18,7 +18,7 @@ import javax.ws.rs.core.MediaType;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DropwizardResourceConfigTest {
+class DropwizardResourceConfigTest {
     private DropwizardResourceConfig rc = DropwizardResourceConfig.forTesting();
     private AbstractJerseyTest jerseyTest = new AbstractJerseyTest() {
         @Override

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/JerseyContentTypeTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/JerseyContentTypeTest.java
@@ -9,7 +9,7 @@ import javax.ws.rs.core.Response;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class JerseyContentTypeTest extends AbstractJerseyTest {
+class JerseyContentTypeTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/ProvidersBinderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/ProvidersBinderTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Demonstrates that DropwizardResourceConfig.register needs to include an extra condition for hk2 binder, but not for
  * jersey Binder as it will be picked up as a Provider
  */
-public class ProvidersBinderTest {
+class ProvidersBinderTest {
 
     @Test
     void demonstrateThatHk2BinderIsNotPickedUpAsProvider() {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/caching/CacheControlledResponseFeatureTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/caching/CacheControlledResponseFeatureTest.java
@@ -11,7 +11,7 @@ import javax.ws.rs.core.Response;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CacheControlledResponseFeatureTest extends AbstractJerseyTest {
+class CacheControlledResponseFeatureTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/EarlyEofExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/EarlyEofExceptionMapperTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
 
-public class EarlyEofExceptionMapperTest {
+class EarlyEofExceptionMapperTest {
 
     private final EarlyEofExceptionMapper mapper = new EarlyEofExceptionMapper();
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/EofExceptionWriterInterceptorJerseyTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/EofExceptionWriterInterceptorJerseyTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.LongAdder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class EofExceptionWriterInterceptorJerseyTest extends AbstractJerseyTest {
+class EofExceptionWriterInterceptorJerseyTest extends AbstractJerseyTest {
     @Override
     protected TestContainerFactory getTestContainerFactory() throws TestContainerException {
         return new JettyTestContainerFactory();

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/EofExceptionWriterInterceptorTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/EofExceptionWriterInterceptorTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.verify;
 
-public class EofExceptionWriterInterceptorTest {
+class EofExceptionWriterInterceptorTest {
     @SuppressWarnings("NullAway")
     @Test
     void shouldSwallowEofException() throws IOException {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/ErrorEntityWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/ErrorEntityWriterTest.java
@@ -19,7 +19,7 @@ import javax.ws.rs.core.Response;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class ErrorEntityWriterTest extends AbstractJerseyTest {
+class ErrorEntityWriterTest extends AbstractJerseyTest {
 
     public static class ErrorEntityWriterTestResourceConfig extends DropwizardResourceConfig {
         public ErrorEntityWriterTestResourceConfig() {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/IllegalStateExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/IllegalStateExceptionMapperTest.java
@@ -10,7 +10,7 @@ import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class IllegalStateExceptionMapperTest {
+class IllegalStateExceptionMapperTest {
 
     private final IllegalStateExceptionMapper mapper = new IllegalStateExceptionMapper();
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/LoggingExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/LoggingExceptionMapperTest.java
@@ -12,7 +12,7 @@ import javax.ws.rs.core.MediaType;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class LoggingExceptionMapperTest extends AbstractJerseyTest {
+class LoggingExceptionMapperTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/AllowedMethodsFilterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/AllowedMethodsFilterTest.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class AllowedMethodsFilterTest extends AbstractJerseyTest {
+class AllowedMethodsFilterTest extends AbstractJerseyTest {
 
     private static final int DISALLOWED_STATUS_CODE = Response.Status.METHOD_NOT_ALLOWED.getStatusCode();
     private static final int OK_STATUS_CODE = Response.Status.OK.getStatusCode();

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/CharsetUtf8FilterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/CharsetUtf8FilterTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class CharsetUtf8FilterTest {
+class CharsetUtf8FilterTest {
 
     private ContainerRequestContext request = mock(ContainerRequestContext.class);
     private ContainerResponseContext response = mock(ContainerResponseContext.class);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/RequestIdFilterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/RequestIdFilterTest.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class RequestIdFilterTest {
+class RequestIdFilterTest {
 
     private ContainerRequestContext request = mock(ContainerRequestContext.class);
     private ContainerResponseContext response = mock(ContainerResponseContext.class);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalCookieParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalCookieParamResourceTest.java
@@ -17,7 +17,7 @@ import javax.ws.rs.core.Application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class OptionalCookieParamResourceTest extends AbstractJerseyTest {
+class OptionalCookieParamResourceTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalFormParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalFormParamResourceTest.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class OptionalFormParamResourceTest extends AbstractJerseyTest {
+class OptionalFormParamResourceTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalHeaderParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalHeaderParamResourceTest.java
@@ -17,7 +17,7 @@ import javax.ws.rs.core.Application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class OptionalHeaderParamResourceTest extends AbstractJerseyTest {
+class OptionalHeaderParamResourceTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalMessageBodyWriterTest.java
@@ -19,7 +19,7 @@ import javax.ws.rs.core.MediaType;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class OptionalMessageBodyWriterTest extends AbstractJerseyTest {
+class OptionalMessageBodyWriterTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalQueryParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalQueryParamResourceTest.java
@@ -17,7 +17,7 @@ import javax.ws.rs.core.Application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class OptionalQueryParamResourceTest extends AbstractJerseyTest {
+class OptionalQueryParamResourceTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/gzip/ConfiguredGZipEncoderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/gzip/ConfiguredGZipEncoderTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class ConfiguredGZipEncoderTest {
+class ConfiguredGZipEncoderTest {
     @Test
     void gzipParametersSpec() throws IOException {
         ClientRequestContext context = mock(ClientRequestContext.class);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JsonProcessingExceptionMapperTest.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class JsonProcessingExceptionMapperTest extends AbstractJerseyTest {
+class JsonProcessingExceptionMapperTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/InstantParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/InstantParamTest.java
@@ -5,7 +5,7 @@ import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class InstantParamTest {
+class InstantParamTest {
     @Test
     void parsesInstants() throws Exception {
         final InstantParam param = new InstantParam("1488751730055");

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/InstantSecondParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/InstantSecondParamTest.java
@@ -5,7 +5,7 @@ import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class InstantSecondParamTest {
+class InstantSecondParamTest {
     @Test
     void parsesInstants() throws Exception {
         final InstantSecondParam param = new InstantSecondParam("1488752017");

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/LocalDateParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/LocalDateParamTest.java
@@ -6,7 +6,7 @@ import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class LocalDateParamTest {
+class LocalDateParamTest {
     @Test
     void parsesDateTimes() throws Exception {
         final LocalDateParam param = new LocalDateParam("2012-11-19");

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/LocalDateTimeParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/LocalDateTimeParamTest.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class LocalDateTimeParamTest {
+class LocalDateTimeParamTest {
     @Test
     void parsesDateTimes() throws Exception {
         final LocalDateTimeParam param = new LocalDateTimeParam("2012-11-19T13:37");

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/LocalTimeParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/LocalTimeParamTest.java
@@ -6,7 +6,7 @@ import java.time.LocalTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class LocalTimeParamTest {
+class LocalTimeParamTest {
     @Test
     void parsesDateTimes() throws Exception {
         final LocalTimeParam param = new LocalTimeParam("12:34:56");

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/OffsetDateTimeParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/OffsetDateTimeParamTest.java
@@ -7,7 +7,7 @@ import java.time.ZoneOffset;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class OffsetDateTimeParamTest {
+class OffsetDateTimeParamTest {
     @Test
     void parsesDateTimes() throws Exception {
         final OffsetDateTimeParam param = new OffsetDateTimeParam("2012-11-19T13:37+01:00");

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/YearMonthParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/YearMonthParamTest.java
@@ -7,7 +7,7 @@ import java.time.YearMonth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class YearMonthParamTest {
+class YearMonthParamTest {
     @Test
     void parsesDateTimes() throws Exception {
         final YearMonthParam param = new YearMonthParam("2012-11");

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/YearParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/YearParamTest.java
@@ -6,7 +6,7 @@ import java.time.Year;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class YearParamTest {
+class YearParamTest {
     @Test
     void parsesDateTimes() throws Exception {
         final YearParam param = new YearParam("2012");

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/ZoneIdParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/ZoneIdParamTest.java
@@ -6,7 +6,7 @@ import java.time.ZoneId;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ZoneIdParamTest {
+class ZoneIdParamTest {
     @Test
     void parsesDateTimes() throws Exception {
         final ZoneIdParam param = new ZoneIdParam("Europe/Berlin");

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/ZonedDateTimeParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jsr310/ZonedDateTimeParamTest.java
@@ -7,7 +7,7 @@ import java.time.ZonedDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ZonedDateTimeParamTest {
+class ZonedDateTimeParamTest {
     @Test
     void parsesDateTimes() throws Exception {
         final ZonedDateTimeParam param = new ZonedDateTimeParam("2012-11-19T13:37+01:00[Europe/Berlin]");

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalBeanParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalBeanParamResourceTest.java
@@ -29,7 +29,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class OptionalBeanParamResourceTest extends AbstractJerseyTest {
+class OptionalBeanParamResourceTest extends AbstractJerseyTest {
     @Override
     protected Application configure() {
         return DropwizardResourceConfig.forTesting()

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalCookieParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalCookieParamResourceTest.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class OptionalCookieParamResourceTest extends AbstractJerseyTest {
+class OptionalCookieParamResourceTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalDoubleMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalDoubleMessageBodyWriterTest.java
@@ -21,7 +21,7 @@ import java.util.OptionalDouble;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class OptionalDoubleMessageBodyWriterTest extends AbstractJerseyTest {
+class OptionalDoubleMessageBodyWriterTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalFormParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalFormParamResourceTest.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class OptionalFormParamResourceTest extends AbstractJerseyTest {
+class OptionalFormParamResourceTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalHeaderParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalHeaderParamResourceTest.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class OptionalHeaderParamResourceTest extends AbstractJerseyTest {
+class OptionalHeaderParamResourceTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalIntMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalIntMessageBodyWriterTest.java
@@ -21,7 +21,7 @@ import java.util.OptionalInt;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class OptionalIntMessageBodyWriterTest extends AbstractJerseyTest {
+class OptionalIntMessageBodyWriterTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/BooleanParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/BooleanParamTest.java
@@ -9,7 +9,7 @@ import javax.ws.rs.WebApplicationException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class BooleanParamTest {
+class BooleanParamTest {
 
     @Test
     void trueReturnsTrue() {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/DateTimeParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/DateTimeParamTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DateTimeParamTest {
+class DateTimeParamTest {
     @Test
     void parsesDateTimes() {
         final DateTimeParam param = new DateTimeParam("2012-11-19");

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/DurationParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/DurationParamTest.java
@@ -9,7 +9,7 @@ import javax.ws.rs.WebApplicationException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class DurationParamTest {
+class DurationParamTest {
 
     @Test
     void parseDurationSeconds() {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/InstantParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/InstantParamTest.java
@@ -11,7 +11,7 @@ import javax.ws.rs.WebApplicationException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class InstantParamTest {
+class InstantParamTest {
     @Test
     void parsesDateTimes() {
         final InstantParam param = new InstantParam("2012-11-19T00:00:00Z");

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/IntParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/IntParamTest.java
@@ -8,7 +8,7 @@ import javax.ws.rs.WebApplicationException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class IntParamTest {
+class IntParamTest {
     @Test
     void anIntegerReturnsAnInteger() {
         assertThat(new IntParam("200").get()).isEqualTo(200);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/LocalDateParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/LocalDateParamTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class LocalDateParamTest {
+class LocalDateParamTest {
     @Test
     void parsesLocalDates() {
         final LocalDateParam param = new LocalDateParam("2012-11-20");

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/LongParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/LongParamTest.java
@@ -8,7 +8,7 @@ import javax.ws.rs.WebApplicationException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class LongParamTest {
+class LongParamTest {
     @Test
     void aLongReturnsALong() {
         final LongParam param = new LongParam("200");

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/NonEmptyStringParamProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/NonEmptyStringParamProviderTest.java
@@ -12,7 +12,7 @@ import javax.ws.rs.core.Application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class NonEmptyStringParamProviderTest extends AbstractJerseyTest {
+class NonEmptyStringParamProviderTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/NonEmptyStringParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/NonEmptyStringParamTest.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class NonEmptyStringParamTest {
+class NonEmptyStringParamTest {
     @Test
     void aBlankStringIsAnAbsentString() {
         final NonEmptyStringParam param = new NonEmptyStringParam("");

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/SizeParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/SizeParamTest.java
@@ -9,7 +9,7 @@ import javax.ws.rs.WebApplicationException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class SizeParamTest {
+class SizeParamTest {
 
     @Test
     void parseSizeKilobytes() {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/UUIDParamTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/UUIDParamTest.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class UUIDParamTest {
+class UUIDParamTest {
     private void UuidParamNegativeTest(String input) {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> new UUIDParam(input))

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/sessions/FlashFactoryTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/sessions/FlashFactoryTest.java
@@ -21,7 +21,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class FlashFactoryTest extends AbstractJerseyTest {
+class FlashFactoryTest extends AbstractJerseyTest {
 
     @Override
     protected TestContainerFactory getTestContainerFactory()

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/sessions/HttpSessionFactoryTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/sessions/HttpSessionFactoryTest.java
@@ -21,7 +21,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class HttpSessionFactoryTest extends AbstractJerseyTest {
+class HttpSessionFactoryTest extends AbstractJerseyTest {
 
     @Override
     protected TestContainerFactory getTestContainerFactory()

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/setup/JerseyEnvironmentTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/setup/JerseyEnvironmentTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-public class JerseyEnvironmentTest {
+class JerseyEnvironmentTest {
 
     private final JerseyContainerHolder holder = mock(JerseyContainerHolder.class);
     private final DropwizardResourceConfig config = new DropwizardResourceConfig();

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
@@ -25,7 +25,7 @@ import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
-public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
+class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     private static final Locale DEFAULT_LOCALE = Locale.getDefault();
 
     @Override
@@ -37,13 +37,13 @@ public class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @BeforeAll
-    public static void init() {
+    static void init() {
         // Set default locale to English because some tests assert localized error messages
         Locale.setDefault(Locale.ENGLISH);
     }
 
     @AfterAll
-    public static void shutdown() {
+    static void shutdown() {
         Locale.setDefault(DEFAULT_LOCALE);
     }
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/FuzzyEnumParamConverterProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/FuzzyEnumParamConverterProviderTest.java
@@ -13,7 +13,7 @@ import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
-public class FuzzyEnumParamConverterProviderTest {
+class FuzzyEnumParamConverterProviderTest {
     private final FuzzyEnumParamConverterProvider paramConverterProvider = new FuzzyEnumParamConverterProvider();
 
     private enum Fuzzy {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/JerseyViolationExceptionTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/JerseyViolationExceptionTest.java
@@ -12,7 +12,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
 
-public class JerseyViolationExceptionTest {
+class JerseyViolationExceptionTest {
 
     @Test
     void testAccessors() {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ParamValidatorUnwrapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ParamValidatorUnwrapperTest.java
@@ -15,7 +15,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ParamValidatorUnwrapperTest {
+class ParamValidatorUnwrapperTest {
     private static class Example {
         @NotNull(payload = Unwrapping.Skip.class)
         @Min(3)

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/MutableServletContextHandlerTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/MutableServletContextHandlerTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MutableServletContextHandlerTest {
+class MutableServletContextHandlerTest {
     private final MutableServletContextHandler handler = new MutableServletContextHandler();
 
     @Test

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NetUtilTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NetUtilTest.java
@@ -11,7 +11,7 @@ import java.util.Collection;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
-public class NetUtilTest {
+class NetUtilTest {
 
     private static final String OS_NAME_PROPERTY = "os.name";
 

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NonblockingServletHolderTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NonblockingServletHolderTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class NonblockingServletHolderTest {
+class NonblockingServletHolderTest {
     private final Servlet servlet = mock(Servlet.class);
     @SuppressWarnings("deprecation")
     private final NonblockingServletHolder holder = new NonblockingServletHolder(servlet);

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/RoutingHandlerTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/RoutingHandlerTest.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class RoutingHandlerTest {
+class RoutingHandlerTest {
     private final Connector connector1 = mock(Connector.class);
     private final Connector connector2 = mock(Connector.class);
     private final Handler handler1 = spy(new ContextHandler());

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/ServerPushFilterFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/ServerPushFilterFactoryTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-public class ServerPushFilterFactoryTest {
+class ServerPushFilterFactoryTest {
 
     @Test
     void testLoadConfiguration() throws Exception {

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/ZipExceptionHandlingInputStreamDelegateTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/ZipExceptionHandlingInputStreamDelegateTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-public class ZipExceptionHandlingInputStreamDelegateTest {
+class ZipExceptionHandlingInputStreamDelegateTest {
 
     private final InputStream delegate = Mockito.mock(InputStream.class);
     private final ZipExceptionHandlingInputStream in = new ZipExceptionHandlingInputStream(delegate, "gzip");

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/ZipExceptionHandlingInputStreamExceptionTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/ZipExceptionHandlingInputStreamExceptionTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-public class ZipExceptionHandlingInputStreamExceptionTest {
+class ZipExceptionHandlingInputStreamExceptionTest {
 
     public static Stream<Arguments> parameters() {
         return Stream.of(
@@ -36,7 +36,7 @@ public class ZipExceptionHandlingInputStreamExceptionTest {
 
     @ParameterizedTest
     @MethodSource("parameters")
-    public void testReadBytes(Exception t, Class<? extends Exception> expected) throws Exception {
+    void testReadBytes(Exception t, Class<? extends Exception> expected) throws Exception {
         doThrow(t).when(delegate).read(Mockito.any(byte[].class), anyInt(), anyInt());
         byte[] buffer = new byte[20];
         assertThatExceptionOfType(expected).isThrownBy(() -> in.read(buffer, 4, 16));
@@ -46,7 +46,7 @@ public class ZipExceptionHandlingInputStreamExceptionTest {
 
     @ParameterizedTest
     @MethodSource("parameters")
-    public void testReadByte(Exception t, Class<? extends Exception> expected) throws Exception {
+    void testReadByte(Exception t, Class<? extends Exception> expected) throws Exception {
         doThrow(t).when(delegate).read();
         assertThatExceptionOfType(expected).isThrownBy(() -> in.read());
         verify(delegate).read();
@@ -55,7 +55,7 @@ public class ZipExceptionHandlingInputStreamExceptionTest {
 
     @ParameterizedTest
     @MethodSource("parameters")
-    public void testSkip(Exception t, Class<? extends Exception> expected) throws Exception {
+    void testSkip(Exception t, Class<? extends Exception> expected) throws Exception {
         doThrow(t).when(delegate).skip(anyLong());
         assertThatExceptionOfType(expected).isThrownBy(() -> in.skip(42L));
         verify(delegate).skip(42L);
@@ -64,7 +64,7 @@ public class ZipExceptionHandlingInputStreamExceptionTest {
 
     @ParameterizedTest
     @MethodSource("parameters")
-    public void testAvailable(Exception t, Class<? extends Exception> expected) throws Exception {
+    void testAvailable(Exception t, Class<? extends Exception> expected) throws Exception {
         doThrow(t).when(delegate).available();
         assertThatExceptionOfType(expected).isThrownBy(() -> in.available());
         verify(delegate).available();
@@ -73,7 +73,7 @@ public class ZipExceptionHandlingInputStreamExceptionTest {
 
     @ParameterizedTest
     @MethodSource("parameters")
-    public void testClose(Exception t, Class<? extends Exception> expected) throws Exception {
+    void testClose(Exception t, Class<? extends Exception> expected) throws Exception {
         doThrow(t).when(delegate).close();
         assertThatExceptionOfType(expected).isThrownBy(() -> in.close());
         verify(delegate).close();
@@ -82,7 +82,7 @@ public class ZipExceptionHandlingInputStreamExceptionTest {
 
     @ParameterizedTest
     @MethodSource("parameters")
-    public void testReset(Exception t, Class<? extends Exception> expected) throws Exception {
+    void testReset(Exception t, Class<? extends Exception> expected) throws Exception {
         doThrow(t).when(delegate).reset();
         assertThatExceptionOfType(expected).isThrownBy(() -> in.reset());
         verify(delegate).reset();


### PR DESCRIPTION
As identified by Sonar - unnecessary to have these public since JUnit 5