### PR TITLE
Clarify that maxRequestHeaderSize is a combined limit for all headers

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -330,10 +330,10 @@ outputBufferSize         32KiB               The size of the buffer into which r
                                              the client. A larger buffer can improve performance by allowing a content producer
                                              to run without blocking, however larger buffers consume more memory and may induce
                                              some latency before a client starts processing the content.
-maxRequestHeaderSize     8KiB                The maximum size of a request header. Larger headers will allow for more and/or
-                                             larger cookies plus larger form content encoded in a URL. However, larger headers
-                                             consume more memory and can make a server more vulnerable to denial of service
-                                             attacks.
+maxRequestHeaderSize     8KiB                The maximum allowed size in bytes for the HTTP request line and HTTP request headers.
+                                             Larger headers will allow for more and/or larger cookies plus larger form content
+                                             encoded in a URL. However, larger headers consume more memory and can make a server
+                                             more vulnerable to denial of service attacks.
 maxResponseHeaderSize    8KiB                The maximum size of a response header. Larger headers will allow for more and/or
                                              larger cookies and longer HTTP headers (eg for redirection).  However, larger headers
                                              will also consume more memory.
@@ -1317,7 +1317,7 @@ Health Checks
 Options around a particular health check which is registered in an Application
 
   .. code-block:: yaml
-     
+
       health:
         healthChecks:
           - name: file-system

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
@@ -85,10 +85,10 @@ import static com.codahale.metrics.MetricRegistry.name;
  *         <td>{@code maxRequestHeaderSize}</td>
  *         <td>8KiB</td>
  *         <td>
- *             The maximum size of a request header. Larger headers will allow for more and/or
- *             larger cookies plus larger form content encoded  in a URL. However, larger headers
- *             consume more memory and can make a server more vulnerable to denial of service
- *             attacks.
+ *             The maximum allowed size in bytes for the HTTP request line and HTTP request headers.
+ *             Larger headers will allow for more and/or larger cookies plus larger form content
+ *             encoded in a URL. However, larger headers consume more memory and can make a server
+ *             more vulnerable to denial of service attacks.
  *         </td>
  *     </tr>
  *     <tr>


### PR DESCRIPTION

###### Problem:
maxRequestHeaderSize was documented in Dropwizard (and Jetty) as being a
limit for the size of a single request header, but it's actually a limit
for the combined size of all request headers and the request line.

Corresponding Jetty PR: https://github.com/eclipse/jetty.project/pull/7417
###### Solution:
Clarify the documentation accordingly.

