### PR TITLE
Remove old slf4jtest configuration

### DIFF
--- a/dropwizard-validation/src/test/resources/slf4jtest.properties
+++ b/dropwizard-validation/src/test/resources/slf4jtest.properties
@@ -1,1 +1,0 @@
-print.level=INFO


### PR DESCRIPTION
slf4jtest is no longer used, following https://github.com/dropwizard/dropwizard/pull/4399