### PR TITLE
Tighten AssertJ exception matching

### DIFF
--- a/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactoryTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactoryTest.java
@@ -38,7 +38,7 @@ import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.bouncycastle.jce.provider.BouncyCastleProvider.PROVIDER_NAME;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
@@ -212,17 +212,17 @@ class DropwizardSSLConnectionSocketFactoryTest {
     @Test
     void shouldErrorIfHostnameVerificationOnAndServerHostnameDoesntMatch() {
         final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).build("bad_host_broken");
-        final Throwable exn = catchThrowable(() -> client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(3))).request().get());
-        assertThat(exn).hasCauseExactlyInstanceOf(SSLPeerUnverifiedException.class);
-        assertThat(exn.getCause()).hasMessage("Certificate for <localhost> doesn't match any of the subject alternative names: []");
+        assertThatThrownBy(() -> client.target(String.format("https://localhost:%d", TLS_APP_RULE.getPort(3))).request().get())
+            .hasCauseExactlyInstanceOf(SSLPeerUnverifiedException.class)
+            .hasRootCauseMessage("Certificate for <localhost> doesn't match any of the subject alternative names: []");
     }
 
     @Test
     void shouldErrorIfHostnameVerificationOnAndServerHostnameMatchesAndFailVerifierSpecified() {
         final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).using(new FailVerifier()).build("bad_host_broken_fail_verifier");
-        final Throwable exn = catchThrowable(() -> client.target(String.format("https://localhost:%d", TLS_APP_RULE.getLocalPort())).request().get());
-        assertThat(exn).hasCauseExactlyInstanceOf(SSLPeerUnverifiedException.class);
-        assertThat(exn.getCause()).hasMessage("Certificate for <localhost> doesn't match any of the subject alternative names: []");
+        assertThatThrownBy(() -> client.target(String.format("https://localhost:%d", TLS_APP_RULE.getLocalPort())).request().get())
+            .hasCauseExactlyInstanceOf(SSLPeerUnverifiedException.class)
+            .hasRootCauseMessage("Certificate for <localhost> doesn't match any of the subject alternative names: []");
     }
 
     @Test
@@ -241,7 +241,7 @@ class DropwizardSSLConnectionSocketFactoryTest {
     }
 
     @Test
-    void shouldBeOkIfHostnameVerificationOffAndServerHostnameMatchesAndFailVerfierSpecified() {
+    void shouldBeOkIfHostnameVerificationOffAndServerHostnameMatchesAndFailVerifierSpecified() {
         tlsConfiguration.setVerifyHostname(false);
         final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).using(new FailVerifier()).build("bad_host_fail_verifier_working");
         final Response response = client.target(String.format("https://localhost:%d", TLS_APP_RULE.getLocalPort())).request().get();

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
@@ -66,7 +66,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -98,7 +98,7 @@ class JerseyClientBuilderTest {
 
     @Test
     void throwsAnExceptionWithoutAnEnvironmentOrAThreadPoolAndObjectMapper() {
-        assertThatExceptionOfType(IllegalStateException.class)
+        assertThatIllegalStateException()
             .isThrownBy(() -> builder.build("test"))
             .withMessage("Must have either an environment or both an executor service and an object mapper");
     }
@@ -106,7 +106,7 @@ class JerseyClientBuilderTest {
     @Test
     void throwsAnExceptionWithoutAnEnvironmentAndOnlyObjectMapper() {
         JerseyClientBuilder configuredBuilder = builder.using(objectMapper);
-        assertThatExceptionOfType(IllegalStateException.class)
+        assertThatIllegalStateException()
             .isThrownBy(() -> configuredBuilder.build("test"))
             .withMessage("Must have either an environment or both an executor service and an object mapper");
     }
@@ -114,7 +114,7 @@ class JerseyClientBuilderTest {
     @Test
     void throwsAnExceptionWithoutAnEnvironmentAndOnlyAThreadPool() {
         JerseyClientBuilder configuredBuilder = builder.using(executorService);
-        assertThatExceptionOfType(IllegalStateException.class)
+        assertThatIllegalStateException()
             .isThrownBy(() -> configuredBuilder.build("test"))
             .withMessage("Must have either an environment or both an executor service and an object mapper");
     }

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/BaseConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/BaseConfigurationFactoryTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 public abstract class BaseConfigurationFactoryTest {
 
@@ -313,7 +314,7 @@ public abstract class BaseConfigurationFactoryTest {
     @Test
     void throwsAnExceptionOnUnexpectedArrayOverride() {
         System.setProperty("dw.servers.port", "9000");
-        assertThatExceptionOfType(IllegalArgumentException.class)
+        assertThatIllegalArgumentException()
             .isThrownBy(() -> factory.build(validFile))
             .withMessageContaining("target is an array but no index specified");
     }
@@ -405,7 +406,7 @@ public abstract class BaseConfigurationFactoryTest {
         System.setProperty("dw.name", "Coda Hale Overridden");
         final YamlConfigurationFactory<NonInsatiableExample> factory =
             new YamlConfigurationFactory<>(NonInsatiableExample.class, validator, Jackson.newObjectMapper(), "dw");
-        assertThatExceptionOfType(IllegalArgumentException.class)
+        assertThatIllegalArgumentException()
             .isThrownBy(factory::build)
             .withMessage("Unable to create an instance of the configuration class: " +
                 "'io.dropwizard.configuration.BaseConfigurationFactoryTest.NonInsatiableExample'");

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/SubstitutingSourceProviderTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/SubstitutingSourceProviderTest.java
@@ -11,7 +11,7 @@ import org.apache.commons.text.lookup.StringLookup;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIOException;
 
 class SubstitutingSourceProviderTest {
     @Test
@@ -23,7 +23,7 @@ class SubstitutingSourceProviderTest {
         assertThat(provider.open("foo: ${bar}")).hasSameContentAs(new ByteArrayInputStream("foo: baz".getBytes(StandardCharsets.UTF_8)));
 
         // ensure that opened streams are closed
-        assertThatExceptionOfType(IOException.class)
+        assertThatIOException()
             .isThrownBy(() -> dummyProvider.lastStream.read())
             .withMessage("Stream closed");
     }

--- a/dropwizard-core/src/test/java/io/dropwizard/cli/ServerCommandTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/cli/ServerCommandTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIOException;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -91,7 +91,7 @@ class ServerCommandTest {
             }
         });
 
-        assertThatExceptionOfType(IOException.class)
+        assertThatIOException()
             .isThrownBy(() -> command.run(environment, namespace, configuration))
             .withMessage("oh crap");
 

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkApplicationListenerTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkApplicationListenerTest.java
@@ -18,6 +18,7 @@ import java.lang.reflect.Method;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.hibernate.resource.transaction.spi.TransactionStatus.ACTIVE;
 import static org.hibernate.resource.transaction.spi.TransactionStatus.NOT_ACTIVE;
 import static org.mockito.Mockito.doAnswer;
@@ -235,7 +236,7 @@ class UnitOfWorkApplicationListenerTest {
     @Test
     void throwsExceptionOnNotRegisteredDatabase() throws Exception {
         prepareResourceMethod("methodWithUnitOfWorkOnNotRegisteredDatabase");
-        assertThatExceptionOfType(IllegalArgumentException.class)
+        assertThatIllegalArgumentException()
             .isThrownBy(this::execute)
             .withMessage("Unregistered Hibernate bundle: 'warehouse'");
     }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactoryTest.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -80,7 +80,7 @@ class UnitOfWorkAwareProxyFactoryTest {
 
     @Test
     void testProxyHandlesErrors() {
-        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(()->
+        assertThatIllegalStateException().isThrownBy(()->
             new UnitOfWorkAwareProxyFactory("default", sessionFactory)
                 .create(BrokenAuthenticator.class)
                 .authenticate("b812ae4"))
@@ -137,9 +137,7 @@ class UnitOfWorkAwareProxyFactoryTest {
         final NestedCall nestedCall = unitOfWorkAwareProxyFactory
                 .create(NestedCall.class, SessionFactory.class, sessionFactory);
 
-        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(()-> {
-            nestedCall.invalidNestedCall();
-        });
+        assertThatIllegalStateException().isThrownBy(nestedCall::invalidNestedCall);
     }
 
     static class SessionDao {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/FuzzyEnumParamConverterProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/FuzzyEnumParamConverterProviderTest.java
@@ -11,7 +11,7 @@ import java.lang.annotation.Annotation;
 
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class FuzzyEnumParamConverterProviderTest {
     private final FuzzyEnumParamConverterProvider paramConverterProvider = new FuzzyEnumParamConverterProvider();
@@ -170,12 +170,12 @@ class FuzzyEnumParamConverterProviderTest {
         assertThat(converter.fromString("A_1 ")).isSameAs(Fuzzy.A_1);
         assertThat(converter.fromString("A_2")).isSameAs(Fuzzy.A_2);
 
-        final WebApplicationException throwable = catchThrowableOfType(() -> converter.fromString("B"), WebApplicationException.class);
-        assertThat(throwable.getResponse())
-            .extracting(Response::getEntity)
-            .matches(e -> ((ErrorMessage) e).getCode() == 400)
-            .matches(e -> ((ErrorMessage) e).getMessage().contains("A_1"))
-            .matches(e -> ((ErrorMessage) e).getMessage().contains("A_2"));
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> converter.fromString("B"))
+            .extracting(e -> (ErrorMessage)e.getResponse().getEntity())
+            .matches(e -> e.getCode() == 400)
+            .matches(e -> e.getMessage().contains("A_1"))
+            .matches(e -> e.getMessage().contains("A_2"));
     }
 
 
@@ -195,44 +195,44 @@ class FuzzyEnumParamConverterProviderTest {
         final ParamConverter<ExplicitFromString> converter = getConverter(ExplicitFromString.class);
         assertThat(converter.fromString("1")).isSameAs(ExplicitFromString.A);
         assertThat(converter.fromString("2")).isSameAs(ExplicitFromString.B);
-        final WebApplicationException throwable = catchThrowableOfType(() -> converter.fromString("3"), WebApplicationException.class);
-        assertThat(throwable.getResponse())
-            .extracting(Response::getEntity)
-            .matches(e -> ((ErrorMessage) e).getCode() == 400)
-            .matches(e -> ((ErrorMessage) e).getMessage().contains("is not a valid ExplicitFromString"));
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> converter.fromString("3"))
+            .extracting(e -> (ErrorMessage)e.getResponse().getEntity())
+            .matches(e -> e.getCode() == 400)
+            .matches(e -> e.getMessage().contains("is not a valid ExplicitFromString"));
     }
 
     @Test
     void testEnumViaExplicitFromStringThatThrowsWebApplicationException() {
         final ParamConverter<ExplicitFromStringThrowsWebApplicationException> converter =
             getConverter(ExplicitFromStringThrowsWebApplicationException.class);
-        final WebApplicationException throwable = catchThrowableOfType(() -> converter.fromString("3"), WebApplicationException.class);
-        assertThat(throwable.getResponse())
-            .extracting(Response::getStatusInfo)
-            .matches(e -> ((Response.StatusType) e).getStatusCode() == 418)
-            .matches(e -> ((Response.StatusType) e).getReasonPhrase().contains("I am a teapot"));
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> converter.fromString("3"))
+            .extracting(e -> e.getResponse().getStatusInfo())
+            .matches(e -> e.getStatusCode() == 418)
+            .matches(e -> e.getReasonPhrase().contains("I am a teapot"));
     }
 
     @Test
     void testEnumViaExplicitFromStringThatThrowsOtherException() {
         final ParamConverter<ExplicitFromStringThrowsOtherException> converter =
             getConverter(ExplicitFromStringThrowsOtherException.class);
-        final WebApplicationException throwable = catchThrowableOfType(() -> converter.fromString("1"), WebApplicationException.class);
-        assertThat(throwable.getResponse())
-            .extracting(Response::getEntity)
-            .matches(e -> ((ErrorMessage) e).getCode() == 400)
-            .matches(e -> ((ErrorMessage) e).getMessage().contains("Failed to convert"));
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> converter.fromString("1"))
+            .extracting(e -> (ErrorMessage)e.getResponse().getEntity())
+            .matches(e -> e.getCode() == 400)
+            .matches(e -> e.getMessage().contains("Failed to convert"));
     }
 
     @Test
     void testEnumViaExplicitFromStringNonStatic() {
         final ParamConverter<ExplicitFromStringNonStatic> converter = getConverter(ExplicitFromStringNonStatic.class);
-        final WebApplicationException throwable = catchThrowableOfType(() -> converter.fromString("1"), WebApplicationException.class);
-        assertThat(throwable.getResponse())
-            .extracting(Response::getEntity)
-            .matches(e -> ((ErrorMessage) e).getCode() == 400)
-            .matches(e -> ((ErrorMessage) e).getMessage().contains("A"))
-            .matches(e -> ((ErrorMessage) e).getMessage().contains("B"));
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> converter.fromString("1"))
+            .extracting(e -> (ErrorMessage)e.getResponse().getEntity())
+            .matches(e -> e.getCode() == 400)
+            .matches(e -> e.getMessage().contains("A"))
+            .matches(e -> e.getMessage().contains("B"));
 
         assertThat(converter.fromString("A")).isSameAs(ExplicitFromStringNonStatic.A);
     }
@@ -240,10 +240,10 @@ class FuzzyEnumParamConverterProviderTest {
     @Test
     void testEnumViaExplicitFromStringPrivate() {
         final ParamConverter<ExplicitFromStringPrivate> converter = getConverter(ExplicitFromStringPrivate.class);
-        final WebApplicationException throwable = catchThrowableOfType(() -> converter.fromString("1"), WebApplicationException.class);
-        assertThat(throwable.getResponse())
-            .extracting(Response::getEntity)
-            .matches(e -> ((ErrorMessage) e).getCode() == 400)
-            .matches(e -> ((ErrorMessage) e).getMessage().contains("Not permitted to call"));
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> converter.fromString("1"))
+            .extracting(e -> (ErrorMessage)e.getResponse().getEntity())
+            .matches(e -> e.getCode() == 400)
+            .matches(e -> e.getMessage().contains("Not permitted to call"));
     }
 }

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NonblockingServletHolderTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NonblockingServletHolderTest.java
@@ -11,7 +11,7 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIOException;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -48,9 +48,8 @@ class NonblockingServletHolderTest {
     @Test
     void servicesRequestException() throws Exception {
         doThrow(new IOException()).when(servlet).service(request, response);
-        assertThatExceptionOfType(IOException.class).isThrownBy(() -> {
-            holder.handle(baseRequest, request, response);
-        });
+        assertThatIOException()
+            .isThrownBy(() -> holder.handle(baseRequest, request, response));
     }
 
     @Test

--- a/dropwizard-util/src/test/java/io/dropwizard/util/DataSizeTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/DataSizeTest.java
@@ -10,7 +10,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 class DataSizeTest {
     @Test
@@ -222,21 +222,21 @@ class DataSizeTest {
 
     @Test
     void unableParseWrongDataSizeCount() {
-        assertThatExceptionOfType(IllegalArgumentException.class)
+        assertThatIllegalArgumentException()
             .isThrownBy(() -> DataSize.parse("three bytes"))
             .withMessage("Invalid size: three bytes");
     }
 
     @Test
     void unableParseWrongDataSizeUnit() {
-        assertThatExceptionOfType(IllegalArgumentException.class)
+        assertThatIllegalArgumentException()
             .isThrownBy(() -> DataSize.parse("1EB"))
             .withMessage("Invalid size: 1EB. Wrong size unit");
     }
 
     @Test
     void unableParseWrongDataSizeFormat() {
-        assertThatExceptionOfType(IllegalArgumentException.class)
+        assertThatIllegalArgumentException()
             .isThrownBy(() -> DataSize.parse("1 mega byte"))
             .withMessage("Invalid size: 1 mega byte");
     }

--- a/dropwizard-util/src/test/java/io/dropwizard/util/StringsTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/StringsTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 class StringsTest {
 
@@ -31,9 +32,9 @@ class StringsTest {
 
   @Test
   void repeatExceptions() {
-    assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> Strings.repeat("", -2_147_483_647))
+      assertThatIllegalArgumentException().isThrownBy(() -> Strings.repeat("", -2_147_483_647))
         .withMessage("invalid count: -2147483647" );
-    assertThatExceptionOfType(ArrayIndexOutOfBoundsException.class).isThrownBy(() -> Strings.repeat("00000000", 319_979_524))
+      assertThatExceptionOfType(ArrayIndexOutOfBoundsException.class).isThrownBy(() -> Strings.repeat("00000000", 319_979_524))
         .withMessage("Required array size too large: 2559836192");
   }
 


### PR DESCRIPTION
Use more specific matchers where we can and clean up some of the assertions to
remove repetition.