### PR TITLE
Suppress console output in `dropwizard-validations` tests

### DIFF
--- a/dropwizard-validation/pom.xml
+++ b/dropwizard-validation/pom.xml
@@ -78,5 +78,10 @@
             <version>1.2.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/SelfValidatingValidator.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/SelfValidatingValidator.java
@@ -24,7 +24,15 @@ import java.util.stream.Collectors;
  * the validation methods efficiently and then calls them.
  */
 public class SelfValidatingValidator implements ConstraintValidator<SelfValidating, Object> {
-    private static final Logger log = LoggerFactory.getLogger(SelfValidatingValidator.class);
+    private final Logger log;
+
+    public SelfValidatingValidator() {
+        this(LoggerFactory.getLogger(SelfValidatingValidator.class));
+    }
+
+    SelfValidatingValidator(Logger logger) {
+        log = logger;
+    }
 
     @SuppressWarnings("rawtypes")
     private final ConcurrentMap<Class<?>, List<ValidationCaller>> methodMap = new ConcurrentHashMap<>();

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/SelfValidationTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/SelfValidationTest.java
@@ -28,6 +28,7 @@ class SelfValidationTest {
     public void clearAllLoggers() {
         //this must be a clear all because the validation runs in other threads
         TestLoggerFactory.clearAll();
+        TestLoggerFactory.getInstance().setPrintLevel(Level.OFF);
     }
 
     @SelfValidating

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/selfvalidating/SelfValidatingValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/selfvalidating/SelfValidatingValidatorTest.java
@@ -8,6 +8,7 @@ import com.fasterxml.classmate.TypeResolver;
 import com.fasterxml.classmate.members.ResolvedMethod;
 import io.dropwizard.validation.BaseValidator;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
@@ -15,52 +16,65 @@ import java.util.Arrays;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 class SelfValidatingValidatorTest {
-    private SelfValidatingValidator selfValidatingValidator = new SelfValidatingValidator();
+    private final Logger log = mock(Logger.class);
+    private final SelfValidatingValidator selfValidatingValidator = new SelfValidatingValidator(log);
 
     @Test
-    void validObjectHasNoViolations() throws Exception {
+    void validObjectHasNoViolations() {
         final Validator validator = BaseValidator.newValidator();
         final Set<ConstraintViolation<ValidExample>> violations = validator.validate(new ValidExample(1));
         assertThat(violations).isEmpty();
     }
 
     @Test
-    void invalidObjectHasViolations() throws Exception {
+    void invalidObjectHasViolations() {
         final Validator validator = BaseValidator.newValidator();
         final Set<ConstraintViolation<ValidExample>> violations = validator.validate(new ValidExample(-1));
         assertThat(violations)
-                .isNotEmpty()
-                .allSatisfy(violation -> assertThat(violation.getMessage()).isEqualTo("n must be positive!"));
+                .singleElement()
+                .extracting(ConstraintViolation::getMessage)
+                .isEqualTo("n must be positive!");
     }
 
     @Test
-    void correctMethod() throws Exception {
+    void correctMethod() {
         assertThat(selfValidatingValidator.isMethodCorrect(
                 getMethod("validateCorrect", ViolationCollector.class)))
                 .isTrue();
     }
 
     @Test
-    void voidIsNotAccepted() throws Exception {
+    void voidIsNotAccepted() {
         assertThat(selfValidatingValidator.isMethodCorrect(
                 getMethod("validateFailReturn", ViolationCollector.class)))
                 .isFalse();
     }
 
     @Test
-    void privateIsNotAccepted() throws Exception {
+    @SuppressWarnings("Slf4jFormatShouldBeConst")
+    void privateIsNotAccepted() throws NoSuchMethodException {
         assertThat(selfValidatingValidator.isMethodCorrect(
                 getMethod("validateFailPrivate", ViolationCollector.class)))
                 .isFalse();
+
+        verify(log).error("The method {} is annotated with @SelfValidation but is not public",
+            InvalidExample.class.getDeclaredMethod("validateFailPrivate", ViolationCollector.class));
     }
 
     @Test
-    void additionalParametersAreNotAccepted() throws Exception {
+    @SuppressWarnings("Slf4jFormatShouldBeConst")
+    void additionalParametersAreNotAccepted() throws NoSuchMethodException {
         assertThat(selfValidatingValidator.isMethodCorrect(
                 getMethod("validateFailAdditionalParameters", ViolationCollector.class, int.class)))
                 .isFalse();
+
+        verify(log).error("The method {} is annotated with @SelfValidation but does not have a single parameter of type {}",
+            InvalidExample.class.getMethod("validateFailAdditionalParameters", ViolationCollector.class, int.class),
+            ViolationCollector.class);
     }
 
     private ResolvedMethod getMethod(String name, Class<?>... params) {


### PR DESCRIPTION
###### Problem:
The `dropwizard-validations` tests produce output to the console:

```
[INFO] --- maven-surefire-plugin:2.22.2:test (default-test) @ dropwizard-validation ---
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running io.dropwizard.validation.selfvalidating.SelfValidatingValidatorTest
2021-11-02T20:35:23.035Z [main] ERROR io.dropwizard.validation.selfvalidating.SelfValidatingValidator - The method public boolean io.dropwizard.validation.selfvalidating.SelfValidatingValidatorTest$InvalidExample.validateFailReturn(io.dropwizard.validation.selfvalidating.ViolationCollector) is annotated with @SelfValidation but does not return void. It is ignored
Nov 02, 2021 8:35:23 PM org.hibernate.validator.internal.util.Version <clinit>
INFO: HV000001: Hibernate Validator 6.2.0.Final
2021-11-02T20:35:24.557Z [main] ERROR io.dropwizard.validation.selfvalidating.SelfValidatingValidator - The method public void io.dropwizard.validation.selfvalidating.SelfValidatingValidatorTest$InvalidExample.validateFailAdditionalParameters(io.dropwizard.validation.selfvalidating.ViolationCollector,int) is annotated with @SelfValidation but does not have a single parameter of type class io.dropwizard.validation.selfvalidating.ViolationCollector
2021-11-02T20:35:24.568Z [main] ERROR io.dropwizard.validation.selfvalidating.SelfValidatingValidator - The method private void io.dropwizard.validation.selfvalidating.SelfValidatingValidatorTest$InvalidExample.validateFailPrivate(io.dropwizard.validation.selfvalidating.ViolationCollector) is annotated with @SelfValidation but is not public
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.279 s - in io.dropwizard.validation.selfvalidating.SelfValidatingValidatorTest
[INFO] Running io.dropwizard.validation.valuehandling.OptionalValidatedValueUnwrapperTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.13 s - in io.dropwizard.validation.valuehandling.OptionalValidatedValueUnwrapperTest
[INFO] Running io.dropwizard.validation.valuehandling.GuavaOptionalValueExtractorTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.095 s - in io.dropwizard.validation.valuehandling.GuavaOptionalValueExtractorTest
[INFO] Running io.dropwizard.validation.PortRangeValidatorTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.266 s - in io.dropwizard.validation.PortRangeValidatorTest
[INFO] Running io.dropwizard.validation.MethodValidatorTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.021 s - in io.dropwizard.validation.MethodValidatorTest
[INFO] Running io.dropwizard.validation.DurationValidatorTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.317 s - in io.dropwizard.validation.DurationValidatorTest
[INFO] Running io.dropwizard.validation.SizeValidatorTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.126 s - in io.dropwizard.validation.SizeValidatorTest
[INFO] Running io.dropwizard.validation.DataSizeValidatorTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.139 s - in io.dropwizard.validation.DataSizeValidatorTest
[INFO] Running io.dropwizard.validation.OneOfValidatorTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.326 s - in io.dropwizard.validation.OneOfValidatorTest
[INFO] Running io.dropwizard.validation.SelfValidationTest
2021-11-02T20:35:28.220Z [main] ERROR io.dropwizard.validation.selfvalidating.SelfValidatingValidator - The method public boolean io.dropwizard.validation.SelfValidationTest$InvalidExample.validateFailReturn(io.dropwizard.validation.selfvalidating.ViolationCollector) is annotated with @SelfValidation but does not return void. It is ignored
2021-11-02T20:35:28.221Z [main] ERROR io.dropwizard.validation.selfvalidating.SelfValidatingValidator - The method private void io.dropwizard.validation.SelfValidationTest$InvalidExample.validateFailPrivate(io.dropwizard.validation.selfvalidating.ViolationCollector) is annotated with @SelfValidation but is not public
2021-11-02T20:35:28.221Z [main] ERROR io.dropwizard.validation.selfvalidating.SelfValidatingValidator - The method public void io.dropwizard.validation.SelfValidationTest$InvalidExample.validateFailAdditionalParameters(io.dropwizard.validation.selfvalidating.ViolationCollector,int) is annotated with @SelfValidation but does not have a single parameter of type class io.dropwizard.validation.selfvalidating.ViolationCollector
2021-11-02T20:35:28.423Z [main] WARN io.dropwizard.validation.selfvalidating.SelfValidatingValidator - The class class io.dropwizard.validation.SelfValidationTest$NoValidations is annotated with @SelfValidating but contains no valid methods that are annotated with @SelfValidation
Nov 02, 2021 8:35:28 PM org.hibernate.validator.messageinterpolation.AbstractMessageInterpolator interpolate
WARN: HV000168: The message descriptor '{value' contains an unbalanced meta character '{'.
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.418 s - in io.dropwizard.validation.SelfValidationTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 44, Failures: 0, Errors: 0, Skipped: 0
```
###### Solution:
We can update `SelfValidatingValidatorTest` to mock the `Logger` and also test the contents of the log messages using mockito.

For `SelfValidationTest` we can turn off printing to the console in `TestLoggerFactory`

###### Result:
Life is quieter:

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running io.dropwizard.validation.selfvalidating.SelfValidatingValidatorTest
Nov 02, 2021 8:38:19 PM org.hibernate.validator.internal.util.Version <clinit>
INFO: HV000001: Hibernate Validator 6.2.0.Final
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.214 s - in io.dropwizard.validation.selfvalidating.SelfValidatingValidatorTest
[INFO] Running io.dropwizard.validation.valuehandling.OptionalValidatedValueUnwrapperTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.134 s - in io.dropwizard.validation.valuehandling.OptionalValidatedValueUnwrapperTest
[INFO] Running io.dropwizard.validation.valuehandling.GuavaOptionalValueExtractorTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.113 s - in io.dropwizard.validation.valuehandling.GuavaOptionalValueExtractorTest
[INFO] Running io.dropwizard.validation.PortRangeValidatorTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.208 s - in io.dropwizard.validation.PortRangeValidatorTest
[INFO] Running io.dropwizard.validation.MethodValidatorTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.026 s - in io.dropwizard.validation.MethodValidatorTest
[INFO] Running io.dropwizard.validation.DurationValidatorTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.317 s - in io.dropwizard.validation.DurationValidatorTest
[INFO] Running io.dropwizard.validation.SizeValidatorTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.149 s - in io.dropwizard.validation.SizeValidatorTest
[INFO] Running io.dropwizard.validation.DataSizeValidatorTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.113 s - in io.dropwizard.validation.DataSizeValidatorTest
[INFO] Running io.dropwizard.validation.OneOfValidatorTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.258 s - in io.dropwizard.validation.OneOfValidatorTest
[INFO] Running io.dropwizard.validation.SelfValidationTest
Nov 02, 2021 8:38:24 PM org.hibernate.validator.messageinterpolation.AbstractMessageInterpolator interpolate
WARN: HV000168: The message descriptor '{value' contains an unbalanced meta character '{'.
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.403 s - in io.dropwizard.validation.SelfValidationTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 44, Failures: 0, Errors: 0, Skipped: 0
```

The hibernate validator log messages are quite resistant to being suppressed - there's some static lookup magic hiding in `jboss-logging`.