### PR TITLE
Bump jersey version on 2.0 branch

### DIFF
--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -47,7 +47,7 @@
         <jaxb-api.version>2.3.3</jaxb-api.version>
         <jcip-annotations.version>1.0</jcip-annotations.version>
         <jdbi3.version>3.25.0</jdbi3.version>
-        <jersey.version>2.33</jersey.version>
+        <jersey.version>2.34</jersey.version>
         <jetty-setuid-java.version>1.0.4</jetty-setuid-java.version>
         <jetty.version>9.4.44.v20210927</jetty.version>
         <joda-time.version>2.10.13</joda-time.version>


### PR DESCRIPTION
###### Problem:
Having a conflict with Jersey version in conjunction with Confluent's schema-registry. Updating this to 2.34 will solve that

###### Solution:
Updated Jersey to 2.34

###### Result:
Jersey will be at 2.34
