### PR TITLE
Replace slf4j-test by logback

### DIFF
--- a/dropwizard-validation/pom.xml
+++ b/dropwizard-validation/pom.xml
@@ -67,15 +67,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>uk.org.lidalia</groupId>
-            <artifactId>lidalia-slf4j-ext</artifactId>
-            <version>1.0.0</version>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>uk.org.lidalia</groupId>
-            <artifactId>slf4j-test</artifactId>
-            <version>1.2.0</version>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
###### Problem:
The `slf4j-test` and `lidalia-slf4j-ext` packages only get used in one test and can be replaced with `logback` functionality.

###### Solution:
Use `logback` over the `uk.org.lidalia` packages, since `logback` is used elsewhere in the project.

###### Result:
The project will contain less dependencies.
