### PR TITLE
Clean up a few sonar gripes

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
@@ -491,14 +491,13 @@ public class HttpClientBuilder {
     protected InstrumentedHttpClientConnectionManager createConnectionManager(Registry<ConnectionSocketFactory> registry,
                                                                               String name) {
         final Duration ttl = configuration.getTimeToLive();
-        final InstrumentedHttpClientConnectionManager manager = new InstrumentedHttpClientConnectionManager(
-                metricRegistry,
-                registry,
-                null, null,
-                resolver,
-                ttl.getQuantity(),
-                ttl.getUnit(),
-                name);
+        final InstrumentedHttpClientConnectionManager manager = InstrumentedHttpClientConnectionManager.builder(metricRegistry)
+            .socketFactoryRegistry(registry)
+            .dnsResolver(resolver)
+            .connTTL(ttl.getQuantity())
+            .connTTLTimeUnit(ttl.getUnit())
+            .name(name)
+            .build();
         return configureConnectionManager(manager);
     }
 

--- a/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
@@ -143,7 +143,7 @@ class HttpClientBuilderTest {
         final MetricRegistry metricRegistry = new MetricRegistry();
         configuration = new HttpClientConfiguration();
         builder = new HttpClientBuilder(metricRegistry);
-        connectionManager = spy(new InstrumentedHttpClientConnectionManager(metricRegistry, registry));
+        connectionManager = spy(InstrumentedHttpClientConnectionManager.builder(metricRegistry).socketFactoryRegistry(registry).build());
         apacheBuilder = org.apache.http.impl.client.HttpClientBuilder.create();
         anotherApacheBuilder = spy(AnotherHttpClientBuilder.create());
     }

--- a/dropwizard-core/src/main/java/io/dropwizard/setup/Environment.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/Environment.java
@@ -93,9 +93,9 @@ public class Environment {
 
         this.jerseyServletContainer = new JerseyContainerHolder(new JerseyServletContainer(jerseyConfig));
 
-        final JerseyEnvironment jerseyEnvironment = new JerseyEnvironment(jerseyServletContainer, jerseyConfig);
-        jerseyEnvironment.register(new InjectValidatorFeature(validatorFactory));
-        this.jerseyEnvironment = jerseyEnvironment;
+        final JerseyEnvironment jerseyEnv = new JerseyEnvironment(jerseyServletContainer, jerseyConfig);
+        jerseyEnv.register(new InjectValidatorFeature(validatorFactory));
+        this.jerseyEnvironment = jerseyEnv;
 
         final HealthCheckConfiguration healthCheckConfig = adminFactory.getHealthChecks();
         this.healthCheckExecutorService = this.lifecycle().executorService("TimeBoundHealthCheck-pool-%d")

--- a/dropwizard-core/src/main/java/io/dropwizard/sslreload/SslReloadTask.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/sslreload/SslReloadTask.java
@@ -21,13 +21,13 @@ public class SslReloadTask extends Task {
     @Override
     public void execute(Map<String, List<String>> parameters, PrintWriter output) throws Exception {
         // Iterate through all the reloaders first to ensure valid configuration
-        for (SslReload reloader : getReloaders()) {
-            reloader.reload(new SslContextFactory.Server());
+        for (SslReload sslReload : getReloaders()) {
+            sslReload.reload(new SslContextFactory.Server());
         }
 
         // Now we know that configuration is valid, reload for real
-        for (SslReload reloader : getReloaders()) {
-            reloader.reload();
+        for (SslReload sslReload : getReloaders()) {
+            sslReload.reload();
         }
 
         output.write("Reloaded certificate configuration\n");

--- a/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
+++ b/dropwizard-db/src/main/java/io/dropwizard/db/DataSourceFactory.java
@@ -518,6 +518,9 @@ public class DataSourceFactory implements PooledDataSourceFactory {
         return validationQuery;
     }
 
+    /**
+     * @deprecated use {@link #getValidationQuery()} instead
+     */
     @Override
     @Deprecated
     @JsonIgnore
@@ -560,12 +563,18 @@ public class DataSourceFactory implements PooledDataSourceFactory {
         this.checkConnectionWhileIdle = checkConnectionWhileIdle;
     }
 
+    /**
+     * @deprecated use {@link #getReadOnlyByDefault()} instead
+     */
     @Deprecated
     @JsonProperty
     public boolean isDefaultReadOnly() {
         return Boolean.TRUE.equals(readOnlyByDefault);
     }
 
+    /**
+     * @deprecated use {@link #setReadOnlyByDefault(Boolean)} instead
+     */
     @Deprecated
     @JsonProperty
     public void setDefaultReadOnly(boolean defaultReadOnly) {
@@ -810,6 +819,9 @@ public class DataSourceFactory implements PooledDataSourceFactory {
         this.validatorClassName = validatorClassName;
     }
 
+    /**
+     * @deprecated use {@link #getValidationQueryTimeout()} instead
+     */
     @Override
     @Deprecated
     @JsonIgnore

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/GzipHandlerFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/GzipHandlerFactory.java
@@ -198,13 +198,14 @@ public class GzipHandlerFactory {
     /**
      * @deprecated  gzip handler no longer supports inflate streams
      */
+    @Deprecated
     @JsonProperty
     public boolean isGzipCompatibleInflation() {
         return gzipCompatibleInflation;
     }
 
     /**
-     * @deprecated  gzip handler no longer supports inflate streams
+     * @deprecated gzip handler no longer supports inflate streams
      */
     @Deprecated
     @JsonProperty
@@ -213,7 +214,7 @@ public class GzipHandlerFactory {
     }
 
     /**
-     * @deprecated
+     * @deprecated excluding by user agent will be removed in Jetty 10
      */
     @Deprecated
     public Set<String> getExcludedUserAgentPatterns() {
@@ -221,7 +222,7 @@ public class GzipHandlerFactory {
     }
 
     /**
-     * @deprecated
+     * @deprecated excluding by user agent will be removed in Jetty 10
      */
     @Deprecated
     public void setExcludedUserAgentPatterns(Set<String> excludedUserAgentPatterns) {

--- a/dropwizard-util/src/main/java/io/dropwizard/util/Optionals.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Optionals.java
@@ -2,6 +2,9 @@ package io.dropwizard.util;
 
 import java.util.Optional;
 
+/**
+ * @deprecated prefer using {@link java.util.Optional} directly
+ */
 @Deprecated
 public abstract class Optionals {
     /**

--- a/dropwizard-views/src/main/java/io/dropwizard/views/ViewMessageBodyWriter.java
+++ b/dropwizard-views/src/main/java/io/dropwizard/views/ViewMessageBodyWriter.java
@@ -40,6 +40,10 @@ public class ViewMessageBodyWriter implements MessageBodyWriter<View> {
     private final Iterable<ViewRenderer> renderers;
     private final MetricRegistry metricRegistry;
 
+    /**
+     * @deprecated use {@link #ViewMessageBodyWriter(MetricRegistry, Iterable)} instead
+     * @param metricRegistry
+     */
     @Deprecated
     public ViewMessageBodyWriter(MetricRegistry metricRegistry) {
         this(metricRegistry, ServiceLoader.load(ViewRenderer.class));


### PR DESCRIPTION
###### Problem:
Sonar is upset about things which are annotated with `@Deprecated` but which lack the corresponding javadoc `@deprecated` tag.

Sonar is also upset about local variables which have the same name as fields.

The `InstrumentedHttpClientConnectionManager` constructor has been deprecated in favour of a builder.

###### Solution:
Add missing javadoc, rename local variables, use the `InstrumentedHttpClientConnectionManager` builder.

###### Result:
Sonar will grumble less