### PR TITLE
Deprecate the `Size` validators in favour of `DataSize` validators

### DIFF
--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/MaxSize.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/MaxSize.java
@@ -21,9 +21,12 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * whose value must be less than or equal to the specified maximum.
  * <p/>
  * <code>null</code> elements are considered valid
+ *
+ * @deprecated Use {@link MaxDataSize} for correct SI and IEC prefixes.
  */
 @Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
 @Retention(RUNTIME)
+@Deprecated
 @Documented
 @Constraint(validatedBy = MaxSizeValidator.class)
 public @interface MaxSize {

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/MaxSizeValidator.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/MaxSizeValidator.java
@@ -9,7 +9,10 @@ import javax.validation.ConstraintValidatorContext;
 /**
  * Check that a {@link Size} being validated is less than or equal to the
  * minimum value specified.
+ *
+ * @deprecated Use {@link MaxDataSizeValidator} for correct SI and IEC prefixes.
  */
+@Deprecated
 public class MaxSizeValidator implements ConstraintValidator<MaxSize, Size> {
 
     private long maxQty = 0;

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/MinSize.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/MinSize.java
@@ -21,9 +21,12 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * whose value must be higher or equal to the specified minimum.
  * <p/>
  * <code>null</code> elements are considered valid
+ *
+ * @deprecated Use {@link MinDataSize} for correct SI and IEC prefixes.
  */
 @Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
 @Retention(RUNTIME)
+@Deprecated
 @Documented
 @Constraint(validatedBy = MinSizeValidator.class)
 public @interface MinSize {

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/MinSizeValidator.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/MinSizeValidator.java
@@ -9,7 +9,10 @@ import javax.validation.ConstraintValidatorContext;
 /**
  * Check that a {@link Size} being validated is greater than or equal to the
  * minimum value specified.
+ *
+ * @deprecated Use {@link MinDataSizeValidator} for correct SI and IEC prefixes.
  */
+@Deprecated
 public class MinSizeValidator implements ConstraintValidator<MinSize, Size> {
 
     private long minQty = 0;

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/SizeRange.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/SizeRange.java
@@ -21,7 +21,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * The annotated element has to be in the appropriate range. Apply on
  * {@link io.dropwizard.util.Size} instances.
+ * @deprecated Use {@link DataSizeRange} for correct SI and IEC prefixes.
  */
+@Deprecated
 @Documented
 @Constraint(validatedBy = { })
 @Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })


### PR DESCRIPTION
`Size` is deprecated in favour of `DataSize` so it makes sense to also deprecate the corresponding validators.