### PR TITLE
Add flattening to AccessJsonLayout

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -951,7 +951,7 @@ includes                 (timestamp, level,
                                                 - ``message``     *true*   Whether to include the formatted message as the ``message`` field.
                                                 - ``exception``   *true*   Whether to log exceptions. If the property enabled and there is an exception, it will be formatted to a string as the ``exception`` field.
                                                 - ``contextName`` *false*  Whether to include the logging context name as the ``context`` field .
-customFieldNames         (empty)                Map of field name replacements . For example ``(requestTime:request_time, userAgent:user_agent)``.
+customFieldNames         (empty)                Map of field name replacements . For example ``(requestTime:request_time, userAgent:user_agent)``. Custom field name collisions will result in one value being picked.
 additionalFields         (empty)                Map of fields to add in the JSON map.
 includesMdcKeys          (empty)                Set of MDC keys which should be included in the JSON map. By default includes everything.
 flattenMdc               false                  Flatten the MDC to the root of the JSON object instead of nested in the ``mdc`` field.
@@ -999,14 +999,18 @@ JSON access log layout
       prettyPrint: false
       appendLineSeparator: true
       includes: [timestamp, remoteAddress, remoteUser, protocol, method, requestUri, statusCode, requestTime, contentLength, userAgent]
+      flattenRequestHeaders: false
       requestHeaders:
         - X-Request-Id
+      flattenResponseHeaders: false
       responseHeaders:
         - X-Request-Id
+      flattenRequestAttributes: true
       requestAttributes:
         - SomeAttributeName
       customFieldNames:
         timestamp: "@timestamp"
+        SomeAttributeName: some-attribute-name
       additionalFields:
         service-name: "user-service"
 
@@ -1042,9 +1046,12 @@ includes                 (timestamp, remoteAddress,
                                                       - ``responseContent``   *false*    Whether to include the response body as the ``responseContent`` field. Must register_ the TeeFilter_ to be effective.
                                                       - ``serverName``        *false*    Whether to include the name of the server to which the request was sent as the ``serverName`` field.
 requestHeaders           (empty)                      Set of request headers included in the JSON map as the ``headers`` field.
+flattenRequestHeaders    false                        Flattens the ``requestHeaders`` to the root of the JSON object instead of nested in the ``requestHeaders`` field. Field name collisions will result in one value being picked.
 responseHeaders          (empty)                      Set of response headers included in the JSON map as the ``responseHeaders`` field.
+flattenResponseHeaders   false                        Flattens the ``responseHeaders`` to the root of the JSON object instead of nested in the ``responseHeaders`` field. Field name collisions will result in one value being picked.
 requestAttributes        (empty)                      Set of ServletRequest attributes included in the JSON map as the ``requestAttributes`` field.
-customFieldNames         (empty)                      Map of field name replacements in the JSON map. For example ``requestTime:request_time, userAgent:user_agent)``.
+flattenRequestAttributes false                        Flatten the ``requestAttributes`` to the root of the JSON object instead of nested in the ``requestAttributes`` field. Field name collisions will result in one value being picked.
+customFieldNames         (empty)                      Map of field name replacements in the JSON map. For example ``requestTime:request_time, userAgent:user_agent)``. Custom field name collisions will result in one value being picked.
 additionalFields         (empty)                      Map of fields to add in the JSON map.
 =======================  ===========================  ================
 

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/AccessJsonLayoutBaseFactory.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/AccessJsonLayoutBaseFactory.java
@@ -51,8 +51,11 @@ public class AccessJsonLayoutBaseFactory extends AbstractJsonLayoutBaseFactory<I
             AccessAttribute.TIMESTAMP);
 
     private Set<String> responseHeaders = Collections.emptySet();
+    private boolean flattenResponseHeaders;
     private Set<String> requestHeaders = Collections.emptySet();
+    private boolean flattenRequestHeaders;
     private Set<String> requestAttributes = Collections.emptySet();
+    private boolean flattenRequestAttributes;
 
     @JsonProperty
     public Set<String> getResponseHeaders() {
@@ -62,6 +65,22 @@ public class AccessJsonLayoutBaseFactory extends AbstractJsonLayoutBaseFactory<I
     @JsonProperty
     public void setResponseHeaders(Set<String> responseHeaders) {
         this.responseHeaders = responseHeaders;
+    }
+
+    /**
+     * @since 2.0
+     */
+    @JsonProperty
+    public boolean isFlattenResponseHeaders() {
+        return flattenResponseHeaders;
+    }
+
+    /**
+     * @since 2.0
+     */
+    @JsonProperty
+    public void setFlattenResponseHeaders(boolean flattenResponseHeaders) {
+        this.flattenResponseHeaders = flattenResponseHeaders;
     }
 
     @JsonProperty
@@ -78,6 +97,22 @@ public class AccessJsonLayoutBaseFactory extends AbstractJsonLayoutBaseFactory<I
      * @since 2.0
      */
     @JsonProperty
+    public boolean isFlattenRequestHeaders() {
+        return flattenRequestHeaders;
+    }
+
+    /**
+     * @since 2.0
+     */
+    @JsonProperty
+    public void setFlattenRequestHeaders(boolean flattenRequestHeaders) {
+        this.flattenRequestHeaders = flattenRequestHeaders;
+    }
+
+    /**
+     * @since 2.0
+     */
+    @JsonProperty
     public Set<String> getRequestAttributes() {
         return requestAttributes;
     }
@@ -88,6 +123,22 @@ public class AccessJsonLayoutBaseFactory extends AbstractJsonLayoutBaseFactory<I
     @JsonProperty
     public void setRequestAttributes(Set<String> requestAttributes) {
         this.requestAttributes = requestAttributes;
+    }
+
+    /**
+     * @since 2.0
+     */
+    @JsonProperty
+    public boolean isFlattenRequestAttributes() {
+        return flattenRequestAttributes;
+    }
+
+    /**
+     * @since 2.0
+     */
+    @JsonProperty
+    public void setFlattenRequestAttributes(boolean flattenRequestAttributes) {
+        this.flattenRequestAttributes = flattenRequestAttributes;
     }
 
     @JsonProperty
@@ -112,6 +163,9 @@ public class AccessJsonLayoutBaseFactory extends AbstractJsonLayoutBaseFactory<I
         jsonLayout.setRequestHeaders(requestHeaders);
         jsonLayout.setResponseHeaders(responseHeaders);
         jsonLayout.setRequestAttributes(requestAttributes);
+        jsonLayout.setFlattenRequestHeaders(flattenRequestHeaders);
+        jsonLayout.setFlattenResponseHeaders(flattenResponseHeaders);
+        jsonLayout.setFlattenRequestAttributes(flattenRequestAttributes);
         return jsonLayout;
     }
 }

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/AccessJsonLayout.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/AccessJsonLayout.java
@@ -3,6 +3,7 @@ package io.dropwizard.logging.json.layout;
 import ch.qos.logback.access.spi.IAccessEvent;
 import io.dropwizard.logging.json.AccessAttribute;
 
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -23,8 +24,11 @@ public class AccessJsonLayout extends AbstractJsonLayout<IAccessEvent> {
     private Set<AccessAttribute> includes;
 
     private SortedSet<String> requestHeaders = Collections.emptySortedSet();
+    private boolean flattenRequestHeaders;
     private SortedSet<String> responseHeaders = Collections.emptySortedSet();
+    private boolean flattenResponseHeaders;
     private SortedSet<String> requestAttributes = Collections.emptySortedSet();
+    private boolean flattenRequestAttributes;
 
     @Nullable
     private String jsonProtocolVersion;
@@ -45,7 +49,7 @@ public class AccessJsonLayout extends AbstractJsonLayout<IAccessEvent> {
 
     @Override
     protected Map<String, Object> toJsonMap(IAccessEvent event) {
-        return new MapBuilder(timestampFormatter, customFieldNames, additionalFields, includes.size())
+        final MapBuilder mapBuilder = new MapBuilder(timestampFormatter, customFieldNames, additionalFields, includes.size())
             .addNumber("port", isIncluded(AccessAttribute.LOCAL_PORT), event::getLocalPort)
             .addNumber("contentLength", isIncluded(AccessAttribute.CONTENT_LENGTH), event::getContentLength)
             .addTimestamp("timestamp", isIncluded(AccessAttribute.TIMESTAMP), event.getTimeStamp())
@@ -53,25 +57,32 @@ public class AccessJsonLayout extends AbstractJsonLayout<IAccessEvent> {
             .add("protocol", isIncluded(AccessAttribute.PROTOCOL), event::getProtocol)
             .add("requestContent", isIncluded(AccessAttribute.REQUEST_CONTENT), event::getRequestContent)
             .add("remoteAddress", isIncluded(AccessAttribute.REMOTE_ADDRESS), event::getRemoteAddr)
-            .add("remoteUser", isIncluded(AccessAttribute.REMOTE_USER), event::getRemoteUser)
-            .addMap("headers", !requestHeaders.isEmpty(),
-                () -> filterHeaders(event.getRequestHeaderMap(), requestHeaders))
+            .add("remoteUser", isIncluded(AccessAttribute.REMOTE_USER), event::getRemoteUser);
+        addMapOrFlatten(mapBuilder, "headers", !requestHeaders.isEmpty(), () -> filterHeaders(event.getRequestHeaderMap(), requestHeaders), flattenRequestHeaders);
+        mapBuilder
             .addMap("params", isIncluded(AccessAttribute.REQUEST_PARAMETERS), event::getRequestParameterMap)
             .addNumber("requestTime", isIncluded(AccessAttribute.REQUEST_TIME), event::getElapsedTime)
             .add("uri", isIncluded(AccessAttribute.REQUEST_URI), event::getRequestURI)
             .add("url", isIncluded(AccessAttribute.REQUEST_URL), event::getRequestURL)
             .add("pathQuery", isIncluded(AccessAttribute.PATH_QUERY), () -> event.getRequestURI() + event.getQueryString())
             .add("remoteHost", isIncluded(AccessAttribute.REMOTE_HOST), event::getRemoteHost)
-            .add("responseContent", isIncluded(AccessAttribute.RESPONSE_CONTENT), event::getResponseContent)
-            .addMap("responseHeaders", !responseHeaders.isEmpty(),
-                () -> filterHeaders(event.getResponseHeaderMap(), responseHeaders))
+            .add("responseContent", isIncluded(AccessAttribute.RESPONSE_CONTENT), event::getResponseContent);
+        addMapOrFlatten(mapBuilder, "responseHeaders", !responseHeaders.isEmpty(), () -> filterHeaders(event.getResponseHeaderMap(), responseHeaders), flattenResponseHeaders);
+        mapBuilder
             .add("serverName", isIncluded(AccessAttribute.SERVER_NAME), event::getServerName)
             .addNumber("status", isIncluded(AccessAttribute.STATUS_CODE), event::getStatusCode)
             .add("userAgent", isIncluded(AccessAttribute.USER_AGENT), () -> event.getRequestHeader(USER_AGENT))
-            .add("version", jsonProtocolVersion != null, jsonProtocolVersion)
-            .addMap("requestAttributes", !requestAttributes.isEmpty(),
-                () -> filterRequestAttributes(requestAttributes, event))
-            .build();
+            .add("version", jsonProtocolVersion != null, jsonProtocolVersion);
+        addMapOrFlatten(mapBuilder, "requestAttributes", !requestAttributes.isEmpty(), () -> filterRequestAttributes(requestAttributes, event), flattenRequestAttributes);
+        return mapBuilder.build();
+    }
+
+    private static void addMapOrFlatten(MapBuilder mapBuilder, String mapName, boolean hasContent, Supplier<Map<String,String>> mapGenerator, boolean flatten){
+        if (flatten) {
+            mapGenerator.get().forEach((k, v) -> mapBuilder.add(k, hasContent, v));
+        } else {
+            mapBuilder.addMap(mapName, hasContent, mapGenerator::get);
+        }
     }
 
     private boolean isIncluded(AccessAttribute attribute) {
@@ -120,6 +131,20 @@ public class AccessJsonLayout extends AbstractJsonLayout<IAccessEvent> {
         this.requestHeaders = headers;
     }
 
+    /**
+     * @since 2.0
+     */
+    public boolean isFlattenRequestHeaders() {
+        return flattenRequestHeaders;
+    }
+
+    /**
+     * @since 2.0
+     */
+    public void setFlattenRequestHeaders(boolean flattenRequestHeaders) {
+        this.flattenRequestHeaders = flattenRequestHeaders;
+    }
+
     public Set<String> getResponseHeaders() {
         return responseHeaders;
     }
@@ -128,6 +153,20 @@ public class AccessJsonLayout extends AbstractJsonLayout<IAccessEvent> {
         final TreeSet<String> headers = new TreeSet<>(String::compareToIgnoreCase);
         headers.addAll(responseHeaders);
         this.responseHeaders = headers;
+    }
+
+    /**
+     * @since 2.0
+     */
+    public boolean isFlattenResponseHeaders() {
+        return flattenResponseHeaders;
+    }
+
+    /**
+     * @since 2.0
+     */
+    public void setFlattenResponseHeaders(boolean flattenResponseHeaders) {
+        this.flattenResponseHeaders = flattenResponseHeaders;
     }
 
     /**
@@ -144,5 +183,19 @@ public class AccessJsonLayout extends AbstractJsonLayout<IAccessEvent> {
         final TreeSet<String> attributes = new TreeSet<>(String::compareToIgnoreCase);
         attributes.addAll(requestAttributes);
         this.requestAttributes = attributes;
+    }
+
+    /**
+     * @since 2.0
+     */
+    public boolean isFlattenRequestAttributes() {
+        return flattenRequestAttributes;
+    }
+
+    /**
+     * @since 2.0
+     */
+    public void setFlattenRequestAttributes(boolean flattenRequestAttributes) {
+        this.flattenRequestAttributes = flattenRequestAttributes;
     }
 }


### PR DESCRIPTION
Closes  #4396
Make flattening of request-headers, request-attributes and response-headers configurable for AccessJsonLayout

###### Problem:
When configuring f.x RequestAttributes to be emitted in the json access log it is not possible to get a "flat" object where all values are scalars.

###### Solution:
Allow users of AccessJsonLayoutFactory/AccessJsonLayout to configure flattening of the complex fields:
* RequestHeaders
* RequestAttributes
* ResponseHeaders

Note that the caller needs to understand that flattening could cause collisions since there is nothing preventing `RequestHeaders`, `ResponseHeaders` or `RequestAttribute` containing a key that already exists

###### Result:
Given a config like:
```
layout:
  type: access-json
  flattenRequestHeaders: true
  requestHeaders:
    - X-Request-Id
  flattenResponseHeaders: true
  responseHeaders:
    - X-Response-Id
  flattenRequestAttributes: true
  requestAttributes:
    - SomeAttributeName
  customFieldNames:
    SomeAttributeName: some-attribute-name
```

Output Json could look like:
```json
{
"some-attribute-name": "...",
"X-Request-Id": "...",
"X-Response-Id": "..."
}
```