### PR TITLE
Sonar tidy

### DIFF
--- a/dropwizard-e2e/src/main/java/com/example/app1/CustomClassBodyWriter.java
+++ b/dropwizard-e2e/src/main/java/com/example/app1/CustomClassBodyWriter.java
@@ -14,7 +14,7 @@ import java.nio.charset.StandardCharsets;
 /** Demonstration that one can provider their own message body writers (see issue #1005) */
 @Produces(MediaType.APPLICATION_JSON)
 public class CustomClassBodyWriter implements MessageBodyWriter<CustomClass> {
-    private final static byte[] RESPONSE = "I'm a custom class".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] RESPONSE = "I'm a custom class".getBytes(StandardCharsets.UTF_8);
 
     @Override
     public boolean isWriteable(Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType) {

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -183,34 +183,6 @@ public class DropwizardResourceConfig extends ResourceConfig {
         return PATH_DIRTY_SLASHES.matcher(path).replaceAll("/").trim();
     }
 
-    private static String mergePaths(@NotNull String context, String... pathSegments) {
-        if (pathSegments == null || pathSegments.length == 0) {
-            return cleanUpPath(context);
-        }
-
-        final StringBuilder path = new StringBuilder();
-        if (context.endsWith("/")) {
-            path.append(context, 0, context.length() - 1);
-        } else {
-            path.append(context);
-        }
-
-        for (String segment : pathSegments) {
-            if (Strings.isNullOrEmpty(segment)) {
-                continue;
-            }
-            if ("/".equals(segment)) {
-                path.append('/');
-            } else {
-                final int startIndex = segment.startsWith("/") ? 1 : 0;
-                final int endIndex = segment.endsWith("/") ? segment.length() - 1 : segment.length();
-                path.append('/').append(segment, startIndex, endIndex);
-            }
-        }
-
-        return cleanUpPath(path.toString());
-    }
-
     /**
      * @since 2.0
      */
@@ -322,6 +294,34 @@ public class DropwizardResourceConfig extends ResourceConfig {
             }
 
             return methodLines;
+        }
+
+        private static String mergePaths(@NotNull String context, String... pathSegments) {
+            if (pathSegments == null || pathSegments.length == 0) {
+                return cleanUpPath(context);
+            }
+
+            final StringBuilder path = new StringBuilder();
+            if (context.endsWith("/")) {
+                path.append(context, 0, context.length() - 1);
+            } else {
+                path.append(context);
+            }
+
+            for (String segment : pathSegments) {
+                if (Strings.isNullOrEmpty(segment)) {
+                    continue;
+                }
+                if ("/".equals(segment)) {
+                    path.append('/');
+                } else {
+                    final int startIndex = segment.startsWith("/") ? 1 : 0;
+                    final int endIndex = segment.endsWith("/") ? segment.length() - 1 : segment.length();
+                    path.append('/').append(segment, startIndex, endIndex);
+                }
+            }
+
+            return cleanUpPath(path.toString());
         }
 
         private List<EndpointLogLine> logResourceLines(Resource resource, String contextPath) {

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/ZipExceptionHandlingInputStream.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/ZipExceptionHandlingInputStream.java
@@ -77,7 +77,7 @@ class ZipExceptionHandlingInputStream extends InputStream {
     }
 
     @Override
-    synchronized public void reset() throws IOException {
+    public synchronized void reset() throws IOException {
         try {
             delegate.reset();
         } catch (IOException e) {

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
@@ -249,18 +249,18 @@ class HttpsConnectorFactoryTest {
     @Test
     void nonWindowsKeyStoreValidation() {
         HttpsConnectorFactory factory = new HttpsConnectorFactory();
-        Collection<String> properties = getViolationProperties(validator.validate(factory));
-        assertThat(properties).contains("validKeyStorePassword");
-        assertThat(properties).contains("validKeyStorePath");
+        assertThat(getViolationProperties(validator.validate(factory)))
+                .contains("validKeyStorePassword")
+                .contains("validKeyStorePath");
     }
 
     @Test
     void windowsKeyStoreValidation() {
         HttpsConnectorFactory factory = new HttpsConnectorFactory();
         factory.setKeyStoreType(WINDOWS_MY_KEYSTORE_NAME);
-        Collection<String> properties = getViolationProperties(validator.validate(factory));
-        assertThat(properties).doesNotContain("validKeyStorePassword");
-        assertThat(properties).doesNotContain("validKeyStorePath");
+        assertThat(getViolationProperties(validator.validate(factory)))
+                .doesNotContain("validKeyStorePassword")
+                .doesNotContain("validKeyStorePath");
     }
 
     @Test

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NetUtilTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NetUtilTest.java
@@ -62,17 +62,17 @@ class NetUtilTest {
     void testAllLocalIps() throws Exception {
         NetUtil.setLocalIpFilter((nif, adr) ->
             (adr != null) && !adr.isLoopbackAddress() && (nif.isPointToPoint() || !adr.isLinkLocalAddress()));
-        final Collection<InetAddress> addresses = NetUtil.getAllLocalIPs();
-        assertThat(addresses).isNotEmpty();
-        assertThat(addresses).doesNotContain(InetAddress.getLoopbackAddress());
+        assertThat(NetUtil.getAllLocalIPs())
+                .isNotEmpty()
+                .doesNotContain(InetAddress.getLoopbackAddress());
     }
 
     @Test
     void testLocalIpsWithLocalFilter() throws Exception {
         NetUtil.setLocalIpFilter((inf, adr) -> adr != null);
-        final Collection<InetAddress> addresses = NetUtil.getAllLocalIPs();
-        assertThat(addresses).isNotEmpty();
-        assertThat(addresses).contains(InetAddress.getLoopbackAddress());
+        assertThat(NetUtil.getAllLocalIPs())
+                .isNotEmpty()
+                .contains(InetAddress.getLoopbackAddress());
     }
 
     private boolean isTcpBacklogSettingReadable() {

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/ResilientOutputStreamBase.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/ResilientOutputStreamBase.java
@@ -33,7 +33,7 @@ import java.io.OutputStream;
 @SuppressWarnings("NullAway")
 abstract class ResilientOutputStreamBase extends OutputStream {
 
-    private final static int STATUS_COUNT_LIMIT = 2 * 4;
+    private static final int STATUS_COUNT_LIMIT = 2 * 4;
 
     private int noContextWarning = 0;
     private int statusCount = 0;

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/common/DAOTest.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/common/DAOTest.java
@@ -18,7 +18,7 @@ import java.util.function.Consumer;
 
 public class DAOTest {
     @SuppressWarnings("unchecked")
-    public static abstract class Builder<B extends Builder<B>> {
+    public abstract static class Builder<B extends Builder<B>> {
         private String url = "jdbc:h2:mem:" + UUID.randomUUID();
         private String username = "sa";
         private String password = "";

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/SelfValidatingValidator.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/SelfValidatingValidator.java
@@ -82,7 +82,7 @@ public class SelfValidatingValidator implements ConstraintValidator<SelfValidati
         return true;
     }
 
-    final static class ProxyValidationCaller<T> extends ValidationCaller<T> {
+    static final class ProxyValidationCaller<T> extends ValidationCaller<T> {
         private final Class<T> cls;
         private final ResolvedMethod resolvedMethod;
 


### PR DESCRIPTION
###### Problem:
Sonar never stops complaining

- AssertJ assertions can be chained
- A private helper function is only used by an inner class
- The order of modifiers doesn't match the Java Language Specification

###### Solution:
Do the things Sonar suggests

###### Result:
Sonar will still complain, just marginally less.