### PR TITLE
Add JsonProperty annotations to constructor parameters of Person in `dropwizard-jackson`

### DIFF
--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/ParanamerModuleTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/ParanamerModuleTest.java
@@ -20,7 +20,7 @@ class ParanamerModuleTest {
     }
 
     @Test
-    void deserializePersonWithoutAnnotations() throws IOException {
+    void deserializePerson() throws IOException {
         final ObjectReader reader = mapper.readerFor(Person.class);
         final Person person = reader.readValue("{ \"name\": \"Foo\", \"surname\": \"Bar\" }");
         assertThat(person.getName()).isEqualTo("Foo");
@@ -28,7 +28,7 @@ class ParanamerModuleTest {
     }
 
     @Test
-    void serializePersonWithoutAnnotations() throws IOException {
+    void serializePerson() throws IOException {
         final ObjectWriter reader = mapper.writerFor(Person.class);
         final String person = reader.writeValueAsString(new Person("Foo", "Bar"));
         assertThat(person)

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/Person.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/Person.java
@@ -1,10 +1,12 @@
 package io.dropwizard.jackson;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class Person {
     private final String name;
     private final String surname;
 
-    public Person(String name, String surname) {
+    public Person(@JsonProperty("name") String name, @JsonProperty("surname") String surname) {
         this.name = name;
         this.surname = surname;
     }


### PR DESCRIPTION
###### Problem:
The tests of `dropwizard-jackson` fail after upgrading Jackson to version 2.13.0. Thereby the `Person` class cannot be deserialized.

###### Solution:
The constructor parameters of the `Person` class get annotated with proper `@JsonProperty` annotations.

###### Result:
The test works again.
