### PR TITLE
Remove duplicate logfile from dropwizard-logging tests (#4568)

### DIFF
--- a/dropwizard-logging/src/test/resources/yaml/logging.yml
+++ b/dropwizard-logging/src/test/resources/yaml/logging.yml
@@ -15,12 +15,6 @@ appenders:
     currentLogFilename: ./logs/max-file-size-example.log
     archivedLogFilenamePattern: ./logs/max-file-size-example-%d-%i.log.gz
     archivedFileCount: 5
-  - type: file
-    threshold: ALL
-    maxFileSize: 100MiB
-    currentLogFilename: ./logs/max-file-size-example.log
-    archivedLogFilenamePattern: ./logs/max-file-size-example-%i.log.gz
-    archivedFileCount: 5
   - type: syslog
     host: localhost
     facility: local0


### PR DESCRIPTION
This was added in cc53136ae8754c20df268b6ea1a0cf3528618450 but isn't used by the tests.

It causes errors to be logged during tests as the `currentLogFilename` is identical to another log configuration in the same file.

`FileAppenderFactoryTest` tests the behaviour of `FileAppenderFactory` directly without roundtripping through the YAML configuration parser.

Remove the duplicate log file definition.