### PR TITLE
Register resources in the same way for Java 8 and 11

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -9,7 +9,6 @@ import io.dropwizard.jersey.caching.CacheControlledResponseFeature;
 import io.dropwizard.jersey.params.AbstractParamConverterProvider;
 import io.dropwizard.jersey.sessions.SessionFactoryProvider;
 import io.dropwizard.jersey.validation.FuzzyEnumParamConverterProvider;
-import io.dropwizard.util.JavaVersion;
 import javassist.ClassPool;
 import javassist.CtClass;
 import javassist.LoaderClassPath;
@@ -29,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -163,12 +163,7 @@ public class DropwizardResourceConfig extends ResourceConfig {
                 pool.insertClassPath(new LoaderClassPath(this.getClass().getClassLoader()));
                 final CtClass cc = pool.makeClass(SpecificBinder.class.getName() + UUID.randomUUID());
                 cc.setSuperclass(pool.get(SpecificBinder.class.getName()));
-                final Object binderProxy;
-                if (JavaVersion.isJava8()) {
-                    binderProxy = cc.toClass().getConstructor(Object.class, Class.class).newInstance(object, clazz);
-                } else {
-                    binderProxy = cc.toClass(SpecificBinder.class).getConstructor(Object.class, Class.class).newInstance(object, clazz);
-                }
+                final Object binderProxy = cc.toClass(MethodHandles.lookup()).getConstructor(Object.class, Class.class).newInstance(object, clazz);
                 super.register(binderProxy);
                 return super.register(clazz);
             } catch (Exception e) {
@@ -185,8 +180,8 @@ public class DropwizardResourceConfig extends ResourceConfig {
      * @since 2.0
      */
     public static class SpecificBinder extends AbstractBinder {
-        private Object object;
-        private Class<?> clazz;
+        private final Object object;
+        private final Class<?> clazz;
 
         public SpecificBinder(Object object, Class<?> clazz) {
             this.object = object;

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
@@ -19,8 +19,8 @@ import javax.ws.rs.core.MediaType;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class DropwizardResourceConfigTest {
-    private DropwizardResourceConfig rc = DropwizardResourceConfig.forTesting();
-    private AbstractJerseyTest jerseyTest = new AbstractJerseyTest() {
+    private final DropwizardResourceConfig rc = DropwizardResourceConfig.forTesting();
+    private final AbstractJerseyTest jerseyTest = new AbstractJerseyTest() {
         @Override
         protected Application configure() {
             return rc;
@@ -437,7 +437,7 @@ class DropwizardResourceConfigTest {
     }
 
     public static class ResourceWithInjectedDependency implements ResourceInterface {
-        private Dependency dependency;
+        private final Dependency dependency;
 
         @Inject
         public ResourceWithInjectedDependency(Dependency dependency) {

--- a/dropwizard-util/src/main/java/io/dropwizard/util/JavaVersion.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/JavaVersion.java
@@ -4,7 +4,10 @@ import javax.annotation.Nullable;
 
 /**
  * @since 2.0
+ *
+ * @deprecated will be removed in a future release
  */
+@Deprecated
 public final class JavaVersion {
     private JavaVersion() {
     }

--- a/dropwizard-util/src/test/java/io/dropwizard/util/JavaVersionTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/JavaVersionTest.java
@@ -4,6 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * @deprecated {@link JavaVersion} is deprecated
+ */
+@Deprecated
 class JavaVersionTest {
     @Test
     void isJava8_returns_false_if_specVersion_cannot_be_read() {


### PR DESCRIPTION
Is "it passes tests" enough validation?

Use `CtClass#toClass(MethodHandles.Lookup)` to register resources. Note that I'm not really familiar with this API - am I doing it right?

The javaassist docs suggest this will work under both Java 8 and 11.

Deprecate `JavaVersion` as it is now unused.