### PR TITLE
Stop reporting `accept()` failures during `TcpServer` shutdown

### DIFF
--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/TcpServer.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/TcpServer.java
@@ -26,7 +26,9 @@ class TcpServer {
                 try {
                     socket = serverSocket.accept();
                 } catch (IOException e) {
-                    fail("Error setting up logging server", e);
+                    if (!Thread.currentThread().isInterrupted()) {
+                        fail("Error setting up logging server", e);
+                    }
                     continue;
                 }
                 new Thread(() -> readAndVerifyData(socket)).start();


### PR DESCRIPTION
###### Problem:
When `TcpServer#tearDown()` is called, it marks its acceptor thread interrupted and closes the `ServerSocket`.

This causes the `accept()` call to throw a `SocketException` which triggers a call to `fail()`. This doesn't actually fail the test because it's not called in the main thread.

###### Solution:
Silence this log noise by first checking to see if the current thread has been interrupted (i.e. we are shutting down and an exception is expected).

###### Result:
The tests will have less output and fewer scary-looking exceptions.