### PR TITLE
Mark remaining test classes private

### DIFF
--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
@@ -41,7 +41,7 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class LayoutIntegrationTests {
+class LayoutIntegrationTests {
 
     static {
         BootstrapLogging.bootstrap(Level.INFO, new EventJsonLayoutBaseFactory());

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/AccessJsonLayoutTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/AccessJsonLayoutTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.Mockito.when;
 
-public class AccessJsonLayoutTest {
+class AccessJsonLayoutTest {
 
     private String remoteHost = "nw-4.us.crawl.io";
     private String serverName = "sw-2.us.api.example.io";

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/EventJsonLayoutTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/EventJsonLayoutTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class EventJsonLayoutTest {
+class EventJsonLayoutTest {
     private static final String timestamp = "2018-01-02T15:19:21.000+0000";
     private static final String logger = "com.example.user.service";
     private static final String message = "User[18] has been registered";

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/ExceptionFormatTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/ExceptionFormatTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ExceptionFormatTest {
+class ExceptionFormatTest {
 
     @Test
     void testDefaults() {

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/JsonFormatterTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/JsonFormatterTest.java
@@ -13,7 +13,7 @@ import java.util.TreeMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class JsonFormatterTest {
+class JsonFormatterTest {
 
     private final SortedMap<String, Object> map = new TreeMap<>(Maps.of(
             "name", "Jim",

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/MapBuilderTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/MapBuilderTest.java
@@ -8,7 +8,7 @@ import java.util.Collections;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
-public class MapBuilderTest {
+class MapBuilderTest {
 
     private int size = 4;
     private TimestampFormatter timestampFormatter = new TimestampFormatter("yyyy-MM-dd'T'HH:mm:ss.SSSZ", ZoneId.of("UTC"));

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/TimestampFormatterTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/TimestampFormatterTest.java
@@ -6,7 +6,7 @@ import java.time.ZoneId;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TimestampFormatterTest {
+class TimestampFormatterTest {
 
     private final long timestamp = 1513956631000L;
 

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/AutoCloseableManagerTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/AutoCloseableManagerTest.java
@@ -5,7 +5,7 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 
-public class AutoCloseableManagerTest {
+class AutoCloseableManagerTest {
 
     private final AutoCloseable managed = mock(AutoCloseable.class);
     private final AutoCloseableManager closeableManager = new AutoCloseableManager(this.managed);

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/ExecutorServiceManagerTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/ExecutorServiceManagerTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import io.dropwizard.util.Duration;
 
-public class ExecutorServiceManagerTest {
+class ExecutorServiceManagerTest {
 
     private static final Duration TEST_DURATION = Duration.seconds(1L);
     private final ExecutorService exec = mock(ExecutorService.class);

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/JettyManagedTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/JettyManagedTest.java
@@ -6,7 +6,7 @@ import org.mockito.InOrder;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 
-public class JettyManagedTest {
+class JettyManagedTest {
     private final Managed managed = mock(Managed.class);
     private final JettyManaged jettyManaged = new JettyManaged(managed);
 

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/LifecycleEnvironmentTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/LifecycleEnvironmentTest.java
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-public class LifecycleEnvironmentTest {
+class LifecycleEnvironmentTest {
 
     private final LifecycleEnvironment environment = new LifecycleEnvironment(new MetricRegistry());
 

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilderTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ScheduledExecutorServiceBuilderTest.java
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ScheduledExecutorServiceBuilderTest {
+class ScheduledExecutorServiceBuilderTest {
 
     private static final Duration DEFAULT_SHUTDOWN_PERIOD = Duration.seconds(5L);
 

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/AppenderFactoryCustomTimeZoneTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/AppenderFactoryCustomTimeZoneTest.java
@@ -20,7 +20,7 @@ import java.util.TimeZone;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class AppenderFactoryCustomTimeZoneTest {
+class AppenderFactoryCustomTimeZoneTest {
 
     static {
         BootstrapLogging.bootstrap();

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/ConsoleAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/ConsoleAppenderFactoryTest.java
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ConsoleAppenderFactoryTest {
+class ConsoleAppenderFactoryTest {
     static {
         BootstrapLogging.bootstrap();
     }

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/DefaultLoggingFactoryPrintErrorMessagesTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/DefaultLoggingFactoryPrintErrorMessagesTest.java
@@ -22,7 +22,7 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class DefaultLoggingFactoryPrintErrorMessagesTest {
+class DefaultLoggingFactoryPrintErrorMessagesTest {
     private DefaultLoggingFactory factory;
     private ByteArrayOutputStream output;
 

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/DefaultLoggingFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/DefaultLoggingFactoryTest.java
@@ -35,7 +35,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DefaultLoggingFactoryTest {
+class DefaultLoggingFactoryTest {
     private final ObjectMapper objectMapper = Jackson.newObjectMapper();
     private final YamlConfigurationFactory<DefaultLoggingFactory> factory = new YamlConfigurationFactory<>(
             DefaultLoggingFactory.class,

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/DropwizardLayoutTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/DropwizardLayoutTest.java
@@ -8,7 +8,7 @@ import java.util.TimeZone;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-public class DropwizardLayoutTest {
+class DropwizardLayoutTest {
     private final LoggerContext context = mock(LoggerContext.class);
     private final TimeZone timeZone = TimeZone.getTimeZone("UTC");
     private final DropwizardLayout layout = new DropwizardLayout(context, timeZone);

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/ExternalLoggingFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/ExternalLoggingFactoryTest.java
@@ -11,7 +11,7 @@ import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ExternalLoggingFactoryTest {
+class ExternalLoggingFactoryTest {
 
     @Test
     void canBeDeserialized() throws Exception {

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/PrefixedExtendedThrowableProxyConverterTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/PrefixedExtendedThrowableProxyConverterTest.java
@@ -9,7 +9,7 @@ import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class PrefixedExtendedThrowableProxyConverterTest {
+class PrefixedExtendedThrowableProxyConverterTest {
     private final PrefixedExtendedThrowableProxyConverter converter = new PrefixedExtendedThrowableProxyConverter();
     private final ThrowableProxy proxy = new ThrowableProxy(new IOException("noo"));
 

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/PrefixedRootCauseFirstThrowableProxyConverterTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/PrefixedRootCauseFirstThrowableProxyConverterTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests {@link PrefixedRootCauseFirstThrowableProxyConverter}.
  */
-public class PrefixedRootCauseFirstThrowableProxyConverterTest {
+class PrefixedRootCauseFirstThrowableProxyConverterTest {
 
     private final PrefixedRootCauseFirstThrowableProxyConverter converter
             = new PrefixedRootCauseFirstThrowableProxyConverter();

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/PrefixedThrowableProxyConverterTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/PrefixedThrowableProxyConverterTest.java
@@ -9,7 +9,7 @@ import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class PrefixedThrowableProxyConverterTest {
+class PrefixedThrowableProxyConverterTest {
     private final PrefixedThrowableProxyConverter converter = new PrefixedThrowableProxyConverter();
     private final ThrowableProxy proxy = new ThrowableProxy(new IOException("noo"));
 

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/SyslogAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/SyslogAppenderFactoryTest.java
@@ -18,7 +18,7 @@ import java.util.Locale;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-public class SyslogAppenderFactoryTest {
+class SyslogAppenderFactoryTest {
 
     static {
         BootstrapLogging.bootstrap();

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/TlsSocketAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/TlsSocketAppenderFactoryTest.java
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TlsSocketAppenderFactoryTest {
+class TlsSocketAppenderFactoryTest {
 
     public TcpServer tcpServer = new TcpServer(createServerSocket());
 

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/UdpSocketAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/UdpSocketAppenderFactoryTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeUnit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class UdpSocketAppenderFactoryTest {
+class UdpSocketAppenderFactoryTest {
 
     private static final int UDP_PORT = 32144;
 

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/socket/DropwizardUdpSocketAppenderTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/socket/DropwizardUdpSocketAppenderTest.java
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DropwizardUdpSocketAppenderTest {
+class DropwizardUdpSocketAppenderTest {
 
     private OutputStreamAppender<ILoggingEvent> udpStreamAppender;
 

--- a/dropwizard-metrics-graphite/src/test/java/io/dropwizard/metrics/graphite/GraphiteReporterFactoryTest.java
+++ b/dropwizard-metrics-graphite/src/test/java/io/dropwizard/metrics/graphite/GraphiteReporterFactoryTest.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class GraphiteReporterFactoryTest {
+class GraphiteReporterFactoryTest {
 
     private final GraphiteReporter.Builder builderSpy = mock(GraphiteReporter.Builder.class);
 

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/BaseReporterFactoryTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/BaseReporterFactoryTest.java
@@ -16,12 +16,12 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-public class BaseReporterFactoryTest {
+class BaseReporterFactoryTest {
     private static final Set<String> INCLUDES = Sets.of("inc", "both", "inc.+");
     private static final Set<String> EXCLUDES = Sets.of("exc", "both", "exc.+");
     private static final Set<String> EMPTY = Collections.emptySet();
 
-    public static Stream<Arguments> data() {
+    static Stream<Arguments> data() {
 
         return Stream.of(
                 /*
@@ -85,7 +85,7 @@ public class BaseReporterFactoryTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testDefaultMatching(Set<String> includes, Set<String> excludes, String name,
+    void testDefaultMatching(Set<String> includes, Set<String> excludes, String name,
                                     boolean expectedDefaultResult, boolean expectedRegexResult,
                                     boolean expectedSubstringResult, String msg) {
         factory.setIncludes(includes);
@@ -100,7 +100,7 @@ public class BaseReporterFactoryTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testRegexMatching(Set<String> includes, Set<String> excludes, String name,
+    void testRegexMatching(Set<String> includes, Set<String> excludes, String name,
                                   boolean expectedDefaultResult, boolean expectedRegexResult,
                                   boolean expectedSubstringResult, String msg) {
         factory.setIncludes(includes);
@@ -115,7 +115,7 @@ public class BaseReporterFactoryTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void tesSubstringMatching(Set<String> includes, Set<String> excludes, String name,
+    void tesSubstringMatching(Set<String> includes, Set<String> excludes, String name,
                                      boolean expectedDefaultResult, boolean expectedRegexResult,
                                      boolean expectedSubstringResult, String msg) {
         factory.setIncludes(includes);

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/ConsoleReporterFactoryTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/ConsoleReporterFactoryTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ConsoleReporterFactoryTest {
+class ConsoleReporterFactoryTest {
     @Test
     void isDiscoverable() throws Exception {
         assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/CsvReporterFactoryTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/CsvReporterFactoryTest.java
@@ -15,7 +15,7 @@ import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CsvReporterFactoryTest {
+class CsvReporterFactoryTest {
     private final ObjectMapper objectMapper = Jackson.newObjectMapper();
     private final YamlConfigurationFactory<MetricsFactory> factory =
             new YamlConfigurationFactory<>(MetricsFactory.class,

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/MetricAttributesTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/MetricAttributesTest.java
@@ -12,7 +12,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MetricAttributesTest {
+class MetricAttributesTest {
 
     private static final EnumSet<MetricAttribute> ALL = EnumSet.allOf(MetricAttribute.class);
     private static final EnumSet<MetricAttribute> NONE = EnumSet.noneOf(MetricAttribute.class);
@@ -36,7 +36,7 @@ public class MetricAttributesTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testGetDisabledAttributes(EnumSet<MetricAttribute> includes, EnumSet<MetricAttribute> excludes,
+    void testGetDisabledAttributes(EnumSet<MetricAttribute> includes, EnumSet<MetricAttribute> excludes,
                                           EnumSet<MetricAttribute> expectedResult) {
         factory.setIncludesAttributes(includes);
         factory.setExcludesAttributes(excludes);

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/MetricsFactoryTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/MetricsFactoryTest.java
@@ -16,7 +16,7 @@ import java.util.EnumSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MetricsFactoryTest {
+class MetricsFactoryTest {
     static {
         BootstrapLogging.bootstrap();
     }

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/ScheduledReporterManagerTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/ScheduledReporterManagerTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-public class ScheduledReporterManagerTest {
+class ScheduledReporterManagerTest {
 
     @Test
     void testStopWithoutReporting() throws Exception {

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/Slf4jReporterFactoryTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/Slf4jReporterFactoryTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class Slf4jReporterFactoryTest {
+class Slf4jReporterFactoryTest {
     @Test
     void isDiscoverable() throws Exception {
         assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/AbstractMigrationTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/AbstractMigrationTest.java
@@ -10,7 +10,7 @@ import org.jdbi.v3.core.Handle;
 import java.sql.SQLException;
 import java.util.UUID;
 
-public class AbstractMigrationTest {
+class AbstractMigrationTest {
 
     static {
         SqlGeneratorFactory.getInstance().unregister(AddColumnGeneratorSQLite.class);

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/CloseableLiquibaseTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/CloseableLiquibaseTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
-public class CloseableLiquibaseTest {
+class CloseableLiquibaseTest {
 
     CloseableLiquibase liquibase;
     ManagedPooledDataSource dataSource;

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbCalculateChecksumCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbCalculateChecksumCommandTest.java
@@ -16,7 +16,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
-public class DbCalculateChecksumCommandTest extends AbstractMigrationTest {
+class DbCalculateChecksumCommandTest extends AbstractMigrationTest {
 
     private final DbCalculateChecksumCommand<TestMigrationConfiguration> migrateCommand = new DbCalculateChecksumCommand<>(
         TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations.xml");

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbClearChecksumsCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbClearChecksumsCommandTest.java
@@ -15,7 +15,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
-public class DbClearChecksumsCommandTest extends AbstractMigrationTest {
+class DbClearChecksumsCommandTest extends AbstractMigrationTest {
 
     private final DbClearChecksumsCommand<TestMigrationConfiguration> clearChecksums = new DbClearChecksumsCommand<>(
         TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations.xml");

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDumpCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDumpCommandTest.java
@@ -32,7 +32,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
-public class DbDumpCommandTest extends AbstractMigrationTest {
+class DbDumpCommandTest extends AbstractMigrationTest {
 
     private static final List<String> ATTRIBUTE_NAMES = Arrays.asList("columns", "foreign-keys", "indexes",
             "primary-keys", "sequences", "tables", "unique-constraints", "views");

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbGenerateDocsCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbGenerateDocsCommandTest.java
@@ -15,7 +15,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
-public class DbGenerateDocsCommandTest extends AbstractMigrationTest {
+class DbGenerateDocsCommandTest extends AbstractMigrationTest {
 
     private final DbGenerateDocsCommand<TestMigrationConfiguration> generateDocsCommand = new DbGenerateDocsCommand<>(
         TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations.xml");

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbLocksCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbLocksCommandTest.java
@@ -16,7 +16,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.*;
 
 @NotThreadSafe
-public class DbLocksCommandTest extends AbstractMigrationTest {
+class DbLocksCommandTest extends AbstractMigrationTest {
 
     private final DbLocksCommand<TestMigrationConfiguration> locksCommand = new DbLocksCommand<>(
         TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations.xml");

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbPrepareRollbackCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbPrepareRollbackCommandTest.java
@@ -15,7 +15,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
-public class DbPrepareRollbackCommandTest extends AbstractMigrationTest {
+class DbPrepareRollbackCommandTest extends AbstractMigrationTest {
 
     private final DbPrepareRollbackCommand<TestMigrationConfiguration> prepareRollbackCommand =
         new DbPrepareRollbackCommand<>(new TestMigrationDatabaseConfiguration(), TestMigrationConfiguration.class,

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbStatusCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbStatusCommandTest.java
@@ -17,7 +17,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
-public class DbStatusCommandTest extends AbstractMigrationTest {
+class DbStatusCommandTest extends AbstractMigrationTest {
 
     private final DbStatusCommand<TestMigrationConfiguration> statusCommand =
             new DbStatusCommand<>(new TestMigrationDatabaseConfiguration(), TestMigrationConfiguration.class, "migrations.xml");

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbTagCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbTagCommandTest.java
@@ -13,7 +13,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
-public class DbTagCommandTest extends AbstractMigrationTest {
+class DbTagCommandTest extends AbstractMigrationTest {
 
     private final String migrationsFileName = "migrations-ddl.xml";
     private final DbTagCommand<TestMigrationConfiguration> dbTagCommand = new DbTagCommand<>(

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbTestCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbTestCommandTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 @NotThreadSafe
-public class DbTestCommandTest extends AbstractMigrationTest {
+class DbTestCommandTest extends AbstractMigrationTest {
 
     private final DbTestCommand<TestMigrationConfiguration> dbTestCommand = new DbTestCommand<>(
         new TestMigrationDatabaseConfiguration(), TestMigrationConfiguration.class, "migrations-ddl.xml");

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/LogbackAccessRequestLogTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/LogbackAccessRequestLogTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class LogbackAccessRequestLogTest {
+class LogbackAccessRequestLogTest {
 
     @SuppressWarnings("unchecked")
     private final Appender<IAccessEvent> appender = mock(Appender.class);

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/RequestLogFactoryTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/RequestLogFactoryTest.java
@@ -16,7 +16,7 @@ import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class RequestLogFactoryTest {
+class RequestLogFactoryTest {
     private LogbackAccessRequestLogFactory logbackAccessRequestLogFactory;
 
     @BeforeEach

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/filter/UriFilterFactoryTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/filter/UriFilterFactoryTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
-public class UriFilterFactoryTest {
+class UriFilterFactoryTest {
     private final IAccessEvent accessEvent = mock(IAccessEvent.class);
     private final UriFilterFactory filterFactory = new UriFilterFactory();
 

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/layout/LogbackAccessRequestLayoutTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/layout/LogbackAccessRequestLayoutTest.java
@@ -9,7 +9,7 @@ import java.util.TimeZone;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-public class LogbackAccessRequestLayoutTest {
+class LogbackAccessRequestLayoutTest {
     final Context context = mock(LoggerContext.class);
     private final TimeZone timeZone = TimeZone.getTimeZone("UTC");
     final LogbackAccessRequestLayout layout = new LogbackAccessRequestLayout(context, timeZone);

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/layout/SafeRequestParameterConverterTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/layout/SafeRequestParameterConverterTest.java
@@ -13,7 +13,7 @@ import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SafeRequestParameterConverterTest {
+class SafeRequestParameterConverterTest {
 
     private final SafeRequestParameterConverter safeRequestParameterConverter = new SafeRequestParameterConverter();
     private final HttpServletRequest httpServletRequest = Mockito.mock(HttpServletRequest.class);

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/old/DropwizardSlf4jRequestLogWriterTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/old/DropwizardSlf4jRequestLogWriterTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class DropwizardSlf4jRequestLogWriterTest {
+class DropwizardSlf4jRequestLogWriterTest {
     static {
         BootstrapLogging.bootstrap();
     }

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/old/LogbackClassicRequestLogFactoryTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/old/LogbackClassicRequestLogFactoryTest.java
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class LogbackClassicRequestLogFactoryTest {
+class LogbackClassicRequestLogFactoryTest {
 
     static {
         BootstrapLogging.bootstrap();

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/CacheBustingFilterTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/CacheBustingFilterTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
-public class CacheBustingFilterTest {
+class CacheBustingFilterTest {
     private final HttpServletRequest request = mock(HttpServletRequest.class);
     private final HttpServletResponse response = mock(HttpServletResponse.class);
     private final FilterChain chain = mock(FilterChain.class);

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/ServletsTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/ServletsTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class ServletsTest {
+class ServletsTest {
     private final HttpServletRequest request = mock(HttpServletRequest.class);
     private final HttpServletRequest fullRequest = mock(HttpServletRequest.class);
 

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/SlowRequestFilterTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/SlowRequestFilterTest.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class SlowRequestFilterTest {
+class SlowRequestFilterTest {
 
     private HttpServletRequest request = mock(HttpServletRequest.class);
     private HttpServletResponse response = mock(HttpServletResponse.class);

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/ThreadNameFilterTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/ThreadNameFilterTest.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ThreadNameFilterTest {
+class ThreadNameFilterTest {
 
     private HttpServletRequest request = mock(HttpServletRequest.class);
 

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/assets/ByteRangeTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/assets/ByteRangeTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ByteRangeTest {
+class ByteRangeTest {
 
     private static final int RESOURCE_LENGTH = 10000;
 
@@ -52,7 +52,7 @@ public class ByteRangeTest {
     }
 
     @Test
-    public void nonASCIIDisallowed() {
+    void nonASCIIDisallowed() {
         assertThatExceptionOfType(NumberFormatException.class)
             .isThrownBy(() -> ByteRange.parse("០-០", RESOURCE_LENGTH));
     }

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/GarbageCollectionTaskTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/GarbageCollectionTaskTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @SuppressWarnings("CallToSystemGC")
-public class GarbageCollectionTaskTest {
+class GarbageCollectionTaskTest {
     private final Runtime runtime = mock(Runtime.class);
     private final PrintWriter output = mock(PrintWriter.class);
     private final GarbageCollectionTask task = new GarbageCollectionTask(runtime);

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/LogConfigurationTaskTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/LogConfigurationTaskTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class LogConfigurationTaskTest {
+class LogConfigurationTaskTest {
 
     private final LoggerContext loggerContext = new LoggerContext();
     private final Logger logger1 = loggerContext.getLogger("logger.one");

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/PostBodyTaskTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/PostBodyTaskTest.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class PostBodyTaskTest {
+class PostBodyTaskTest {
     private final PostBodyTask task = new PostBodyTask("test") {
         @Override
         public void execute(Map<String, List<String>> parameters, String body, PrintWriter output) throws Exception {

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/TaskTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/TaskTest.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TaskTest {
+class TaskTest {
     private final Task task = new Task("test") {
         @Override
         public void execute(Map<String, List<String>> parameters,

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/LogbackExcludedTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/LogbackExcludedTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.fail;
 /**
  * Verify that Logback can be excluded from the classpath without generating any noise.
  */
-public class LogbackExcludedTest {
+class LogbackExcludedTest {
 
     @Test
     void testLogbackExcludedClassNotFound() throws Exception {

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/ResourceExtensionRandomPortsTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/ResourceExtensionRandomPortsTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ResourceExtensionRandomPortsTest {
 
     @Test
-    public void eachTestShouldUseANewPort() throws Throwable {
+    void eachTestShouldUseANewPort() throws Throwable {
         final ResourceExtension resources = ResourceExtension.builder()
                 .setTestContainerFactory(new GrizzlyTestContainerFactory())
                 .build();

--- a/dropwizard-util/src/test/java/io/dropwizard/util/ByteStreamsTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/ByteStreamsTest.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-public class ByteStreamsTest {
+class ByteStreamsTest {
 
     @Test
     void testToByteArray() throws IOException {

--- a/dropwizard-util/src/test/java/io/dropwizard/util/CharStreamsTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/CharStreamsTest.java
@@ -7,7 +7,7 @@ import java.io.StringReader;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CharStreamsTest {
+class CharStreamsTest {
 
     @Test
     void testToString() throws IOException {

--- a/dropwizard-util/src/test/java/io/dropwizard/util/DurationTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/DurationTest.java
@@ -13,7 +13,7 @@ import java.util.concurrent.TimeUnit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
-public class DurationTest {
+class DurationTest {
     @Test
     void convertsDays() throws Exception {
         assertThat(Duration.days(2).toDays())

--- a/dropwizard-util/src/test/java/io/dropwizard/util/EnumsTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/EnumsTest.java
@@ -8,7 +8,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class EnumsTest {
+class EnumsTest {
 
     enum VideoFormat {
         OGG,

--- a/dropwizard-util/src/test/java/io/dropwizard/util/GenericsTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/GenericsTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @SuppressWarnings("serial")
-public class GenericsTest<T> {
+class GenericsTest<T> {
 
     public static Stream<Arguments> data() {
         return Stream.of(

--- a/dropwizard-util/src/test/java/io/dropwizard/util/JarLocationTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/JarLocationTest.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class JarLocationTest {
+class JarLocationTest {
     @Test
     void isHumanReadable() throws Exception {
         assertThat(new JarLocation(JarLocationTest.class))

--- a/dropwizard-util/src/test/java/io/dropwizard/util/MapsTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/MapsTest.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MapsTest {
+class MapsTest {
 
     @Test
     void of2KeyValuePairs() {

--- a/dropwizard-util/src/test/java/io/dropwizard/util/OptionalsTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/OptionalsTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class OptionalsTest {
+class OptionalsTest {
     @Test
     void testFromGuavaOptional() throws Exception {
         assertFalse(Optionals.fromGuavaOptional(com.google.common.base.Optional.absent()).isPresent());

--- a/dropwizard-util/src/test/java/io/dropwizard/util/SetsTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/SetsTest.java
@@ -8,7 +8,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SetsTest {
+class SetsTest {
 
     @Test
     void of2Elements() {

--- a/dropwizard-util/src/test/java/io/dropwizard/util/StringsTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/StringsTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class StringsTest {
+class StringsTest {
 
   @Test
   void emptyToNull() {

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/DurationValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/DurationValidatorTest.java
@@ -14,7 +14,7 @@ import java.util.concurrent.TimeUnit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class DurationValidatorTest {
+class DurationValidatorTest {
     @SuppressWarnings("unused")
     public static class Example {
         @MaxDuration(value = 30, unit = TimeUnit.SECONDS)

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/MethodValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/MethodValidatorTest.java
@@ -9,7 +9,7 @@ import java.util.Collection;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings({"FieldMayBeFinal", "MethodMayBeStatic", "UnusedDeclaration"})
-public class MethodValidatorTest {
+class MethodValidatorTest {
     public static class SubExample {
         @ValidationMethod(message = "also needs something special")
         public boolean isOK() {

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/OneOfValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/OneOfValidatorTest.java
@@ -12,7 +12,7 @@ import static io.dropwizard.validation.ConstraintViolations.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class OneOfValidatorTest {
+class OneOfValidatorTest {
     @SuppressWarnings("UnusedDeclaration")
     public static class Example {
         @OneOf({"one", "two", "three"})

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/PortRangeValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/PortRangeValidatorTest.java
@@ -12,7 +12,7 @@ import java.util.Locale;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
-public class PortRangeValidatorTest {
+class PortRangeValidatorTest {
     @SuppressWarnings("PublicField")
     public static class Example {
         @PortRange

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/SelfValidationTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/SelfValidationTest.java
@@ -18,7 +18,7 @@ import java.util.Collections;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
-public class SelfValidationTest {
+class SelfValidationTest {
 
     private static final String FAILED = "failed";
     private static final String FAILED_RESULT = " " + FAILED;

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/SizeValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/SizeValidatorTest.java
@@ -13,7 +13,7 @@ import java.util.Locale;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class SizeValidatorTest {
+class SizeValidatorTest {
     @SuppressWarnings("unused")
     public static class Example {
         @MaxSize(value = 30, unit = SizeUnit.KILOBYTES)

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/selfvalidating/SelfValidatingValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/selfvalidating/SelfValidatingValidatorTest.java
@@ -16,7 +16,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SelfValidatingValidatorTest {
+class SelfValidatingValidatorTest {
     private SelfValidatingValidator selfValidatingValidator = new SelfValidatingValidator();
 
     @Test

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/valuehandling/GuavaOptionalValueExtractorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/valuehandling/GuavaOptionalValueExtractorTest.java
@@ -14,7 +14,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class GuavaOptionalValueExtractorTest {
+class GuavaOptionalValueExtractorTest {
 
     public static class Example {
 

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/valuehandling/OptionalValidatedValueUnwrapperTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/valuehandling/OptionalValidatedValueUnwrapperTest.java
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 // Dropwizard used to supply its own Java 8 optional validator but since
 // Hibernate Validator 5.2, it's built in, so the class was removed but
 // the test class stays to ensure behavior remains
-public class OptionalValidatedValueUnwrapperTest {
+class OptionalValidatedValueUnwrapperTest {
 
     public static class Example {
 

--- a/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/FreemarkerViewRendererTest.java
+++ b/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/FreemarkerViewRendererTest.java
@@ -30,7 +30,7 @@ import java.util.Collections;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class FreemarkerViewRendererTest extends JerseyTest {
+class FreemarkerViewRendererTest extends JerseyTest {
     static {
         BootstrapLogging.bootstrap();
     }
@@ -116,7 +116,7 @@ public class FreemarkerViewRendererTest extends JerseyTest {
 
     @Test
     @Disabled("Flaky on JUnit5")
-    public void returnsA500ForViewsThatCantCompile() {
+    void returnsA500ForViewsThatCantCompile() {
         assertThatExceptionOfType(WebApplicationException.class)
             .isThrownBy(() -> target("/test/error").request().get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(500))

--- a/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/MultipleContentTypeTest.java
+++ b/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/MultipleContentTypeTest.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MultipleContentTypeTest extends JerseyTest {
+class MultipleContentTypeTest extends JerseyTest {
     static {
         BootstrapLogging.bootstrap();
     }

--- a/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererFileSystemTest.java
+++ b/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererFileSystemTest.java
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  *
  * @since 1.1.0
  */
-public class MustacheViewRendererFileSystemTest extends JerseyTest {
+class MustacheViewRendererFileSystemTest extends JerseyTest {
     static {
         BootstrapLogging.bootstrap();
     }

--- a/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererTest.java
+++ b/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererTest.java
@@ -23,7 +23,7 @@ import java.util.Collections;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
-public class MustacheViewRendererTest extends JerseyTest {
+class MustacheViewRendererTest extends JerseyTest {
     static {
         BootstrapLogging.bootstrap();
     }

--- a/dropwizard-views/src/test/java/io/dropwizard/views/ViewMessageBodyWriterTest.java
+++ b/dropwizard-views/src/test/java/io/dropwizard/views/ViewMessageBodyWriterTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-public class ViewMessageBodyWriterTest {
+class ViewMessageBodyWriterTest {
 
     public ContainerRequest headers = mock(ContainerRequest.class);
     public MetricRegistry metricRegistry = mock(MetricRegistry.class);

--- a/dropwizard-views/src/test/java/io/dropwizard/views/ViewTest.java
+++ b/dropwizard-views/src/test/java/io/dropwizard/views/ViewTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ViewTest {
+class ViewTest {
     private final View view = new View("/blah.tmp") {
     };
 


### PR DESCRIPTION
This is the last batch which Sonar is unhappy about.

Since JUnit 5, test classes and methods needn't be public