### PR TITLE
Do not throw `IOException`s from servlet methods

### DIFF
--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/assets/AssetServlet.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/assets/AssetServlet.java
@@ -257,7 +257,10 @@ public class AssetServlet extends HttpServlet {
                 }
             }
         } catch (RuntimeException | URISyntaxException ignored) {
-            resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+            if (!resp.isCommitted()) {
+                resp.reset();
+                resp.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            }
         }
     }
 

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/TaskServletTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/tasks/TaskServletTest.java
@@ -55,7 +55,7 @@ class TaskServletTest {
 
         servlet.service(request, response);
 
-        verify(response).sendError(404);
+        verify(response).setStatus(404);
     }
 
     @Test
@@ -211,7 +211,7 @@ class TaskServletTest {
         when(request.getPathInfo()).thenReturn("/absent");
         servlet.service(request, response);
 
-        verify(response).sendError(404);
+        verify(response).setStatus(404);
     }
 
     @Test
@@ -220,7 +220,7 @@ class TaskServletTest {
         when(request.getPathInfo()).thenReturn("/gc");
         servlet.service(request, response);
 
-        verify(response).sendError(405);
+        verify(response).setStatus(405);
     }
 
     @Test
@@ -306,7 +306,7 @@ class TaskServletTest {
 
         servlet.service(request, response);
 
-        verify(response).sendError(404);
+        verify(response).setStatus(404);
     }
 
     @Test


### PR DESCRIPTION
Raised for consideration regarding issue #4279.

This PR suppresses `IOException`s from being thrown from servlet methods since Sonar suggests not to throw them because of the possibility of denial of service attacks or information exposure.

Therefore the `IOException` from an error at `getWriter()` is logged and a status code 500 is set. Calls to `sendError(...)` are converted to
```java
if (!response.isCommitted()) {
    response.reset();
    response.setStatus(...);
}
```
since this code won't throw an exception. This results in not committing the response in the servlet method and deferring the processing to the underlying servlet container.
