### PR TITLE
Mark dropwizard-jetty's `NetUtil` deprecated

### DIFF
--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/NetUtil.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/NetUtil.java
@@ -40,7 +40,12 @@ import static java.util.Objects.requireNonNull;
  *
  * The {@link #getAllLocalIPs()} method was taken from the Apache Curator project
  * which is also under the Apache 2.0 license.
+ *
+ * @deprecated This class is intended for internal use and should be treated as
+ *             package-private.
  */
+
+@Deprecated
 public class NetUtil {
     public static final int DEFAULT_TCP_BACKLOG_WINDOWS = 200;
     public static final int DEFAULT_TCP_BACKLOG_LINUX = 128;


### PR DESCRIPTION
This is an internal class which should probably be package-private.

Mark it deprecated as a step towards doing that.

(this is as an alternative to just straight up doing that - https://github.com/dropwizard/dropwizard/pull/4569)