### PR TITLE
Ignore code coverage metrics for dropwizard-benchmarks

### DIFF
--- a/dropwizard-benchmarks/pom.xml
+++ b/dropwizard-benchmarks/pom.xml
@@ -21,6 +21,9 @@
         <maven.site.skip>true</maven.site.skip>
         <maven.site.deploy.skip>true</maven.site.deploy.skip>
         <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+		  <!-- Ignore test coverage metrics for this module  -->
+		  <jacoco.skip>true</jacoco.skip>
+        <sonar.coverage.exclusions>**/*.java</sonar.coverage.exclusions>
     </properties>
 
     <artifactId>dropwizard-benchmarks</artifactId>

--- a/dropwizard-benchmarks/pom.xml
+++ b/dropwizard-benchmarks/pom.xml
@@ -21,8 +21,8 @@
         <maven.site.skip>true</maven.site.skip>
         <maven.site.deploy.skip>true</maven.site.deploy.skip>
         <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
-		  <!-- Ignore test coverage metrics for this module  -->
-		  <jacoco.skip>true</jacoco.skip>
+        <!-- Ignore test coverage metrics for this module  -->
+        <jacoco.skip>true</jacoco.skip>
         <sonar.coverage.exclusions>**/*.java</sonar.coverage.exclusions>
     </properties>
 


### PR DESCRIPTION
This module's code is already test code. Don't report on test coverage for it.

Note: I'm not sure if this is quite the way to do it - the Sonar docs aren't very clear to me.

https://docs.sonarqube.org/latest/project-administration/narrowing-the-focus/#header-3
