### PR TITLE
Prepare ByteStreams for deprecation in Java 9+

### DIFF
--- a/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
@@ -14,7 +14,7 @@ import io.dropwizard.logging.FileAppenderFactory;
 import io.dropwizard.logging.SyslogAppenderFactory;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.setup.ExceptionMapperBinder;
-import io.dropwizard.util.CharStreams;
+import io.dropwizard.util.ByteStreams;
 import io.dropwizard.util.Resources;
 import io.dropwizard.validation.BaseValidator;
 import org.eclipse.jetty.server.AbstractNetworkConnector;
@@ -28,7 +28,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import java.io.File;
-import java.io.InputStreamReader;
+import java.io.InputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -201,8 +201,9 @@ class DefaultServerFactoryTest {
             URL url = new URL("http://localhost:" + port + "/app/test");
             URLConnection connection = url.openConnection();
             connection.connect();
-
-            return CharStreams.toString(new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8));
+            try (InputStream in = connection.getInputStream()) {
+                return new String(ByteStreams.toByteArray(in), StandardCharsets.UTF_8);
+            }
         });
 
         requestReceived.await(10, TimeUnit.SECONDS);

--- a/dropwizard-core/src/test/java/io/dropwizard/server/SimpleServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/SimpleServerFactoryTest.java
@@ -13,7 +13,7 @@ import io.dropwizard.logging.FileAppenderFactory;
 import io.dropwizard.logging.SyslogAppenderFactory;
 import io.dropwizard.servlets.tasks.Task;
 import io.dropwizard.setup.Environment;
-import io.dropwizard.util.CharStreams;
+import io.dropwizard.util.ByteStreams;
 import io.dropwizard.util.Resources;
 import io.dropwizard.validation.BaseValidator;
 import org.eclipse.jetty.server.AbstractNetworkConnector;
@@ -27,7 +27,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import java.io.File;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.HttpURLConnection;
@@ -122,8 +121,8 @@ public class SimpleServerFactoryTest {
         final HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
         connection.setRequestMethod(requestMethod);
         connection.connect();
-        try (InputStream inputStream = connection.getInputStream()) {
-            return CharStreams.toString(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+        try (InputStream in = connection.getInputStream()) {
+            return new String(ByteStreams.toByteArray(in), StandardCharsets.UTF_8);
         }
     }
 

--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/TaskServlet.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/TaskServlet.java
@@ -6,7 +6,7 @@ import com.codahale.metrics.Timer;
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
-import io.dropwizard.util.CharStreams;
+import io.dropwizard.util.ByteStreams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,7 +15,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.InputStream;
 import java.io.PrintWriter;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
@@ -164,7 +164,9 @@ public class TaskServlet extends HttpServlet {
     }
 
     private String getBody(HttpServletRequest req) throws IOException {
-        return CharStreams.toString(new InputStreamReader(req.getInputStream(), StandardCharsets.UTF_8));
+        try (InputStream in = req.getInputStream()) {
+            return new String(ByteStreams.toByteArray(in), StandardCharsets.UTF_8);
+        }
     }
 
     public Collection<Task> getTasks() {

--- a/dropwizard-util/src/main/java/io/dropwizard/util/ByteStreams.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/ByteStreams.java
@@ -15,11 +15,19 @@ public final class ByteStreams {
 
     public static byte[] toByteArray(InputStream in) throws IOException {
         ByteArrayOutputStream to = new ByteArrayOutputStream();
-        copy(in, to);
+        copyInternal(in, to);
         return to.toByteArray();
     }
 
+    /**
+     * @deprecated this is an internal method to dropwizard-util. Consider apache-commons instead.
+     */
+    @Deprecated
     public static void copy(InputStream in, OutputStream to) throws IOException {
+        copyInternal(in, to);
+    }
+
+    static void copyInternal(InputStream in, OutputStream to) throws IOException {
         byte[] buffer = new byte[4096];
         int length;
         while ((length = in.read(buffer)) != -1) {

--- a/dropwizard-util/src/main/java/io/dropwizard/util/Resources.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Resources.java
@@ -2,7 +2,6 @@ package io.dropwizard.util;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.URL;
 import java.nio.charset.Charset;
@@ -60,7 +59,7 @@ public final class Resources {
      */
     public static String toString(URL url, Charset charset) throws IOException {
         try (InputStream inputStream = url.openStream()) {
-            return CharStreams.toString(new InputStreamReader(inputStream, charset));
+            return new String(ByteStreams.toByteArray(inputStream), charset);
         }
     }
 
@@ -74,7 +73,7 @@ public final class Resources {
     @Deprecated
     public static void copy(URL from, OutputStream to) throws IOException {
         try (InputStream inputStream = from.openStream()) {
-            ByteStreams.copy(inputStream, to);
+            ByteStreams.copyInternal(inputStream, to);
         }
     }
 }


### PR DESCRIPTION
In Java 9+ we can use `InputStream#readAllBytes()` to slurp an `InputStream` into a `String`. Prepare for this future refactor by using `ByteStreams#toByteArray()` to convert `InputStream`s to a byte array whenever we're converting an `InputStream` to a `String`.

`ByteStreams#copy()` is only used by `dropwizard-util`, so deprecate it and replace it with a package-private method.