### PR TITLE
Make more use of `ResourceConfigurationSourceProvider` in tests

### DIFF
--- a/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
@@ -3,8 +3,8 @@ package io.dropwizard.client;
 import com.codahale.metrics.health.HealthCheck;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.setup.Environment;
-import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.util.Duration;
@@ -58,7 +58,8 @@ class DropwizardApacheConnectorTest {
 
     private static final DropwizardAppExtension<Configuration> APP_RULE = new DropwizardAppExtension<>(
             TestApplication.class,
-            ResourceHelpers.resourceFilePath("yaml/dropwizardApacheConnectorTest.yml"));
+            "yaml/dropwizardApacheConnectorTest.yml",
+            new ResourceConfigurationSourceProvider());
 
 
     private final URI testUri = URI.create("http://localhost:" + APP_RULE.getLocalPort());

--- a/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactoryTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactoryTest.java
@@ -3,9 +3,8 @@ package io.dropwizard.client;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.client.ssl.TlsConfiguration;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.setup.Environment;
-import io.dropwizard.testing.ConfigOverride;
-import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.util.Duration;
@@ -33,9 +32,13 @@ import javax.ws.rs.core.Response;
 import java.io.File;
 import java.io.IOException;
 import java.net.SocketException;
+import java.net.URISyntaxException;
 import java.security.Security;
 import java.util.Collections;
 
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static io.dropwizard.util.Resources.getResource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -75,33 +78,34 @@ class DropwizardSSLConnectionSocketFactoryTest {
     }
 
     private static final DropwizardAppExtension<Configuration> TLS_APP_RULE = new DropwizardAppExtension<>(TlsTestApplication.class,
-        ResourceHelpers.resourceFilePath("yaml/ssl_connection_socket_factory_test.yml"),
+        "yaml/ssl_connection_socket_factory_test.yml",
+        new ResourceConfigurationSourceProvider(),
         "tls",
-        ConfigOverride.config("tls", "server.applicationConnectors[0].keyStorePath", ResourceHelpers.resourceFilePath("stores/server/keycert.p12")),
-        ConfigOverride.config("tls", "server.applicationConnectors[1].keyStorePath", ResourceHelpers.resourceFilePath("stores/server/self_sign_keycert.p12")),
-        ConfigOverride.config("tls", "server.applicationConnectors[2].keyStorePath", ResourceHelpers.resourceFilePath("stores/server/keycert.p12")),
-        ConfigOverride.config("tls", "server.applicationConnectors[2].trustStorePath", ResourceHelpers.resourceFilePath("stores/server/ca_truststore.ts")),
-        ConfigOverride.config("tls", "server.applicationConnectors[2].wantClientAuth", "true"),
-        ConfigOverride.config("tls", "server.applicationConnectors[2].needClientAuth", "true"),
-        ConfigOverride.config("tls", "server.applicationConnectors[2].validatePeers", "false"),
-        ConfigOverride.config("tls", "server.applicationConnectors[2].trustStorePassword", "password"),
-        ConfigOverride.config("tls", "server.applicationConnectors[3].keyStorePath", ResourceHelpers.resourceFilePath("stores/server/bad_host_keycert.p12")),
-        ConfigOverride.config("tls", "server.applicationConnectors[4].keyStorePath", ResourceHelpers.resourceFilePath("stores/server/keycert.p12")),
-        ConfigOverride.config("tls", "server.applicationConnectors[4].supportedProtocols", "SSLv1,SSLv2,SSLv3"),
-        ConfigOverride.config("tls", "server.applicationConnectors[5].keyStorePath", ResourceHelpers.resourceFilePath("stores/server/acme-weak.keystore.p12")),
-        ConfigOverride.config("tls", "server.applicationConnectors[5].trustStorePath", ResourceHelpers.resourceFilePath("stores/server/acme-weak.truststore.p12")),
-        ConfigOverride.config("tls", "server.applicationConnectors[5].wantClientAuth", "true"),
-        ConfigOverride.config("tls", "server.applicationConnectors[5].needClientAuth", "true"),
-        ConfigOverride.config("tls", "server.applicationConnectors[5].validatePeers", "true"),
-        ConfigOverride.config("tls", "server.applicationConnectors[5].trustStorePassword", "acme2"),
-        ConfigOverride.config("tls", "server.applicationConnectors[5].keyStorePassword", "acme2"),
-        ConfigOverride.config("tls", "server.applicationConnectors[5].trustStoreProvider", PROVIDER_NAME),
-        ConfigOverride.config("tls", "server.applicationConnectors[5].keyStoreProvider", PROVIDER_NAME));
+        config("tls", "server.applicationConnectors[0].keyStorePath", resourceFilePath("stores/server/keycert.p12")),
+        config("tls", "server.applicationConnectors[1].keyStorePath", resourceFilePath("stores/server/self_sign_keycert.p12")),
+        config("tls", "server.applicationConnectors[2].keyStorePath", resourceFilePath("stores/server/keycert.p12")),
+        config("tls", "server.applicationConnectors[2].trustStorePath", resourceFilePath("stores/server/ca_truststore.ts")),
+        config("tls", "server.applicationConnectors[2].wantClientAuth", "true"),
+        config("tls", "server.applicationConnectors[2].needClientAuth", "true"),
+        config("tls", "server.applicationConnectors[2].validatePeers", "false"),
+        config("tls", "server.applicationConnectors[2].trustStorePassword", "password"),
+        config("tls", "server.applicationConnectors[3].keyStorePath", resourceFilePath("stores/server/bad_host_keycert.p12")),
+        config("tls", "server.applicationConnectors[4].keyStorePath", resourceFilePath("stores/server/keycert.p12")),
+        config("tls", "server.applicationConnectors[4].supportedProtocols", "SSLv1,SSLv2,SSLv3"),
+        config("tls", "server.applicationConnectors[5].keyStorePath", resourceFilePath("stores/server/acme-weak.keystore.p12")),
+        config("tls", "server.applicationConnectors[5].trustStorePath", resourceFilePath("stores/server/acme-weak.truststore.p12")),
+        config("tls", "server.applicationConnectors[5].wantClientAuth", "true"),
+        config("tls", "server.applicationConnectors[5].needClientAuth", "true"),
+        config("tls", "server.applicationConnectors[5].validatePeers", "true"),
+        config("tls", "server.applicationConnectors[5].trustStorePassword", "acme2"),
+        config("tls", "server.applicationConnectors[5].keyStorePassword", "acme2"),
+        config("tls", "server.applicationConnectors[5].trustStoreProvider", PROVIDER_NAME),
+        config("tls", "server.applicationConnectors[5].keyStoreProvider", PROVIDER_NAME));
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         tlsConfiguration = new TlsConfiguration();
-        tlsConfiguration.setTrustStorePath(new File(ResourceHelpers.resourceFilePath("stores/server/ca_truststore.ts")));
+        tlsConfiguration.setTrustStorePath(toFile("stores/server/ca_truststore.ts"));
         tlsConfiguration.setTrustStorePassword("password");
         jerseyClientConfiguration = new JerseyClientConfiguration();
         jerseyClientConfiguration.setTlsConfiguration(tlsConfiguration);
@@ -122,8 +126,8 @@ class DropwizardSSLConnectionSocketFactoryTest {
     }
 
     @Test
-    void shouldErrorIfServerCertNotFoundInTruststore() {
-        tlsConfiguration.setTrustStorePath(new File(ResourceHelpers.resourceFilePath("stores/server/other_cert_truststore.ts")));
+    void shouldErrorIfServerCertNotFoundInTruststore() throws Exception {
+        tlsConfiguration.setTrustStorePath(toFile("stores/server/other_cert_truststore.ts"));
         final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).build("tls_broken_client");
         Invocation.Builder request = client.target(String.format("https://localhost:%d", TLS_APP_RULE.getLocalPort())).request();
         assertThatExceptionOfType(ProcessingException.class)
@@ -150,8 +154,8 @@ class DropwizardSSLConnectionSocketFactoryTest {
 
     @Test
     @DisabledOnOs(OS.WINDOWS) // https://github.com/dropwizard/dropwizard/issues/4330
-    void shouldReturn200IfAbleToClientAuth() {
-        tlsConfiguration.setKeyStorePath(new File(ResourceHelpers.resourceFilePath("stores/client/keycert.p12")));
+    void shouldReturn200IfAbleToClientAuth() throws Exception {
+        tlsConfiguration.setKeyStorePath(toFile("stores/client/keycert.p12"));
         tlsConfiguration.setKeyStorePassword("password");
         tlsConfiguration.setKeyStoreType("PKCS12");
         final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).build("client_auth_working");
@@ -160,8 +164,8 @@ class DropwizardSSLConnectionSocketFactoryTest {
     }
 
     @Test
-    void shouldErrorIfClientAuthFails() {
-        tlsConfiguration.setKeyStorePath(new File(ResourceHelpers.resourceFilePath("stores/server/self_sign_keycert.p12")));
+    void shouldErrorIfClientAuthFails() throws Exception {
+        tlsConfiguration.setKeyStorePath(toFile("stores/server/self_sign_keycert.p12"));
         tlsConfiguration.setKeyStorePassword("password");
         tlsConfiguration.setKeyStoreType("PKCS12");
         final Client client = new JerseyClientBuilder(TLS_APP_RULE.getEnvironment()).using(jerseyClientConfiguration).build("client_auth_broken");
@@ -173,8 +177,8 @@ class DropwizardSSLConnectionSocketFactoryTest {
 
     @Test
     @DisabledOnOs(OS.WINDOWS) // https://github.com/dropwizard/dropwizard/issues/4330
-    void shouldReturn200IfAbleToClientAuthSpecifyingCertAliasForGoodCert() {
-        tlsConfiguration.setKeyStorePath(new File(ResourceHelpers.resourceFilePath("stores/client/twokeys.p12")));
+    void shouldReturn200IfAbleToClientAuthSpecifyingCertAliasForGoodCert() throws Exception {
+        tlsConfiguration.setKeyStorePath(toFile("stores/client/twokeys.p12"));
         tlsConfiguration.setKeyStorePassword("password");
         tlsConfiguration.setKeyStoreType("PKCS12");
         tlsConfiguration.setCertAlias("1");
@@ -184,8 +188,8 @@ class DropwizardSSLConnectionSocketFactoryTest {
     }
 
     @Test
-    void shouldErrorIfTryToClientAuthSpecifyingCertAliasForBadCert() {
-        tlsConfiguration.setKeyStorePath(new File(ResourceHelpers.resourceFilePath("stores/client/twokeys.p12")));
+    void shouldErrorIfTryToClientAuthSpecifyingCertAliasForBadCert() throws Exception {
+        tlsConfiguration.setKeyStorePath(toFile("stores/client/twokeys.p12"));
         tlsConfiguration.setKeyStorePassword("password");
         tlsConfiguration.setKeyStoreType("PKCS12");
         tlsConfiguration.setCertAlias("2");
@@ -197,8 +201,8 @@ class DropwizardSSLConnectionSocketFactoryTest {
     }
 
     @Test
-    void shouldErrorIfTryToClientAuthSpecifyingUnknownCertAlias() {
-        tlsConfiguration.setKeyStorePath(new File(ResourceHelpers.resourceFilePath("stores/client/twokeys.p12")));
+    void shouldErrorIfTryToClientAuthSpecifyingUnknownCertAlias() throws Exception {
+        tlsConfiguration.setKeyStorePath(toFile("stores/client/twokeys.p12"));
         tlsConfiguration.setKeyStorePassword("password");
         tlsConfiguration.setKeyStoreType("PKCS12");
         tlsConfiguration.setCertAlias("unknown");
@@ -260,17 +264,17 @@ class DropwizardSSLConnectionSocketFactoryTest {
 
     @Test
     @DisabledOnOs(OS.WINDOWS) // https://github.com/dropwizard/dropwizard/issues/4330
-    void shouldSucceedWithBcProvider() {
+    void shouldSucceedWithBcProvider() throws Exception {
         // switching host verifier off for simplicity
         tlsConfiguration.setVerifyHostname(false);
 
-        tlsConfiguration.setKeyStorePath(new File(ResourceHelpers.resourceFilePath("stores/client/acme-weak.keystore.p12")));
+        tlsConfiguration.setKeyStorePath(toFile("stores/client/acme-weak.keystore.p12"));
         tlsConfiguration.setKeyStorePassword("acme2");
         tlsConfiguration.setKeyStoreType("PKCS12");
         tlsConfiguration.setKeyStoreProvider(PROVIDER_NAME);
         tlsConfiguration.setCertAlias("acme-weak");
 
-        tlsConfiguration.setTrustStorePath(new File(ResourceHelpers.resourceFilePath("stores/server/acme-weak.truststore.p12")));
+        tlsConfiguration.setTrustStorePath(toFile("stores/server/acme-weak.truststore.p12"));
         tlsConfiguration.setTrustStorePassword("acme2");
         tlsConfiguration.setTrustStoreType("PKCS12");
         tlsConfiguration.setTrustStoreProvider(PROVIDER_NAME);
@@ -286,5 +290,9 @@ class DropwizardSSLConnectionSocketFactoryTest {
         public boolean verify(String arg0, SSLSession arg1) {
             return false;
         }
+    }
+
+    private static File toFile(final String resourceName) throws URISyntaxException {
+        return new File(getResource(resourceName).toURI());
     }
 }

--- a/dropwizard-e2e/pom.xml
+++ b/dropwizard-e2e/pom.xml
@@ -140,6 +140,11 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-configuration</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/dropwizard-e2e/src/test/java/com/example/app1/App1Test.java
+++ b/dropwizard-e2e/src/test/java/com/example/app1/App1Test.java
@@ -3,8 +3,8 @@ package com.example.app1;
 import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.client.JerseyClientConfiguration;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.jackson.Jackson;
-import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.util.Duration;
@@ -31,7 +31,7 @@ import static org.awaitility.Awaitility.await;
 @ExtendWith(DropwizardExtensionsSupport.class)
 public class App1Test {
     public static final DropwizardAppExtension<Configuration> RULE =
-        new DropwizardAppExtension<>(App1.class, ResourceHelpers.resourceFilePath("app1/config.yml"));
+        new DropwizardAppExtension<>(App1.class, "app1/config.yml", new ResourceConfigurationSourceProvider());
 
     private static Client client;
 

--- a/dropwizard-e2e/src/test/java/com/example/badlog/BadLogTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/badlog/BadLogTest.java
@@ -1,9 +1,9 @@
 package com.example.badlog;
 
 import io.dropwizard.Configuration;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.DropwizardTestSupport;
-import io.dropwizard.testing.ResourceHelpers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,6 +17,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -30,7 +31,7 @@ class BadLogTest {
     private ByteArrayOutputStream err;
 
     @BeforeEach
-    void setup() throws Exception {
+    void setup() {
         out = new ByteArrayOutputStream();
         err = new ByteArrayOutputStream();
         System.setOut(new PrintStream(out));
@@ -63,8 +64,8 @@ class BadLogTest {
         final Path logFile = Files.write(tempDir.resolve("example.log"), new byte[0]);
 
         final ConfigOverride logOverride = ConfigOverride.config("logging.appenders[0].currentLogFilename", logFile.toString());
-        final String configPath = ResourceHelpers.resourceFilePath("badlog/config.yaml");
-        final DropwizardTestSupport<Configuration> app = new DropwizardTestSupport<>(BadLogApp.class, configPath, logOverride);
+        final String configResource = "badlog/config.yaml";
+        final DropwizardTestSupport<Configuration> app = new DropwizardTestSupport<>(BadLogApp.class, configResource, new ResourceConfigurationSourceProvider(), logOverride);
         assertThatThrownBy(app::before).hasMessage("I'm a bad app");
 
         // Dropwizard test support resets configuration overrides if `before` throws an exception
@@ -74,7 +75,7 @@ class BadLogTest {
         logOverride.addToSystemProperties();
 
         // Explicitly run the command so that the fatal error function runs
-        app.getApplication().run("server", configPath);
+        app.getApplication().run("server", resourceFilePath(configResource));
         app.after();
         Thread.sleep(100L);
 
@@ -111,14 +112,14 @@ class BadLogTest {
         // Clear out the log file
         Files.write(logFile, new byte[0]);
 
-        final DropwizardTestSupport<Configuration> app3 = new DropwizardTestSupport<>(BadLogApp.class, configPath, logOverride);
+        final DropwizardTestSupport<Configuration> app3 = new DropwizardTestSupport<>(BadLogApp.class, configResource, new ResourceConfigurationSourceProvider(), logOverride);
         assertThatThrownBy(app3::before).hasMessage("I'm a bad app");
 
         // See comment above about manually adding config to system properties
         logOverride.addToSystemProperties();
 
         // Explicitly run the command so that the fatal error function runs
-        app3.getApplication().run("server", configPath);
+        app3.getApplication().run("server", resourceFilePath(configResource));
         app3.after();
         Thread.sleep(100L);
 

--- a/dropwizard-e2e/src/test/java/com/example/forms/FormsAppTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/forms/FormsAppTest.java
@@ -3,8 +3,8 @@ package com.example.forms;
 import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.client.JerseyClientConfiguration;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.jersey.errors.ErrorMessage;
-import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.util.Duration;
@@ -27,12 +27,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(DropwizardExtensionsSupport.class)
 public class FormsAppTest {
     public static final DropwizardAppExtension<Configuration> RULE =
-        new DropwizardAppExtension<>(FormsApp.class, ResourceHelpers.resourceFilePath("app1/config.yml"));
+        new DropwizardAppExtension<>(FormsApp.class, "app1/config.yml", new ResourceConfigurationSourceProvider());
 
     private final JerseyClientConfiguration config = new JerseyClientConfiguration();
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         config.setTimeout(Duration.seconds(2));
     }
 
@@ -60,8 +60,6 @@ public class FormsAppTest {
      * sending forms to work. Maybe someday this requirement will be relaxed and
      * this test can be updated for the new behavior. For more info, see issues
      * #1013 and #1094
-     *
-     * @throws IOException
      */
     @Test
     void failOnNoChunkedEncoding() throws IOException {

--- a/dropwizard-e2e/src/test/java/com/example/health/HealthIntegrationTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/health/HealthIntegrationTest.java
@@ -1,8 +1,8 @@
 package com.example.health;
 
 import io.dropwizard.Configuration;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.testing.ConfigOverride;
-import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.awaitility.Awaitility;
@@ -38,7 +38,8 @@ class HealthIntegrationTest {
 
     public final DropwizardAppExtension<Configuration> TEST_APP_RULE = new DropwizardAppExtension<>(
             HealthApp.class,
-            ResourceHelpers.resourceFilePath(CONFIG_PATH),
+            CONFIG_PATH,
+            new ResourceConfigurationSourceProvider(),
             ConfigOverride.config(APP_PORT_KEY, APP_PORT));
 
     private final Client client = new JerseyClientBuilder().build();

--- a/dropwizard-e2e/src/test/java/com/example/httpsessions/HttpSessionsTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/httpsessions/HttpSessionsTest.java
@@ -1,7 +1,7 @@
 package com.example.httpsessions;
 
 import io.dropwizard.Configuration;
-import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.junit.jupiter.api.Test;
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(DropwizardExtensionsSupport.class)
 class HttpSessionsTest {
     public static final DropwizardAppExtension<Configuration> RULE =
-        new DropwizardAppExtension<>(HttpSessionsApp.class, ResourceHelpers.resourceFilePath("httpsessions/config.yml"));
+        new DropwizardAppExtension<>(HttpSessionsApp.class, "httpsessions/config.yml", new ResourceConfigurationSourceProvider());
 
     @Test
     void testInjectedSessionsIsNotNull() {

--- a/dropwizard-e2e/src/test/java/com/example/request_log/AbstractRequestLogPatternIntegrationTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/request_log/AbstractRequestLogPatternIntegrationTest.java
@@ -5,9 +5,9 @@ import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.client.JerseyClientConfiguration;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.ConfigOverride;
-import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.util.Duration;
@@ -34,11 +34,11 @@ public abstract class AbstractRequestLogPatternIntegrationTest {
         }
 
         @Override
-        public void run(Configuration configuration, Environment environment) throws Exception {
+        public void run(Configuration configuration, Environment environment) {
             environment.jersey().register(TestResource.class);
             environment.healthChecks().register("dummy", new HealthCheck() {
                 @Override
-                protected Result check() throws Exception {
+                protected Result check() {
                     return Result.healthy();
                 }
             });
@@ -60,7 +60,8 @@ public abstract class AbstractRequestLogPatternIntegrationTest {
     protected Client client;
 
     DropwizardAppExtension<Configuration> dropwizardAppRule = new DropwizardAppExtension<>(TestApplication.class,
-        ResourceHelpers.resourceFilePath("request_log/test-custom-request-log.yml"),
+        "request_log/test-custom-request-log.yml",
+        new ResourceConfigurationSourceProvider(),
         configOverrides().toArray(new ConfigOverride[0]));
 
     protected List<ConfigOverride> configOverrides() {

--- a/dropwizard-e2e/src/test/java/com/example/sslreload/SslReloadAppTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/sslreload/SslReloadAppTest.java
@@ -1,8 +1,8 @@
 package com.example.sslreload;
 
 import io.dropwizard.Configuration;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.testing.ConfigOverride;
-import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.util.ByteStreams;
@@ -50,7 +50,8 @@ public class SslReloadAppTest {
     private static Path keystore;
 
     public final DropwizardAppExtension<Configuration> rule =
-        new DropwizardAppExtension<>(SslReloadApp.class, ResourceHelpers.resourceFilePath("sslreload/config.yml"),
+        new DropwizardAppExtension<>(SslReloadApp.class, "sslreload/config.yml",
+            new ResourceConfigurationSourceProvider(),
             ConfigOverride.config("server.applicationConnectors[0].keyStorePath", keystore.toString()),
             ConfigOverride.config("server.adminConnectors[0].keyStorePath", keystore.toString()));
 

--- a/dropwizard-e2e/src/test/java/com/example/validation/BeanValidatorTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/validation/BeanValidatorTest.java
@@ -3,6 +3,7 @@ package com.example.validation;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.Configuration;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
@@ -26,13 +27,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 public class BeanValidatorTest {
     public static final DropwizardAppExtension<Configuration> APP = new DropwizardAppExtension<>(
-        DefaultValidatorApp.class, resourceFilePath("app1/config.yml"));
+        DefaultValidatorApp.class, "app1/config.yml", new ResourceConfigurationSourceProvider());
 
     private final ObjectMapper mapper = Jackson.newMinimalObjectMapper();
     private WebTarget target;

--- a/dropwizard-e2e/src/test/java/com/example/validation/InjectValidatorTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/validation/InjectValidatorTest.java
@@ -1,6 +1,7 @@
 package com.example.validation;
 
 import io.dropwizard.Configuration;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.junit.jupiter.api.Test;
@@ -10,7 +11,6 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
@@ -18,7 +18,7 @@ public class InjectValidatorTest {
 
     public static final DropwizardAppExtension<Configuration> RULE = new DropwizardAppExtension<>(
             DefaultValidatorApp.class,
-        resourceFilePath("app1/config.yml")
+        "app1/config.yml", new ResourceConfigurationSourceProvider()
     );
 
     @Test

--- a/dropwizard-example/src/test/java/com/example/helloworld/DockerIntegrationTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/DockerIntegrationTest.java
@@ -2,8 +2,8 @@ package com.example.helloworld;
 
 import com.example.helloworld.api.Saying;
 import com.example.helloworld.core.Person;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.testing.ConfigOverride;
-import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.eclipse.jetty.http.HttpStatus;
@@ -30,6 +30,7 @@ import java.nio.file.Path;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
@@ -40,7 +41,7 @@ public class DockerIntegrationTest {
     @Container
     private static final MySQLContainer<?> MY_SQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0.28"));
 
-    private static final String CONFIG_PATH = ResourceHelpers.resourceFilePath("test-docker-example.yml");
+    private static final String CONFIG = "test-docker-example.yml";
 
     @TempDir
     static Path tempDir;
@@ -48,7 +49,7 @@ public class DockerIntegrationTest {
     static Supplier<String> ARCHIVED_LOG = () -> tempDir.resolve("application-%d-%i.log.gz").toString();
 
     public static final DropwizardAppExtension<HelloWorldConfiguration> APP = new DropwizardAppExtension<>(
-            HelloWorldApplication.class, CONFIG_PATH,
+            HelloWorldApplication.class, CONFIG, new ResourceConfigurationSourceProvider(),
             ConfigOverride.config("database.url", MY_SQL_CONTAINER::getJdbcUrl),
             ConfigOverride.config("database.user", MY_SQL_CONTAINER::getUsername),
             ConfigOverride.config("database.password", MY_SQL_CONTAINER::getPassword),
@@ -59,7 +60,7 @@ public class DockerIntegrationTest {
 
     @BeforeAll
     public static void migrateDb() throws Exception {
-        APP.getApplication().run("db", "migrate", CONFIG_PATH);
+        APP.getApplication().run("db", "migrate", resourceFilePath(CONFIG));
     }
 
     @Test

--- a/dropwizard-example/src/test/java/com/example/helloworld/IntegrationTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/IntegrationTest.java
@@ -2,7 +2,7 @@ package com.example.helloworld;
 
 import com.example.helloworld.api.Saying;
 import com.example.helloworld.core.Person;
-import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.eclipse.jetty.http.HttpStatus;
@@ -24,12 +24,13 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 class IntegrationTest {
-    private static final String CONFIG_PATH = ResourceHelpers.resourceFilePath("test-example.yml");
+    private static final String CONFIG = "test-example.yml";
 
     @TempDir
     static Path tempDir;
@@ -37,7 +38,8 @@ class IntegrationTest {
     static Supplier<String> ARCHIVED_LOG = () -> tempDir.resolve("application-%d-%i.log.gz").toString();
 
     static final DropwizardAppExtension<HelloWorldConfiguration> APP = new DropwizardAppExtension<>(
-            HelloWorldApplication.class, CONFIG_PATH,
+            HelloWorldApplication.class, CONFIG,
+            new ResourceConfigurationSourceProvider(),
             config("database.url", () -> "jdbc:h2:" + tempDir.resolve("database.h2")),
             config("logging.appenders[1].currentLogFilename", CURRENT_LOG),
             config("logging.appenders[1].archivedLogFilenamePattern", ARCHIVED_LOG)
@@ -45,7 +47,7 @@ class IntegrationTest {
 
     @BeforeAll
     public static void migrateDb() throws Exception {
-        APP.getApplication().run("db", "migrate", CONFIG_PATH);
+        APP.getApplication().run("db", "migrate", resourceFilePath(CONFIG));
     }
 
     @Test

--- a/dropwizard-hibernate/pom.xml
+++ b/dropwizard-hibernate/pom.xml
@@ -159,6 +159,11 @@
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-configuration</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>
             <scope>test</scope>
         </dependency>

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/LazyLoadingTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/LazyLoadingTest.java
@@ -3,13 +3,12 @@ package io.dropwizard.hibernate;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.db.PooledDataSourceFactory;
 import io.dropwizard.jersey.errors.ErrorMessage;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
-import io.dropwizard.testing.ConfigOverride;
-import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.hibernate.FlushMode;
@@ -35,14 +34,14 @@ import javax.ws.rs.ext.ExceptionMapper;
 import java.util.Arrays;
 import java.util.Optional;
 
+import static io.dropwizard.testing.ConfigOverride.config;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 class LazyLoadingTest {
     private final DropwizardAppExtension<TestConfiguration> appExtension = new DropwizardAppExtension<>(
-        TestApplication.class,
-        ResourceHelpers.resourceFilePath("hibernate-integration-test.yaml"),
-        ConfigOverride.config("dataSource.url", "jdbc:h2:mem:DbTest" + System.nanoTime())
+        TestApplication.class, "hibernate-integration-test.yaml", new ResourceConfigurationSourceProvider(),
+        config("dataSource.url", "jdbc:h2:mem:DbTest" + System.nanoTime())
     );
 
     @Test
@@ -70,9 +69,9 @@ class LazyLoadingTest {
     @ExtendWith(DropwizardExtensionsSupport.class)
     class LazyLoadingDisabledTest {
         private final DropwizardAppExtension<TestConfiguration> appExtension = new DropwizardAppExtension<>(
-            TestApplicationWithDisabledLazyLoading.class,
-            ResourceHelpers.resourceFilePath("hibernate-integration-test.yaml"),
-            ConfigOverride.config("dataSource.url", "jdbc:h2:mem:DbTest" + System.nanoTime())
+            TestApplicationWithDisabledLazyLoading.class, "hibernate-integration-test.yaml",
+            new ResourceConfigurationSourceProvider(),
+            config("dataSource.url", "jdbc:h2:mem:DbTest" + System.nanoTime())
         );
 
         @Test

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SubResourcesTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SubResourcesTest.java
@@ -3,12 +3,12 @@ package io.dropwizard.hibernate;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.db.PooledDataSourceFactory;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.ConfigOverride;
-import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.hibernate.Session;
@@ -36,7 +36,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SubResourcesTest {
     private static final DropwizardAppExtension<TestConfiguration> appExtension = new DropwizardAppExtension<>(
         TestApplication.class,
-        ResourceHelpers.resourceFilePath("hibernate-sub-resource-test.yaml"),
+        "hibernate-sub-resource-test.yaml",
+        new ResourceConfigurationSourceProvider(),
         ConfigOverride.config("dataSource.url", "jdbc:h2:mem:sub-resources-" + System.nanoTime()));
 
     private String baseUri() {
@@ -134,7 +135,7 @@ class SubResourcesTest {
         }
 
         @Override
-        public void run(TestConfiguration configuration, Environment environment) throws Exception {
+        public void run(TestConfiguration configuration, Environment environment) {
             final SessionFactory sessionFactory = hibernate.getSessionFactory();
             initDatabase(sessionFactory);
 

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/TransactionHandlingTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/TransactionHandlingTest.java
@@ -2,12 +2,12 @@ package io.dropwizard.hibernate;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.db.PooledDataSourceFactory;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.ConfigOverride;
-import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.hibernate.FlushMode;
@@ -34,7 +34,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 class TransactionHandlingTest {
     private final DropwizardAppExtension<TestConfiguration> appExtension = new DropwizardAppExtension<>(
         TestApplication.class,
-        ResourceHelpers.resourceFilePath("transaction-handling-test.yaml"),
+        "transaction-handling-test.yaml",
+        new ResourceConfigurationSourceProvider(),
         ConfigOverride.config("dataSource.url", "jdbc:h2:mem:DbTest" + System.nanoTime()),
         ConfigOverride.config("server.registerDefaultExceptionMappers", "false")
     );
@@ -112,7 +113,7 @@ class TransactionHandlingTest {
         }
 
         @Override
-        public void run(TestConfiguration configuration, Environment environment) throws Exception {
+        public void run(TestConfiguration configuration, Environment environment) {
 
             final SessionFactory sessionFactory = hibernate.getSessionFactory();
             initDatabase(sessionFactory);

--- a/dropwizard-http2/pom.xml
+++ b/dropwizard-http2/pom.xml
@@ -154,6 +154,11 @@
 
         <dependency>
             <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-configuration</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>
             <scope>test</scope>
         </dependency>

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/AbstractHttp2Test.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/AbstractHttp2Test.java
@@ -1,7 +1,6 @@
 package io.dropwizard.http2;
 
 import io.dropwizard.logging.BootstrapLogging;
-import io.dropwizard.testing.ResourceHelpers;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.client.api.Result;
@@ -17,6 +16,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -34,7 +34,7 @@ class AbstractHttp2Test {
 
     @BeforeEach
     void setUp() throws Exception {
-        sslContextFactory.setTrustStorePath(ResourceHelpers.resourceFilePath("stores/http2_client.jts"));
+        sslContextFactory.setTrustStorePath(resourceFilePath("stores/http2_client.jts"));
         sslContextFactory.setTrustStorePassword("http2_client");
         sslContextFactory.start();
 

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2CIntegrationTest.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2CIntegrationTest.java
@@ -1,7 +1,7 @@
 package io.dropwizard.http2;
 
 import io.dropwizard.Configuration;
-import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.eclipse.jetty.client.HttpClient;
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class Http2CIntegrationTest extends AbstractHttp2Test {
 
     final DropwizardAppExtension<Configuration> appRule = new DropwizardAppExtension<>(
-            FakeApplication.class, ResourceHelpers.resourceFilePath("test-http2c.yml"));
+            FakeApplication.class, "test-http2c.yml", new ResourceConfigurationSourceProvider());
 
     @BeforeEach
     @Override

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2IntegrationTest.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2IntegrationTest.java
@@ -1,26 +1,28 @@
 package io.dropwizard.http2;
 
 import io.dropwizard.Configuration;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.testing.ConfigOverride;
-import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.eclipse.jetty.http.HttpVersion;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 class Http2IntegrationTest extends AbstractHttp2Test {
 
     final DropwizardAppExtension<Configuration> appRule = new DropwizardAppExtension<>(
-        FakeApplication.class, ResourceHelpers.resourceFilePath("test-http2.yml"),
+        FakeApplication.class, "test-http2.yml",
+        new ResourceConfigurationSourceProvider(),
         "tls_http2",
         ConfigOverride.config("tls_http2", "server.connector.keyStorePath",
-            ResourceHelpers.resourceFilePath("stores/http2_server.jks")),
+            resourceFilePath("stores/http2_server.jks")),
         ConfigOverride.config("tls_http2", "server.connector.trustStorePath",
-            ResourceHelpers.resourceFilePath("stores/http2_client.jts"))
+            resourceFilePath("stores/http2_client.jts"))
     );
 
     @Test

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2WithConscryptTest.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2WithConscryptTest.java
@@ -1,6 +1,7 @@
 package io.dropwizard.http2;
 
 import io.dropwizard.Configuration;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.conscrypt.OpenSSLProvider;
@@ -21,8 +22,10 @@ class Http2WithConscryptTest extends AbstractHttp2Test {
     }
 
     private static final String PREFIX = "tls_conscrypt";
+
     final DropwizardAppExtension<Configuration> appRule = new DropwizardAppExtension<>(
-        FakeApplication.class, resourceFilePath("test-http2-with-conscrypt.yml"),
+        FakeApplication.class, "test-http2-with-conscrypt.yml",
+        new ResourceConfigurationSourceProvider(),
         PREFIX,
         config(PREFIX, "server.connector.keyStorePath", resourceFilePath("stores/http2_server.jks")),
         config(PREFIX, "server.connector.trustStorePath", resourceFilePath("stores/http2_client.jts"))

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2WithCustomCipherTest.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2WithCustomCipherTest.java
@@ -1,6 +1,7 @@
 package io.dropwizard.http2;
 
 import io.dropwizard.Configuration;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.eclipse.jetty.http.HttpVersion;
@@ -15,7 +16,8 @@ class Http2WithCustomCipherTest extends AbstractHttp2Test {
     private static final String PREFIX = "tls_custom_http2";
 
     final DropwizardAppExtension<Configuration> appRule = new DropwizardAppExtension<>(
-        FakeApplication.class, resourceFilePath("test-http2-with-custom-cipher.yml"),
+        FakeApplication.class, "test-http2-with-custom-cipher.yml",
+        new ResourceConfigurationSourceProvider(),
         PREFIX,
         config(PREFIX, "server.connector.keyStorePath", resourceFilePath("stores/http2_server.jks")),
         config(PREFIX, "server.connector.trustStorePath", resourceFilePath("stores/http2_client.jts"))

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/ResourceHelpers.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/ResourceHelpers.java
@@ -1,8 +1,8 @@
 package io.dropwizard.testing;
 
-import io.dropwizard.util.Resources;
-
 import java.io.File;
+
+import static io.dropwizard.util.Resources.getResource;
 
 /**
  * A set of helper methods for working with classpath resources.
@@ -18,7 +18,7 @@ public class ResourceHelpers {
      */
     public static String resourceFilePath(final String resourceClassPathLocation) {
         try {
-            return new File(Resources.getResource(resourceClassPathLocation).toURI()).getAbsolutePath();
+            return new File(getResource(resourceClassPathLocation).toURI()).getAbsolutePath();
         } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportTest.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.configuration.JsonConfigurationFactory;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
-import io.dropwizard.jackson.Jackson;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.servlets.tasks.PostBodyTask;
 import io.dropwizard.servlets.tasks.Task;
@@ -21,20 +21,19 @@ import javax.validation.Validator;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
-import java.io.File;
 import java.io.PrintWriter;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static io.dropwizard.jackson.Jackson.newObjectMapper;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class DropwizardTestSupportTest {
     private static final TestServiceListener<TestConfiguration> TEST_SERVICE_LISTENER = new TestServiceListener<>();
     private static final TestManaged TEST_MANAGED = new TestManaged();
     private static final DropwizardTestSupport<TestConfiguration> TEST_SUPPORT =
-            new DropwizardTestSupport<>(TestApplication.class, resourceFilePath("test-config.yaml"))
+            new DropwizardTestSupport<>(TestApplication.class, "test-config.yaml", new ResourceConfigurationSourceProvider())
                     .addListener(TEST_SERVICE_LISTENER)
                     .manage(TEST_MANAGED);
 
@@ -110,9 +109,9 @@ class DropwizardTestSupportTest {
         TestConfiguration config = new YamlConfigurationFactory<>(
                 TestConfiguration.class,
                 BaseValidator.newValidator(),
-                Jackson.newObjectMapper(),
+                newObjectMapper(),
                 "dw"
-        ).build(new File(resourceFilePath("test-config.yaml")));
+        ).build(new ResourceConfigurationSourceProvider(), "test-config.yaml");
 
         DropwizardTestSupport<TestConfiguration> support = new DropwizardTestSupport<>(
                 FailingApplication.class,

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/GzipDefaultVaryBehaviourTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/GzipDefaultVaryBehaviourTest.java
@@ -1,5 +1,6 @@
 package io.dropwizard.testing.app;
 
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -8,7 +9,6 @@ import javax.ws.rs.core.Response;
 
 import java.util.Collections;
 
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static javax.ws.rs.core.HttpHeaders.ACCEPT_ENCODING;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_ENCODING;
 import static javax.ws.rs.core.HttpHeaders.VARY;
@@ -19,7 +19,7 @@ public class GzipDefaultVaryBehaviourTest {
     @SuppressWarnings("deprecation")
     @ClassRule
     public static final DropwizardAppRule<TestConfiguration> RULE =
-            new DropwizardAppRule<>(TestApplication.class, resourceFilePath("gzip-vary-test-config.yaml"));
+            new DropwizardAppRule<>(TestApplication.class, "gzip-vary-test-config.yaml", new ResourceConfigurationSourceProvider());
 
     @Test
     public void testDefaultVaryHeader() {

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleConfigOverrideTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleConfigOverrideTest.java
@@ -1,19 +1,20 @@
 package io.dropwizard.testing.junit;
 
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.testing.app.TestApplication;
 import io.dropwizard.testing.app.TestConfiguration;
 import org.junit.ClassRule;
 import org.junit.Test;
 
 import static io.dropwizard.testing.ConfigOverride.config;
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DropwizardAppRuleConfigOverrideTest {
     @SuppressWarnings("deprecation")
     @ClassRule
     public static final DropwizardAppRule<TestConfiguration> RULE =
-        new DropwizardAppRule<>(TestApplication.class, resourceFilePath("test-config.yaml"),
+        new DropwizardAppRule<>(TestApplication.class, "test-config.yaml",
+            new ResourceConfigurationSourceProvider(),
             "app-rule",
             config("app-rule", "message", "A new way to say Hooray!"),
             config("app-rule", "extra", () -> "supplied"),
@@ -28,8 +29,9 @@ public class DropwizardAppRuleConfigOverrideTest {
     }
 
     @Test
-    public void supportsSuppliedConfigAttributeOverrides() throws Exception {
-        assertThat(System.getProperty("app-rule.extra")).isEqualTo("supplied");
-        assertThat(System.getProperty("dw.extra")).isEqualTo("supplied again");
+    public void supportsSuppliedConfigAttributeOverrides() {
+        assertThat(System.getProperties())
+            .containsEntry("app-rule.extra", "supplied")
+            .containsEntry("dw.extra", "supplied again");
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleResetConfigOverrideTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleResetConfigOverrideTest.java
@@ -1,18 +1,19 @@
 package io.dropwizard.testing.junit;
 
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.testing.app.TestApplication;
 import io.dropwizard.testing.app.TestConfiguration;
 import org.junit.Test;
 
 import static io.dropwizard.testing.ConfigOverride.config;
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DropwizardAppRuleResetConfigOverrideTest {
     @SuppressWarnings("deprecation")
     private final DropwizardAppRule<TestConfiguration> dropwizardAppRule = new DropwizardAppRule<>(
         TestApplication.class,
-        resourceFilePath("test-config.yaml"),
+        "test-config.yaml",
+        new ResourceConfigurationSourceProvider(),
         "app-rule-reset",
         config("app-rule-reset", "message", "A new way to say Hooray!"));
 

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleTest.java
@@ -1,5 +1,6 @@
 package io.dropwizard.testing.junit;
 
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.app.DropwizardTestApplication;
 import io.dropwizard.testing.app.TestConfiguration;
@@ -10,14 +11,13 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DropwizardAppRuleTest {
     @SuppressWarnings("deprecation")
     @ClassRule
     public static final DropwizardAppRule<TestConfiguration> RULE =
-        new DropwizardAppRule<>(DropwizardTestApplication.class, resourceFilePath("test-config.yaml"));
+        new DropwizardAppRule<>(DropwizardTestApplication.class, "test-config.yaml", new ResourceConfigurationSourceProvider());
 
     @Test
     public void canGetExpectedResourceOverHttp() {

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionConfigOverrideTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionConfigOverrideTest.java
@@ -1,22 +1,22 @@
 package io.dropwizard.testing.junit5;
 
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.testing.app.TestApplication;
 import io.dropwizard.testing.app.TestConfiguration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.Optional;
-
 import static io.dropwizard.testing.ConfigOverride.config;
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 class DropwizardAppExtensionConfigOverrideTest {
 
     private static final DropwizardAppExtension<TestConfiguration> EXTENSION =
-        new DropwizardAppExtension<>(TestApplication.class, resourceFilePath("test-config.yaml"),
-            Optional.of("app-rule"),
+        new DropwizardAppExtension<>(TestApplication.class,
+            "test-config.yaml",
+            new ResourceConfigurationSourceProvider(),
+            "app-rule",
             config("app-rule", "message", "A new way to say Hooray!"),
             config("app-rule", "extra", () -> "supplied"),
             config("extra", () -> "supplied again"));
@@ -30,8 +30,9 @@ class DropwizardAppExtensionConfigOverrideTest {
     }
 
     @Test
-    void supportsSuppliedConfigAttributeOverrides() throws Exception {
-        assertThat(System.getProperty("app-rule.extra")).isEqualTo("supplied");
-        assertThat(System.getProperty("dw.extra")).isEqualTo("supplied again");
+    void supportsSuppliedConfigAttributeOverrides() {
+        assertThat(System.getProperties())
+            .containsEntry("app-rule.extra", "supplied")
+            .containsEntry("dw.extra", "supplied again");
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionRegisterExtensionTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionRegisterExtensionTest.java
@@ -1,7 +1,6 @@
 package io.dropwizard.testing.junit5;
 
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
-
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.testing.app.DropwizardTestApplication;
 import io.dropwizard.testing.app.TestConfiguration;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -10,7 +9,8 @@ class DropwizardAppExtensionRegisterExtensionTest extends AbstractDropwizardAppE
 
     @RegisterExtension
     public static final DropwizardAppExtension<TestConfiguration> EXTENSION =
-            new DropwizardAppExtension<>(DropwizardTestApplication.class, resourceFilePath("test-config.yaml"));
+            new DropwizardAppExtension<>(DropwizardTestApplication.class,
+                "test-config.yaml", new ResourceConfigurationSourceProvider());
 
     @Override
     DropwizardAppExtension<TestConfiguration> getExtension() {

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionResetConfigOverrideTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionResetConfigOverrideTest.java
@@ -1,21 +1,20 @@
 package io.dropwizard.testing.junit5;
 
 
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.testing.app.TestApplication;
 import io.dropwizard.testing.app.TestConfiguration;
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
-
 import static io.dropwizard.testing.ConfigOverride.config;
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class DropwizardAppExtensionResetConfigOverrideTest {
     private final DropwizardAppExtension<TestConfiguration> dropwizardAppExtension = new DropwizardAppExtension<>(
             TestApplication.class,
-            resourceFilePath("test-config.yaml"),
-            Optional.of("app-rule-reset"),
+            "test-config.yaml",
+            new ResourceConfigurationSourceProvider(),
+            "app-rule-reset",
             config("app-rule-reset", "message", "A new way to say Hooray!"));
 
     @Test

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DropwizardAppExtensionTest.java
@@ -1,16 +1,16 @@
 package io.dropwizard.testing.junit5;
 
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.testing.app.DropwizardTestApplication;
 import io.dropwizard.testing.app.TestConfiguration;
 import org.junit.jupiter.api.extension.ExtendWith;
-
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 class DropwizardAppExtensionTest extends AbstractDropwizardAppExtensionTest {
 
     private static final DropwizardAppExtension<TestConfiguration> EXTENSION =
-            new DropwizardAppExtension<>(DropwizardTestApplication.class, resourceFilePath("test-config.yaml"));
+            new DropwizardAppExtension<>(DropwizardTestApplication.class,
+                "test-config.yaml", new ResourceConfigurationSourceProvider());
 
     @Override
     DropwizardAppExtension<TestConfiguration> getExtension() {

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/GzipDefaultVaryBehaviourTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/GzipDefaultVaryBehaviourTest.java
@@ -1,5 +1,6 @@
 package io.dropwizard.testing.junit5;
 
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.testing.app.TestApplication;
 import io.dropwizard.testing.app.TestConfiguration;
 import org.junit.jupiter.api.Test;
@@ -8,7 +9,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import javax.ws.rs.core.Response;
 import java.util.Collections;
 
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static javax.ws.rs.core.HttpHeaders.ACCEPT_ENCODING;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_ENCODING;
 import static javax.ws.rs.core.HttpHeaders.VARY;
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class GzipDefaultVaryBehaviourTest {
 
     private final DropwizardAppExtension<TestConfiguration> extension = new DropwizardAppExtension<>(TestApplication.class,
-        resourceFilePath("gzip-vary-test-config.yaml"));
+        "gzip-vary-test-config.yaml", new ResourceConfigurationSourceProvider());
 
     @Test
     void testDefaultVaryHeader() {

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/NestedResourceTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/NestedResourceTest.java
@@ -1,27 +1,29 @@
 package io.dropwizard.testing.junit5;
 
+import io.dropwizard.configuration.ConfigurationSourceProvider;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.testing.app.TestApplication;
 import io.dropwizard.testing.app.TestConfiguration;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 class NestedResourceTest {
-    private static DropwizardAppExtension<TestConfiguration> staticApp = new DropwizardAppExtension<>(
-            TestApplication.class, resourceFilePath("test-config.yaml"));
-    private static DropwizardClientExtension staticClient = new DropwizardClientExtension();
-    private static DAOTestExtension staticDao = DAOTestExtension.newBuilder().build();
-    private static ResourceExtension staticResources = ResourceExtension.builder().build();
+    private static final ConfigurationSourceProvider resourceConfigurationSourceProvider = new ResourceConfigurationSourceProvider();
+    private static final DropwizardAppExtension<TestConfiguration> staticApp = new DropwizardAppExtension<>(
+            TestApplication.class, "test-config.yaml", resourceConfigurationSourceProvider);
+    private static final DropwizardClientExtension staticClient = new DropwizardClientExtension();
+    private static final DAOTestExtension staticDao = DAOTestExtension.newBuilder().build();
+    private static final ResourceExtension staticResources = ResourceExtension.builder().build();
 
-    private DropwizardAppExtension<TestConfiguration> app = new DropwizardAppExtension<>(
-            TestApplication.class, resourceFilePath("test-config.yaml"));
-    private DropwizardClientExtension client = new DropwizardClientExtension();
-    private DAOTestExtension dao = DAOTestExtension.newBuilder().build();
-    private ResourceExtension resources = ResourceExtension.builder().build();
+    private final DropwizardAppExtension<TestConfiguration> app = new DropwizardAppExtension<>(
+            TestApplication.class, "test-config.yaml", resourceConfigurationSourceProvider);
+    private final DropwizardClientExtension client = new DropwizardClientExtension();
+    private final DAOTestExtension dao = DAOTestExtension.newBuilder().build();
+    private final ResourceExtension resources = ResourceExtension.builder().build();
 
     @Test
     void staticApp() {

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/ReuseDropwizardAppExtensionTestSuite.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/ReuseDropwizardAppExtensionTestSuite.java
@@ -1,5 +1,6 @@
 package io.dropwizard.testing.junit5;
 
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.testing.app.DropwizardTestApplication;
 import io.dropwizard.testing.app.TestConfiguration;
 import org.junit.jupiter.api.Test;
@@ -8,12 +9,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ReuseDropwizardAppExtensionTestSuite {
     static final DropwizardAppExtension<TestConfiguration> EXTENSION =
-        new DropwizardAppExtension<>(DropwizardTestApplication.class, resourceFilePath("test-config.yaml"));
+        new DropwizardAppExtension<>(DropwizardTestApplication.class, "test-config.yaml",
+            new ResourceConfigurationSourceProvider());
 
 }
 


### PR DESCRIPTION
This is neater than using `ResourceHelpers#resourceFilePath(String)`.

Clean up a few linter gripes in the affected tests at the same time.