### PR TITLE
Mostly remove Guava

### DIFF
--- a/dropwizard-e2e/pom.xml
+++ b/dropwizard-e2e/pom.xml
@@ -142,11 +142,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
             <scope>test</scope>

--- a/dropwizard-e2e/src/test/java/com/example/health/HealthIntegrationTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/health/HealthIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.example.health;
 
-import com.google.common.primitives.Longs;
 import io.dropwizard.Configuration;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.ResourceHelpers;
@@ -32,7 +31,7 @@ class HealthIntegrationTest {
     private static final Duration POLL_DELAY = Duration.ofMillis(10);
 
     private static final Duration testTimeout = Optional.ofNullable(System.getenv(TEST_TIMEOUT_MS_OVERRIDE_ENV_VAR))
-            .map(Longs::tryParse)
+            .map(Long::parseLong)
             .map(Duration::ofMillis)
             // Default to 5 seconds
             .orElse(Duration.ofSeconds(5));

--- a/dropwizard-health/src/main/java/io/dropwizard/health/DefaultHealthFactory.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/DefaultHealthFactory.java
@@ -7,7 +7,6 @@ import com.codahale.metrics.health.HealthCheckRegistry;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.dropwizard.health.response.HealthResponderFactory;
 import io.dropwizard.health.response.HealthResponseProvider;
@@ -27,6 +26,8 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static java.util.Collections.singletonList;
 
 @JsonTypeName("default")
 public class DefaultHealthFactory implements HealthFactory {
@@ -56,7 +57,7 @@ public class DefaultHealthFactory implements HealthFactory {
     @NotNull
     @Size(min = 1)
     @JsonProperty
-    private List<String> healthCheckUrlPaths = ImmutableList.of(DEFAULT_PATH);
+    private List<String> healthCheckUrlPaths = singletonList(DEFAULT_PATH);
 
     @Valid
     @JsonProperty("responseProvider")

--- a/dropwizard-health/src/main/java/io/dropwizard/health/check/http/HttpHealthCheck.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/check/http/HttpHealthCheck.java
@@ -1,7 +1,6 @@
 package io.dropwizard.health.check.http;
 
 import com.codahale.metrics.health.HealthCheck;
-import com.google.common.base.Preconditions;
 import org.glassfish.jersey.client.ClientProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,8 +29,9 @@ public class HttpHealthCheck extends HealthCheck {
                            final Duration readTimeout,
                            final Duration connectionTimeout) {
         this.url = Objects.requireNonNull(url);
-        Preconditions.checkState(readTimeout.toMillis() > 0L);
-        Preconditions.checkState(connectionTimeout.toMillis() > 0L);
+        if (readTimeout.toMillis() <= 0L || connectionTimeout.toMillis() <= 0L) {
+            throw new IllegalStateException();
+        }
         this.client = ClientBuilder.newClient()
             .property(ClientProperties.CONNECT_TIMEOUT, (int) connectionTimeout.toMillis())
             .property(ClientProperties.READ_TIMEOUT, (int) readTimeout.toMillis());

--- a/dropwizard-health/src/main/java/io/dropwizard/health/check/tcp/TcpHealthCheck.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/check/tcp/TcpHealthCheck.java
@@ -1,7 +1,6 @@
 package io.dropwizard.health.check.tcp;
 
 import com.codahale.metrics.health.HealthCheck;
-import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,9 +31,12 @@ public class TcpHealthCheck extends HealthCheck {
                           final Duration connectionTimeout) {
         this.host = Objects.requireNonNull(host);
         this.port = port;
-        Preconditions.checkState(!connectionTimeout.isNegative(), "connectionTimeout must be a non-negative value.");
-        Preconditions.checkState(connectionTimeout.toMillis() <= Integer.MAX_VALUE,
-            "Cannot configure a connectionTimeout greater than the max integer value");
+        if (connectionTimeout.isNegative()) {
+            throw new IllegalStateException("connectionTimeout must be a non-negative value.");
+        }
+        if (connectionTimeout.toMillis() > Integer.MAX_VALUE) {
+            throw new IllegalStateException("Cannot configure a connectionTimeout greater than the max integer value");
+        }
         this.connectionTimeout = connectionTimeout;
     }
 

--- a/dropwizard-health/src/main/java/io/dropwizard/health/response/JsonHealthResponseProvider.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/response/JsonHealthResponseProvider.java
@@ -1,7 +1,6 @@
 package io.dropwizard.health.response;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
 import io.dropwizard.health.HealthStateAggregator;
 import io.dropwizard.health.HealthStateView;
 import io.dropwizard.health.HealthStatusChecker;
@@ -10,6 +9,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.ws.rs.core.MediaType;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -18,6 +18,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static java.util.Collections.unmodifiableList;
 
 public class JsonHealthResponseProvider implements HealthResponseProvider {
     public static final String CHECK_TYPE_QUERY_PARAM = "type";
@@ -86,19 +88,16 @@ public class JsonHealthResponseProvider implements HealthResponseProvider {
 
         final Collection<HealthStateView> views;
         if (shouldReturnAllViews(names)) {
-            views = healthStateAggregator.healthStateViews();
+            return unmodifiableList(new ArrayList<>(healthStateAggregator.healthStateViews()));
         } else {
-            views = names.stream()
+            return unmodifiableList(names.stream()
                 .map(healthStateAggregator::healthStateView)
                 // replace with .flatMap(Optional::stream) in Java 9+
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 // replace with Collector.toUnmodifiableList in Java 10+
-                .collect(Collectors.toList());
+                .collect(Collectors.toList()));
         }
-
-        // ensure views are immutable
-        return ImmutableList.copyOf(views);
     }
 
     private boolean shouldReturnAllViews(final Set<String> names) {

--- a/dropwizard-health/src/test/java/io/dropwizard/health/DefaultHealthFactoryTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/DefaultHealthFactoryTest.java
@@ -1,8 +1,6 @@
 package io.dropwizard.health;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
-import com.google.common.io.Resources;
 import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.validation.Validators;
@@ -12,6 +10,7 @@ import javax.validation.Validator;
 import java.io.File;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class DefaultHealthFactoryTest {
@@ -22,14 +21,14 @@ class DefaultHealthFactoryTest {
 
     @Test
     void shouldBuildHealthFactoryFromYaml() throws Exception {
-        final File yml = new File(Resources.getResource("yml/health.yml").toURI());
+        final File yml = new File(getClass().getResource("/yml/health.yml").toURI());
         final DefaultHealthFactory healthFactory = configFactory.build(yml);
 
         assertThat(healthFactory.isDelayedShutdownHandlerEnabled()).isTrue();
         assertThat(healthFactory.isEnabled()).isTrue();
         assertThat(healthFactory.isInitialOverallState()).isTrue();
         assertThat(healthFactory.getShutdownWaitPeriod().toMilliseconds()).isEqualTo(1L);
-        assertThat(healthFactory.getHealthCheckUrlPaths()).isEqualTo(ImmutableList.of("/health-check"));
+        assertThat(healthFactory.getHealthCheckUrlPaths()).isEqualTo(singletonList("/health-check"));
 
         assertThat(healthFactory.getHealthChecks()).isEqualTo(healthFactory.getHealthCheckConfigurations());
 

--- a/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckConfigurationTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckConfigurationTest.java
@@ -1,7 +1,6 @@
 package io.dropwizard.health;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.io.Resources;
 import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.validation.Validators;
@@ -20,7 +19,7 @@ class HealthCheckConfigurationTest {
 
     @Test
     void shouldBuildHealthCheckConfigurationFromYaml() throws Exception {
-        final File yml = new File(Resources.getResource("yml/healthCheck.yml").toURI());
+        final File yml = new File(getClass().getResource("/yml/healthCheck.yml").toURI());
         final HealthCheckConfiguration healthCheckConfig = configFactory.build(yml);
 
         assertThat(healthCheckConfig.getName()).isEqualTo("cassandra");

--- a/dropwizard-health/src/test/java/io/dropwizard/health/ScheduleTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/ScheduleTest.java
@@ -1,7 +1,6 @@
 package io.dropwizard.health;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.io.Resources;
 import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.validation.Validators;
@@ -20,7 +19,7 @@ class ScheduleTest {
 
     @Test
     void shouldBuildAScheduleFromYaml() throws Exception {
-        final File yml = new File(Resources.getResource("yml/schedule.yml").toURI());
+        final File yml = new File(getClass().getResource("/yml/schedule.yml").toURI());
         final Schedule schedule = configFactory.build(yml);
 
         assertThat(schedule.getCheckInterval().toMilliseconds()).isEqualTo(2500L);

--- a/dropwizard-health/src/test/java/io/dropwizard/health/check/tcp/TcpHealthCheckTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/check/tcp/TcpHealthCheckTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.health.check.tcp;
 
-import com.google.common.util.concurrent.Uninterruptibles;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -11,7 +10,6 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -54,7 +52,7 @@ class TcpHealthCheckTest {
         serverSocket = new ServerSocket();
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
         executorService.submit(() -> {
-            Uninterruptibles.sleepUninterruptibly(tcpHealthCheck.getConnectionTimeout().toMillis() * 3, TimeUnit.MILLISECONDS);
+            Thread.sleep(tcpHealthCheck.getConnectionTimeout().toMillis() * 3);
             serverSocket.bind(new InetSocketAddress("127.0.0.1", port));
             return true;
         });

--- a/dropwizard-health/src/test/java/io/dropwizard/health/response/JsonHealthResponseProviderFactoryTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/response/JsonHealthResponseProviderFactoryTest.java
@@ -1,7 +1,6 @@
 package io.dropwizard.health.response;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.io.Resources;
 import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.health.HealthStateAggregator;
 import io.dropwizard.health.HealthStatusChecker;
@@ -49,7 +48,7 @@ class JsonHealthResponseProviderFactoryTest {
     @Test
     void testBuildJsonHealthResponseProvider() throws Exception {
         // given
-        final File yml = new File(Resources.getResource("yml/json-response-provider.yml").toURI());
+        final File yml = new File(getClass().getResource("/yml/json-response-provider.yml").toURI());
 
         // when
         when(healthStatusChecker.isHealthy(isNull())).thenReturn(true);

--- a/dropwizard-health/src/test/java/io/dropwizard/health/response/JsonHealthResponseProviderTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/response/JsonHealthResponseProviderTest.java
@@ -2,7 +2,6 @@ package io.dropwizard.health.response;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Charsets;
 import io.dropwizard.health.HealthCheckType;
 import io.dropwizard.health.HealthStateAggregator;
 import io.dropwizard.health.HealthStateView;
@@ -24,6 +23,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -34,9 +34,6 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class JsonHealthResponseProviderTest {
-    private static final String READY_TYPE = HealthCheckType.READY.name().toLowerCase();
-    private static final String ALIVE_TYPE = HealthCheckType.ALIVE.name().toLowerCase();
-
     private final ObjectMapper mapper = Jackson.newObjectMapper();
     @Mock
     private HealthStatusChecker healthStatusChecker;
@@ -135,7 +132,7 @@ class JsonHealthResponseProviderTest {
     private String fixture(final String filename) {
         final URL resource = Resources.getResource(filename);
         try {
-            return Resources.toString(resource, Charsets.UTF_8).trim();
+            return Resources.toString(resource, UTF_8).trim();
         } catch (final IOException e) {
             throw new IllegalArgumentException(e);
         }

--- a/dropwizard-health/src/test/java/io/dropwizard/health/response/ServletHealthResponderFactoryTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/response/ServletHealthResponderFactoryTest.java
@@ -1,7 +1,6 @@
 package io.dropwizard.health.response;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.io.Resources;
 import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.health.HealthEnvironment;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
@@ -94,7 +93,7 @@ class ServletHealthResponderFactoryTest {
     @Test
     void testBuildHealthServlet() throws Exception {
         // given
-        File yml = new File(Resources.getResource("yml/servlet-responder-factory-caching.yml").toURI());
+        File yml = new File(getClass().getResource("/yml/servlet-responder-factory-caching.yml").toURI());
         setupServletStubbing();
 
         // when
@@ -116,7 +115,7 @@ class ServletHealthResponderFactoryTest {
     @Test
     void testBuildHealthServletWithCacheControlDisabled() throws Exception {
         // given
-        File yml = new File(Resources.getResource("yml/servlet-responder-factory-caching-header-disabled.yml").toURI());
+        File yml = new File(getClass().getResource("/yml/servlet-responder-factory-caching-header-disabled.yml").toURI());
         setupServletStubbing();
 
         // when

--- a/dropwizard-health/src/test/java/io/dropwizard/health/response/ServletHealthResponderTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/response/ServletHealthResponderTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.health.response;
 
-import com.google.common.collect.ImmutableList;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpTester;
@@ -15,11 +14,14 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.ws.rs.core.MediaType;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import static java.util.Collections.unmodifiableList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -119,8 +121,11 @@ class ServletHealthResponderTest {
         final String name = "all";
         final String anotherName = "foo";
         final Map<String, Collection<String>> queryParams = new HashMap<>();
+        final List<String> nameQueryParams = new ArrayList<>();
+        nameQueryParams.add(name);
+        nameQueryParams.add(anotherName);
         queryParams.put(typeQueryParam, Collections.singletonList(type));
-        queryParams.put(nameQueryParam, ImmutableList.of(name, anotherName));
+        queryParams.put(nameQueryParam, unmodifiableList(nameQueryParams));
 
         // when
         when(healthResponseProvider.healthResponse(queryParams)).thenReturn(SUCCESS);


### PR DESCRIPTION
This removes almost all Guava usages except for one reference to
`ThreadFactoryBuilder` in `dropwizard-health` and the various Guava converters
which still exist.