### PR TITLE
More Sonar-induced fixups

### DIFF
--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/CachingAuthorizer.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/CachingAuthorizer.java
@@ -113,8 +113,7 @@ public class CachingAuthorizer<P extends Principal> implements Authorizer<P> {
     public boolean authorize(P principal, String role, @Nullable ContainerRequestContext requestContext) {
         try (Timer.Context context = getsTimer.time()) {
             final AuthorizationContext<P> cacheKey = getAuthorizationContext(principal, role, requestContext);
-            final Boolean result = cache.get(cacheKey);
-            return result == null ? false : result;
+            return Boolean.TRUE.equals(cache.get(cacheKey));
         } catch (CompletionException e) {
             Throwable cause = e.getCause();
             if (cause instanceof RuntimeException) {

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/BaseConfigurationFactory.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/BaseConfigurationFactory.java
@@ -173,11 +173,10 @@ public abstract class BaseConfigurationFactory<T> implements ConfigurationFactor
             final ObjectNode obj = (ObjectNode) node;
 
             final String remainingPath = String.join(".", parts.subList(i, parts.size()));
-            if (obj.has(remainingPath) && !remainingPath.equals(key)) {
-                if (obj.get(remainingPath).isValueNode()) {
-                    obj.put(remainingPath, value);
-                    return;
-                }
+            if (obj.has(remainingPath) && !remainingPath.equals(key)
+                    && obj.get(remainingPath).isValueNode()) {
+                obj.put(remainingPath, value);
+                return;
             }
 
             JsonNode child;

--- a/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/JdbiHealthCheckTest.java
+++ b/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/JdbiHealthCheckTest.java
@@ -25,7 +25,7 @@ import com.codahale.metrics.health.HealthCheck;
 
 import io.dropwizard.util.Duration;
 
-public class JdbiHealthCheckTest {
+class JdbiHealthCheckTest {
     private static final String VALIDATION_QUERY = "select 1";
 
     private Jdbi jdbi;

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/RuntimeFilterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/RuntimeFilterTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class RuntimeFilterTest {
+class RuntimeFilterTest {
 
     private ContainerRequestContext request = mock(ContainerRequestContext.class);
     private ContainerResponseContext response = mock(ContainerResponseContext.class);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalLongMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalLongMessageBodyWriterTest.java
@@ -21,7 +21,7 @@ import java.util.OptionalLong;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class OptionalLongMessageBodyWriterTest extends AbstractJerseyTest {
+class OptionalLongMessageBodyWriterTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalQueryParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalQueryParamResourceTest.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class OptionalQueryParamResourceTest extends AbstractJerseyTest {
+class OptionalQueryParamResourceTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/AccessJsonLayoutTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/AccessJsonLayoutTest.java
@@ -216,7 +216,7 @@ class AccessJsonLayoutTest {
     }
 
     @Test
-    public void testStartAndStop() {
+    void testStartAndStop() {
         accessJsonLayout.start();
         assertThat(accessJsonLayout.isStarted()).isTrue();
         accessJsonLayout.stop();

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/AppenderFactoryCustomLayoutTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/AppenderFactoryCustomLayoutTest.java
@@ -23,7 +23,7 @@ import java.net.URISyntaxException;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings("unchecked")
-public class AppenderFactoryCustomLayoutTest {
+class AppenderFactoryCustomLayoutTest {
 
     static {
         BootstrapLogging.bootstrap();

--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/assets/AssetServlet.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/assets/AssetServlet.java
@@ -211,13 +211,7 @@ public class AssetServlet extends HttpServlet {
                 final String ifRange = req.getHeader(IF_RANGE);
 
                 if (ifRange == null || cachedAsset.getETag().equals(ifRange)) {
-
-                    try {
-                        ranges = parseRangeHeader(rangeHeader, resourceLength);
-                    } catch (NumberFormatException e) {
-                        resp.sendError(HttpServletResponse.SC_REQUESTED_RANGE_NOT_SATISFIABLE);
-                        return;
-                    }
+                    ranges = parseRangeHeader(rangeHeader, resourceLength);
 
                     if (ranges.isEmpty()) {
                         resp.sendError(HttpServletResponse.SC_REQUESTED_RANGE_NOT_SATISFIABLE);
@@ -322,20 +316,24 @@ public class AssetServlet extends HttpServlet {
      * @return List of parsed ranges
      */
     private List<ByteRange> parseRangeHeader(final String rangeHeader, final int resourceLength) {
-        final List<ByteRange> byteRanges;
-        if (rangeHeader.contains("=")) {
-            final String[] parts = rangeHeader.split("=", -1);
-            if (parts.length > 1) {
-                byteRanges = Arrays.stream(parts[1].split(",", -1))
-                        .map(String::trim)
-                        .map(s -> ByteRange.parse(s, resourceLength))
-                        .collect(Collectors.toList());
-            } else {
-                byteRanges = Collections.emptyList();
-            }
-        } else {
-            byteRanges = Collections.emptyList();
+        try {
+			final List<ByteRange> byteRanges;
+			if (rangeHeader.contains("=")) {
+				final String[] parts = rangeHeader.split("=", -1);
+				if (parts.length > 1) {
+					byteRanges = Arrays.stream(parts[1].split(",", -1))
+							.map(String::trim)
+							.map(s -> ByteRange.parse(s, resourceLength))
+							.collect(Collectors.toList());
+				} else {
+					byteRanges = Collections.emptyList();
+				}
+			} else {
+				byteRanges = Collections.emptyList();
+			}
+			return byteRanges;
+        } catch (NumberFormatException e) {
+            return Collections.emptyList();
         }
-        return byteRanges;
     }
 }

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
@@ -252,10 +252,9 @@ public class DropwizardTestSupport<C extends Configuration> {
             }
             try {
                 jettyServer.stop();
+            } catch (RuntimeException e) {
+                throw (RuntimeException) e;
             } catch (Exception e) {
-                if (e instanceof RuntimeException) {
-                  throw (RuntimeException) e;
-                }
                 throw new RuntimeException(e);
             } finally {
                 jettyServer = null;

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/ResourceHelpers.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/ResourceHelpers.java
@@ -19,10 +19,9 @@ public class ResourceHelpers {
     public static String resourceFilePath(final String resourceClassPathLocation) {
         try {
             return new File(Resources.getResource(resourceClassPathLocation).toURI()).getAbsolutePath();
+        } catch (RuntimeException e) {
+            throw (RuntimeException) e;
         } catch (Exception e) {
-            if (e instanceof RuntimeException) {
-                throw (RuntimeException) e;
-            }
             throw new RuntimeException(e);
         }
     }

--- a/dropwizard-util/src/test/java/io/dropwizard/util/EnumsTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/EnumsTest.java
@@ -45,7 +45,7 @@ class EnumsTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void canGuess(String text, VideoFormat result) {
+    void canGuess(String text, VideoFormat result) {
         assertThat(Enums.fromStringFuzzy(text, VideoFormat.values())).isEqualTo(result);
     }
 }

--- a/dropwizard-util/src/test/java/io/dropwizard/util/GenericsTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/GenericsTest.java
@@ -30,7 +30,7 @@ class GenericsTest<T> {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testTypeParameter(Class<?> klass, Class<?> typeParameter, Class<? super T> bound, Class<?> boundTypeParameter,
+    void testTypeParameter(Class<?> klass, Class<?> typeParameter, Class<? super T> bound, Class<?> boundTypeParameter,
                                   Class<? extends Exception> expectedException, String expectedMessage) {
         if (expectedException == null) {
             assertThat(Generics.getTypeParameter(klass)).isEqualTo(typeParameter);
@@ -42,7 +42,7 @@ class GenericsTest<T> {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testBoundTypeParameter(Class<?> klass, Class<?> typeParameter, Class<? super T> bound, Class<?> boundTypeParameter,
+    void testBoundTypeParameter(Class<?> klass, Class<?> typeParameter, Class<? super T> bound, Class<?> boundTypeParameter,
                                        Class<? extends Exception> expectedException, String expectedMessage) {
         if (expectedException == null) {
             assertThat(Generics.getTypeParameter(klass, bound)).isEqualTo(boundTypeParameter);


### PR DESCRIPTION
###### Problem:
- Some tests are still marked public (I missed a few earlier)
- `BaseConfigurationFactory` has a couple of nested `if` statements
- `CachingAuthorizer` in `dropwizard-auth` has a complex boolean comparison which can be simpler
- `AssetServlet` has nested try-catch blocks, which Sonar doesn't like
- A couple of `catch` blocks use `instanceof` to match certain types of exception

###### Solution:
- Remove `public` from the remaining tests
- Merge nested `if` statements
- Use `Boolean.TRUE.equals()` to cope with possible null values when comparing
- Move inner try-catch to the helper function it was surrounding
- Match exception types using `catch` rather than `instanceof`

###### Result:
This should be a no-op and Sonar should be a little happier.
A secondary effect is that I will probably not raise any more Sonar PRs for a while, as the remaining issues look more gnarly or are Sonar getting the wrong end of the stick. The number of 'code smells' in Sonar has been more than halved by the recent series of PRs.