### PR TITLE
Simplify ResourceConfigurationSourceProviderTest

### DIFF
--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ResourceConfigurationSourceProviderTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ResourceConfigurationSourceProviderTest.java
@@ -1,31 +1,23 @@
 package io.dropwizard.configuration;
 
-import io.dropwizard.util.CharStreams;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ResourceConfigurationSourceProviderTest {
     private final ConfigurationSourceProvider provider = new ResourceConfigurationSourceProvider();
 
-    @Test
-    void readsFileContents() throws Exception {
-        assertForWheeContent("example.txt");
-        assertForWheeContent("io/dropwizard/configuration/not-root-example.txt");
-        assertForWheeContent("/io/dropwizard/configuration/not-root-example.txt");
-    }
-
-    private void assertForWheeContent(String path) throws Exception {
-        assertThat(loadResourceAsString(path)).isEqualToIgnoringWhitespace("whee");
-    }
-
-    private String loadResourceAsString(String path) throws Exception {
-        try (InputStream inputStream = provider.open(path)) {
-            return CharStreams.toString(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
-        }
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "example.txt",
+        "io/dropwizard/configuration/not-root-example.txt",
+        "/io/dropwizard/configuration/not-root-example.txt"
+    })
+    void readsFileContents(String path) throws Exception {
+        assertThat(provider.open(path))
+            .asString(UTF_8)
+            .isEqualToIgnoringWhitespace("whee");
     }
 }


### PR DESCRIPTION
AssertJ can assert on `InputStream`s so we can substantially simplify this
test.