### PR TITLE
Remove deprecated tag as HttpProcessor is supported in httpclient 5

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
@@ -241,9 +241,7 @@ public class HttpClientBuilder {
      *
      * @param httpProcessor a {@link HttpProcessor} instance
      * @return {@code} this
-     * @deprecated
      */
-    @Deprecated
     public HttpClientBuilder using(HttpProcessor httpProcessor) {
         this.httpProcessor = httpProcessor;
         return this;


### PR DESCRIPTION
###### Problem:
`HttpProcessor` is marked as deprecated but is supported in httpclient-5.

###### Solution:
Remove the `@Deprecated` tag.

Refs #4338