### PR TITLE
Fix `BadLogTest`

### DIFF
--- a/dropwizard-e2e/src/test/java/com/example/badlog/BadLogTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/badlog/BadLogTest.java
@@ -7,8 +7,6 @@ import io.dropwizard.testing.ResourceHelpers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
-@DisabledOnOs(OS.WINDOWS)
 class BadLogTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(BadLogTest.class);
     private static final PrintStream oldOut = System.out;

--- a/dropwizard-testing/pom.xml
+++ b/dropwizard-testing/pom.xml
@@ -86,6 +86,14 @@
             <artifactId>jsr305</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
@@ -10,6 +10,7 @@ import io.dropwizard.cli.ServerCommand;
 import io.dropwizard.configuration.ConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.lifecycle.Managed;
+import io.dropwizard.logging.LoggingUtil;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Sets;
@@ -17,6 +18,7 @@ import net.sourceforge.argparse4j.inf.Namespace;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
@@ -238,6 +240,7 @@ public class DropwizardTestSupport<C extends Configuration> {
             stopIfRequired();
         } finally {
             resetConfigOverrides();
+            LoggingUtil.getLoggerContext().getLogger(Logger.ROOT_LOGGER_NAME).detachAndStopAllAppenders();
         }
     }
 

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
@@ -240,7 +240,6 @@ public class DropwizardTestSupport<C extends Configuration> {
             stopIfRequired();
         } finally {
             resetConfigOverrides();
-            LoggingUtil.getLoggerContext().getLogger(Logger.ROOT_LOGGER_NAME).detachAndStopAllAppenders();
         }
     }
 
@@ -266,6 +265,8 @@ public class DropwizardTestSupport<C extends Configuration> {
         // Don't leak logging appenders into other test cases
         if (configuration != null) {
             configuration.getLoggingFactory().reset();
+        } else {
+            LoggingUtil.getLoggerContext().getLogger(Logger.ROOT_LOGGER_NAME).detachAndStopAllAppenders();
         }
     }
 


### PR DESCRIPTION
###### Problem:
`dropwizard-e2e`'s `BadLogTest` is failing on windows, because a file is not properly closed on application shutdown.

###### Solution:
Stop all logging appenders in the `DropwizardTestSupport.after()` method to free the occupied resources.

###### Result:
Used resources are properly freed and therefore the `BadLogTest` can be re-enabled for Windows.
