### PR TITLE
Replace doesNotThrow assertions with more explicit checks

### DIFF
--- a/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
@@ -3,6 +3,7 @@ package io.dropwizard.server;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.configuration.ConfigurationException;
 import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
 import io.dropwizard.jackson.Jackson;
@@ -28,6 +29,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import java.io.File;
 import java.io.InputStreamReader;
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
@@ -39,7 +42,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class DefaultServerFactoryTest {
@@ -243,17 +245,18 @@ class DefaultServerFactoryTest {
     }
 
     @Test
-    void testDeserializeWithoutJsonAutoDetect() {
+    void testDeserializeWithoutJsonAutoDetect() throws ConfigurationException, IOException, URISyntaxException {
         final ObjectMapper objectMapper = Jackson.newObjectMapper()
             .setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE);
 
-        assertThatCode(() -> new YamlConfigurationFactory<>(
-            DefaultServerFactory.class,
-            BaseValidator.newValidator(),
-            objectMapper,
-            "dw"
-            ).build(new File(Resources.getResource("yaml/server.yml").toURI()))
-        ).doesNotThrowAnyException();
+        assertThat(new YamlConfigurationFactory<>(
+                DefaultServerFactory.class,
+                BaseValidator.newValidator(),
+                objectMapper,
+                "dw"
+                ).build(new File(Resources.getResource("yaml/server.yml").toURI()))
+                .getMaxThreads())
+            .isEqualTo(101);
     }
 
     @Path("/test")

--- a/dropwizard-core/src/test/java/io/dropwizard/server/SimpleServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/SimpleServerFactoryTest.java
@@ -3,6 +3,7 @@ package io.dropwizard.server;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.configuration.ConfigurationException;
 import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
 import io.dropwizard.jackson.Jackson;
@@ -27,8 +28,10 @@ import javax.ws.rs.Produces;
 import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.HttpURLConnection;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -36,7 +39,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SimpleServerFactoryTest {
@@ -102,17 +104,18 @@ public class SimpleServerFactoryTest {
     }
 
     @Test
-    void testDeserializeWithoutJsonAutoDetect() {
+    void testDeserializeWithoutJsonAutoDetect() throws ConfigurationException, IOException, URISyntaxException {
         final ObjectMapper objectMapper = Jackson.newObjectMapper()
             .setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE);
 
-        assertThatCode(() -> new YamlConfigurationFactory<>(
-            SimpleServerFactory.class,
-            BaseValidator.newValidator(),
-            objectMapper,
-            "dw"
-            ).build(new File(Resources.getResource("yaml/simple_server.yml").toURI()))
-        ).doesNotThrowAnyException();
+        assertThat(new YamlConfigurationFactory<>(
+                SimpleServerFactory.class,
+                BaseValidator.newValidator(),
+                objectMapper,
+                "dw"
+                ).build(new File(Resources.getResource("yaml/simple_server.yml").toURI()))
+                .getApplicationContextPath())
+            .isEqualTo("/service");
     }
 
     public static String httpRequest(String requestMethod, String url) throws Exception {

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonTest.java
@@ -1,6 +1,7 @@
 package io.dropwizard.jackson;
 
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -11,7 +12,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 
 class JacksonTest {
     @Test
@@ -48,11 +48,11 @@ class JacksonTest {
     }
 
     @Test
-    void objectMapperIgnoresUnknownProperties() {
-        assertThatCode(() ->
-            Jackson.newObjectMapper()
-                .readValue("{\"unknown\": 4711, \"path\": \"/var/log/app/server.log\"}", LogMetadata.class)
-        ).doesNotThrowAnyException();
+    void objectMapperIgnoresUnknownProperties() throws JsonProcessingException {
+        assertThat(Jackson.newObjectMapper()
+                .readValue("{\"unknown\": 4711, \"path\": \"/var/log/app/objectMapperIgnoresUnknownProperties.log\"}", LogMetadata.class)
+                .path)
+            .hasFileName("objectMapperIgnoresUnknownProperties.log");
     }
 
     static class LogMetadata {

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NonblockingServletHolderTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NonblockingServletHolderTest.java
@@ -11,7 +11,6 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
@@ -42,9 +41,7 @@ class NonblockingServletHolderTest {
     @Test
     void servicesRequestHandleEofException() throws Exception {
         doThrow(new EofException()).when(servlet).service(request, response);
-        assertThatCode(() -> {
-            holder.handle(baseRequest, request, response);
-        }).doesNotThrowAnyException();
+        holder.handle(baseRequest, request, response);
         verify(servlet).service(request, response);
     }
 

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/SyslogAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/SyslogAppenderFactoryTest.java
@@ -16,7 +16,6 @@ import org.slf4j.LoggerFactory;
 import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 
 class SyslogAppenderFactoryTest {
 
@@ -83,9 +82,8 @@ class SyslogAppenderFactoryTest {
     @Test
     void syslogFacilityTest() {
         for (SyslogAppenderFactory.Facility facility : SyslogAppenderFactory.Facility.values()) {
-            assertThatCode(() ->
-                    SyslogAppender.facilityStringToint(facility.toString().toLowerCase(Locale.ENGLISH)))
-                .doesNotThrowAnyException();
+            assertThat(SyslogAppender.facilityStringToint(facility.toString().toLowerCase(Locale.ENGLISH)))
+                .isNotNegative();
         }
     }
 }

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/TaskServletTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/TaskServletTest.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 
 import static com.codahale.metrics.MetricRegistry.name;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -176,15 +175,19 @@ class TaskServletTest {
      * depends on this to perform record metrics on Tasks
      */
     @Test
-    void verifyTaskExecuteMethod() {
-        assertThatCode(() -> Task.class.getMethod("execute", Map.class, PrintWriter.class))
-            .doesNotThrowAnyException();
+    void verifyTaskExecuteMethod() throws NoSuchMethodException {
+        assertThat(Task.class
+                .getMethod("execute", Map.class, PrintWriter.class)
+                .getReturnType())
+            .isEqualTo(Void.TYPE);
     }
 
     @Test
-    void verifyPostBodyTaskExecuteMethod() {
-        assertThatCode(() -> PostBodyTask.class.getMethod("execute", Map.class, String.class, PrintWriter.class))
-            .doesNotThrowAnyException();
+    void verifyPostBodyTaskExecuteMethod() throws NoSuchMethodException {
+        assertThat(PostBodyTask.class
+                .getMethod("execute", Map.class, String.class, PrintWriter.class)
+                .getReturnType())
+            .isEqualTo(Void.TYPE);
     }
 
     @Test


### PR DESCRIPTION
Rather than checking some code doesn't explode, it's better to check that it does something.