### PR TITLE
Sonar cleanup

### DIFF
--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/PolymorphicPrincipalEntityTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/principal/PolymorphicPrincipalEntityTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.Invocation;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.DynamicFeature;
 import javax.ws.rs.core.HttpHeaders;
@@ -129,8 +130,9 @@ class PolymorphicPrincipalEntityTest extends JerseyTest {
 
     @Test
     void jsonPrincipalEntityResourceNoAuth401() {
+        Invocation.Builder request = target("/auth-test/json-principal-entity").request();
         assertThatExceptionOfType(WebApplicationException.class)
-            .isThrownBy(() -> target("/auth-test/json-principal-entity").request().get(String.class))
+            .isThrownBy(() -> request.get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(401));
     }
 
@@ -144,8 +146,9 @@ class PolymorphicPrincipalEntityTest extends JerseyTest {
 
     @Test
     void nullPrincipalEntityResourceNoAuth401() {
+        Invocation.Builder request = target("/auth-test/null-principal-entity").request();
         assertThatExceptionOfType(WebApplicationException.class)
-            .isThrownBy(() -> target("/auth-test/null-principal-entity").request().get(String.class))
+            .isThrownBy(() -> request.get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(401));
     }
 

--- a/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
@@ -33,6 +33,7 @@ import org.mockito.Mockito;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.ProcessingException;
+import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.Response;
@@ -90,8 +91,9 @@ class DropwizardApacheConnectorTest {
 
     @Test
     void when_no_read_timeout_override_then_client_request_times_out() {
+        Invocation.Builder request = client.target(testUri + "/long_running").request();
         assertThatExceptionOfType(ProcessingException.class)
-            .isThrownBy(() ->client.target(testUri + "/long_running").request().get())
+            .isThrownBy(request::get)
             .withCauseInstanceOf(SocketTimeoutException.class);
     }
 

--- a/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactoryTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactoryTest.java
@@ -26,6 +26,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.Response;
 import java.io.File;
 import java.io.IOException;
@@ -122,8 +123,9 @@ class DropwizardSSLConnectionSocketFactoryTest {
     void shouldErrorIfServerCertNotFoundInTruststore() {
         tlsConfiguration.setTrustStorePath(new File(ResourceHelpers.resourceFilePath("stores/server/other_cert_truststore.ts")));
         final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).build("tls_broken_client");
+        Invocation.Builder request = client.target(String.format("https://localhost:%d", TLS_APP_RULE.getLocalPort())).request();
         assertThatExceptionOfType(ProcessingException.class)
-            .isThrownBy(() -> client.target(String.format("https://localhost:%d", TLS_APP_RULE.getLocalPort())).request().get())
+            .isThrownBy(request::get)
             .withCauseInstanceOf(SSLHandshakeException.class);
     }
 
@@ -138,8 +140,9 @@ class DropwizardSSLConnectionSocketFactoryTest {
     @Test
     void shouldErrorIfServerCertSelfSignedAndSelfSignedCertsNotAllowed() {
         final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).build("self_sign_failure");
+        Invocation.Builder request = client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(1))).request();
         assertThatExceptionOfType(ProcessingException.class)
-            .isThrownBy(() -> client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(1))).request().get(ClientResponse.class))
+            .isThrownBy(() -> request.get(ClientResponse.class))
             .withCauseInstanceOf(SSLHandshakeException.class);
     }
 
@@ -159,8 +162,9 @@ class DropwizardSSLConnectionSocketFactoryTest {
         tlsConfiguration.setKeyStorePassword("password");
         tlsConfiguration.setKeyStoreType("PKCS12");
         final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).build("client_auth_broken");
+        Invocation.Builder request = client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(2))).request();
         assertThatExceptionOfType(ProcessingException.class)
-            .isThrownBy(() -> client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(2))).request().get())
+            .isThrownBy(request::get)
             .satisfies(e -> assertThat(e.getCause()).isInstanceOfAny(SocketException.class, SSLHandshakeException.class, SSLException.class));
     }
 
@@ -182,8 +186,9 @@ class DropwizardSSLConnectionSocketFactoryTest {
         tlsConfiguration.setKeyStoreType("PKCS12");
         tlsConfiguration.setCertAlias("2");
         final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).build("client_auth_using_cert_alias_broken");
+        Invocation.Builder request = client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(2))).request();
         assertThatExceptionOfType(ProcessingException.class)
-            .isThrownBy(() -> client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(2))).request().get())
+            .isThrownBy(request::get)
             .satisfies(e -> assertThat(e.getCause()).isInstanceOfAny(SocketException.class, SSLHandshakeException.class, SSLException.class));
     }
 
@@ -194,8 +199,9 @@ class DropwizardSSLConnectionSocketFactoryTest {
         tlsConfiguration.setKeyStoreType("PKCS12");
         tlsConfiguration.setCertAlias("unknown");
         final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).build("client_auth_using_unknown_cert_alias_broken");
+        Invocation.Builder request = client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(2))).request();
         assertThatExceptionOfType(ProcessingException.class)
-            .isThrownBy(() -> client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(2))).request().get())
+            .isThrownBy(request::get)
             .satisfies(e -> assertThat(e.getCause()).isInstanceOfAny(SocketException.class, SSLHandshakeException.class, SSLException.class));
     }
 
@@ -242,8 +248,9 @@ class DropwizardSSLConnectionSocketFactoryTest {
     void shouldRejectNonSupportedProtocols() {
         tlsConfiguration.setSupportedProtocols(Collections.singletonList("TLSv1.2"));
         final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).build("reject_non_supported");
+        Invocation.Builder request = client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(4))).request();
         assertThatExceptionOfType(ProcessingException.class)
-            .isThrownBy(() -> client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(4))).request().get())
+            .isThrownBy(request::get)
             .withRootCauseInstanceOf(IOException.class);
     }
 

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
@@ -105,15 +105,17 @@ class JerseyClientBuilderTest {
 
     @Test
     void throwsAnExceptionWithoutAnEnvironmentAndOnlyObjectMapper() {
+        JerseyClientBuilder configuredBuilder = builder.using(objectMapper);
         assertThatExceptionOfType(IllegalStateException.class)
-            .isThrownBy(() -> builder.using(objectMapper).build("test"))
+            .isThrownBy(() -> configuredBuilder.build("test"))
             .withMessage("Must have either an environment or both an executor service and an object mapper");
     }
 
     @Test
     void throwsAnExceptionWithoutAnEnvironmentAndOnlyAThreadPool() {
+        JerseyClientBuilder configuredBuilder = builder.using(executorService);
         assertThatExceptionOfType(IllegalStateException.class)
-            .isThrownBy(() -> builder.using(executorService).build("test"))
+            .isThrownBy(() -> configuredBuilder.build("test"))
             .withMessage("Must have either an environment or both an executor service and an object mapper");
     }
 

--- a/dropwizard-e2e/src/test/java/com/example/health/HealthIntegrationTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/health/HealthIntegrationTest.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-public class HealthIntegrationTest {
+class HealthIntegrationTest {
     private static final String CONFIG_PATH = "health/config.yml";
     private static final String HOST = "localhost";
     private static final String APP_PORT_KEY = "server.connector.port";
@@ -60,12 +60,12 @@ public class HealthIntegrationTest {
     }
 
     @Test
-    public void healthCheckShouldReportUnhealthyOnInitialStart() {
+    void healthCheckShouldReportUnhealthyOnInitialStart() {
         assertThat(isAppHealthy()).isFalse();
     }
 
     @Test
-    public void healthCheckShouldReportHealthyWhenInitialStateFalseCriticalCheckGoesHealthy() {
+    void healthCheckShouldReportHealthyWhenInitialStateFalseCriticalCheckGoesHealthy() {
         final HealthApp app = TEST_APP_RULE.getApplication();
 
         assertThat(isAppHealthy()).isFalse();
@@ -84,7 +84,7 @@ public class HealthIntegrationTest {
     }
 
     @Test
-    public void healthCheckShouldReportHealthyWhenAllHealthChecksHealthy() {
+    void healthCheckShouldReportHealthyWhenAllHealthChecksHealthy() {
         final HealthApp app = TEST_APP_RULE.getApplication();
         app.getCriticalCheckHealthy1().set(true);
         app.getCriticalCheckHealthy2().set(true);
@@ -101,7 +101,7 @@ public class HealthIntegrationTest {
     }
 
     @Test
-    public void nonCriticalHealthCheckFailureShouldNotResultInUnhealthyApp() {
+    void nonCriticalHealthCheckFailureShouldNotResultInUnhealthyApp() {
         final HealthApp app = TEST_APP_RULE.getApplication();
         app.getCriticalCheckHealthy1().set(true);
         app.getCriticalCheckHealthy2().set(true);
@@ -119,7 +119,7 @@ public class HealthIntegrationTest {
     }
 
     @Test
-    public void criticalHealthCheckFailureShouldResultInUnhealthyApp() {
+    void criticalHealthCheckFailureShouldResultInUnhealthyApp() {
         final HealthApp app = TEST_APP_RULE.getApplication();
         app.getCriticalCheckHealthy1().set(false);
 
@@ -134,7 +134,7 @@ public class HealthIntegrationTest {
     }
 
     @Test
-    public void appShouldRecoverOnceCriticalCheckReturnsToHealthyStatus() {
+    void appShouldRecoverOnceCriticalCheckReturnsToHealthyStatus() {
         final HealthApp app = TEST_APP_RULE.getApplication();
         app.getCriticalCheckHealthy1().set(false);
 

--- a/dropwizard-example/src/test/java/com/example/helloworld/resources/ProtectedClassResourceTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/resources/ProtectedClassResourceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.HttpHeaders;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -72,10 +73,10 @@ final class ProtectedClassResourceTest {
 
     @Test
     void testProtectedBasicUserEndpointPrincipalIsNotAuthorized403() {
+        Invocation.Builder request = RULE.target("/protected").request()
+            .header(HttpHeaders.AUTHORIZATION, "Basic Z3Vlc3Q6c2VjcmV0");
         assertThatExceptionOfType(ForbiddenException.class)
-            .isThrownBy(() -> RULE.target("/protected").request()
-            .header(HttpHeaders.AUTHORIZATION, "Basic Z3Vlc3Q6c2VjcmV0")
-            .get(String.class))
+            .isThrownBy(() -> request.get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(403));
     }
 

--- a/dropwizard-example/src/test/java/com/example/helloworld/resources/ProtectedResourceTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/resources/ProtectedResourceTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.NotAuthorizedException;
+import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.HttpHeaders;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,9 +49,9 @@ class ProtectedResourceTest {
 
     @Test
     void testProtectedEndpointNoCredentials401() {
+        Invocation.Builder request = RULE.target("/protected").request();
         assertThatExceptionOfType(NotAuthorizedException.class)
-            .isThrownBy(() -> RULE.target("/protected").request()
-                .get(String.class))
+            .isThrownBy(() -> request.get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(401))
             .satisfies(e -> assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
             .containsOnly("Basic realm=\"SUPER SECRET STUFF\""));
@@ -58,10 +59,10 @@ class ProtectedResourceTest {
 
     @Test
     void testProtectedEndpointBadCredentials401() {
+        Invocation.Builder request = RULE.target("/protected").request()
+            .header(HttpHeaders.AUTHORIZATION, "Basic c25lYWt5LWJhc3RhcmQ6YXNkZg==");
         assertThatExceptionOfType(NotAuthorizedException.class)
-            .isThrownBy(() -> RULE.target("/protected").request()
-                .header(HttpHeaders.AUTHORIZATION, "Basic c25lYWt5LWJhc3RhcmQ6YXNkZg==")
-                .get(String.class))
+            .isThrownBy(() -> request.get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(401))
             .satisfies(e -> assertThat(e.getResponse().getHeaders().get(HttpHeaders.WWW_AUTHENTICATE))
                 .containsOnly("Basic realm=\"SUPER SECRET STUFF\""));
@@ -77,10 +78,10 @@ class ProtectedResourceTest {
 
     @Test
     void testProtectedAdminEndpointPrincipalIsNotAuthorized403() {
+        Invocation.Builder request = RULE.target("/protected/admin").request()
+            .header(HttpHeaders.AUTHORIZATION, "Basic Z29vZC1ndXk6c2VjcmV0");
         assertThatExceptionOfType(ForbiddenException.class)
-            .isThrownBy(() -> RULE.target("/protected/admin").request()
-                    .header(HttpHeaders.AUTHORIZATION, "Basic Z29vZC1ndXk6c2VjcmV0")
-                    .get(String.class))
+            .isThrownBy(() -> request.get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(403));
     }
 }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
@@ -29,6 +29,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
@@ -169,9 +170,9 @@ class JerseyIntegrationTest extends JerseyTest {
 
     @Test
     void doesNotFindMissingData() {
+        Invocation.Builder request = target("/people/Poof").request(MediaType.APPLICATION_JSON);
         assertThatExceptionOfType(WebApplicationException.class)
-            .isThrownBy(() -> target("/people/Poof").request(MediaType.APPLICATION_JSON)
-                    .get(Person.class))
+            .isThrownBy(() -> request.get(Person.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(404));
     }
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/ErrorEntityWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/ErrorEntityWriterTest.java
@@ -13,6 +13,7 @@ import org.glassfish.jersey.test.spi.TestContainerFactory;
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -53,10 +54,9 @@ class ErrorEntityWriterTest extends AbstractJerseyTest {
 
     @Test
     void formatsErrorsAsHtml() {
+        Invocation.Builder request = target("/exception/html-exception").request(MediaType.TEXT_HTML_TYPE);
         assertThatExceptionOfType(WebApplicationException.class)
-            .isThrownBy(() -> target("/exception/html-exception")
-                .request(MediaType.TEXT_HTML_TYPE)
-                .get(String.class))
+            .isThrownBy(() -> request.get(String.class))
             .satisfies(e -> {
                 final Response response = e.getResponse();
                 assertThat(response.getStatus()).isEqualTo(400);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/LoggingExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/LoggingExceptionMapperTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 
@@ -24,8 +25,9 @@ class LoggingExceptionMapperTest extends AbstractJerseyTest {
 
     @Test
     void returnsAnErrorMessage() {
+        Invocation.Builder request = target("/exception/").request(MediaType.APPLICATION_JSON);
         assertThatExceptionOfType(WebApplicationException.class)
-            .isThrownBy(() -> target("/exception/").request(MediaType.APPLICATION_JSON).get(String.class))
+            .isThrownBy(() -> request.get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(500))
             .satisfies(e -> assertThat(e.getResponse().readEntity(String.class)).startsWith("{\"code\":500,\"message\":"
                 + "\"There was an error processing your request. It has been logged (ID "));
@@ -33,8 +35,9 @@ class LoggingExceptionMapperTest extends AbstractJerseyTest {
 
     @Test
     void handlesJsonMappingException() {
+        Invocation.Builder request = target("/exception/json-mapping-exception").request(MediaType.APPLICATION_JSON);
         assertThatExceptionOfType(WebApplicationException.class)
-            .isThrownBy(() -> target("/exception/json-mapping-exception").request(MediaType.APPLICATION_JSON).get(String.class))
+            .isThrownBy(() -> request.get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(500))
             .satisfies(e -> assertThat(e.getResponse().readEntity(String.class)).startsWith("{\"code\":500,\"message\":"
                 + "\"There was an error processing your request. It has been logged (ID "));
@@ -42,10 +45,10 @@ class LoggingExceptionMapperTest extends AbstractJerseyTest {
 
     @Test
     void handlesMethodNotAllowedWithHeaders() {
+        Invocation.Builder request = target("/exception/json-mapping-exception").request(MediaType.APPLICATION_JSON);
+        Entity<String> jsonEntity = Entity.json("A");
         assertThatExceptionOfType(WebApplicationException.class)
-            .isThrownBy(() -> target("/exception/json-mapping-exception")
-            .request(MediaType.APPLICATION_JSON)
-            .post(Entity.json("A"), String.class))
+            .isThrownBy(() -> request.post(jsonEntity, String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(405))
             .satisfies(e -> assertThat(e.getResponse().getAllowedMethods()).containsOnly("GET", "OPTIONS"))
             .satisfies(e -> assertThat(e.getResponse().readEntity(String.class))
@@ -54,8 +57,9 @@ class LoggingExceptionMapperTest extends AbstractJerseyTest {
 
     @Test
     void formatsWebApplicationException() {
+        Invocation.Builder request = target("/exception/web-application-exception").request(MediaType.APPLICATION_JSON);
         assertThatExceptionOfType(WebApplicationException.class)
-            .isThrownBy(() -> target("/exception/web-application-exception").request(MediaType.APPLICATION_JSON).get(String.class))
+            .isThrownBy(() -> request.get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(400))
             .satisfies(e -> assertThat(e.getResponse().readEntity(String.class))
                 .isEqualTo("{\"code\":400,\"message\":\"KAPOW\"}"));

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalMessageBodyWriterTest.java
@@ -13,6 +13,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 
@@ -38,8 +39,9 @@ class OptionalMessageBodyWriterTest extends AbstractJerseyTest {
 
     @Test
     void absentOptionalsThrowANotFound() {
+        Invocation.Builder request = target("/optional-return/").request();
         assertThatExceptionOfType(WebApplicationException.class)
-            .isThrownBy(() -> target("/optional-return/").request().get(String.class))
+            .isThrownBy(() -> request.get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(404));
     }
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalDoubleMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalDoubleMessageBodyWriterTest.java
@@ -13,6 +13,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -48,8 +49,9 @@ class OptionalDoubleMessageBodyWriterTest extends AbstractJerseyTest {
 
     @Test
     void absentOptionalsThrowANotFound() {
+        Invocation.Builder request = target("optional-return").request();
         assertThatExceptionOfType(WebApplicationException.class)
-            .isThrownBy(() -> target("optional-return").request().get(Double.class))
+            .isThrownBy(() -> request.get(Double.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(404));
     }
 
@@ -78,12 +80,14 @@ class OptionalDoubleMessageBodyWriterTest extends AbstractJerseyTest {
 
     @Test
     void valueInvalidReturns404() {
+        Invocation.Builder request = target("optional-return/default").queryParam("id", "invalid")
+            .request();
         assertThatExceptionOfType(NotFoundException.class)
-            .isThrownBy(() -> target("optional-return/default").queryParam("id", "invalid")
-                .request().get(Double.class));
+            .isThrownBy(() -> request.get(Double.class));
+        Invocation.Builder doubleRequest = target("optional-return/double/default").queryParam("id", "invalid")
+            .request();
         assertThatExceptionOfType(NotFoundException.class)
-            .isThrownBy(() -> target("optional-return/double/default").queryParam("id", "invalid")
-                .request().get(Double.class));
+            .isThrownBy(() -> doubleRequest.get(Double.class));
     }
 
     @Path("optional-return")

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalDoubleParamConverterProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalDoubleParamConverterProviderTest.java
@@ -8,8 +8,10 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 class OptionalDoubleParamConverterProviderTest {
     @Test
     void verifyInvalidDefaultValueFailsFast() {
+        OptionalDoubleParamConverterProvider.OptionalDoubleParamConverter converter =
+            new OptionalDoubleParamConverterProvider.OptionalDoubleParamConverter("invalid");
         assertThatExceptionOfType(NumberFormatException.class)
-            .isThrownBy(() -> new OptionalDoubleParamConverterProvider.OptionalDoubleParamConverter("invalid").fromString("invalid"));
+            .isThrownBy(() -> converter.fromString("invalid"));
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalIntMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalIntMessageBodyWriterTest.java
@@ -13,6 +13,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -48,8 +49,9 @@ class OptionalIntMessageBodyWriterTest extends AbstractJerseyTest {
 
     @Test
     void absentOptionalsThrowANotFound() {
+        Invocation.Builder request = target("optional-return").request();
         assertThatExceptionOfType(WebApplicationException.class)
-            .isThrownBy(() -> target("optional-return").request().get(Integer.class))
+            .isThrownBy(() -> request.get(Integer.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(404));
     }
 
@@ -80,19 +82,22 @@ class OptionalIntMessageBodyWriterTest extends AbstractJerseyTest {
 
     @Test
     void valueInvalidReturns404() {
+        Invocation.Builder request = target("optional-return/default").queryParam("id", "invalid")
+            .request();
         assertThatExceptionOfType(NotFoundException.class)
-            .isThrownBy(() -> target("optional-return/default").queryParam("id", "invalid")
-                .request().get(Integer.class));
+            .isThrownBy(() -> request.get(Integer.class));
+        Invocation.Builder intRequest = target("optional-return/int/default").queryParam("id", "invalid")
+            .request();
         assertThatExceptionOfType(NotFoundException.class)
-            .isThrownBy(() -> target("optional-return/int/default").queryParam("id", "invalid")
-                .request().get(Integer.class));
+            .isThrownBy(() -> intRequest.get(Integer.class));
     }
 
     @Test
     void verifyInvalidDefaultValueFailsFast() {
+        OptionalIntParamConverterProvider.OptionalIntParamConverter converter =
+            new OptionalIntParamConverterProvider.OptionalIntParamConverter("invalid");
         assertThatExceptionOfType(NumberFormatException.class)
-            .isThrownBy(() -> new OptionalIntParamConverterProvider.OptionalIntParamConverter("invalid")
-                .fromString("invalid"));
+            .isThrownBy(() -> converter.fromString("invalid"));
     }
 
     @Path("optional-return")

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalIntParamConverterProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalIntParamConverterProviderTest.java
@@ -8,8 +8,10 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 class OptionalIntParamConverterProviderTest {
     @Test
     void verifyInvalidDefaultValueFailsFast() {
+        OptionalIntParamConverterProvider.OptionalIntParamConverter converter =
+            new OptionalIntParamConverterProvider.OptionalIntParamConverter("invalid");
         assertThatExceptionOfType(NumberFormatException.class)
-            .isThrownBy(() -> new OptionalIntParamConverterProvider.OptionalIntParamConverter("invalid").fromString("invalid"));
+            .isThrownBy(() -> converter.fromString("invalid"));
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalLongMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalLongMessageBodyWriterTest.java
@@ -13,6 +13,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -21,7 +22,7 @@ import java.util.OptionalLong;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class OptionalLongMessageBodyWriterTest extends AbstractJerseyTest {
+class OptionalLongMessageBodyWriterTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {
@@ -48,8 +49,9 @@ public class OptionalLongMessageBodyWriterTest extends AbstractJerseyTest {
 
     @Test
     void absentOptionalsThrowANotFound() {
+        Invocation.Builder request = target("optional-return").request();
         assertThatExceptionOfType(WebApplicationException.class)
-            .isThrownBy(() -> target("optional-return").request().get(Long.class))
+            .isThrownBy(() -> request.get(Long.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(404));
     }
 
@@ -76,12 +78,14 @@ public class OptionalLongMessageBodyWriterTest extends AbstractJerseyTest {
 
     @Test
     void valueInvalidReturns404() {
+        Invocation.Builder request = target("optional-return/default").queryParam("id", "invalid")
+            .request();
         assertThatExceptionOfType(NotFoundException.class)
-            .isThrownBy(() -> target("optional-return/default").queryParam("id", "invalid")
-                .request().get(Long.class));;
+            .isThrownBy(() -> request.get(Long.class));
+        Invocation.Builder longRequest = target("optional-return/long/default").queryParam("id", "invalid")
+            .request();
         assertThatExceptionOfType(NotFoundException.class)
-            .isThrownBy(() -> target("optional-return/long/default").queryParam("id", "invalid")
-                .request().get(Long.class));
+            .isThrownBy(() -> longRequest.get(Long.class));
     }
 
     @Path("optional-return")

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalLongParamConverterProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalLongParamConverterProviderTest.java
@@ -8,8 +8,10 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 class OptionalLongParamConverterProviderTest {
     @Test
     void verifyInvalidDefaultValueFailsFast() {
+        OptionalLongParamConverterProvider.OptionalLongParamConverter converter =
+            new OptionalLongParamConverterProvider.OptionalLongParamConverter("invalid");
         assertThatExceptionOfType(NumberFormatException.class)
-            .isThrownBy(() -> new OptionalLongParamConverterProvider.OptionalLongParamConverter("invalid").fromString("invalid"));
+            .isThrownBy(() -> converter.fromString("invalid"));
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalMessageBodyWriterTest.java
@@ -11,6 +11,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -19,7 +20,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class OptionalMessageBodyWriterTest extends AbstractJerseyTest {
+class OptionalMessageBodyWriterTest extends AbstractJerseyTest {
 
     @Override
     protected Application configure() {
@@ -46,8 +47,9 @@ public class OptionalMessageBodyWriterTest extends AbstractJerseyTest {
 
     @Test
     void absentOptionalsThrowANotFound() {
+        Invocation.Builder request = target("optional-return").request();
         assertThatExceptionOfType(WebApplicationException.class)
-            .isThrownBy(() -> target("optional-return").request().get(String.class))
+            .isThrownBy(() -> request.get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(404));
     }
 

--- a/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/FreemarkerViewRendererTest.java
+++ b/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/FreemarkerViewRendererTest.java
@@ -21,6 +21,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Form;
 import javax.ws.rs.core.MediaType;
@@ -107,8 +108,9 @@ class FreemarkerViewRendererTest extends JerseyTest {
 
     @Test
     void returnsA500ForViewsWithBadTemplatePaths() {
+        Invocation.Builder request = target("/test/bad").request();
         assertThatExceptionOfType(WebApplicationException.class)
-            .isThrownBy(() -> target("/test/bad").request().get(String.class))
+            .isThrownBy(() -> request.get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(500))
             .satisfies(e -> assertThat(e.getResponse().readEntity(String.class))
                 .isEqualTo(ViewRenderExceptionMapper.TEMPLATE_ERROR_MSG));
@@ -117,8 +119,9 @@ class FreemarkerViewRendererTest extends JerseyTest {
     @Test
     @Disabled("Flaky on JUnit5")
     void returnsA500ForViewsThatCantCompile() {
+        Invocation.Builder request = target("/test/error").request();
         assertThatExceptionOfType(WebApplicationException.class)
-            .isThrownBy(() -> target("/test/error").request().get(String.class))
+            .isThrownBy(() -> request.get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(500))
             .satisfies(e -> assertThat(e.getResponse().readEntity(String.class))
                 .isEqualTo(ViewRenderExceptionMapper.TEMPLATE_ERROR_MSG));

--- a/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererFileSystemTest.java
+++ b/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererFileSystemTest.java
@@ -16,6 +16,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import java.util.Collections;
@@ -99,8 +100,9 @@ class MustacheViewRendererFileSystemTest extends JerseyTest {
 
     @Test
     void returnsA500ForViewsWithBadTemplatePaths() {
+        Invocation.Builder request = target("/test/bad").request();
         assertThatExceptionOfType(WebApplicationException.class)
-            .isThrownBy(() -> target("/test/bad").request().get(String.class))
+            .isThrownBy(() -> request.get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(500))
             .satisfies(e -> assertThat(e.getResponse().readEntity(String.class))
                 .isEqualTo(ViewRenderExceptionMapper.TEMPLATE_ERROR_MSG));
@@ -108,8 +110,9 @@ class MustacheViewRendererFileSystemTest extends JerseyTest {
 
     @Test
     void returnsA500ForViewsThatCantCompile() {
+        Invocation.Builder request = target("/test/error").request();
         assertThatExceptionOfType(WebApplicationException.class)
-            .isThrownBy(() -> target("/test/error").request().get(String.class))
+            .isThrownBy(() -> request.get(String.class))
             .satisfies(e -> assertThat(e.getResponse().getStatus()).isEqualTo(500))
             .satisfies(e -> assertThat(e.getResponse().readEntity(String.class))
                 .isEqualTo(ViewRenderExceptionMapper.TEMPLATE_ERROR_MSG));


### PR DESCRIPTION
###### Problem:
Sonar warns, if methods are chained inside the lambda of `isThrownBy`.

###### Solution:
Extract the chained methods to a local variable and only call the last method inside `isThrownBy`.

###### Result:
Sonar will provide less code smells.
