### PR TITLE
Make `NetUtil` package-private

### DIFF
--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/NetUtil.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/NetUtil.java
@@ -41,7 +41,7 @@ import static java.util.Objects.requireNonNull;
  * The {@link #getAllLocalIPs()} method was taken from the Apache Curator project
  * which is also under the Apache 2.0 license.
  */
-public class NetUtil {
+class NetUtil {
     public static final int DEFAULT_TCP_BACKLOG_WINDOWS = 200;
     public static final int DEFAULT_TCP_BACKLOG_LINUX = 128;
     public static final String TCP_BACKLOG_SETTING_LOCATION = "/proc/sys/net/core/somaxconn";


### PR DESCRIPTION
This class is only used by `HttpConnectorFactory` so it can be package-private.

This is technically a breaking change, but maybe an acceptable one?