### PR TITLE
Increase test coverage for `HealthCheckManager`

### DIFF
--- a/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckManagerTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckManagerTest.java
@@ -54,6 +54,10 @@ class HealthCheckManagerTest {
 
         // then
         verifyNoInteractions(scheduler);
+        assertThat(manager.healthStateView(NAME))
+            .isEmpty();
+        assertThat(manager.healthStateViews())
+            .isEmpty();
     }
 
     @Test
@@ -71,6 +75,10 @@ class HealthCheckManagerTest {
 
         // then
         verifyCheckWasScheduled(scheduler, true);
+        assertThat(manager.healthStateViews())
+            .singleElement()
+            .isEqualTo(manager.healthStateView(NAME).orElseThrow(IllegalStateException::new))
+            .satisfies(view -> assertThat(view.getName()).isEqualTo(NAME));
     }
 
     @Test
@@ -86,6 +94,11 @@ class HealthCheckManagerTest {
 
         // then
         verify(scheduler).unschedule(NAME);
+        assertThat(manager.healthStateView(NAME))
+            .isEmpty();
+        assertThat(manager.healthStateViews())
+            .singleElement()
+            .isNull();
     }
 
     @Test


### PR DESCRIPTION
Test the behaviour of `HealthCheckManager#healthStateView()` and
`HealthCheckManager#healthStateViews()`

Question: Is it correct that when a healthcheck is removed via `HealthCheckManager#onHealthCheckRemoved()`, `HealthCheckManager#healthStateViews()` returns a collection containing `null`? Should `onHealthCheckRemoved()` remove it from the `checks` collection?

`onHealthCheckRemoved()` is never called by Dropwizard.