### PR TITLE
Extend DAOTestExtension with junit5 callbacks

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DAOTestExtension.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DAOTestExtension.java
@@ -1,7 +1,11 @@
 package io.dropwizard.testing.junit5;
 
 import io.dropwizard.testing.common.DAOTest;
+import org.hibernate.HibernateException;
 import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.util.concurrent.Callable;
 
@@ -34,7 +38,7 @@ import java.util.concurrent.Callable;
  * </p>
  */
 //@formatter:on
-public class DAOTestExtension implements DropwizardExtension {
+public class DAOTestExtension implements DropwizardExtension, BeforeAllCallback, AfterAllCallback {
     private final DAOTest daoTest;
 
     public static class Builder extends DAOTest.Builder<Builder> {
@@ -68,6 +72,20 @@ public class DAOTestExtension implements DropwizardExtension {
     @Override
     public void after() {
         daoTest.after();
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) throws Exception {
+        try {
+            before();
+        } catch (Throwable e) {
+            throw new HibernateException(e);
+        }
+    }
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) {
+        after();
     }
 
     /**

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DAOTestExtensionRegisterExtensionTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DAOTestExtensionRegisterExtensionTest.java
@@ -1,0 +1,24 @@
+package io.dropwizard.testing.junit5;
+
+import io.dropwizard.testing.app.TestEntity;
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class DAOTestExtensionRegisterExtensionTest {
+
+    @RegisterExtension
+    static final DAOTestExtension daoTestExtension =
+        DAOTestExtension.newBuilder()
+            .addEntityClass(TestEntity.class)
+            .build();
+
+    @Test
+    void shouldProvideSession() {
+        final SessionFactory sessionFactory = daoTestExtension.getSessionFactory();
+        assertThat(sessionFactory).isNotNull();
+    }
+}


### PR DESCRIPTION
###### Problem:
The DAOTestExtension currently does not implement the Junit5 `BeforeAll` and `AfterAll` callbacks, therefore its not possible to register it as a proper extension during testing.

###### Solution:
Implement the `BeforeAllCallback` and `AfterAllCallback` interfaces.

###### Result:
DAOTestExtension can be registered as a proper extension during testing using the `@RegisterExtension` annotation.
