### PR TITLE
Explain/remove empty methods

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardExecutorProvider.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardExecutorProvider.java
@@ -25,5 +25,10 @@ class DropwizardExecutorProvider implements ExecutorServiceProvider {
 
     @Override
     public void dispose(ExecutorService executorService) {
+        /*
+         Jersey makes copies of clients, including the executor
+         This means we cannot shut down the ExecutorService here as it may be in use elsewhere
+         https://github.com/dropwizard/dropwizard/issues/2218
+         */
     }
 }

--- a/dropwizard-core/src/main/java/io/dropwizard/cli/Cli.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/Cli.java
@@ -165,6 +165,7 @@ public class Cli {
 
         @Override
         public void onAttach(Argument arg) {
+            // Nothing to do
         }
     }
 }

--- a/dropwizard-e2e/src/main/java/com/example/health/HealthApp.java
+++ b/dropwizard-e2e/src/main/java/com/example/health/HealthApp.java
@@ -4,7 +4,6 @@ import com.codahale.metrics.health.HealthCheck;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.health.HealthStateListener;
-import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -22,10 +21,6 @@ public class HealthApp extends Application<Configuration> {
     private final AtomicInteger healthyCheckCounter = new AtomicInteger();
     private final AtomicInteger unhealthyCheckCounter = new AtomicInteger();
     private final AtomicInteger stateChangeCounter = new AtomicInteger();
-
-    @Override
-    public void initialize(Bootstrap<Configuration> bootstrap) {
-    }
 
     @Override
     public void run(final Configuration configuration, final Environment environment) throws Exception {

--- a/dropwizard-e2e/src/main/java/com/example/sslreload/SslReloadApp.java
+++ b/dropwizard-e2e/src/main/java/com/example/sslreload/SslReloadApp.java
@@ -14,5 +14,6 @@ public class SslReloadApp extends Application<Configuration> {
 
     @Override
     public void run(Configuration configuration, Environment environment) throws Exception {
+        // Nothing to do
     }
 }

--- a/dropwizard-e2e/src/main/java/com/example/validation/WasInjectedConstraintValidator.java
+++ b/dropwizard-e2e/src/main/java/com/example/validation/WasInjectedConstraintValidator.java
@@ -11,11 +11,6 @@ public class WasInjectedConstraintValidator implements ConstraintValidator<WasIn
     private UriInfo uriInfo;
 
     @Override
-    public void initialize(WasInjected constraintAnnotation) {
-
-    }
-
-    @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
         return uriInfo != null;
     }

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryFactory.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryFactory.java
@@ -103,6 +103,7 @@ public class SessionFactoryFactory {
     }
 
     protected void configure(Configuration configuration, ServiceRegistry registry) {
+        // Default implementation is a no-op
     }
 
     protected BootstrapServiceRegistryBuilder configureBootstrapServiceRegistryBuilder(BootstrapServiceRegistryBuilder builder) {

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkApplicationListener.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkApplicationListener.java
@@ -15,7 +15,6 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-
 /**
  * An application event listener that listens for Jersey application initialization to
  * be finished, then creates a map of resource method that have metrics annotations.
@@ -28,8 +27,8 @@ import java.util.concurrent.ConcurrentMap;
 @Provider
 public class UnitOfWorkApplicationListener implements ApplicationEventListener {
 
-    private ConcurrentMap<ResourceMethod, Optional<UnitOfWork>> methodMap = new ConcurrentHashMap<>();
-    private Map<String, SessionFactory> sessionFactories = new HashMap<>();
+    private final ConcurrentMap<ResourceMethod, Optional<UnitOfWork>> methodMap = new ConcurrentHashMap<>();
+    private final Map<String, SessionFactory> sessionFactories = new HashMap<>();
 
     public UnitOfWorkApplicationListener() {
     }
@@ -59,7 +58,7 @@ public class UnitOfWorkApplicationListener implements ApplicationEventListener {
     }
 
     private static class UnitOfWorkEventListener implements RequestEventListener {
-        private ConcurrentMap<ResourceMethod, Optional<UnitOfWork>> methodMap;
+        private final ConcurrentMap<ResourceMethod, Optional<UnitOfWork>> methodMap;
         private final UnitOfWorkAspect unitOfWorkAspect;
 
         UnitOfWorkEventListener(ConcurrentMap<ResourceMethod, Optional<UnitOfWork>> methodMap,
@@ -99,12 +98,12 @@ public class UnitOfWorkApplicationListener implements ApplicationEventListener {
 
     @Override
     public void onEvent(ApplicationEvent event) {
+        // Nothing to do
     }
 
     @Override
     public RequestEventListener onRequest(RequestEvent event) {
         return new UnitOfWorkEventListener(methodMap, sessionFactories);
     }
-
 
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/AllowedMethodsFilter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/AllowedMethodsFilter.java
@@ -50,8 +50,4 @@ public class AllowedMethodsFilter implements Filter {
             response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
         }
     }
-
-    @Override
-    public void destroy() {
-    }
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/MutableValidatorFactory.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/MutableValidatorFactory.java
@@ -18,7 +18,9 @@ public class MutableValidatorFactory implements ConstraintValidatorFactory {
     }
 
     @Override
-    public void releaseInstance(ConstraintValidator<?, ?> instance) { }
+    public void releaseInstance(ConstraintValidator<?, ?> instance) {
+        // Nothing to do
+    }
 
     public void setValidatorFactory(ConstraintValidatorFactory validatorFactory) {
         this.validatorFactory = validatorFactory;

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/ExternalLoggingFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/ExternalLoggingFactory.java
@@ -4,21 +4,23 @@ import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 /**
- * A logging factory which does configure a logging infrastructure.
- * Useful when the users doesn't want to use the Dropwizard logging configuration abilities.
+ * A no-op logging factory to use when logging is configured independently of Dropwizard.
  */
 @JsonTypeName("external")
 public class ExternalLoggingFactory implements LoggingFactory {
 
     @Override
     public void configure(MetricRegistry metricRegistry, String name) {
+        // Do nothing
     }
 
     @Override
     public void stop() {
+        // Do nothing
     }
 
     @Override
     public void reset() {
+        // Do nothing
     }
 }

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/MethodValidator.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/MethodValidator.java
@@ -8,11 +8,6 @@ import javax.validation.ConstraintValidatorContext;
  */
 public class MethodValidator implements ConstraintValidator<ValidationMethod, Boolean> {
     @Override
-    public void initialize(ValidationMethod constraintAnnotation) {
-
-    }
-
-    @Override
     public boolean isValid(Boolean value, ConstraintValidatorContext context) {
         return (value == null) || value;
     }


### PR DESCRIPTION
Sonar gets upset when a method does nothing without explaining why.

In some cases, the empty methods can just fall back to a default no-op implementation in the corresponding `interface` - remove such methods.

For the rest, add a comment explaining why the method is empty, or at least acknowledging that it does nothing intentionally.