### PR TITLE
Deprecate `DataSize#toSize()` and `DataSize#fromSize()`

### DIFF
--- a/dropwizard-benchmarks/src/main/java/io/dropwizard/benchmarks/util/SizeBenchmark.java
+++ b/dropwizard-benchmarks/src/main/java/io/dropwizard/benchmarks/util/SizeBenchmark.java
@@ -12,9 +12,14 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.concurrent.TimeUnit;
 
+/**
+ * @deprecated {@link Size} is deprecated in favour of {@link io.dropwizard.util.DataSize}
+ */
+
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
+@Deprecated
 public class SizeBenchmark {
 
     /**

--- a/dropwizard-util/src/main/java/io/dropwizard/util/DataSize.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/DataSize.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Locale;
-import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
@@ -231,7 +230,12 @@ public class DataSize implements Comparable<DataSize>, Serializable {
         return Long.compare(toBytes(), other.toBytes());
     }
 
-    @SuppressWarnings("deprecation")
+    /**
+     * Construct an equivalent {@link Size} object from this {@link DataSize}
+     *
+     * @deprecated {@link Size} is deprecated in favour of {@link DataSize}
+     */
+    @Deprecated
     public Size toSize() {
         switch (unit) {
             case BYTES:
@@ -258,7 +262,12 @@ public class DataSize implements Comparable<DataSize>, Serializable {
         }
     }
 
-    @SuppressWarnings("deprecation")
+    /**
+     * Construct an equivalent {@link DataSize} object from a {@link Size} object
+     *
+     * @deprecated {@link Size} is deprecated in favour of {@link DataSize}
+     */
+    @Deprecated
     public static DataSize fromSize(Size size) {
         switch (size.getUnit()) {
             case BYTES:

--- a/dropwizard-util/src/test/java/io/dropwizard/util/DataSizeTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/DataSizeTest.java
@@ -672,7 +672,7 @@ class DataSizeTest {
         assertThat(DataSize.parse("128", DataSizeUnit.KIBIBYTES)).isEqualTo(DataSize.kibibytes(128L));
     }
 
-    @SuppressWarnings("deprecation")
+    @Deprecated
     @Test
     void testToSize() {
         assertThat(DataSize.bytes(5L).toSize()).isEqualTo(Size.bytes(5L));
@@ -688,7 +688,7 @@ class DataSizeTest {
         assertThat(DataSize.pebibytes(5L).toSize()).isEqualTo(Size.terabytes(5L * 1024L));
     }
 
-    @SuppressWarnings("deprecation")
+    @Deprecated
     @Test
     void testFromSize() {
         assertThat(DataSize.fromSize(Size.bytes(5L))).isEqualTo(DataSize.bytes(5L));


### PR DESCRIPTION
Since `Size` is deprecated, it makes sense for these conversion methods to also be deprecated.

Annotate the corresponding tests as `@Deprecated` as an alternative to `@SuppressWarnings`.

Also deprecate `SizeBenchmark` for the same reason.