### PR TITLE
Simplify inheritance in dropwizard-configuration test

### DIFF
--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/BaseConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/BaseConfigurationFactoryTest.java
@@ -144,6 +144,7 @@ public abstract class BaseConfigurationFactoryTest {
         }
     };
     protected String malformedFile = "/";
+    protected String malformedFileError = "value-not-overridden";
     protected String emptyFile = "/";
     protected String invalidFile = "/";
     protected String validFile = "/";
@@ -151,6 +152,7 @@ public abstract class BaseConfigurationFactoryTest {
     protected String typoFile = "/";
     protected String wrongTypeFile = "/";
     protected String malformedAdvancedFile = "/";
+    protected String malformedAdvancedFileError = "value-not-overridden";
 
     protected ConfigurationSourceProvider configurationSourceProvider = new ResourceConfigurationSourceProvider();
 
@@ -334,7 +336,8 @@ public abstract class BaseConfigurationFactoryTest {
     @Test
     void throwsAnExceptionOnMalformedFiles() {
         assertThatExceptionOfType(ConfigurationParsingException.class)
-            .isThrownBy(() -> factory.build(configurationSourceProvider, malformedFile));
+            .isThrownBy(() -> factory.build(configurationSourceProvider, malformedFile))
+            .withMessageContaining(malformedFileError);
     }
 
     @Test
@@ -416,7 +419,9 @@ public abstract class BaseConfigurationFactoryTest {
     }
 
     @Test
-    void printsDetailedInformationOnMalformedContent() throws Exception {
-        factory.build(configurationSourceProvider, malformedAdvancedFile);
+    void printsDetailedInformationOnMalformedContent() {
+        assertThatExceptionOfType(ConfigurationParsingException.class)
+            .isThrownBy(() -> factory.build(configurationSourceProvider, malformedAdvancedFile))
+            .withMessageContaining(malformedAdvancedFileError);
     }
 }

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/JsonConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/JsonConfigurationFactoryTest.java
@@ -2,14 +2,13 @@ package io.dropwizard.configuration;
 
 import com.fasterxml.jackson.core.JsonParser.Feature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.dropwizard.jackson.Jackson;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
+import static io.dropwizard.jackson.Jackson.newObjectMapper;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class JsonConfigurationFactoryTest extends BaseConfigurationFactoryTest {
@@ -18,8 +17,9 @@ class JsonConfigurationFactoryTest extends BaseConfigurationFactoryTest {
 
     @BeforeEach
     void setUp() {
-        this.factory = new JsonConfigurationFactory<>(Example.class, validator, Jackson.newObjectMapper(), "dw");
+        this.factory = new JsonConfigurationFactory<>(Example.class, validator, newObjectMapper(), "dw");
         this.malformedFile = "factory-test-malformed.json";
+        this.malformedFileError = "* Malformed JSON at line:";
         this.emptyFile = "factory-test-empty.json";
         this.invalidFile = "factory-test-invalid.json";
         this.validFile = "factory-test-valid.json";
@@ -28,21 +28,8 @@ class JsonConfigurationFactoryTest extends BaseConfigurationFactoryTest {
         this.typoFile = "factory-test-typo.json";
         this.wrongTypeFile = "factory-test-wrong-type.json";
         this.malformedAdvancedFile = "factory-test-malformed-advanced.json";
-    }
-
-    @Override
-    public void throwsAnExceptionOnMalformedFiles() {
-        assertThatThrownBy(super::throwsAnExceptionOnMalformedFiles)
-                .hasMessageContaining("* Malformed JSON at line:");
-    }
-
-    @Override
-    public void printsDetailedInformationOnMalformedContent() {
-        assertThatExceptionOfType(ConfigurationParsingException.class)
-            .isThrownBy(super::printsDetailedInformationOnMalformedContent)
-            .withMessageContaining(String.format(
-                    "%s has an error:%n" +
-                    "  * Malformed JSON at line: 7, column: 3; Unexpected close marker '}': expected ']'", malformedFile));
+        this.malformedAdvancedFileError = String.format("%s has an error:%n" +
+                "  * Malformed JSON at line: 7, column: 3; Unexpected close marker '}': expected ']'", malformedAdvancedFile);
     }
 
     @Test
@@ -56,8 +43,7 @@ class JsonConfigurationFactoryTest extends BaseConfigurationFactoryTest {
 
     @Test
     void configuredMapperAllowsComment() throws IOException, ConfigurationException {
-        ObjectMapper mapper = Jackson
-            .newObjectMapper()
+        ObjectMapper mapper = newObjectMapper()
             .configure(Feature.ALLOW_COMMENTS, true);
 
         JsonConfigurationFactory<Example> factory = new JsonConfigurationFactory<>(Example.class, validator, mapper, "dw");

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/YamlConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/YamlConfigurationFactoryTest.java
@@ -1,16 +1,16 @@
 package io.dropwizard.configuration;
 
-import io.dropwizard.jackson.Jackson;
 import org.junit.jupiter.api.BeforeEach;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static io.dropwizard.jackson.Jackson.newObjectMapper;
 
 public class YamlConfigurationFactoryTest extends BaseConfigurationFactoryTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        this.factory = new YamlConfigurationFactory<>(Example.class, validator, Jackson.newObjectMapper(), "dw");
+        this.factory = new YamlConfigurationFactory<>(Example.class, validator, newObjectMapper(), "dw");
         this.malformedFile = "factory-test-malformed.yml";
+        this.malformedFileError = " * Failed to parse configuration; Cannot construct instance of `io.dropwizard.configuration.BaseConfigurationFactoryTest$Example`";
         this.emptyFile = "factory-test-empty.yml";
         this.invalidFile = "factory-test-invalid.yml";
         this.validFile = "factory-test-valid.yml";
@@ -18,20 +18,8 @@ public class YamlConfigurationFactoryTest extends BaseConfigurationFactoryTest {
         this.typoFile = "factory-test-typo.yml";
         this.wrongTypeFile = "factory-test-wrong-type.yml";
         this.malformedAdvancedFile = "factory-test-malformed-advanced.yml";
-    }
-
-    @Override
-    public void throwsAnExceptionOnMalformedFiles() {
-        assertThatThrownBy(super::throwsAnExceptionOnMalformedFiles)
-            .hasMessageContaining(" * Failed to parse configuration; Cannot construct instance of `io.dropwizard.configuration.BaseConfigurationFactoryTest$Example`");
-    }
-
-    @Override
-    public void printsDetailedInformationOnMalformedContent() {
-        assertThatThrownBy(super::printsDetailedInformationOnMalformedContent)
-            .hasMessageContaining(String.format(
-                "%s has an error:%n" +
-                "  * Malformed YAML at line: 3, column: 22; while parsing a flow sequence\n" +
-                " in 'reader'", malformedAdvancedFile));
+        this.malformedAdvancedFileError = String.format("%s has an error:%n" +
+            "  * Malformed YAML at line: 3, column: 22; while parsing a flow sequence\n" +
+            " in 'reader'", malformedAdvancedFile);
     }
 }


### PR DESCRIPTION
This was inspired by Sonar getting upset about the lack of assertions in `BaseConfigurationFactoryTest#printsDetailedInformationOnMalformedContent()`.

Move assertion logic to the base class, with subclasses simply supplying the string to check for.

This should remove 1 of the 6 'Blocker' issues in Sonar.

Not sure I'm completely satisfied with the result, but see what you think....