### PR TITLE
`SocketTimeoutException` instead of `ConnectException` thrown on Windows

### DIFF
--- a/dropwizard-health/src/test/java/io/dropwizard/health/check/tcp/TcpHealthCheckTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/check/tcp/TcpHealthCheckTest.java
@@ -8,11 +8,12 @@ import java.io.IOException;
 import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
+import java.net.SocketTimeoutException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class TcpHealthCheckTest {
     private ServerSocket serverSocket;
@@ -40,7 +41,7 @@ class TcpHealthCheckTest {
     @Test
     void tcpHealthCheckShouldReturnUnhealthyIfCannotConnect() throws IOException {
         serverSocket.close();
-        assertThrows(ConnectException.class, () -> tcpHealthCheck.check());
+        assertThatThrownBy(() -> tcpHealthCheck.check()).isInstanceOfAny(ConnectException.class, SocketTimeoutException.class);
     }
 
     @Test
@@ -57,6 +58,6 @@ class TcpHealthCheckTest {
             return true;
         });
 
-        assertThrows(ConnectException.class, () -> tcpHealthCheck.check());
+        assertThatThrownBy(() -> tcpHealthCheck.check()).isInstanceOfAny(ConnectException.class, SocketTimeoutException.class);
     }
 }


### PR DESCRIPTION
When executing the tests on Windows with Java 11, a `SocketTimeoutException` is thrown in a test of `dropwizard-health` instead of a `ConnectException`. However, the test completes successfully when running with Java 17 or when running the test on Linux.

Since the framework will probably support Java 11 for quite some time, the test should succeed on Windows. Therefore the test is modified to allow both exception types.