### PR TITLE
Improve dropwizard-logging socket-based tests

### DIFF
--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/ResilientSocketOutputStreamTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/ResilientSocketOutputStreamTest.java
@@ -1,61 +1,26 @@
 package io.dropwizard.logging;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.net.SocketFactory;
 import java.io.IOException;
 import java.net.ServerSocket;
-import java.net.Socket;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.CountDownLatch;
+import java.util.List;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 class ResilientSocketOutputStreamTest {
-
-    private ResilientSocketOutputStream resilientSocketOutputStream;
-
-    private Thread thread;
-    private ServerSocket ss;
-    private CountDownLatch latch = new CountDownLatch(1);
-
-    @BeforeEach
-    void setUp() throws Exception {
-        ss = new ServerSocket(0);
-        thread = new Thread(() -> {
-            while (!Thread.currentThread().isInterrupted()) {
-                try (Socket socket = ss.accept()) {
-                    byte[] buffer = new byte[128];
-                    int read = socket.getInputStream().read(buffer);
-                    if (read > 0) {
-                        assertThat(new String(buffer, 0, read, StandardCharsets.UTF_8)).isEqualTo("Test message");
-                        latch.countDown();
-                    }
-                } catch (IOException e) {
-                    break;
-                }
-            }
-        });
-        thread.start();
-        resilientSocketOutputStream = new ResilientSocketOutputStream("localhost", ss.getLocalPort(),
-            1024, 500, SocketFactory.getDefault());
-    }
-
-    @AfterEach
-    void tearDown() throws Exception {
-        ss.close();
-        thread.interrupt();
-        resilientSocketOutputStream.close();
-    }
-
     @Test
-    void testCreatesCleanOutputStream() {
-        assertThat(resilientSocketOutputStream.presumedClean).isTrue();
-        assertThat(resilientSocketOutputStream.os).isNotNull();
+    void testCreatesCleanOutputStream() throws IOException {
+        try (ServerSocket ss = new ServerSocket(0); ResilientSocketOutputStream resilientSocketOutputStream = new ResilientSocketOutputStream("localhost", ss.getLocalPort(),
+            1024, 500, SocketFactory.getDefault())) {
+                assertThat(resilientSocketOutputStream.presumedClean).isTrue();
+                assertThat(resilientSocketOutputStream.os).isNotNull();
+            }
     }
 
     @Test
@@ -67,16 +32,25 @@ class ResilientSocketOutputStreamTest {
 
     @Test
     void testWriteMessage() throws Exception {
-        resilientSocketOutputStream.write("Test message".getBytes(StandardCharsets.UTF_8));
-        resilientSocketOutputStream.flush();
+        try (ServerSocket ss = new ServerSocket(0);
+             TcpServer tcpServer = new TcpServer(ss);
+             ResilientSocketOutputStream resilientSocketOutputStream = new ResilientSocketOutputStream("localhost", ss.getLocalPort(), 1024, 500, SocketFactory.getDefault())) {
+            Future<List<String>> receivedMessages = tcpServer.receive();
+            resilientSocketOutputStream.write("Test message".getBytes(StandardCharsets.UTF_8));
+            resilientSocketOutputStream.close();
 
-        latch.await(5, TimeUnit.SECONDS);
-        assertThat(latch.getCount()).isZero();
+            assertThat(receivedMessages.get(5, TimeUnit.SECONDS))
+                .singleElement()
+                .isEqualTo("Test message");
+        }
     }
 
     @Test
-    void testGetDescription() {
-        assertThat(resilientSocketOutputStream.getDescription()).isEqualTo(String.format("tcp [localhost:%d]",
-            ss.getLocalPort()));
+    void testGetDescription() throws IOException {
+        try (ServerSocket ss = new ServerSocket(0); ResilientSocketOutputStream resilientSocketOutputStream = new ResilientSocketOutputStream("localhost", ss.getLocalPort(),
+            1024, 500, SocketFactory.getDefault())) {
+            assertThat(resilientSocketOutputStream.getDescription()).isEqualTo(String.format("tcp [localhost:%d]",
+                ss.getLocalPort()));
+        }
     }
 }

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/TcpServer.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/TcpServer.java
@@ -6,71 +6,42 @@ import java.io.InputStreamReader;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.CountDownLatch;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
+class TcpServer implements AutoCloseable {
 
-class TcpServer {
-
-    private final Thread thread;
     private final ServerSocket serverSocket;
-    private final int messageCount = 100;
-    private final CountDownLatch latch = new CountDownLatch(messageCount);
+    private final ExecutorService es;
 
     TcpServer(ServerSocket serverSocket) {
         this.serverSocket = serverSocket;
-        thread = new Thread(() -> {
-            while (!Thread.currentThread().isInterrupted()) {
-                Socket socket;
-                try {
-                    socket = serverSocket.accept();
-                } catch (IOException e) {
-                    fail("Error setting up logging server", e);
-                    continue;
-                }
-                new Thread(() -> readAndVerifyData(socket)).start();
+        es = Executors.newFixedThreadPool(1);
+    }
+
+    Future<List<String>> receive() {
+        return es.submit(() -> {
+            try (Socket s = serverSocket.accept(); BufferedReader reader = new BufferedReader(new InputStreamReader(s.getInputStream(), StandardCharsets.UTF_8))) {
+                return reader.lines().collect(Collectors.toList());
+            } catch (IOException e) {
+                throw new IllegalStateException("Error reading logs", e);
             }
         });
     }
 
-    int getMessageCount() {
-        return messageCount;
-    }
-
-    CountDownLatch getLatch() {
-        return latch;
-    }
-
-    int getPort() {
-        return serverSocket.getLocalPort();
-    }
-
-    public void setUp() throws Exception {
-        thread.start();
-    }
-
-    public void tearDown() throws Exception {
-        thread.interrupt();
+    public void close() {
+        es.shutdownNow();
         try {
-            serverSocket.close();
-        } catch (IOException e) {
-            throw new IllegalStateException(e);
-        }
-    }
-
-    private void readAndVerifyData(Socket socket) {
-        try (Socket s = socket; BufferedReader reader = new BufferedReader(new InputStreamReader(s.getInputStream(), StandardCharsets.UTF_8))) {
-            for (int i = 0; i < messageCount; i++) {
-                String line = reader.readLine();
-                if (line == null) {
-                    break;
-                }
-                assertThat(line).startsWith("INFO").contains("com.example.app: Application log " + i);
-                latch.countDown();
+            if (!es.awaitTermination(1, TimeUnit.MINUTES)) {
+                throw new IllegalStateException("server did not terminate");
             }
-        } catch (IOException e) {
-            fail("Error reading logs", e);
+        } catch (InterruptedException ie) {
+            es.shutdownNow();
+            Thread.currentThread().interrupt();
         }
     }
 }

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/TlsSocketAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/TlsSocketAppenderFactoryTest.java
@@ -10,7 +10,6 @@ import io.dropwizard.util.Maps;
 import io.dropwizard.validation.BaseValidator;
 import org.apache.commons.text.StringSubstitutor;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -19,13 +18,15 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.net.ServerSocket;
 import java.net.URISyntaxException;
+import java.util.List;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class TlsSocketAppenderFactoryTest {
-
-    public TcpServer tcpServer = new TcpServer(createServerSocket());
 
     private final ObjectMapper objectMapper = Jackson.newObjectMapper();
     private final YamlConfigurationFactory<DefaultLoggingFactory> yamlConfigurationFactory = new YamlConfigurationFactory<>(
@@ -33,13 +34,7 @@ class TlsSocketAppenderFactoryTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        tcpServer.setUp();
         objectMapper.getSubtypeResolver().registerSubtypes(TcpSocketAppenderFactory.class);
-    }
-
-    @AfterEach
-    void tearDown() throws Exception {
-        tcpServer.tearDown();
     }
 
     private ServerSocket createServerSocket() {
@@ -64,22 +59,28 @@ class TlsSocketAppenderFactoryTest {
 
     @Test
     void testTlsLogging() throws Exception {
-        DefaultLoggingFactory loggingFactory = yamlConfigurationFactory.build(new SubstitutingSourceProvider(
-            new ResourceConfigurationSourceProvider(), new StringSubstitutor(Maps.of(
-            "tls.trust_store.path", resourcePath("/stores/tls_client.jks"),
-            "tls.trust_store.pass", "client_pass",
-            "tls.server_port", tcpServer.getPort()
-        ))), "/yaml/logging-tls.yml");
-        loggingFactory.configure(new MetricRegistry(), "tls-appender-test");
+        try (ServerSocket serverSocket = createServerSocket(); TcpServer tcpServer = new TcpServer(serverSocket)) {
+            Future<List<String>> receivedMessages = tcpServer.receive();
+            DefaultLoggingFactory loggingFactory = yamlConfigurationFactory.build(new SubstitutingSourceProvider(
+                new ResourceConfigurationSourceProvider(), new StringSubstitutor(Maps.of(
+                "tls.trust_store.path", resourcePath("/stores/tls_client.jks"),
+                "tls.trust_store.pass", "client_pass",
+                "tls.server_port", serverSocket.getLocalPort()
+            ))), "/yaml/logging-tls.yml");
+            loggingFactory.configure(new MetricRegistry(), "tls-appender-test");
 
-        Logger logger = LoggerFactory.getLogger("com.example.app");
-        for (int i = 0; i < tcpServer.getMessageCount(); i++) {
-            logger.info("Application log {}", i);
+            Logger logger = LoggerFactory.getLogger("com.example.app");
+            List<String> loggedMessages = generateLogs(logger);
+
+            loggingFactory.reset();
+
+            assertThat(receivedMessages.get(1, TimeUnit.MINUTES))
+                .hasSize(100)
+                .allSatisfy(s -> assertThat(s).startsWith("INFO"))
+                // Strip preamble from e.g. "INFO  [2021-11-20 10:23:57,620] com.example.app: Application log 0"
+                .extracting(s -> s.substring(s.lastIndexOf("com.example.app: ") + "com.example.app: ".length()))
+                .containsExactlyElementsOf(loggedMessages);
         }
-
-        tcpServer.getLatch().await(5, TimeUnit.SECONDS);
-        assertThat(tcpServer.getLatch().getCount()).isZero();
-        loggingFactory.reset();
     }
 
     @Test
@@ -107,5 +108,12 @@ class TlsSocketAppenderFactoryTest {
                 .satisfies(factory -> assertThat(factory.getSupportedCipherSuites())
                     .containsExactly("ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-ECDSA-AES128-GCM-SHA256"))
                 .satisfies(factory -> assertThat(factory.getExcludedCipherSuites()).isEmpty()));
+    }
+
+    private static List<String> generateLogs(final Logger logger) {
+        return IntStream.range(0, 100)
+            .mapToObj(i -> String.format("Application log %d", i))
+            .peek(logger::info)
+            .collect(Collectors.toList());
     }
 }

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/UdpServer.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/UdpServer.java
@@ -1,0 +1,55 @@
+package io.dropwizard.logging;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class UdpServer implements AutoCloseable {
+
+    private final DatagramSocket socket;
+    private final ExecutorService es;
+    private int messageCount;
+
+    public UdpServer(DatagramSocket socket, int messageCount) {
+        this.messageCount = messageCount;
+        this.socket = socket;
+        es = Executors.newFixedThreadPool(1);
+    }
+
+    public Future<List<String>> receive() {
+        return es.submit(() -> {
+            List<String> messages = new ArrayList<>();
+            for (; messageCount > 0; messageCount--){
+                byte[] buffer = new byte[128];
+                DatagramPacket datagramPacket = new DatagramPacket(buffer, buffer.length);
+                try {
+                    socket.receive(datagramPacket);
+                    messages.add(new String(buffer, 0, datagramPacket.getLength(), UTF_8));
+                } catch (IOException e) {
+                    throw new IllegalStateException("Error reading logs", e);
+                }
+            }
+            return messages;
+        });
+    }
+
+    public void close() {
+        es.shutdownNow();
+        try {
+            if (!es.awaitTermination(1, TimeUnit.MINUTES)) {
+                throw new IllegalStateException("server did not terminate");
+            }
+        } catch (InterruptedException ie) {
+            es.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/socket/DropwizardUdpSocketAppenderTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/socket/DropwizardUdpSocketAppenderTest.java
@@ -3,15 +3,13 @@ package io.dropwizard.logging.socket;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Context;
 import ch.qos.logback.core.OutputStreamAppender;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import io.dropwizard.logging.UdpServer;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import java.io.IOException;
-import java.net.DatagramPacket;
 import java.net.DatagramSocket;
-import java.util.concurrent.CountDownLatch;
+import java.util.List;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -19,47 +17,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class DropwizardUdpSocketAppenderTest {
 
-    private OutputStreamAppender<ILoggingEvent> udpStreamAppender;
-
-    private DatagramSocket datagramSocket;
-    private Thread thread;
-    private CountDownLatch countDownLatch = new CountDownLatch(1);
-
-    @BeforeEach
-    void setUp() throws Exception {
-        datagramSocket = new DatagramSocket();
-        thread = new Thread(() -> {
-            byte[] buffer = new byte[128];
-            while (!Thread.currentThread().isInterrupted()) {
-                DatagramPacket datagramPacket = new DatagramPacket(buffer, buffer.length);
-                try {
-                    datagramSocket.receive(datagramPacket);
-                    assertThat(new String(buffer, 0, datagramPacket.getLength(), UTF_8))
-                        .isEqualTo("Test message");
-                    countDownLatch.countDown();
-                } catch (IOException e) {
-                    break;
-                }
-            }
-        });
-        thread.start();
-        udpStreamAppender = new DropwizardUdpSocketAppender<>("localhost", datagramSocket.getLocalPort());
-        udpStreamAppender.setContext(Mockito.mock(Context.class));
-        udpStreamAppender.start();
-    }
-
-    @AfterEach
-    void tearDown() throws Exception {
-        datagramSocket.close();
-        thread.interrupt();
-        udpStreamAppender.stop();
-    }
-
     @Test
     void testSendMessage() throws Exception {
-        udpStreamAppender.getOutputStream().write("Test message".getBytes(UTF_8));
+        try (DatagramSocket datagramSocket = new DatagramSocket(); UdpServer udpServer = new UdpServer(datagramSocket, 1)
+) {
+            Future<List<String>> receivedMessage = udpServer.receive();
+            OutputStreamAppender<ILoggingEvent> udpStreamAppender = new DropwizardUdpSocketAppender<>("localhost", datagramSocket.getLocalPort());
+            udpStreamAppender.setContext(Mockito.mock(Context.class));
+            udpStreamAppender.start();
+            udpStreamAppender.getOutputStream().write("Test message".getBytes(UTF_8));
 
-        countDownLatch.await(5, TimeUnit.SECONDS);
-        assertThat(countDownLatch.getCount()).isZero();
+            assertThat(receivedMessage.get(5, TimeUnit.SECONDS))
+                .singleElement()
+                .isEqualTo("Test message");
+            udpStreamAppender.stop();
+        }
     }
+
 }


### PR DESCRIPTION
These tests relied on `TcpServer` and counting the number of log messages
received.

Replace direct `Thread` usage with `ExecutorService` and `Future` so that we
can instead retrieve the log messages actually received and perform assertions
on them.

Do the same for UDP-based tests, introducing `UdpServer`.

Note that the logs in `UdpSocketAppenderFactoryTest` have trailing newlines, unlike those in `TcpSocketAppenderFactoryTest` - is that expected?