### PR TITLE
Fix build on Windows with Java 17

### DIFF
--- a/dropwizard-parent/pom.xml
+++ b/dropwizard-parent/pom.xml
@@ -122,13 +122,7 @@
                             <compilerArgs>
                                 <arg>-XDcompilePolicy=simple</arg>
                                 <!-- When run as plugin all args must be passed together -->
-                                <arg>-Xplugin:ErrorProne \
-                                    -XepDisableWarningsInGeneratedCode \
-                                    -Xep:EqualsGetClass:OFF \
-                                    -Xep:NullAway:ERROR \
-                                    -XepOpt:NullAway:AnnotatedPackages=io.dropwizard \
-                                    -XepOpt:NullAway:ExcludedFieldAnnotations=org.mockito.Mock \
-                                    -XepOpt:NullAway:UnannotatedSubPackages=io.dropwizard.benchmarks</arg>
+                                <arg>-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode -Xep:EqualsGetClass:OFF -Xep:NullAway:ERROR -XepOpt:NullAway:AnnotatedPackages=io.dropwizard -XepOpt:NullAway:ExcludedFieldAnnotations=org.mockito.Mock -XepOpt:NullAway:UnannotatedSubPackages=io.dropwizard.benchmarks</arg>
                                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
                                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
                                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>


### PR DESCRIPTION
###### Problem:
When building the project with Java 17 on Windows, an error is thrown because of an 'invalid flag'.

###### Solution:
Windows doesn't seem to like new lines in argument definitions, so remove all new lines and place all options on one line.

###### Result:
The build will complete on Windows.
