### PR TITLE
Avoid a potential NPE in `ChainedAuthFilter`

### DIFF
--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/chained/ChainedAuthFilter.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/chained/ChainedAuthFilter.java
@@ -53,6 +53,9 @@ public class ChainedAuthFilter<C, P extends Principal> extends AuthFilter<C, P> 
             }
         }
 
+        if (firstException == null) {
+            throw new WebApplicationException(unauthorizedHandler.buildResponse(prefix, realm));
+        }
         throw firstException;
     }
 }


### PR DESCRIPTION

Picked up by Sonar.

###### Problem:
It is theoretically possible that all `AuthFilter`s in a `ChainedAuthFilter`
could refuse to authenticate the user without throwing any exceptions.

In this case, a `NullPointerException` would be thrown.

###### Solution:
After much discussion on https://github.com/dropwizard/dropwizard/issues/4233 I'm raising this as a proposed improvement.

Instead of throwing an NPE, throw a `WebApplicationException` explicitly denying the request.

###### Result:
Sonar will stop complaining.
Maybe the user will get a better error?