### PR TITLE
Deprecate `Resources#copy()`

### DIFF
--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/GzipHandlerTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/GzipHandlerTest.java
@@ -78,7 +78,7 @@ class GzipHandlerTest {
     void testDecompressRequest() throws Exception {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (GZIPOutputStream gz = new GZIPOutputStream(baos)) {
-            Resources.copy(Resources.getResource("assets/new-banner.txt"), gz);
+            gz.write(Resources.toByteArray(getClass().getResource("/assets/new-banner.txt")));
         }
 
         setRequestPostGzipPlainText(baos.toByteArray());

--- a/dropwizard-util/src/main/java/io/dropwizard/util/Resources.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Resources.java
@@ -71,6 +71,7 @@ public final class Resources {
      * @param to the output stream
      * @throws IOException if an I/O error occurs
      */
+    @Deprecated
     public static void copy(URL from, OutputStream to) throws IOException {
         try (InputStream inputStream = from.openStream()) {
             ByteStreams.copy(inputStream, to);


### PR DESCRIPTION
This was only used by `GzipHandlerTest` and can be replaced by a call to
`Resources#toByteArray()`