### PR TITLE
Simplify switch statement in `ResourceURL#getLastModified()`

### DIFF
--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/assets/ResourceURL.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/assets/ResourceURL.java
@@ -98,26 +98,25 @@ public class ResourceURL {
                     final JarEntry entry = jarConnection.getJarEntry();
                     return entry.getTime();
                 } catch (IOException ignored) {
-                    return 0;
                 }
+                return 0;
             case "file":
                 URLConnection connection = null;
                 try {
                     connection = resourceURL.openConnection();
                     return connection.getLastModified();
                 } catch (IOException ignored) {
-                    return 0;
                 } finally {
                     if (connection != null) {
                         try {
                             connection.getInputStream().close();
                         } catch (IOException ignored) {
-                            // do nothing.
                         }
                     }
                 }
+                return 0;
             default:
-                throw new IllegalArgumentException("Unsupported protocol " + resourceURL.getProtocol() + " for resource " + resourceURL);
+                throw new IllegalArgumentException("Unsupported protocol " + protocol + " for resource " + resourceURL);
         }
     }
 }


### PR DESCRIPTION
This is a bit of a noop change - I don't think there were any gaps in the control flow.

Sonar was struggling to work out whether cases could fall-through, but they can't.

Still, moving the `return 0` to the end of each case statement makes it very clear what the behaviour will be.