### PR TITLE
Deprecate `LocalIpFilter`

### DIFF
--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/LocalIpFilter.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/LocalIpFilter.java
@@ -21,7 +21,11 @@ import java.net.SocketException;
 
 /**
  * @see <a href="https://github.com/apache/curator/blob/master/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/LocalIpFilter.java">LocalIpFilter</a>
+ *
+ * @deprecated This interface is intended for internal use and should be treated as
+ *             package-private.
  */
+@Deprecated
 public interface LocalIpFilter {
     boolean use(NetworkInterface networkInterface, InetAddress address) throws SocketException;
 }


### PR DESCRIPTION
The interface `LocalIpFilter` is only used by `NetUtil`. Since `NetUtil` was marked as deprecated in #4584 to restrict access to package-private, I guess this should be done for `LocalIpFilter` too.
