### PR TITLE
Small test enhancements

### DIFF
--- a/dropwizard-e2e/src/test/java/com/example/health/HealthIntegrationTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/health/HealthIntegrationTest.java
@@ -45,7 +45,7 @@ class HealthIntegrationTest {
     private String hostUrl;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         hostUrl = "http://" + HOST + ":" + TEST_APP_RULE.getLocalPort();
         Awaitility.waitAtMost(APP_STARTUP_MAX_TIMEOUT)
                 .pollInSameThread()
@@ -77,9 +77,9 @@ class HealthIntegrationTest {
                 .pollDelay(POLL_DELAY)
                 .until(this::isAppHealthy);
 
-        assertThat(app.getStateChangeCounter().get()).isPositive();
-        assertThat(app.getHealthyCheckCounter().get()).isPositive();
-        assertThat(app.getUnhealthyCheckCounter().get()).isPositive();
+        assertThat(app.getStateChangeCounter()).hasPositiveValue();
+        assertThat(app.getHealthyCheckCounter()).hasPositiveValue();
+        assertThat(app.getUnhealthyCheckCounter()).hasPositiveValue();
     }
 
     @Test
@@ -94,9 +94,9 @@ class HealthIntegrationTest {
                 .atMost(testTimeout)
                 .pollDelay(POLL_DELAY)
                 .until(this::isAppHealthy);
-        assertThat(app.getStateChangeCounter().get()).isPositive();
-        assertThat(app.getHealthyCheckCounter().get()).isPositive();
-        assertThat(app.getUnhealthyCheckCounter().get()).isPositive();
+        assertThat(app.getStateChangeCounter()).hasPositiveValue();
+        assertThat(app.getHealthyCheckCounter()).hasPositiveValue();
+        assertThat(app.getUnhealthyCheckCounter()).hasPositiveValue();
     }
 
     @Test
@@ -112,9 +112,9 @@ class HealthIntegrationTest {
                 .pollDelay(POLL_DELAY)
                 .until(this::isAppHealthy);
 
-        assertThat(app.getStateChangeCounter().get()).isPositive();
-        assertThat(app.getHealthyCheckCounter().get()).isPositive();
-        assertThat(app.getUnhealthyCheckCounter().get()).isPositive();
+        assertThat(app.getStateChangeCounter()).hasPositiveValue();
+        assertThat(app.getHealthyCheckCounter()).hasPositiveValue();
+        assertThat(app.getUnhealthyCheckCounter()).hasPositiveValue();
     }
 
     @Test
@@ -127,9 +127,9 @@ class HealthIntegrationTest {
                 .pollDelay(POLL_DELAY)
                 .until(() -> !isAppHealthy());
         // 2 state changes (to unhealthy) for critical checks, because of initial value of false
-        assertThat(app.getStateChangeCounter().get()).isPositive();
-        assertThat(app.getHealthyCheckCounter().get()).isZero();
-        assertThat(app.getUnhealthyCheckCounter().get()).isPositive();
+        assertThat(app.getStateChangeCounter()).hasPositiveValue();
+        assertThat(app.getHealthyCheckCounter()).hasValue(0);
+        assertThat(app.getUnhealthyCheckCounter()).hasPositiveValue();
     }
 
     @Test
@@ -150,9 +150,9 @@ class HealthIntegrationTest {
                 .pollDelay(POLL_DELAY)
                 .until(this::isAppHealthy);
 
-        assertThat(app.getStateChangeCounter().get()).isPositive();
-        assertThat(app.getHealthyCheckCounter().get()).isPositive();
-        assertThat(app.getUnhealthyCheckCounter().get()).isPositive();
+        assertThat(app.getStateChangeCounter()).hasPositiveValue();
+        assertThat(app.getHealthyCheckCounter()).hasPositiveValue();
+        assertThat(app.getUnhealthyCheckCounter()).hasPositiveValue();
     }
 
     private boolean isAppHealthy() {

--- a/dropwizard-health/src/test/java/io/dropwizard/health/StateTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/StateTest.java
@@ -42,41 +42,41 @@ class StateTest {
         final State state = new State(NAME, 2, 1, true, listener);
         state.failure();
 
-        assertThat(didStateChange.get()).isFalse();
-        assertThat(state.getHealthy().get()).isTrue();
+        assertThat(didStateChange).isFalse();
+        assertThat(state.getHealthy()).isTrue();
     }
 
     @Test
     void singleFailureShouldChangeStateIfThresholdExceeded() {
         final State state = new State(NAME, 1, 1, true, listener);
-        assertThat(state.getHealthy().get()).isTrue();
+        assertThat(state.getHealthy()).isTrue();
 
         state.failure();
 
-        assertThat(didStateChange.get()).isTrue();
-        assertThat(state.getHealthy().get()).isFalse();
+        assertThat(didStateChange).isTrue();
+        assertThat(state.getHealthy()).isFalse();
     }
 
     @Test
     void singleSuccessShouldNotChangeStateIfThresholdNotExceeded() {
         final State state = new State(NAME, 1, 2, false, listener);
-        assertThat(state.getHealthy().get()).isFalse();
+        assertThat(state.getHealthy()).isFalse();
 
         state.success();
 
-        assertThat(didStateChange.get()).isFalse();
-        assertThat(state.getHealthy().get()).isFalse();
+        assertThat(didStateChange).isFalse();
+        assertThat(state.getHealthy()).isFalse();
     }
 
     @Test
     void singleSuccessShouldChangeStateIfThresholdExceeded() {
         final State state = new State(NAME, 1, 1, false, listener);
-        assertThat(state.getHealthy().get()).isFalse();
+        assertThat(state.getHealthy()).isFalse();
 
         state.success();
 
-        assertThat(didStateChange.get()).isTrue();
-        assertThat(state.getHealthy().get()).isTrue();
+        assertThat(didStateChange).isTrue();
+        assertThat(state.getHealthy()).isTrue();
     }
 
     @Test
@@ -85,47 +85,47 @@ class StateTest {
 
         state.failure();
 
-        assertThat(didStateChange.get()).isTrue();
-        assertThat(state.getHealthy().get()).isFalse();
+        assertThat(didStateChange).isTrue();
+        assertThat(state.getHealthy()).isFalse();
 
         didStateChange.set(false);
 
         state.success();
 
-        assertThat(didStateChange.get()).isTrue();
-        assertThat(state.getHealthy().get()).isTrue();
+        assertThat(didStateChange).isTrue();
+        assertThat(state.getHealthy()).isTrue();
 
         didStateChange.set(false);
 
         state.failure();
 
-        assertThat(didStateChange.get()).isTrue();
-        assertThat(state.getHealthy().get()).isFalse();
+        assertThat(didStateChange).isTrue();
+        assertThat(state.getHealthy()).isFalse();
     }
 
     @Test
     void successFollowedByFailureShouldAllowAStateChangeToHealthyAfterAnotherSuccessOccurs() {
         final State state = new State(NAME, 1, 1, false, listener);
-        assertThat(state.getHealthy().get()).isFalse();
+        assertThat(state.getHealthy()).isFalse();
 
         state.success();
 
-        assertThat(didStateChange.get()).isTrue();
-        assertThat(state.getHealthy().get()).isTrue();
+        assertThat(didStateChange).isTrue();
+        assertThat(state.getHealthy()).isTrue();
 
         didStateChange.set(false);
 
         state.failure();
 
-        assertThat(didStateChange.get()).isTrue();
-        assertThat(state.getHealthy().get()).isFalse();
+        assertThat(didStateChange).isTrue();
+        assertThat(state.getHealthy()).isFalse();
 
         didStateChange.set(false);
 
         state.success();
 
-        assertThat(didStateChange.get()).isTrue();
-        assertThat(state.getHealthy().get()).isTrue();
+        assertThat(didStateChange).isTrue();
+        assertThat(state.getHealthy()).isTrue();
     }
 
     @Test

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/GzipHandlerFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/GzipHandlerFactoryTest.java
@@ -62,8 +62,7 @@ class GzipHandlerFactoryTest {
         final GzipHandler handler = gzip.build(null);
 
         assertThat(handler.getMinGzipSize()).isEqualTo((int) gzip.getMinimumEntitySize().toBytes());
-        assertThat(handler.getExcludedAgentPatterns()).hasSize(1);
-        assertThat(handler.getExcludedAgentPatterns()[0]).isEqualTo("OLD-2.+");
+        assertThat(handler.getExcludedAgentPatterns()).singleElement().isEqualTo("OLD-2.+");
         assertThat(handler.getIncludedMimeTypes()).containsOnly("text/plain");
         assertThat(handler.getIncludedMethods()).containsOnly("GET", "POST");
         assertThat(handler.getCompressionLevel()).isEqualTo(Deflater.DEFAULT_COMPRESSION);

--- a/dropwizard-lifecycle/pom.xml
+++ b/dropwizard-lifecycle/pom.xml
@@ -59,6 +59,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
@@ -5,6 +5,8 @@ import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.util.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.exceptions.verification.WantedButNotInvoked;
 import org.slf4j.Logger;
 
@@ -131,39 +133,37 @@ class ExecutorServiceBuilderTest {
                 assertThat(castedExec.getThreadFactory()).isInstanceOf(InstrumentedThreadFactory.class));
     }
 
-    @Test
-    void nameWithoutFormat() {
-        final String[][] tests = new String[][] {
-            { "my-client-%d", "my-client" },
-            { "my-client--%d", "my-client-" },
-            { "my-client-%d-abc", "my-client-abc" },
-            { "my-client%d", "my-client" },
-            { "my-client%d-abc", "my-client-abc" },
-            { "my-client%s", "my-client" },
-            { "my-client%sabc", "my-clientabc" },
-            { "my-client%10d", "my-client" },
-            { "my-client%10d0", "my-client0" },
-            { "my-client%-10d", "my-client" },
-            { "my-client%-10d0", "my-client0" },
-            { "my-client-%10d", "my-client" },
-            { "my-client-%10dabc", "my-clientabc" },
-            { "my-client-%1$d", "my-client" },
-            { "my-client-%1$d-abc", "my-client-abc" },
-            { "-%d", "" },
-            { "%d", "" },
-            { "%d-abc", "-abc" },
-            { "%10d", "" },
-            { "%10dabc", "abc" },
-            { "%-10d", "" },
-            { "%-10dabc", "abc" },
-            { "%10s", "" },
-            { "%10sabc", "abc" },
-        };
-        for (String[] t : tests) {
-            assertThat(ExecutorServiceBuilder.getNameWithoutFormat(t[0]))
-                .describedAs("%s -> %s", t[0], t[1])
-                .isEqualTo(t[1]);
-        }
+    @CsvSource(value = {
+        "my-client-%d,my-client",
+        "my-client--%d,my-client-",
+        "my-client-%d-abc,my-client-abc",
+        "my-client%d,my-client",
+        "my-client%d-abc,my-client-abc",
+        "my-client%s,my-client",
+        "my-client%sabc,my-clientabc",
+        "my-client%10d,my-client",
+        "my-client%10d0,my-client0",
+        "my-client%-10d,my-client",
+        "my-client%-10d0,my-client0",
+        "my-client-%10d,my-client",
+        "my-client-%10dabc,my-clientabc",
+        "my-client-%1$d,my-client",
+        "my-client-%1$d-abc,my-client-abc",
+        "-%d,''",
+        "%d,''",
+        "%d-abc,-abc",
+        "%10d,''",
+        "%10dabc,abc",
+        "%-10d,''",
+        "%-10dabc,abc",
+        "%10s,''" ,
+        "%10sabc,abc",
+    })
+    @ParameterizedTest
+    void nameWithoutFormat(String format, String name) {
+        assertThat(ExecutorServiceBuilder.getNameWithoutFormat(format))
+            .describedAs("%s -> %s", format, name)
+            .isEqualTo(name);
     }
 
     /**


### PR DESCRIPTION
AssertJ 3.22.0 adds `singleElement()` for `ObjectArrayAssert`. Use it in `GzipHandlerTest`.

Use parameterized tests in `ExecutorServiceBuilderTest`

AssertJ supports asserting on `AtomicInteger` and friends so there's no need to call .get() explicitly.