### PR TITLE
Remove use of deprecated `AbstractLifeCycle.AbstractLifeCycleListener`

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/cli/ServerCommand.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/ServerCommand.java
@@ -5,7 +5,6 @@ import io.dropwizard.Configuration;
 import io.dropwizard.setup.Environment;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.util.component.AbstractLifeCycle;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,7 +66,7 @@ public class ServerCommand<T extends Configuration> extends EnvironmentCommand<T
         }
     }
 
-    private class LifeCycleListener extends AbstractLifeCycle.AbstractLifeCycleListener {
+    private class LifeCycleListener implements LifeCycle.Listener {
         @Override
         public void lifeCycleStopped(LifeCycle event) {
             cleanup();

--- a/dropwizard-core/src/main/java/io/dropwizard/setup/AdminEnvironment.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/AdminEnvironment.java
@@ -9,7 +9,6 @@ import io.dropwizard.servlets.tasks.GarbageCollectionTask;
 import io.dropwizard.servlets.tasks.LogConfigurationTask;
 import io.dropwizard.servlets.tasks.Task;
 import io.dropwizard.servlets.tasks.TaskServlet;
-import org.eclipse.jetty.util.component.AbstractLifeCycle;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,7 +42,7 @@ public class AdminEnvironment extends ServletEnvironment {
         tasks.add(new GarbageCollectionTask());
         tasks.add(new LogConfigurationTask());
         addServlet("tasks", tasks).addMapping("/tasks/*");
-        handler.addLifeCycleListener(new AbstractLifeCycle.AbstractLifeCycleListener() {
+        handler.addLifeCycleListener(new LifeCycle.Listener() {
             @Override
             public void lifeCycleStarting(LifeCycle event) {
                 logTasks();

--- a/dropwizard-core/src/main/java/io/dropwizard/sslreload/SslReloadBundle.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/sslreload/SslReloadBundle.java
@@ -5,7 +5,6 @@ import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.jetty.MutableServletContextHandler;
 import io.dropwizard.jetty.SslReload;
 import io.dropwizard.setup.Environment;
-import org.eclipse.jetty.util.component.AbstractLifeCycle;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,7 +24,7 @@ public class SslReloadBundle implements ConfiguredBundle<Configuration> {
 
     @Override
     public void run(Configuration configuration, Environment environment) {
-        environment.getApplicationContext().addLifeCycleListener(new AbstractLifeCycle.AbstractLifeCycleListener() {
+        environment.getApplicationContext().addLifeCycleListener(new LifeCycle.Listener() {
             @Override
             public void lifeCycleStarted(LifeCycle event) {
                 final Set<SslReload> reloaders = new HashSet<>();

--- a/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2ConnectorFactory.java
+++ b/dropwizard-http2/src/main/java/io/dropwizard/http2/Http2ConnectorFactory.java
@@ -106,7 +106,7 @@ public class Http2ConnectorFactory extends HttpsConnectorFactory {
         alpn.setDefaultProtocol("http/1.1"); // Speak HTTP 1.1 over TLS if negotiation fails
 
         final SslContextFactory sslContextFactory = configureSslContextFactory(new SslContextFactory.Server());
-        sslContextFactory.addLifeCycleListener(logSslInfoOnStart(sslContextFactory));
+        sslContextFactory.addLifeCycleListener(logSslParameters(sslContextFactory));
         server.addBean(sslContextFactory);
         server.addBean(new SslReload(sslContextFactory, this::configureSslContextFactory));
 

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
@@ -600,7 +600,7 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
         final HttpConnectionFactory httpConnectionFactory = buildHttpConnectionFactory(httpConfig);
 
         final SslContextFactory sslContextFactory = configureSslContextFactory(new SslContextFactory.Server());
-        sslContextFactory.addLifeCycleListener(logSslInfoOnStart(sslContextFactory));
+        sslContextFactory.addLifeCycleListener(logSslParameters(sslContextFactory));
 
         server.addBean(sslContextFactory);
         server.addBean(new SslReload(sslContextFactory, this::configureSslContextFactory));
@@ -628,9 +628,21 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
         return config;
     }
 
-    /** Register a listener that waits until the ssl context factory has started. Once it has
-     *  started we can grab the fully initialized context so we can log the parameters.
+    /**
+     * Register a listener that waits until the SSL context factory has started. Once it has
+     * started we can grab the fully initialized context so we can log the parameters.
+     *
+     * @since 2.1.0
      */
+    protected LifeCycle.Listener logSslParameters(final SslContextFactory sslContextFactory) {
+        // Delegate to the old method as it may have been overridden
+        return logSslInfoOnStart(sslContextFactory);
+    }
+
+    /**
+     * @deprecated Use {@link #logSslParameters(SslContextFactory) instead}
+     */
+    @Deprecated
     protected AbstractLifeCycle.AbstractLifeCycleListener logSslInfoOnStart(final SslContextFactory sslContextFactory) {
         return new AbstractLifeCycle.AbstractLifeCycleListener() {
             @Override

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/LifecycleEnvironment.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/LifecycleEnvironment.java
@@ -5,7 +5,6 @@ import io.dropwizard.lifecycle.JettyManaged;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.lifecycle.ServerLifecycleListener;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.util.component.AbstractLifeCycle;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.slf4j.Logger;
@@ -86,7 +85,7 @@ public class LifecycleEnvironment {
         for (LifeCycle object : managedObjects) {
             container.addBean(object);
         }
-        container.addLifeCycleListener(new AbstractLifeCycle.AbstractLifeCycleListener() {
+        container.addLifeCycleListener(new LifeCycle.Listener() {
             @Override
             public void lifeCycleStarting(LifeCycle event) {
                 LOGGER.debug("managed objects = {}", managedObjects);
@@ -104,7 +103,7 @@ public class LifecycleEnvironment {
         return metricRegistry;
     }
 
-    private static class ServerListener extends AbstractLifeCycle.AbstractLifeCycleListener {
+    private static class ServerListener implements LifeCycle.Listener {
         private final ServerLifecycleListener listener;
 
         private ServerListener(ServerLifecycleListener listener) {


### PR DESCRIPTION
`AbstractLifeCycleListener` is deprecated since `LifeCycle.Listener` gained default methods.

Deprecate `HttpsConnectionFactory#logSslInfoOnStart(SslContextFactory) since its return type is the deprecated `AbstractLifeCycle.AbstractLifeCycleListener` but should probably have been `LifeCycle.Listener` all along.

Deprecate the existing method and replace it with a new method, `logSslParameters(SslContextFactory)` which just delegates to the old method until we remove it.
