### PR TITLE
Various linter fixes

### DIFF
--- a/dropwizard-core/src/test/java/io/dropwizard/validation/InjectValidatorFeatureTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/validation/InjectValidatorFeatureTest.java
@@ -15,7 +15,6 @@ import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import javax.validation.constraints.Min;
-import java.util.Optional;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/dropwizard-core/src/test/java/io/dropwizard/validation/InjectValidatorFeatureTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/validation/InjectValidatorFeatureTest.java
@@ -36,7 +36,7 @@ class InjectValidatorFeatureTest {
     private ValidatorFactory validatorFactory;
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         Bootstrap<Configuration> bootstrap = new Bootstrap<>(application);
         application.initialize(bootstrap);
 
@@ -57,14 +57,10 @@ class InjectValidatorFeatureTest {
         // Run validation manually
         Set<ConstraintViolation<Bean>> constraintViolations = validator.validate(new Bean(1));
 
-
-        assertThat(constraintViolations.size()).isEqualTo(1);
-
-        Optional<String> message = constraintViolations.stream()
-            .findFirst()
-            .map(ConstraintViolation::getMessage);
-
-        assertThat(message).hasValue("must be greater than or equal to 10");
+        assertThat(constraintViolations)
+            .singleElement()
+            .extracting(ConstraintViolation::getMessage)
+            .isEqualTo("must be greater than or equal to 10");
     }
 
     @Test

--- a/dropwizard-db/src/main/java/io/dropwizard/db/TimeBoundHealthCheck.java
+++ b/dropwizard-db/src/main/java/io/dropwizard/db/TimeBoundHealthCheck.java
@@ -3,7 +3,6 @@ package io.dropwizard.db;
 import com.codahale.metrics.health.HealthCheck;
 import io.dropwizard.util.Duration;
 
-import java.lang.InterruptedException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 

--- a/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceFactoryTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceFactoryTest.java
@@ -154,19 +154,19 @@ class DataSourceFactoryTest {
     @Test
     void metricsRecorded() throws Exception {
         dataSource();
-        Map<String, Gauge> poolMetrics = metricRegistry.getGauges(MetricFilter.startsWith("io.dropwizard.db.ManagedPooledDataSource.test."));
-        assertThat(poolMetrics)
-            .containsKey("io.dropwizard.db.ManagedPooledDataSource.test.active")
-            .containsKey("io.dropwizard.db.ManagedPooledDataSource.test.idle")
-            .containsKey("io.dropwizard.db.ManagedPooledDataSource.test.waiting")
-            .containsKey("io.dropwizard.db.ManagedPooledDataSource.test.size")
-            .containsKey("io.dropwizard.db.ManagedPooledDataSource.test.created")
-            .containsKey("io.dropwizard.db.ManagedPooledDataSource.test.borrowed")
-            .containsKey("io.dropwizard.db.ManagedPooledDataSource.test.reconnected")
-            .containsKey("io.dropwizard.db.ManagedPooledDataSource.test.released")
-            .containsKey("io.dropwizard.db.ManagedPooledDataSource.test.releasedIdle")
-            .containsKey("io.dropwizard.db.ManagedPooledDataSource.test.returned")
-            .containsKey("io.dropwizard.db.ManagedPooledDataSource.test.removeAbandoned");
+        assertThat(metricRegistry.getGauges(MetricFilter.startsWith("io.dropwizard.db.ManagedPooledDataSource.test.")))
+            .containsOnlyKeys(
+                "io.dropwizard.db.ManagedPooledDataSource.test.active",
+                "io.dropwizard.db.ManagedPooledDataSource.test.idle",
+                "io.dropwizard.db.ManagedPooledDataSource.test.waiting",
+                "io.dropwizard.db.ManagedPooledDataSource.test.size",
+                "io.dropwizard.db.ManagedPooledDataSource.test.created",
+                "io.dropwizard.db.ManagedPooledDataSource.test.borrowed",
+                "io.dropwizard.db.ManagedPooledDataSource.test.reconnected",
+                "io.dropwizard.db.ManagedPooledDataSource.test.released",
+                "io.dropwizard.db.ManagedPooledDataSource.test.releasedIdle",
+                "io.dropwizard.db.ManagedPooledDataSource.test.returned",
+                "io.dropwizard.db.ManagedPooledDataSource.test.removeAbandoned");
     }
 
 }

--- a/dropwizard-e2e/src/main/java/com/example/badlog/BadLogApp.java
+++ b/dropwizard-e2e/src/main/java/com/example/badlog/BadLogApp.java
@@ -10,7 +10,7 @@ public class BadLogApp extends Application<Configuration> {
     private static final Logger LOGGER = LoggerFactory.getLogger(BadLogApp.class);
 
     @Override
-    protected void onFatalError() {
+    protected void onFatalError(Throwable t) {
         LOGGER.warn("Mayday we're going down");
     }
 

--- a/dropwizard-example/src/test/java/com/example/helloworld/DockerIntegrationTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/DockerIntegrationTest.java
@@ -88,7 +88,7 @@ public class DockerIntegrationTest {
             final String date = APP.client().target("http://localhost:" + APP.getLocalPort() + "/hello-world/date")
                 .request()
                 .get(String.class);
-            assertThat(date).isEqualTo("");
+            assertThat(date).isEmpty();
         }
     }
 

--- a/dropwizard-example/src/test/java/com/example/helloworld/IntegrationTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/IntegrationTest.java
@@ -84,7 +84,7 @@ class IntegrationTest {
             final String date = APP.client().target("http://localhost:" + APP.getLocalPort() + "/hello-world/date")
                 .request()
                 .get(String.class);
-            assertThat(date).isEqualTo("");
+            assertThat(date).isEmpty();
         }
     }
 

--- a/dropwizard-health/src/main/java/io/dropwizard/health/HealthCheckManager.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/HealthCheckManager.java
@@ -65,8 +65,8 @@ class HealthCheckManager implements HealthCheckRegistryListener, HealthStatusChe
 
         this.aggregateHealthyName = MetricRegistry.name("health", "aggregate", "healthy");
         this.aggregateUnhealthyName = MetricRegistry.name("health", "aggregate", "unhealthy");
-        metrics.register(aggregateHealthyName, (Gauge) this::calculateNumberOfHealthyChecks);
-        metrics.register(aggregateUnhealthyName, (Gauge) this::calculateNumberOfUnhealthyChecks);
+        metrics.register(aggregateHealthyName, (Gauge<Long>) this::calculateNumberOfHealthyChecks);
+        metrics.register(aggregateUnhealthyName, (Gauge<Long>) this::calculateNumberOfUnhealthyChecks);
     }
 
     // visible for testing

--- a/dropwizard-health/src/main/java/io/dropwizard/health/response/JsonHealthResponseProvider.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/response/JsonHealthResponseProvider.java
@@ -86,7 +86,6 @@ public class JsonHealthResponseProvider implements HealthResponseProvider {
     private Collection<HealthStateView> getViews(final Map<String, Collection<String>> queryParams) {
         final Set<String> names = getNamesFromQueryParams(queryParams);
 
-        final Collection<HealthStateView> views;
         if (shouldReturnAllViews(names)) {
             return unmodifiableList(new ArrayList<>(healthStateAggregator.healthStateViews()));
         } else {

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkApplicationListenerTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/UnitOfWorkApplicationListenerTest.java
@@ -17,7 +17,6 @@ import org.mockito.InOrder;
 import java.lang.reflect.Method;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.hibernate.resource.transaction.spi.TransactionStatus.ACTIVE;
 import static org.hibernate.resource.transaction.spi.TransactionStatus.NOT_ACTIVE;

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/AllowedMethodsFilterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/AllowedMethodsFilterTest.java
@@ -68,14 +68,10 @@ class AllowedMethodsFilterTest extends AbstractJerseyTest {
     }
 
     private int getResponseStatusForRequestMethod(String method, boolean includeEntity) {
-        final Response resourceResponse = includeEntity
-                ? target("/ping").request().method(method, Entity.entity("", MediaType.TEXT_PLAIN))
-                : target("/ping").request().method(method);
-
-        try {
+        try (Response resourceResponse = includeEntity
+            ? target("/ping").request().method(method, Entity.entity("", MediaType.TEXT_PLAIN))
+            : target("/ping").request().method(method)) {
             return resourceResponse.getStatus();
-        } finally {
-            resourceResponse.close();
         }
     }
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalDoubleMessageBodyWriterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalDoubleMessageBodyWriterTest.java
@@ -16,7 +16,6 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 import java.util.OptionalDouble;
 

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
@@ -343,7 +343,7 @@ class FileAppenderFactoryTest {
 
         final FileAppender appender = factory.build(new ResourceConfigurationSourceProvider(), "yaml/appender_file_cap.yaml")
             .buildAppender(new LoggerContext());
-        assertThat(appender).isInstanceOfSatisfying(RollingFileAppender.class, roller -> {
+        assertThat(appender).isInstanceOfSatisfying(RollingFileAppender.class, roller ->
             assertThat(roller.getRollingPolicy()).isInstanceOfSatisfying(SizeAndTimeBasedRollingPolicy.class, policy -> {
                 try {
                     assertThat(totalSizeCap.get(policy))
@@ -358,8 +358,8 @@ class FileAppenderFactoryTest {
                 } catch (IllegalAccessException e) {
                     throw new RuntimeException("Unexpected illegal access", e);
                 }
-            });
-        });
+            })
+        );
     }
 
     @Test

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
@@ -38,7 +38,6 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 
-import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 

--- a/dropwizard-metrics-graphite/src/test/java/io/dropwizard/metrics/graphite/GraphiteReporterFactoryTest.java
+++ b/dropwizard-metrics-graphite/src/test/java/io/dropwizard/metrics/graphite/GraphiteReporterFactoryTest.java
@@ -50,9 +50,10 @@ class GraphiteReporterFactoryTest {
         verify(builderSpy).build(argument.capture());
 
         final Graphite graphite = argument.getValue();
-        assertThat(getField(graphite, "hostname")).isEqualTo("localhost");
-        assertThat(getField(graphite, "port")).isEqualTo(2003);
-        assertThat(getField(graphite, "address")).isNull();
+        final FieldAccessor<Graphite> graphiteFieldAccessor = new FieldAccessor<>(graphite);
+        assertThat(graphiteFieldAccessor.getField("hostname")).isEqualTo("localhost");
+        assertThat(graphiteFieldAccessor.getField("port")).isEqualTo(2003);
+        assertThat(graphiteFieldAccessor.getField("address")).isNull();
     }
 
     @Test
@@ -64,30 +65,23 @@ class GraphiteReporterFactoryTest {
         verify(builderSpy).build(argument.capture());
 
         final GraphiteUDP graphite = argument.getValue();
-        assertThat(getField(graphite, "hostname")).isEqualTo("localhost");
-        assertThat(getField(graphite, "port")).isEqualTo(2003);
-        assertThat(getField(graphite, "address")).isNull();
+        final FieldAccessor<GraphiteUDP> graphiteUDPFieldAccessor = new FieldAccessor<>(graphite);
+        assertThat(graphiteUDPFieldAccessor.getField("hostname")).isEqualTo("localhost");
+        assertThat(graphiteUDPFieldAccessor.getField("port")).isEqualTo(2003);
+        assertThat(graphiteUDPFieldAccessor.getField("address")).isNull();
     }
 
-    private static Object getField(GraphiteUDP graphite, String name) throws NoSuchFieldException {
-        try {
-            return getInaccessibleField(GraphiteUDP.class, name).get(graphite);
-        } catch (IllegalAccessException e) {
-            throw new IllegalStateException(e);
+    private static class FieldAccessor<T> {
+        T obj;
+
+        FieldAccessor(T obj) {
+            this.obj = obj;
         }
-    }
 
-    private static Object getField(Graphite graphite, String name) throws NoSuchFieldException {
-        try {
-            return getInaccessibleField(Graphite.class, name).get(graphite);
-        } catch (IllegalAccessException e) {
-            throw new IllegalStateException(e);
+        Object getField(String name) throws IllegalAccessException, NoSuchFieldException {
+            Field field = obj.getClass().getDeclaredField(name);
+            field.setAccessible(true);
+            return field.get(obj);
         }
-    }
-
-    private static Field getInaccessibleField(Class klass, String name) throws NoSuchFieldException {
-        Field field = klass.getDeclaredField(name);
-        field.setAccessible(true);
-        return field;
     }
 }

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
@@ -254,7 +254,7 @@ public class DropwizardTestSupport<C extends Configuration> {
             try {
                 jettyServer.stop();
             } catch (RuntimeException e) {
-                throw (RuntimeException) e;
+                throw e;
             } catch (Exception e) {
                 throw new RuntimeException(e);
             } finally {

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/ResourceHelpers.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/ResourceHelpers.java
@@ -20,7 +20,7 @@ public class ResourceHelpers {
         try {
             return new File(Resources.getResource(resourceClassPathLocation).toURI()).getAbsolutePath();
         } catch (RuntimeException e) {
-            throw (RuntimeException) e;
+            throw e;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/GzipDefaultVaryBehaviourTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/GzipDefaultVaryBehaviourTest.java
@@ -26,7 +26,8 @@ public class GzipDefaultVaryBehaviourTest {
         final Response clientResponse = RULE.client().target(
             "http://localhost:" + RULE.getLocalPort() + "/test").request().header(ACCEPT_ENCODING, "gzip").get();
 
-        assertThat(clientResponse.getHeaders().get(VARY)).isEqualTo(Collections.singletonList((Object) ACCEPT_ENCODING));
-        assertThat(clientResponse.getHeaders().get(CONTENT_ENCODING)).isEqualTo(Collections.singletonList((Object) "gzip"));
+        assertThat(clientResponse.getHeaders())
+            .containsEntry(VARY, Collections.singletonList(ACCEPT_ENCODING))
+            .containsEntry(CONTENT_ENCODING, Collections.singletonList("gzip"));
     }
 }

--- a/dropwizard-util/src/test/java/io/dropwizard/util/MapsTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/MapsTest.java
@@ -11,8 +11,8 @@ class MapsTest {
 
     @Test
     void of2KeyValuePairs() {
-        final Map map = Maps.of(1, 60, 2, 61);
-        final HashMap hashMap = new HashMap();
+        final Map<Integer,Integer> map = Maps.of(1, 60, 2, 61);
+        final HashMap<Integer,Integer> hashMap = new HashMap<>();
         hashMap.put(1, 60);
         hashMap.put(2, 61);
 
@@ -21,8 +21,8 @@ class MapsTest {
 
     @Test
     void of3KeyValuePairs() {
-        final Map map = Maps.of(1, 60, 2, 61, 3, 62);
-        final HashMap hashMap = new HashMap();
+        final Map<Integer,Integer> map = Maps.of(1, 60, 2, 61, 3, 62);
+        final HashMap<Integer,Integer> hashMap = new HashMap<>();
         hashMap.put(1, 60);
         hashMap.put(2, 61);
         hashMap.put(3, 62);
@@ -32,8 +32,8 @@ class MapsTest {
 
     @Test
     void of4KeyValuePairs() {
-        final Map map = Maps.of(1, 60, 2, 61, 3, 62, 4, 63);
-        final HashMap hashMap = new HashMap();
+        final Map<Integer,Integer> map = Maps.of(1, 60, 2, 61, 3, 62, 4, 63);
+        final HashMap<Integer,Integer> hashMap = new HashMap<>();
         hashMap.put(1, 60);
         hashMap.put(2, 61);
         hashMap.put(3, 62);
@@ -44,8 +44,8 @@ class MapsTest {
 
     @Test
     void of5KeyValuePairs() {
-        final Map map = Maps.of(1, 60, 2, 61, 3, 62, 4, 63, 5, 64);
-        final HashMap hashMap = new HashMap();
+        final Map<Integer,Integer> map = Maps.of(1, 60, 2, 61, 3, 62, 4, 63, 5, 64);
+        final HashMap<Integer,Integer> hashMap = new HashMap<>();
         hashMap.put(1, 60);
         hashMap.put(2, 61);
         hashMap.put(3, 62);
@@ -54,5 +54,4 @@ class MapsTest {
 
         assertThat(map).isEqualTo(hashMap);
     }
-
 }

--- a/dropwizard-util/src/test/java/io/dropwizard/util/SetsTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/SetsTest.java
@@ -12,30 +12,30 @@ class SetsTest {
 
     @Test
     void of2Elements() {
-        final Set set = Sets.of(1, 2);
+        final Set<Integer> set = Sets.of(1, 2);
 
-        assertThat(set).isEqualTo(new HashSet(Arrays.asList(1, 2)));
+        assertThat(set).isEqualTo(new HashSet<>(Arrays.asList(1, 2)));
     }
 
     @Test
     void of3Elements() {
-        final Set set = Sets.of(1, 2, 1);
+        final Set<Integer> set = Sets.of(1, 2, 1);
 
-        assertThat(set).isEqualTo(new HashSet(Arrays.asList(1, 2)));
+        assertThat(set).isEqualTo(new HashSet<>(Arrays.asList(1, 2)));
     }
 
     @Test
     void of4Elements() {
-        final Set set = Sets.of(1, 2, 1, 1);
+        final Set<Integer> set = Sets.of(1, 2, 1, 1);
 
-        assertThat(set).isEqualTo(new HashSet(Arrays.asList(1, 2)));
+        assertThat(set).isEqualTo(new HashSet<>(Arrays.asList(1, 2)));
     }
 
     @Test
     void of5Elements() {
-        final Set set = Sets.of(1, 1, 2, 3, 3);
+        final Set<Integer> set = Sets.of(1, 1, 2, 3, 3);
 
-        assertThat(set).isEqualTo(new HashSet(Arrays.asList(1, 2, 3)));
+        assertThat(set).isEqualTo(new HashSet<>(Arrays.asList(1, 2, 3)));
     }
 
 }

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/DataSizeRange.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/DataSizeRange.java
@@ -38,10 +38,8 @@ public @interface DataSizeRange {
     @OverridesAttribute(constraint = MaxDataSize.class, name = "value")
     long max() default Long.MAX_VALUE;
 
-    @OverridesAttribute.List({
-        @OverridesAttribute(constraint = MinDataSize.class, name = "unit"),
-        @OverridesAttribute(constraint = MaxDataSize.class, name = "unit")
-    })
+    @OverridesAttribute(constraint = MinDataSize.class, name = "unit")
+    @OverridesAttribute(constraint = MaxDataSize.class, name = "unit")
     DataSizeUnit unit() default DataSizeUnit.BYTES;
 
     String message() default "must be between {min} {unit} and {max} {unit}";

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/DurationRange.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/DurationRange.java
@@ -35,10 +35,8 @@ public @interface DurationRange {
     @OverridesAttribute(constraint = MaxDuration.class, name = "value")
     long max() default Long.MAX_VALUE;
 
-    @OverridesAttribute.List({
-        @OverridesAttribute(constraint = MinDuration.class, name = "unit"),
-        @OverridesAttribute(constraint = MaxDuration.class, name = "unit")
-    })
+    @OverridesAttribute(constraint = MinDuration.class, name = "unit")
+    @OverridesAttribute(constraint = MaxDuration.class, name = "unit")
     TimeUnit unit() default TimeUnit.SECONDS;
 
     String message() default "must be between {min} {unit} and {max} {unit}";

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/SizeRange.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/SizeRange.java
@@ -38,10 +38,8 @@ public @interface SizeRange {
     @OverridesAttribute(constraint = MaxSize.class, name = "value")
     long max() default Long.MAX_VALUE;
 
-    @OverridesAttribute.List({
-        @OverridesAttribute(constraint = MinSize.class, name = "unit"),
-        @OverridesAttribute(constraint = MaxSize.class, name = "unit")
-    })
+    @OverridesAttribute(constraint = MinSize.class, name = "unit")
+    @OverridesAttribute(constraint = MaxSize.class, name = "unit")
     SizeUnit unit() default SizeUnit.BYTES;
 
     String message() default "must be between {min} {unit} and {max} {unit}";

--- a/dropwizard-views/src/test/java/io/dropwizard/views/ViewMessageBodyWriterTest.java
+++ b/dropwizard-views/src/test/java/io/dropwizard/views/ViewMessageBodyWriterTest.java
@@ -71,10 +71,8 @@ class ViewMessageBodyWriterTest {
         when(metricRegistry.timer(anyString())).thenReturn(timer);
         when(timer.time()).thenReturn(timerContext);
 
-        assertThatExceptionOfType(WebApplicationException.class).isThrownBy(() -> {
-            writer.writeTo(view, Class.class, Class.class, new Annotation[]{}, new MediaType(),
-                new MultivaluedHashMap<>(), stream);
-        }).withCauseExactlyInstanceOf(ViewRenderException.class);
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> writer.writeTo(view, Class.class, Class.class, new Annotation[]{}, new MediaType(), new MultivaluedHashMap<>(), stream)).withCauseExactlyInstanceOf(ViewRenderException.class);
 
         verify(timerContext).stop();
     }
@@ -95,10 +93,9 @@ class ViewMessageBodyWriterTest {
         doReturn(locale).when(writer).detectLocale(any());
         writer.setHeaders(mock(HttpHeaders.class));
 
-        assertThatExceptionOfType(WebApplicationException.class).isThrownBy(() -> {
-            writer.writeTo(view, Class.class, Class.class, new Annotation[]{}, new MediaType(),
-                new MultivaluedHashMap<>(), stream);
-        }).withCause(exception);
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> writer.writeTo(view, Class.class, Class.class, new Annotation[]{}, new MediaType(), new MultivaluedHashMap<>(), stream))
+            .withCause(exception);
 
         verify(timerContext).stop();
     }
@@ -109,9 +106,8 @@ class ViewMessageBodyWriterTest {
 
         final ViewMessageBodyWriter writer = new ViewMessageBodyWriter(metricRegistry, Collections.emptyList());
 
-        assertThatExceptionOfType(WebApplicationException.class).isThrownBy(() -> {
-            writer.detectLocale(headers);
-        });
+        assertThatExceptionOfType(WebApplicationException.class)
+            .isThrownBy(() -> writer.detectLocale(headers));
     }
 
     @Test


### PR DESCRIPTION
This is a bit of a grab-bag of random changes, addressing linter concerns from Sonar and IntelliJ. Mostly in tests, but not all.

Remove usage of raw generic types in a few places.

Remove a couple of deprecated usages:
- Remove usage of `@OverridesAttribute.List`
- Update BadLogApp to avoid overriding deprecated methods

Some random cleanups:
- Remove unnecessary cast and unused local variable
- Remove unused imports

A few test simplifications:
- Tighten assertion in DataSourceFactoryTest
- Simplify lambdas in tests
- Use try-with-resources in AllowedMethodsFilterTest
- Use more specific AssertJ assertions
- Simplify InjectValidatorFeatureTest