### PR TITLE
Deprecate `AssetServlet#getResourceUrl(String)`

### DIFF
--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/assets/AssetServlet.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/assets/AssetServlet.java
@@ -273,10 +273,10 @@ public class AssetServlet extends HttpServlet {
         final String requestedResourcePath = trimSlashes(key.substring(uriPath.length()));
         final String absoluteRequestedResourcePath = trimSlashes(this.resourcePath + requestedResourcePath);
 
-        URL requestedResourceURL = getResourceUrl(absoluteRequestedResourcePath);
+        URL requestedResourceURL = getResourceURL(absoluteRequestedResourcePath);
         if (ResourceURL.isDirectory(requestedResourceURL)) {
             if (indexFile != null) {
-                requestedResourceURL = getResourceUrl(absoluteRequestedResourcePath + '/' + indexFile);
+                requestedResourceURL = getResourceURL(absoluteRequestedResourcePath + '/' + indexFile);
             } else {
                 // directory requested but no index file defined
                 return null;
@@ -294,8 +294,18 @@ public class AssetServlet extends HttpServlet {
         return new CachedAsset(readResource(requestedResourceURL), lastModified);
     }
 
+    /**
+     * @deprecated use/override {@link AssetServlet#getResourceURL(String)} instead
+     */
+    @Deprecated
     protected URL getResourceUrl(String absoluteRequestedResourcePath) {
         return Resources.getResource(absoluteRequestedResourcePath);
+    }
+
+    @SuppressWarnings("deprecation")
+    protected URL getResourceURL(String absoluteRequestedResourcePath) {
+        // Delegate to the deprecated method as it may have been overridden in existing code.
+        return getResourceUrl(absoluteRequestedResourcePath);
     }
 
     protected byte[] readResource(URL requestedResourceURL) throws IOException {


### PR DESCRIPTION
AssetServlet has `getResourceURL()` and `getResourceUrl(String)`, which is deemed potentially confusing by Sonar.

`getResourceURL()` goes back all the way to 2012 in commit 482b9f552ecb1d0a44a11fba7acdfb35843f2723 whereas `getResourceUrl(String)` is a relative newcomer, added in 2015 in cc20a03a3a297646589ea50c1cd9d8ef5a8c1cc4.

Provide `getResourceURL(String)` as a preferred replacement for `getResourceUrl(String)`, but delegate to the existing method for now, to give anyone subclassing `AssetServlet` time to migrate their usage.