### PR TITLE
Always enforce using Jakarta EE APIs

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -38,10 +38,10 @@ jobs:
         key: ${{ runner.os }}-sonar
         restore-keys: ${{ runner.os }}-sonar
     - name: Build
-      run: ./mvnw --no-transfer-progress -Pjakarta-apis -V -B -ff -s .github/settings.xml install
+      run: ./mvnw --no-transfer-progress -V -B -ff -s .github/settings.xml install
     - name: Analyze with SonarCloud
       if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      run: ./mvnw --no-transfer-progress -Pjakarta-apis -V -B -ff -s .github/settings.xml -Dsonar.projectKey=dropwizard_dropwizard -Dsonar.organization=dropwizard -Dsonar.host.url=https://sonarcloud.io org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+      run: ./mvnw --no-transfer-progress -V -B -ff -s .github/settings.xml -Dsonar.projectKey=dropwizard_dropwizard -Dsonar.organization=dropwizard -Dsonar.host.url=https://sonarcloud.io org.sonarsource.scanner.maven:sonar-maven-plugin:sonar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-${{ secrets.CACHE_VERSION }}-
     - name: Build and Deploy
-      run: ./mvnw -B -V -ntp -Pjakarta-apis -DperformRelease=true deploy
+      run: ./mvnw -B -V -ntp -DperformRelease=true deploy
       env:
         CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
         CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,8 +17,8 @@ cache:
 install:
 - cmd: 'java -version'
 build_script:
-- mvnw.cmd --no-transfer-progress -Pjakarta-apis -V -B -ff install -DskipTests=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Dmaven.deploy.skip=true
+- mvnw.cmd --no-transfer-progress -V -B -ff install -DskipTests=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Dmaven.deploy.skip=true
 test_script:
-- mvnw.cmd --no-transfer-progress -Pjakarta-apis -V -B -ff verify -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Dmaven.deploy.skip=true
+- mvnw.cmd --no-transfer-progress -V -B -ff verify -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Dmaven.deploy.skip=true
 matrix:
   fast_finish: true

--- a/dropwizard-parent/pom.xml
+++ b/dropwizard-parent/pom.xml
@@ -319,6 +319,14 @@
                                 <DependencyConvergence />
                                 <bannedDependencies>
                                     <excludes>
+                                        <!-- Replaced with jakarta.activation:jakarta.activation-api -->
+                                        <exclude>javax.activation:javax.activation-api</exclude>
+                                        <!-- Replaced with jakarta.servlet:jakarta.servlet-api -->
+                                        <exclude>javax.servlet:javax.servlet-api</exclude>
+                                        <!-- Replaced with jakarta.validation:jakarta.validation-api -->
+                                        <exclude>javax.validation:validation-api</exclude>
+                                        <!-- Replaced with jakarta.xml.bind:jakarta.xml.bind-api -->
+                                        <exclude>javax.xml.bind:jaxb-api</exclude>
                                         <!-- This should not exist as it will force SLF4J calls to be delegated to log4j -->
                                         <exclude>org.slf4j:slf4j-log4j12</exclude>
                                         <!-- This should not exist as it will force SLF4J calls to be delegated to jul -->

--- a/pom.xml
+++ b/pom.xml
@@ -283,42 +283,6 @@
             </modules>
         </profile>
         <profile>
-            <id>jakarta-apis</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-enforcer-plugin</artifactId>
-                        <version>${maven-enforcer-plugin.version}</version>
-                        <executions>
-                            <execution>
-                                <id>enforce-jakarta-apis</id>
-                                <goals>
-                                    <goal>enforce</goal>
-                                </goals>
-                                <configuration>
-                                    <rules>
-                                        <bannedDependencies>
-                                            <excludes>
-                                                <!-- Replaced with jakarta.activation:jakarta.activation-api -->
-                                                <exclude>javax.activation:javax.activation-api</exclude>
-                                                <!-- Replaced with jakarta.servlet:jakarta.servlet-api -->
-                                                <exclude>javax.servlet:javax.servlet-api</exclude>
-                                                <!-- Replaced with jakarta.validation:jakarta.validation-api -->
-                                                <exclude>javax.validation:validation-api</exclude>
-                                                <!-- Replaced with jakarta.xml.bind:jakarta.xml.bind-api -->
-                                                <exclude>javax.xml.bind:jaxb-api</exclude>
-                                            </excludes>
-                                        </bannedDependencies>
-                                    </rules>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>release</id>
             <activation>
                 <property>


### PR DESCRIPTION
Instead of relying on activating a build profile, always enforce using Jakarta EE APIs.