### PR TITLE
Session injection

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/setup/Environment.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/Environment.java
@@ -17,6 +17,7 @@ import io.dropwizard.jetty.MutableServletContextHandler;
 import io.dropwizard.jetty.setup.ServletEnvironment;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import io.dropwizard.validation.InjectValidatorFeature;
+import org.eclipse.jetty.server.session.SessionHandler;
 
 import javax.annotation.Nullable;
 import javax.servlet.Servlet;
@@ -76,6 +77,7 @@ public class Environment {
 
         this.servletContext = new MutableServletContextHandler();
         servletContext.setClassLoader(classLoader);
+        servletContext.setSessionHandler(new SessionHandler());
         this.servletEnvironment = new ServletEnvironment(servletContext);
 
         this.adminContext = new MutableServletContextHandler();

--- a/dropwizard-e2e/src/main/java/com/example/httpsessions/HttpSessionsApp.java
+++ b/dropwizard-e2e/src/main/java/com/example/httpsessions/HttpSessionsApp.java
@@ -1,0 +1,12 @@
+package com.example.httpsessions;
+
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Environment;
+
+public class HttpSessionsApp extends Application<Configuration> {
+    @Override
+    public void run(Configuration configuration, Environment environment) throws Exception {
+        environment.jersey().register(new HttpSessionsResource());
+    }
+}

--- a/dropwizard-e2e/src/main/java/com/example/httpsessions/HttpSessionsResource.java
+++ b/dropwizard-e2e/src/main/java/com/example/httpsessions/HttpSessionsResource.java
@@ -1,0 +1,17 @@
+package com.example.httpsessions;
+
+import io.dropwizard.jersey.sessions.Session;
+
+import javax.servlet.http.HttpSession;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+@Path("/")
+public class HttpSessionsResource {
+    @GET
+    @Path("session")
+    public Response isSessionInjected(@Session HttpSession httpSession) {
+        return Response.ok(httpSession != null).build();
+    }
+}

--- a/dropwizard-e2e/src/test/java/com/example/httpsessions/HttpSessionsTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/httpsessions/HttpSessionsTest.java
@@ -1,0 +1,22 @@
+package com.example.httpsessions;
+
+import io.dropwizard.Configuration;
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+class HttpSessionsTest {
+    public static final DropwizardAppExtension<Configuration> RULE =
+        new DropwizardAppExtension<>(HttpSessionsApp.class, ResourceHelpers.resourceFilePath("httpsessions/config.yml"));
+
+    @Test
+    void testInjectedSessionsIsNotNull() {
+        Boolean sessionNotNull = RULE.client().target(String.format("http://localhost:%d/session", RULE.getLocalPort())).request().get(Boolean.class);
+        assertThat(sessionNotNull).isNotNull().isTrue();
+    }
+}

--- a/dropwizard-e2e/src/test/resources/httpsessions/config.yml
+++ b/dropwizard-e2e/src/test/resources/httpsessions/config.yml
@@ -1,0 +1,7 @@
+server:
+  applicationConnectors:
+    - type: http
+      port: 0
+  adminConnectors:
+    - type: http
+      port: 0


### PR DESCRIPTION
###### Problem:
As described in #3340, with the default configuration no session can be injected, although basic support should be provided (see `dropwizard-jersey`s `session` package).

###### Solution:
Register a `SessionHandler` to the application's `MutableServletContextHandler` to support session injection.

###### Result:
When adding a parameter like `@Session HttpSession session` to a resource method, no `IllegalStateException` gets thrown and the session gets injected.
