### PR TITLE
Address some more linter gripes

### DIFF
--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/PolymorphicAuthDynamicFeature.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/PolymorphicAuthDynamicFeature.java
@@ -44,14 +44,9 @@ public class PolymorphicAuthDynamicFeature<T extends Principal> implements Dynam
 
             for (final Annotation annotation : parameterAnnotations[i]) {
                 if (annotation instanceof Auth && authFilterMap.containsKey(paramType)) {
-                    if (type == Optional.class) {
-                        final ContainerRequestFilter filter = authFilterMap.get(paramType);
-                        context.register(new WebApplicationExceptionCatchingFilter(filter));
-                        return;
-                    } else {
-                        context.register(authFilterMap.get(type));
-                        return;
-                    }
+                    final ContainerRequestFilter filter = authFilterMap.get(paramType);
+                    context.register(type == Optional.class ? new WebApplicationExceptionCatchingFilter(filter) : filter);
+                    return;
                 }
             }
         }

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/OptionalAuthFilterOrderingTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/OptionalAuthFilterOrderingTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.security.Principal;
 
 import javax.annotation.Priority;
@@ -94,7 +93,7 @@ class OptionalAuthFilterOrderingTest extends JerseyTest {
     private static class DummyAuthenticationFilter extends AuthFilter<Object, Principal> {
 
         @Override
-        public void filter(ContainerRequestContext requestContext) throws IOException {
+        public void filter(ContainerRequestContext requestContext) {
             requestContext.setSecurityContext(new SecurityContext() {
                 @Override
                 public Principal getUserPrincipal() {
@@ -123,7 +122,7 @@ class OptionalAuthFilterOrderingTest extends JerseyTest {
     private static class DummyAuthorizationFilter implements ContainerRequestFilter {
 
         @Override
-        public void filter(ContainerRequestContext request) throws IOException {
+        public void filter(ContainerRequestContext request) {
             if (request.getSecurityContext().getUserPrincipal() != null) {
                 request.abortWith(Response.ok("authorization ok").build());
             } else {

--- a/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactory.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactory.java
@@ -51,7 +51,7 @@ public class DropwizardSSLConnectionSocketFactory {
         if (supportedCiphers == null) {
             return null;
         }
-        return supportedCiphers.toArray(new String[supportedCiphers.size()]);
+        return supportedCiphers.toArray(new String[0]);
     }
 
     @Nullable
@@ -60,7 +60,7 @@ public class DropwizardSSLConnectionSocketFactory {
         if (supportedProtocols == null) {
             return null;
         }
-        return supportedProtocols.toArray(new String[supportedProtocols.size()]);
+        return supportedProtocols.toArray(new String[0]);
     }
 
     private HostnameVerifier chooseHostnameVerifier() {

--- a/dropwizard-client/src/test/java/io/dropwizard/client/proxy/HttpClientConfigurationTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/proxy/HttpClientConfigurationTest.java
@@ -5,7 +5,6 @@ import io.dropwizard.client.HttpClientConfiguration;
 import io.dropwizard.configuration.ConfigurationParsingException;
 import io.dropwizard.configuration.ConfigurationValidationException;
 import io.dropwizard.configuration.DefaultConfigurationFactoryFactory;
-import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.util.Resources;

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/SubstitutingSourceProvider.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/SubstitutingSourceProvider.java
@@ -36,7 +36,7 @@ public class SubstitutingSourceProvider implements ConfigurationSourceProvider {
      */
     @Override
     public InputStream open(String path) throws IOException {
-        try (InputStream in = delegate.open(path);) {
+        try (InputStream in = delegate.open(path)) {
             final String config = new String(ByteStreams.toByteArray(in), StandardCharsets.UTF_8);
             final String substituted = substitutor.replace(config);
 

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/EnvironmentVariableLookupTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/EnvironmentVariableLookupTest.java
@@ -3,7 +3,6 @@ package io.dropwizard.configuration;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 class EnvironmentVariableLookupTest {

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/SubstitutingSourceProviderTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/SubstitutingSourceProviderTest.java
@@ -48,7 +48,7 @@ class SubstitutingSourceProviderTest {
         InputStream lastStream = new ByteArrayInputStream(new byte[0]);
 
         @Override
-        public InputStream open(String s) throws IOException {
+        public InputStream open(String s) {
             // used to test that the stream is properly closed
             lastStream = new BufferedInputStream(new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8)));
             return lastStream;

--- a/dropwizard-core/src/test/java/io/dropwizard/cli/InheritedServerCommandTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/cli/InheritedServerCommandTest.java
@@ -2,7 +2,6 @@ package io.dropwizard.cli;
 
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
-import io.dropwizard.configuration.ConfigurationException;
 import io.dropwizard.configuration.ConfigurationFactory;
 import io.dropwizard.configuration.ConfigurationSourceProvider;
 import io.dropwizard.logging.LoggingFactory;
@@ -18,7 +17,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -90,12 +88,12 @@ class InheritedServerCommandTest {
 
         class SingletonConfigurationFactory implements ConfigurationFactory<Configuration> {
             @Override
-            public Configuration build(final ConfigurationSourceProvider provider, final String path) throws IOException, ConfigurationException {
+            public Configuration build(final ConfigurationSourceProvider provider, final String path) {
                 return configuration;
             }
 
             @Override
-            public Configuration build() throws IOException, ConfigurationException {
+            public Configuration build() {
                 throw new AssertionError("Didn't use the default config path variable");
             }
         }
@@ -109,7 +107,7 @@ class InheritedServerCommandTest {
         bootstrap.addCommand(new ConfiguredCommand<Configuration>("test", "a test command") {
 
             @Override
-            protected void run(final Bootstrap<Configuration> bootstrap, final Namespace namespace, final Configuration configuration) throws Exception {
+            protected void run(final Bootstrap<Configuration> bootstrap, final Namespace namespace, final Configuration configuration) {
                 assertThat(namespace.getString("file"))
                         .isNotEmpty()
                         .isEqualTo("yaml/server.yml");

--- a/dropwizard-e2e/src/test/java/com/example/app1/App1Test.java
+++ b/dropwizard-e2e/src/test/java/com/example/app1/App1Test.java
@@ -64,7 +64,7 @@ public class App1Test {
     }
 
     @Test
-    void earlyEofTest() throws IOException, InterruptedException {
+    void earlyEofTest() throws IOException {
         // Only eof test so we ensure it's false before test
         ((App1)RULE.getApplication()).wasEofExceptionHit = false;
 

--- a/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckSchedulerTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckSchedulerTest.java
@@ -173,6 +173,6 @@ class HealthCheckSchedulerTest {
         final String name = "test";
 
         assertThatCode(() -> scheduler.unschedule(name))
-            .doesNotThrowAnyException();;
+            .doesNotThrowAnyException();
     }
 }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
@@ -38,7 +38,7 @@ class UnitOfWorkAwareProxyFactoryTest {
         when(environment.metrics()).thenReturn(new MetricRegistry());
 
         final DataSourceFactory dataSourceFactory = new DataSourceFactory();
-        dataSourceFactory.setUrl("jdbc:hsqldb:mem:unit-of-work-" + UUID.randomUUID().toString());
+        dataSourceFactory.setUrl("jdbc:hsqldb:mem:unit-of-work-" + UUID.randomUUID());
         dataSourceFactory.setUser("sa");
         dataSourceFactory.setDriverClass("org.hsqldb.jdbcDriver");
         dataSourceFactory.setValidationQuery("SELECT 1 FROM INFORMATION_SCHEMA.SYSTEM_USERS");

--- a/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/JdbiFactoryTest.java
+++ b/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/JdbiFactoryTest.java
@@ -16,7 +16,6 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 class JdbiFactoryTest {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalFormParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/guava/OptionalFormParamResourceTest.java
@@ -16,7 +16,6 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Form;
 import javax.ws.rs.core.Response;
-import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,7 +29,7 @@ class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    void shouldReturnDefaultMessageWhenMessageIsNotPresent() throws IOException {
+    void shouldReturnDefaultMessageWhenMessageIsNotPresent() {
         final String defaultMessage = "Default Message";
         final Response response = target("/optional/message").request().post(Entity.form(new MultivaluedStringMap()));
 
@@ -38,7 +37,7 @@ class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    void shouldReturnMessageWhenMessageBlank() throws IOException {
+    void shouldReturnMessageWhenMessageBlank() {
         final Form form = new Form("message", "");
         final Response response = target("/optional/message").request().post(Entity.form(form));
 
@@ -46,7 +45,7 @@ class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    void shouldReturnMessageWhenMessageIsPresent() throws IOException {
+    void shouldReturnMessageWhenMessageIsPresent() {
         final String customMessage = "Custom Message";
         final Form form = new Form("message", customMessage);
         final Response response = target("/optional/message").request().post(Entity.form(form));
@@ -55,7 +54,7 @@ class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    void shouldReturnDefaultMessageWhenMyMessageIsNotPresent() throws IOException {
+    void shouldReturnDefaultMessageWhenMyMessageIsNotPresent() {
         final String defaultMessage = "My Default Message";
         final Response response = target("/optional/my-message").request().post(Entity.form(new MultivaluedStringMap()));
 
@@ -63,7 +62,7 @@ class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    void shouldReturnMyMessageWhenMyMessageIsPresent() throws IOException {
+    void shouldReturnMyMessageWhenMyMessageIsPresent() {
         final String myMessage = "My Message";
         final Form form = new Form("mymessage", myMessage);
         final Response response = target("/optional/my-message").request().post(Entity.form(form));
@@ -72,7 +71,7 @@ class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() throws IOException {
+    void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() {
         final String invalidUUID = "invalid-uuid";
         final Form form = new Form("uuid", invalidUUID);
         final Response response = target("/optional/uuid").request().post(Entity.form(form));
@@ -81,7 +80,7 @@ class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    void shouldReturnDefaultUUIDWhenUUIDIsNotPresent() throws IOException {
+    void shouldReturnDefaultUUIDWhenUUIDIsNotPresent() {
         final String defaultUUID = "d5672fa8-326b-40f6-bf71-d9dacf44bcdc";
         final Response response = target("/optional/uuid").request().post(Entity.form(new MultivaluedStringMap()));
 
@@ -89,7 +88,7 @@ class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    void shouldReturnUUIDWhenValidUUIDIsPresent() throws IOException {
+    void shouldReturnUUIDWhenValidUUIDIsPresent() {
         final String uuid = "fd94b00d-bd50-46b3-b42f-905a9c9e7d78";
         final Form form = new Form("uuid", uuid);
         final Response response = target("/optional/uuid").request().post(Entity.form(form));

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/gzip/ConfiguredGZipEncoderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/gzip/ConfiguredGZipEncoderTest.java
@@ -76,7 +76,7 @@ class ConfiguredGZipEncoderTest {
         private final MultivaluedMap<String, Object> headers;
         private OutputStream os = new OutputStream() {
             @Override
-            public void write(int i) throws IOException {
+            public void write(int i) {
                 //void
             }
         };
@@ -87,7 +87,7 @@ class ConfiguredGZipEncoderTest {
         }
 
         @Override
-        public void proceed() throws IOException, WebApplicationException {
+        public void proceed() throws WebApplicationException {
             proceedCalled = true;
         }
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalFormParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalFormParamResourceTest.java
@@ -15,7 +15,6 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Form;
 import javax.ws.rs.core.Response;
-import java.io.IOException;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,7 +29,7 @@ class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    void shouldReturnDefaultMessageWhenMessageIsNotPresent() throws IOException {
+    void shouldReturnDefaultMessageWhenMessageIsNotPresent() {
         final String defaultMessage = "Default Message";
         final Response response = target("/optional/message").request().post(Entity.form(new MultivaluedStringMap()));
 
@@ -38,7 +37,7 @@ class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    void shouldReturnMessageWhenMessageBlank() throws IOException {
+    void shouldReturnMessageWhenMessageBlank() {
         final Form form = new Form("message", "");
         final Response response = target("/optional/message").request().post(Entity.form(form));
 
@@ -46,7 +45,7 @@ class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    void shouldReturnMessageWhenMessageIsPresent() throws IOException {
+    void shouldReturnMessageWhenMessageIsPresent() {
         final String customMessage = "Custom Message";
         final Form form = new Form("message", customMessage);
         final Response response = target("/optional/message").request().post(Entity.form(form));
@@ -55,7 +54,7 @@ class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    void shouldReturnDefaultMessageWhenMyMessageIsNotPresent() throws IOException {
+    void shouldReturnDefaultMessageWhenMyMessageIsNotPresent() {
         final String defaultMessage = "My Default Message";
         final Response response = target("/optional/my-message").request().post(Entity.form(new MultivaluedStringMap()));
 
@@ -63,7 +62,7 @@ class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    void shouldReturnMyMessageWhenMyMessageIsPresent() throws IOException {
+    void shouldReturnMyMessageWhenMyMessageIsPresent() {
         final String myMessage = "My Message";
         final Form form = new Form("mymessage", myMessage);
         final Response response = target("/optional/my-message").request().post(Entity.form(form));
@@ -72,7 +71,7 @@ class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() throws IOException {
+    void shouldThrowBadRequestExceptionWhenInvalidUUIDIsPresent() {
         final String invalidUUID = "invalid-uuid";
         final Form form = new Form("uuid", invalidUUID);
         final Response response = target("/optional/uuid").request().post(Entity.form(form));
@@ -81,7 +80,7 @@ class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    void shouldReturnDefaultUUIDWhenUUIDIsNotPresent() throws IOException {
+    void shouldReturnDefaultUUIDWhenUUIDIsNotPresent() {
         final String defaultUUID = "d5672fa8-326b-40f6-bf71-d9dacf44bcdc";
         final Response response = target("/optional/uuid").request().post(Entity.form(new MultivaluedStringMap()));
 
@@ -89,7 +88,7 @@ class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    void shouldReturnUUIDWhenValidUUIDIsPresent() throws IOException {
+    void shouldReturnUUIDWhenValidUUIDIsPresent() {
         final String uuid = "fd94b00d-bd50-46b3-b42f-905a9c9e7d78";
         final Form form = new Form("uuid", uuid);
         final Response response = target("/optional/uuid").request().post(Entity.form(form));

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/FuzzyEnumParamConverterProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/FuzzyEnumParamConverterProviderTest.java
@@ -18,7 +18,7 @@ class FuzzyEnumParamConverterProviderTest {
 
     private enum Fuzzy {
         A_1,
-        A_2;
+        A_2
     }
 
     private enum WithToString {

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/LocalIpFilter.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/LocalIpFilter.java
@@ -1,17 +1,17 @@
-/**
- * Copyright 2013-2014 The Apache Software Foundation (Curator Project)
- *
- * The Apache Software Foundation licenses this file to you under the Apache
- * License, version 2.0 (the "License"); you may not use this file except in
- * compliance with the License. You may obtain a copy of the License at:
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+/*
+  Copyright 2013-2014 The Apache Software Foundation (Curator Project)
+
+  The Apache Software Foundation licenses this file to you under the Apache
+  License, version 2.0 (the "License"); you may not use this file except in
+  compliance with the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
  */
 package io.dropwizard.jetty;
 

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/RoutingHandler.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/RoutingHandler.java
@@ -37,7 +37,7 @@ public class RoutingHandler extends HandlerCollection {
             this.entries[i++] = new Entry(entry.getKey(), entry.getValue());
             addBean(entry.getValue());
         }
-        setHandlers(handlers.values().toArray(new Handler[handlers.size()]));
+        setHandlers(handlers.values().toArray(new Handler[0]));
     }
 
     @Override

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NetUtilTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NetUtilTest.java
@@ -6,7 +6,6 @@ import java.io.File;
 import java.net.InetAddress;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/AccessAttribute.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/AccessAttribute.java
@@ -24,5 +24,5 @@ public enum AccessAttribute {
     @JsonProperty("localPort") LOCAL_PORT,
     @JsonProperty("requestContent") REQUEST_CONTENT,
     @JsonProperty("responseContent") RESPONSE_CONTENT,
-    @JsonProperty("timestamp") TIMESTAMP;
+    @JsonProperty("timestamp") TIMESTAMP
 }

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/EventJsonLayoutTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/EventJsonLayoutTest.java
@@ -5,7 +5,6 @@ import ch.qos.logback.classic.pattern.ThrowableProxyConverter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggerContextVO;
 import ch.qos.logback.classic.spi.ThrowableProxyVO;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.logging.json.EventAttribute;
 import io.dropwizard.util.Maps;

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
@@ -52,7 +52,7 @@ class ExecutorServiceBuilderTest {
 
     @Test
     @SuppressWarnings("Slf4jFormatShouldBeConst")
-    void testGiveNoWarningAboutMaximumPoolSizeAndBoundedQueue() throws InterruptedException {
+    void testGiveNoWarningAboutMaximumPoolSizeAndBoundedQueue() {
         ExecutorService exe = executorServiceBuilder
             .minThreads(4)
             .maxThreads(8)
@@ -86,7 +86,7 @@ class ExecutorServiceBuilderTest {
      */
     @Test
     @SuppressWarnings("Slf4jFormatShouldBeConst")
-    void shouldNotWarnWhenSettingUpCachedThreadPool() throws InterruptedException {
+    void shouldNotWarnWhenSettingUpCachedThreadPool() {
         ExecutorService exe = executorServiceBuilder
             .minThreads(0)
             .maxThreads(Integer.MAX_VALUE)

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/TlsSocketAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/TlsSocketAppenderFactory.java
@@ -11,7 +11,6 @@ import javax.validation.constraints.NotEmpty;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
-import java.net.UnknownHostException;
 import java.util.List;
 
 /**
@@ -400,22 +399,22 @@ public class TlsSocketAppenderFactory<E extends DeferredProcessingAware> extends
             }
 
             @Override
-            public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+            public Socket createSocket(String host, int port) {
                 return unsupported();
             }
 
             @Override
-            public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException, UnknownHostException {
+            public Socket createSocket(String host, int port, InetAddress localHost, int localPort) {
                 return unsupported();
             }
 
             @Override
-            public Socket createSocket(InetAddress host, int port) throws IOException {
+            public Socket createSocket(InetAddress host, int port) {
                 return unsupported();
             }
 
             @Override
-            public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+            public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) {
                 return unsupported();
             }
 

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/socket/DropwizardUdpSocketAppender.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/socket/DropwizardUdpSocketAppender.java
@@ -38,7 +38,7 @@ public class DropwizardUdpSocketAppender<E extends DeferredProcessingAware> exte
         }
         return new OutputStream() {
             @Override
-            public void write(int b) throws IOException {
+            public void write(int b) {
                 throw new UnsupportedOperationException("Datagram doesn't work at byte level");
             }
 
@@ -49,7 +49,7 @@ public class DropwizardUdpSocketAppender<E extends DeferredProcessingAware> exte
             }
 
             @Override
-            public void close() throws IOException {
+            public void close() {
                 datagramSocket.close();
             }
         };

--- a/dropwizard-metrics-graphite/src/test/java/io/dropwizard/metrics/graphite/GraphiteReporterFactoryTest.java
+++ b/dropwizard-metrics-graphite/src/test/java/io/dropwizard/metrics/graphite/GraphiteReporterFactoryTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.lang.reflect.Field;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/BaseReporterFactoryTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/BaseReporterFactoryTest.java
@@ -4,7 +4,6 @@ import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.ScheduledReporter;
 import io.dropwizard.util.Sets;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibase.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibase.java
@@ -17,7 +17,7 @@ public abstract class CloseableLiquibase extends Liquibase implements AutoClosea
         ResourceAccessor resourceAccessor,
         Database database,
         ManagedDataSource dataSource
-    ) throws LiquibaseException, SQLException {
+    ) {
         super(changeLogFile, resourceAccessor, database);
         this.dataSource = dataSource;
     }

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbDumpCommand.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbDumpCommand.java
@@ -207,7 +207,7 @@ public class DbDumpCommand<T extends Configuration> extends AbstractLiquibaseCom
             throws DatabaseException, IOException, ParserConfigurationException {
         @SuppressWarnings("unchecked")
         final SnapshotControl snapshotControl = new SnapshotControl(database,
-                compareTypes.toArray(new Class[compareTypes.size()]));
+                compareTypes.toArray(new Class[0]));
         final CompareControl compareControl = new CompareControl(new CompareControl.SchemaComparison[]{
             new CompareControl.SchemaComparison(catalogAndSchema, catalogAndSchema)}, compareTypes);
         final CatalogAndSchema[] compareControlSchemas = compareControl

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDropAllCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDropAllCommandTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.sql.SQLException;
 import java.util.Collections;
 
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/LiquibaseScopingTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/LiquibaseScopingTest.java
@@ -6,7 +6,6 @@ import liquibase.database.Database;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.CustomChangeException;
 import liquibase.exception.LiquibaseException;
-import liquibase.exception.SetupException;
 import liquibase.exception.ValidationErrors;
 import liquibase.resource.ResourceAccessor;
 import net.sourceforge.argparse4j.inf.Namespace;
@@ -112,7 +111,7 @@ public class LiquibaseScopingTest extends AbstractMigrationTest implements Custo
         return "";
     }
     @Override
-    public void setUp() throws SetupException {
+    public void setUp() {
     }
     @Override
     public void setFileOpener(ResourceAccessor resourceAccessor) {

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardClientExtensionTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardClientExtensionTest.java
@@ -20,7 +20,7 @@ class DropwizardClientExtensionTest {
     @Test
     void shouldGetStringBodyFromDropWizard() throws IOException {
         final URL url = new URL(EXTENSION_WITH_INSTANCE.baseUri() + "/test");
-        assertThat(Resources.toString(url, StandardCharsets.UTF_8)).isEqualTo("foo");;
+        assertThat(Resources.toString(url, StandardCharsets.UTF_8)).isEqualTo("foo");
     }
 
     @Test

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/LogbackExcludedTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/LogbackExcludedTest.java
@@ -92,7 +92,7 @@ class LogbackExcludedTest {
         return byteStream;
     }
 
-    private static interface CheckedConsumer<T> {
+    private interface CheckedConsumer<T> {
 
         void accept(T t) throws ClassNotFoundException;
     }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/LogbackExcludedTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/LogbackExcludedTest.java
@@ -136,7 +136,7 @@ class LogbackExcludedTest {
             return ClassLoader.getSystemClassLoader().loadClass(name);
         }
 
-        private static Optional<URL> getUrl(Class<?> clazz) throws ClassNotFoundException {
+        private static Optional<URL> getUrl(Class<?> clazz) {
             return Optional.ofNullable(clazz.getProtectionDomain().getCodeSource()).map(CodeSource::getLocation);
         }
     }

--- a/dropwizard-util/src/test/java/io/dropwizard/util/JarLocationTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/JarLocationTest.java
@@ -2,8 +2,6 @@ package io.dropwizard.util;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 class JarLocationTest {

--- a/dropwizard-views/src/test/java/io/dropwizard/views/ViewBundleTest.java
+++ b/dropwizard-views/src/test/java/io/dropwizard/views/ViewBundleTest.java
@@ -10,7 +10,6 @@ import org.mockito.ArgumentCaptor;
 
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.WebApplicationException;
-import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Collections;
 import java.util.Locale;
@@ -70,7 +69,7 @@ class ViewBundleTest {
             }
 
             @Override
-            public void render(View view, Locale locale, OutputStream output) throws IOException, WebApplicationException {
+            public void render(View view, Locale locale, OutputStream output) throws WebApplicationException {
                 //nothing to do
             }
 


### PR DESCRIPTION
###### Problem:
IntelliJ's linter is quite picky and picks up on a few things

- Unnecessary semicolons
- A javadoc comment which is just a software license
- Using sized arrays in calls to `toArray()`
- A redundant call to `toString()`
- Duplication in an `if` statement in `PolymorphicAuthDynamicFeature`
- A static modifier on an inner interface
- Various exceptions declared which aren't thrown
- Various unused imports

###### Solution:
Do the things IntelliJ suggests, at least where it doesn't affect any external-facing API.

###### Result:
Hopefully zero effect, aside from making IntelliJ less grumpy.