### PR TITLE
Remove inconsistency in CsvReporterFactory's directory handling

### DIFF
--- a/dropwizard-metrics/src/main/java/io/dropwizard/metrics/CsvReporterFactory.java
+++ b/dropwizard-metrics/src/main/java/io/dropwizard/metrics/CsvReporterFactory.java
@@ -57,10 +57,10 @@ public class CsvReporterFactory extends BaseFormattedReporterFactory {
 
     @Override
     public ScheduledReporter build(MetricRegistry registry) {
-        final File file = requireNonNull(this.file, "File is not set");
-        final boolean creation = file.mkdirs();
-        if (!creation && !file.exists()) {
-            throw new RuntimeException("Failed to create" + file.getAbsolutePath());
+        final File directory = requireNonNull(getFile(), "File is not set");
+        final boolean creation = directory.mkdirs();
+        if (!creation && !directory.exists()) {
+            throw new RuntimeException("Failed to create" + directory.getAbsolutePath());
         }
 
         return CsvReporter.forRegistry(registry)
@@ -68,6 +68,6 @@ public class CsvReporterFactory extends BaseFormattedReporterFactory {
                           .convertRatesTo(getRateUnit())
                           .filter(getFilter())
                           .formatFor(getLocale())
-                          .build(getFile());
+                          .build(directory);
     }
 }


### PR DESCRIPTION
`CsvReporterFactory#build(MetricRegistry)` does all its validation
directory on the `file` field but uses the result of `getFile()` when
actually constructing the `CsvReporter`.

If someone were to subclass and override `getFile()` this would lead to
confusing behaviour.

Use `getFile()` instead of directly accessing the field.

In addition, the `file` variable in `build(MetricRegistry)` shadowed the
`file` field. Rename it to `directory` to avoid this.