### PR TITLE
Further linter appeasements

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ For example, Dropwizard 2.0.x will receive critical security fixes while Dropwiz
 Once Dropwizard 2.2.x has been released, Dropwizard 2.0.x will be unsupported and Dropwizard 2.1.x will only receive critical security fixes.
 
 | Version | Supported          |
-| ------- | ------------------ |
+|---------|--------------------|
 | 2.1.x   | :white_check_mark: |
 | 2.0.x   | :white_check_mark: |
 | < 2.0   | :x:                |

--- a/dropwizard-core/src/main/java/io/dropwizard/Bundle.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/Bundle.java
@@ -18,7 +18,7 @@ public interface Bundle extends ConfiguredBundle<Configuration> {
      * Initializes the application environment.
      *
      * @param environment the application environment
-     * @deprecated Use {@link ConfiguredBundle#run(Configuration, Environment)}
+     * @deprecated Use {@link ConfiguredBundle<Configuration>#run(Configuration, Environment)}
      */
     @Deprecated
     default void run(Environment environment) {

--- a/dropwizard-core/src/main/java/io/dropwizard/server/DefaultServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/DefaultServerFactory.java
@@ -221,7 +221,7 @@ public class DefaultServerFactory extends AbstractServerFactory {
         for (ConnectorFactory factory : adminConnectors) {
             final Connector connector = factory.build(server, metricRegistry, "admin", threadPool);
             if (connector instanceof ContainerLifeCycle) {
-                ((ContainerLifeCycle) connector).unmanage(threadPool);
+                connector.unmanage(threadPool);
             }
             connectors.add(connector);
         }

--- a/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceFactoryTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceFactoryTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.db;
 
-import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
@@ -19,7 +18,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/LazyLoadingTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/LazyLoadingTest.java
@@ -68,7 +68,7 @@ class LazyLoadingTest {
     @Nested
     @SuppressWarnings("ClassCanBeStatic")
     @ExtendWith(DropwizardExtensionsSupport.class)
-    class LazyLoadingDisabled {
+    class LazyLoadingDisabledTest {
         private final DropwizardAppExtension<TestConfiguration> appExtension = new DropwizardAppExtension<>(
             TestApplicationWithDisabledLazyLoading.class,
             ResourceHelpers.resourceFilePath("hibernate-integration-test.yaml"),
@@ -107,7 +107,7 @@ class LazyLoadingTest {
         }
 
         @Override
-        public void run(TestConfiguration configuration, Environment environment) throws Exception {
+        public void run(TestConfiguration configuration, Environment environment) {
             final SessionFactory sessionFactory = hibernate.getSessionFactory();
             initDatabase(sessionFactory);
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/CustomDeserialization.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/CustomDeserialization.java
@@ -39,7 +39,7 @@ public class CustomDeserialization extends StdDeserializer<CustomRepresentation>
      */
     public static class MyNastyException extends JsonMappingException {
         public MyNastyException(JsonParser jp) {
-            super(jp::close, null);
+            super(jp, null);
         }
 
         @Override

--- a/dropwizard-metrics/src/main/java/io/dropwizard/metrics/MetricsFactory.java
+++ b/dropwizard-metrics/src/main/java/io/dropwizard/metrics/MetricsFactory.java
@@ -93,12 +93,6 @@ public class MetricsFactory {
     }
 
     /**
-     * @since 2.0
-     */
-    @JsonProperty
-
-
-    /**
      * Configures the given lifecycle with the {@link com.codahale.metrics.ScheduledReporter
      * reporters} configured for the given registry.
      * <p />

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/Person.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/Person.java
@@ -48,6 +48,6 @@ public class Person {
 
     @Override
     public String toString() {
-        return "Person{" + "name='" + name + "\'" + ", email='" + email + "'}";
+        return "Person{" + "name='" + name + "'" + ", email='" + email + "'}";
     }
 }

--- a/dropwizard-views-freemarker/src/main/java/io/dropwizard/views/freemarker/FreemarkerViewRenderer.java
+++ b/dropwizard-views-freemarker/src/main/java/io/dropwizard/views/freemarker/FreemarkerViewRenderer.java
@@ -63,6 +63,7 @@ public class FreemarkerViewRenderer implements ViewRenderer {
     /**
      * @deprecated Use {@link #FreemarkerViewRenderer(Version)} instead.
      */
+    @Deprecated
     public FreemarkerViewRenderer() {
         this(Configuration.DEFAULT_INCOMPATIBLE_IMPROVEMENTS);
     }


### PR DESCRIPTION
Address a few linter concerns

- Add missing `@Deprecated` tag to FreemarkerViewRenderer constructor
- Simplify dropwizard-jersey CustomDerialization (test helper)
- Fix javadoc reference in dropwizard-core Bundle
- Adjust test class name in LazyLoadingTest
- Remove unused imports from DataSourceFactoryTest
- Remove unnecessary cast from DefaultServerFactory
- Fix markdown in SECURITY.md
- Remove unnecessary character escape
- Remove stray `@JsonProperty` in MetricsFactory