### PR TITLE
Add default methods to dropwizard-lifecycle's `Managed` interface

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -136,10 +136,6 @@ create a new ``MessageQueueFactory`` class:
             MessageQueueClient client = new MessageQueueClient(getHost(), getPort());
             environment.lifecycle().manage(new Managed() {
                 @Override
-                public void start() {
-                }
-
-                @Override
                 public void stop() {
                     client.close();
                 }
@@ -605,12 +601,11 @@ Managed Objects
 ===============
 
 Most applications involve objects which need to be started and stopped: thread pools, database
-connections, etc. Dropwizard provides the ``Managed`` interface for this. You can either have the
-class in question implement the ``#start()`` and ``#stop()`` methods, or write a wrapper class which
-does so. Adding a ``Managed`` instance to your application's ``Environment`` ties that object's
-lifecycle to that of the application's HTTP server. Before the server starts, the ``#start()`` method is
-called. After the server has stopped (and after its graceful shutdown period) the ``#stop()`` method
-is called.
+connections, etc. Dropwizard provides the ``Managed`` interface for this. You can either have the class
+in question implement the ``#start()`` and/or ``#stop()`` methods, or write a wrapper class which does
+so. Adding a ``Managed`` instance to your application's ``Environment`` ties that object's lifecycle to
+that of the application's HTTP server. Before the server starts, the ``#start()`` method is called.
+After the server has stopped (and after its graceful shutdown period) the ``#stop()`` method is called.
 
 For example, given a theoretical Riak__ client which needs to be started and stopped:
 

--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
@@ -285,10 +285,6 @@ public class HttpClientBuilder {
         if (environment != null) {
             environment.lifecycle().manage(new Managed() {
                 @Override
-                public void start() throws Exception {
-                }
-
-                @Override
                 public void stop() throws Exception {
                     client.close();
                 }

--- a/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
@@ -376,11 +376,7 @@ public class JerseyClientBuilder {
         if (environment != null) {
             environment.lifecycle().manage(new Managed() {
                 @Override
-                public void start() throws Exception {
-                }
-
-                @Override
-                public void stop() throws Exception {
+                public void stop() {
                     client.close();
                 }
             });

--- a/dropwizard-health/src/main/java/io/dropwizard/health/HealthCheckConfigValidator.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/HealthCheckConfigValidator.java
@@ -25,11 +25,6 @@ class HealthCheckConfigValidator implements Managed {
         validateConfiguration(configs, registry.getNames());
     }
 
-    @Override
-    public void stop() throws Exception {
-        // do nothing
-    }
-
     private void validateConfiguration(final List<HealthCheckConfiguration> healthCheckConfigs,
                                        final Set<String> registeredHealthCheckNames) {
         final Set<String> configuredHealthCheckNames = healthCheckConfigs.stream()

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/AutoCloseableManager.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/AutoCloseableManager.java
@@ -28,13 +28,6 @@ public class AutoCloseableManager implements Managed {
     }
 
     /**
-     * The start operation does nothing (i.e. it's a no-op).
-     */
-    @Override
-    public void start() throws Exception {
-    }
-
-    /**
      * Calls {@link AutoCloseable#close()} on the closable provided in
      * {@link AutoCloseableManager#AutoCloseableManager(AutoCloseable)}.
      *

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/ExecutorServiceManager.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/ExecutorServiceManager.java
@@ -19,11 +19,6 @@ public class ExecutorServiceManager implements Managed {
         this.poolName = poolName;
     }
 
-    @Override
-    public void start() throws Exception {
-        // OK BOSS
-    }
-
     /**
      * {@inheritDoc}
      *

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/Managed.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/Managed.java
@@ -1,21 +1,21 @@
 package io.dropwizard.lifecycle;
 
 /**
- * An interface for objects which need to be started and stopped as the application is started or
- * stopped.
+ * An interface for objects which need to take some action as the application is started or stopped.
  */
 public interface Managed {
     /**
-     * Starts the object. Called <i>before</i> the application becomes available.
+     * Starts the object. Called <i>before</i> the application becomes available. The default implementation is a no-op.
      *
      * @throws Exception if something goes wrong; this will halt the application startup.
      */
-    void start() throws Exception;
+    default void start() throws Exception {}
 
     /**
-     * Stops the object. Called <i>after</i> the application is no longer accepting requests.
+     * Stops the object. Called <i>after</i> the application is no longer accepting requests. The default implementation
+     * is a no-op
      *
      * @throws Exception if something goes wrong.
      */
-    void stop() throws Exception;
+    default void stop() throws Exception {}
 }


### PR DESCRIPTION
Not everything needs both a start and stop method. Provide default no-op implementations.