### PR TITLE
Update repository URLs for new OSSRH Sonatype instance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
         <repository>
             <id>ossrh</id>
             <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
             <releases>
                 <enabled>false</enabled>
             </releases>
@@ -253,12 +253,12 @@
         <snapshotRepository>
             <id>ossrh</id>
             <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>
             <id>ossrh</id>
             <name>Nexus Release Repository</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
         <site>
             <id>dropwizard-site</id>
@@ -337,7 +337,7 @@
                         <artifactId>nexus-staging-maven-plugin</artifactId>
                         <configuration>
                             <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>
                         <executions>


### PR DESCRIPTION
After the migration to the new OSSRH Sonatype instance releases will hopefully be more reliable.

https://central.sonatype.org/news/20210223_new-users-on-s01/
https://issues.sonatype.org/browse/OSSRH-76149