### PR TITLE
Update dependency jackson-bom to 2.13.1

### DIFF
--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -36,7 +36,7 @@
         <hk2.version>2.6.1</hk2.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.15</httpcore.version>
-        <jackson.version>2.10.5.20201202</jackson.version>
+        <jackson.version>2.13.1</jackson.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
         <jakarta.el.version>3.0.4</jakarta.el.version>
         <jakarta.servlet-api.version>4.0.4</jakarta.servlet-api.version>

--- a/dropwizard-hibernate/pom.xml
+++ b/dropwizard-hibernate/pom.xml
@@ -161,6 +161,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/LazyLoadingTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/LazyLoadingTest.java
@@ -3,6 +3,7 @@ package io.dropwizard.hibernate;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
+import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.db.PooledDataSourceFactory;
 import io.dropwizard.jersey.errors.ErrorMessage;
@@ -12,7 +13,6 @@ import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.DropwizardTestSupport;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.util.Strings;
-import org.glassfish.jersey.client.JerseyClientBuilder;
 import org.hibernate.FlushMode;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
@@ -153,12 +153,13 @@ public class LazyLoadingTest {
     }
 
     private DropwizardTestSupport<?> dropwizardTestSupport = mock(DropwizardTestSupport.class);
-    private Client client = new JerseyClientBuilder().build();
+    private Client client = mock(Client.class);
 
     public void setup(Class<? extends Application<TestConfiguration>> applicationClass) throws Exception {
         dropwizardTestSupport = new DropwizardTestSupport<>(applicationClass, ResourceHelpers.resourceFilePath("hibernate-integration-test.yaml"),
             ConfigOverride.config("dataSource.url", "jdbc:h2:mem:DbTest" + System.nanoTime()));
         dropwizardTestSupport.before();
+        client = new JerseyClientBuilder(dropwizardTestSupport.getEnvironment()).build("test client");
     }
 
     @AfterEach


### PR DESCRIPTION
(Fix failing test: Use dropwizard client to use a correctly configured ObjectMapper in the client).
See also https://github.com/dropwizard/dropwizard/issues/4210

###### Problem:
Dropwizard 2.0.x currently depends on an old jackson version: `2.10.5.20201202`.

###### Solution:
This PR updates to the latest currently available version of jackson: `2.13.1`.

###### Result:
Dropwizard depends on a more recent version of jackson.