### PR TITLE
Publish Maven test results

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -38,7 +38,24 @@ jobs:
         key: ${{ runner.os }}-sonar
         restore-keys: ${{ runner.os }}-sonar
     - name: Build
-      run: ./mvnw --no-transfer-progress -V -B -ff -s .github/settings.xml install
+      run: ./mvnw --no-transfer-progress -V -B -ff -s .github/settings.xml -e -DtrimStackTrace=false -Dmaven.test.failure.ignore=true -Dsurefire.rerunFailingTestsCount=1 verify
+    - name: Publish Test Results
+      # If the CI run is not initiated from the primary repository, it is highly likely that this is a PR from a user who doesn't have commit rights.
+      # Hence, skip this step to avoid permission failures.
+      if: github.repository == 'dropwizard/dropwizard'
+      uses: scacap/action-surefire-report@v1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        check_name: Test Report (${{ matrix.os }} - Java ${{ matrix.java_version }})
+        report_paths: '**/*-reports/TEST-*.xml'
+    - name: Upload Test Reports
+      # If the CI run is not initiated from the primary repository, it is highly likely that this is a PR from a user who doesn't have commit rights.
+      # Hence, skip this step to avoid permission failures.
+      if: github.repository == 'dropwizard/dropwizard'
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-reports-${{ matrix.os }}-java${{ matrix.java_version }}
+        path: '**/*-reports'
     - name: Analyze with SonarCloud
       if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
       env:


### PR DESCRIPTION
Use https://github.com/ScaCap/action-surefire-report for collecting and publishing Surefire test reports.