### PR TITLE
Use Formatter to validate format strings, rather than String.format()

### DIFF
--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilder.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilder.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import java.util.Formatter;
 import java.util.Locale;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
@@ -50,10 +51,14 @@ public class ExecutorServiceBuilder {
         this(environment, nameFormat, buildThreadFactory(nameFormat));
     }
 
-    @SuppressWarnings("ResultOfMethodCallIgnored")
     private static ThreadFactory buildThreadFactory(String nameFormat) {
         ThreadFactory defaultThreadFactory = Executors.defaultThreadFactory();
-        String.format(Locale.ROOT, nameFormat, 0); // Fail fast on invalid name format
+
+        // Validate the format string
+        try (Formatter fmt = new Formatter()) {
+            fmt.format(Locale.ROOT, nameFormat, 0);
+        }
+
         return r -> {
             final Thread thread = defaultThreadFactory.newThread(r);
             thread.setName(String.format(Locale.ROOT, nameFormat, COUNT.incrementAndGet()));


### PR DESCRIPTION
###### Problem:
- [dropwizard-lifecycle ExecutorServiceBuilder](https://sonarcloud.io/project/issues?id=dropwizard_dropwizard&open=AXUXdI01pBosHuY9-P9n&resolved=false&types=BUG) ignores the result of String.format, but intentionally so as it's using the call to check that the format string is valid.

###### Solution:
Instead of calling `String.format` and throwing away the result, instantiate a `Formatter` and use that. It still throws an exception on invalid format strings, but doesn't generate a formatted string.

###### Result:
Sonar will stop complaining about this