### PR TITLE
Use AssertJ's `Atomic*Assert` support

### DIFF
--- a/dropwizard-e2e/src/test/java/com/example/health/HealthIntegrationTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/health/HealthIntegrationTest.java
@@ -45,7 +45,7 @@ class HealthIntegrationTest {
     private String hostUrl;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         hostUrl = "http://" + HOST + ":" + TEST_APP_RULE.getLocalPort();
         Awaitility.waitAtMost(APP_STARTUP_MAX_TIMEOUT)
                 .pollInSameThread()
@@ -77,9 +77,9 @@ class HealthIntegrationTest {
                 .pollDelay(POLL_DELAY)
                 .until(this::isAppHealthy);
 
-        assertThat(app.getStateChangeCounter().get()).isPositive();
-        assertThat(app.getHealthyCheckCounter().get()).isPositive();
-        assertThat(app.getUnhealthyCheckCounter().get()).isPositive();
+        assertThat(app.getStateChangeCounter()).hasPositiveValue();
+        assertThat(app.getHealthyCheckCounter()).hasPositiveValue();
+        assertThat(app.getUnhealthyCheckCounter()).hasPositiveValue();
     }
 
     @Test
@@ -94,9 +94,9 @@ class HealthIntegrationTest {
                 .atMost(testTimeout)
                 .pollDelay(POLL_DELAY)
                 .until(this::isAppHealthy);
-        assertThat(app.getStateChangeCounter().get()).isPositive();
-        assertThat(app.getHealthyCheckCounter().get()).isPositive();
-        assertThat(app.getUnhealthyCheckCounter().get()).isPositive();
+        assertThat(app.getStateChangeCounter()).hasPositiveValue();
+        assertThat(app.getHealthyCheckCounter()).hasPositiveValue();
+        assertThat(app.getUnhealthyCheckCounter()).hasPositiveValue();
     }
 
     @Test
@@ -112,9 +112,9 @@ class HealthIntegrationTest {
                 .pollDelay(POLL_DELAY)
                 .until(this::isAppHealthy);
 
-        assertThat(app.getStateChangeCounter().get()).isPositive();
-        assertThat(app.getHealthyCheckCounter().get()).isPositive();
-        assertThat(app.getUnhealthyCheckCounter().get()).isPositive();
+        assertThat(app.getStateChangeCounter()).hasPositiveValue();
+        assertThat(app.getHealthyCheckCounter()).hasPositiveValue();
+        assertThat(app.getUnhealthyCheckCounter()).hasPositiveValue();
     }
 
     @Test
@@ -127,9 +127,9 @@ class HealthIntegrationTest {
                 .pollDelay(POLL_DELAY)
                 .until(() -> !isAppHealthy());
         // 2 state changes (to unhealthy) for critical checks, because of initial value of false
-        assertThat(app.getStateChangeCounter().get()).isPositive();
-        assertThat(app.getHealthyCheckCounter().get()).isZero();
-        assertThat(app.getUnhealthyCheckCounter().get()).isPositive();
+        assertThat(app.getStateChangeCounter()).hasPositiveValue();
+        assertThat(app.getHealthyCheckCounter()).hasValue(0);
+        assertThat(app.getUnhealthyCheckCounter()).hasPositiveValue();
     }
 
     @Test
@@ -150,9 +150,9 @@ class HealthIntegrationTest {
                 .pollDelay(POLL_DELAY)
                 .until(this::isAppHealthy);
 
-        assertThat(app.getStateChangeCounter().get()).isPositive();
-        assertThat(app.getHealthyCheckCounter().get()).isPositive();
-        assertThat(app.getUnhealthyCheckCounter().get()).isPositive();
+        assertThat(app.getStateChangeCounter()).hasPositiveValue();
+        assertThat(app.getHealthyCheckCounter()).hasPositiveValue();
+        assertThat(app.getUnhealthyCheckCounter()).hasPositiveValue();
     }
 
     private boolean isAppHealthy() {

--- a/dropwizard-health/src/test/java/io/dropwizard/health/StateTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/StateTest.java
@@ -42,41 +42,41 @@ class StateTest {
         final State state = new State(NAME, 2, 1, true, listener);
         state.failure();
 
-        assertThat(didStateChange.get()).isFalse();
-        assertThat(state.getHealthy().get()).isTrue();
+        assertThat(didStateChange).isFalse();
+        assertThat(state.getHealthy()).isTrue();
     }
 
     @Test
     void singleFailureShouldChangeStateIfThresholdExceeded() {
         final State state = new State(NAME, 1, 1, true, listener);
-        assertThat(state.getHealthy().get()).isTrue();
+        assertThat(state.getHealthy()).isTrue();
 
         state.failure();
 
-        assertThat(didStateChange.get()).isTrue();
-        assertThat(state.getHealthy().get()).isFalse();
+        assertThat(didStateChange).isTrue();
+        assertThat(state.getHealthy()).isFalse();
     }
 
     @Test
     void singleSuccessShouldNotChangeStateIfThresholdNotExceeded() {
         final State state = new State(NAME, 1, 2, false, listener);
-        assertThat(state.getHealthy().get()).isFalse();
+        assertThat(state.getHealthy()).isFalse();
 
         state.success();
 
-        assertThat(didStateChange.get()).isFalse();
-        assertThat(state.getHealthy().get()).isFalse();
+        assertThat(didStateChange).isFalse();
+        assertThat(state.getHealthy()).isFalse();
     }
 
     @Test
     void singleSuccessShouldChangeStateIfThresholdExceeded() {
         final State state = new State(NAME, 1, 1, false, listener);
-        assertThat(state.getHealthy().get()).isFalse();
+        assertThat(state.getHealthy()).isFalse();
 
         state.success();
 
-        assertThat(didStateChange.get()).isTrue();
-        assertThat(state.getHealthy().get()).isTrue();
+        assertThat(didStateChange).isTrue();
+        assertThat(state.getHealthy()).isTrue();
     }
 
     @Test
@@ -85,47 +85,47 @@ class StateTest {
 
         state.failure();
 
-        assertThat(didStateChange.get()).isTrue();
-        assertThat(state.getHealthy().get()).isFalse();
+        assertThat(didStateChange).isTrue();
+        assertThat(state.getHealthy()).isFalse();
 
         didStateChange.set(false);
 
         state.success();
 
-        assertThat(didStateChange.get()).isTrue();
-        assertThat(state.getHealthy().get()).isTrue();
+        assertThat(didStateChange).isTrue();
+        assertThat(state.getHealthy()).isTrue();
 
         didStateChange.set(false);
 
         state.failure();
 
-        assertThat(didStateChange.get()).isTrue();
-        assertThat(state.getHealthy().get()).isFalse();
+        assertThat(didStateChange).isTrue();
+        assertThat(state.getHealthy()).isFalse();
     }
 
     @Test
     void successFollowedByFailureShouldAllowAStateChangeToHealthyAfterAnotherSuccessOccurs() {
         final State state = new State(NAME, 1, 1, false, listener);
-        assertThat(state.getHealthy().get()).isFalse();
+        assertThat(state.getHealthy()).isFalse();
 
         state.success();
 
-        assertThat(didStateChange.get()).isTrue();
-        assertThat(state.getHealthy().get()).isTrue();
+        assertThat(didStateChange).isTrue();
+        assertThat(state.getHealthy()).isTrue();
 
         didStateChange.set(false);
 
         state.failure();
 
-        assertThat(didStateChange.get()).isTrue();
-        assertThat(state.getHealthy().get()).isFalse();
+        assertThat(didStateChange).isTrue();
+        assertThat(state.getHealthy()).isFalse();
 
         didStateChange.set(false);
 
         state.success();
 
-        assertThat(didStateChange.get()).isTrue();
-        assertThat(state.getHealthy().get()).isTrue();
+        assertThat(didStateChange).isTrue();
+        assertThat(state.getHealthy()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
AssertJ supports asserting on `AtomicInteger` and friends so there's no need to call `.get()` explicitly.