### PR TITLE
Remove keyserver list

### DIFF
--- a/dropwizard-parent/pom.xml
+++ b/dropwizard-parent/pom.xml
@@ -23,7 +23,6 @@
         <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
         <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
 
-        <pgpverify.keyserver>hkps://keys.openpgp.org;hkp://pool.sks-keyservers.net;hkps://keyserver.ubuntu.com</pgpverify.keyserver>
         <pgpverify.verifyPomFiles>false</pgpverify.verifyPomFiles>
 
         <surefire.argLine>-Duser.language=en -Duser.region=US -Duser.timezone=UTC</surefire.argLine>


### PR DESCRIPTION
The pgpverify plugin complains about the hkp:// SKS keyservers URL.

Since the plugin's default list of keyservers is the same, just using HTTPS rather than hkp/hkps, remove the explicit list and fall back to the default.