### PR TITLE
Address Sonar warnings in tests

### DIFF
--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2CIntegrationTest.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2CIntegrationTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-class Http2CIntegrationTest extends AbstractHttp2Test {
+class Http2CIntegrationTest extends Http2TestCommon {
 
     final DropwizardAppExtension<Configuration> appRule = new DropwizardAppExtension<>(
             FakeApplication.class, "test-http2c.yml", new ResourceConfigurationSourceProvider());
@@ -43,17 +43,17 @@ class Http2CIntegrationTest extends AbstractHttp2Test {
 
     @Test
     void testHttp1() throws Exception {
-        AbstractHttp2Test.assertResponse(http1Client.GET("http://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_1_1);
+        assertResponse(http1Client.GET("http://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_1_1);
     }
 
     @Test
     void testHttp2c() throws Exception {
-        AbstractHttp2Test.assertResponse(http2Client.GET("http://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_2);
+        assertResponse(http2Client.GET("http://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_2);
     }
 
     @Test
     void testHttp2cManyRequests() throws Exception {
-        assertThat(AbstractHttp2Test.performManyAsyncRequests(http2Client, "http://localhost:" + appRule.getLocalPort() + "/api/test"))
+        assertThat(performManyAsyncRequests(http2Client, "http://localhost:" + appRule.getLocalPort() + "/api/test"))
             .isTrue();
     }
 }

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2IntegrationTest.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2IntegrationTest.java
@@ -13,7 +13,7 @@ import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-class Http2IntegrationTest extends AbstractHttp2Test {
+class Http2IntegrationTest extends Http2TestCommon {
 
     final DropwizardAppExtension<Configuration> appRule = new DropwizardAppExtension<>(
         FakeApplication.class, "test-http2.yml",
@@ -27,17 +27,17 @@ class Http2IntegrationTest extends AbstractHttp2Test {
 
     @Test
     void testHttp1() throws Exception {
-        AbstractHttp2Test.assertResponse(http1Client.GET("https://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_1_1);
+        assertResponse(http1Client.GET("https://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_1_1);
     }
 
     @Test
     void testHttp2() throws Exception {
-        AbstractHttp2Test.assertResponse(http2Client.GET("https://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_2);
+        assertResponse(http2Client.GET("https://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_2);
     }
 
     @Test
     void testHttp2ManyRequests() throws Exception {
-        assertThat(AbstractHttp2Test.performManyAsyncRequests(http2Client, "https://localhost:" + appRule.getLocalPort() + "/api/test"))
+        assertThat(performManyAsyncRequests(http2Client, "https://localhost:" + appRule.getLocalPort() + "/api/test"))
             .isTrue();
     }
 }

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2TestCommon.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2TestCommon.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Common code for HTTP/2 connector tests
  */
-class AbstractHttp2Test {
+class Http2TestCommon {
 
     static {
         BootstrapLogging.bootstrap();

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2WithConscryptTest.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2WithConscryptTest.java
@@ -15,7 +15,7 @@ import static io.dropwizard.testing.ConfigOverride.config;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-class Http2WithConscryptTest extends AbstractHttp2Test {
+class Http2WithConscryptTest extends Http2TestCommon {
 
     static {
         Security.addProvider(new OpenSSLProvider());

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2WithCustomCipherTest.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2WithCustomCipherTest.java
@@ -12,7 +12,7 @@ import static io.dropwizard.testing.ConfigOverride.config;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-class Http2WithCustomCipherTest extends AbstractHttp2Test {
+class Http2WithCustomCipherTest extends Http2TestCommon {
     private static final String PREFIX = "tls_custom_http2";
 
     final DropwizardAppExtension<Configuration> appRule = new DropwizardAppExtension<>(

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbCalculateChecksumCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbCalculateChecksumCommandTest.java
@@ -16,7 +16,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
-class DbCalculateChecksumCommandTest extends AbstractMigrationTest {
+class DbCalculateChecksumCommandTest {
 
     private final DbCalculateChecksumCommand<TestMigrationConfiguration> migrateCommand = new DbCalculateChecksumCommand<>(
         TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations.xml");
@@ -31,14 +31,14 @@ class DbCalculateChecksumCommandTest extends AbstractMigrationTest {
         migrateCommand.run(null, new Namespace(Maps.of(
                 "id", Collections.singletonList("2"),
                 "author", Collections.singletonList("db_dev"))),
-                createConfiguration(getDatabaseUrl()));
+            MigrationTestSupport.createConfiguration());
         assertThat(checkSumVerified).isTrue();
     }
 
     @Test
     void testHelpPage() throws Exception {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
-        createSubparser(migrateCommand).printHelp(new PrintWriter(new OutputStreamWriter(out, UTF_8), true));
+        MigrationTestSupport.createSubparser(migrateCommand).printHelp(new PrintWriter(new OutputStreamWriter(out, UTF_8), true));
         assertThat(out.toString(UTF_8.name())).isEqualTo(String.format(
             "usage: db calculate-checksum [-h] [--migrations MIGRATIONS-FILE]%n" +
                 "          [--catalog CATALOG] [--schema SCHEMA] [file] id author%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbClearChecksumsCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbClearChecksumsCommandTest.java
@@ -15,7 +15,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
-class DbClearChecksumsCommandTest extends AbstractMigrationTest {
+class DbClearChecksumsCommandTest {
 
     private final DbClearChecksumsCommand<TestMigrationConfiguration> clearChecksums = new DbClearChecksumsCommand<>(
         TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations.xml");
@@ -30,7 +30,7 @@ class DbClearChecksumsCommandTest extends AbstractMigrationTest {
     @Test
     void testHelpPage() throws Exception {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
-        createSubparser(clearChecksums).printHelp(new PrintWriter(new OutputStreamWriter(out, UTF_8), true));
+        MigrationTestSupport.createSubparser(clearChecksums).printHelp(new PrintWriter(new OutputStreamWriter(out, UTF_8), true));
         assertThat(out.toString(UTF_8.name())).isEqualTo(String.format(
             "usage: db clear-checksums [-h] [--migrations MIGRATIONS-FILE]%n" +
                 "          [--catalog CATALOG] [--schema SCHEMA] [file]%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbCommandTest.java
@@ -15,15 +15,15 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
-class DbCommandTest extends AbstractMigrationTest {
+class DbCommandTest {
 
     private final DbCommand<TestMigrationConfiguration> dbCommand = new DbCommand<>("db",
         new TestMigrationDatabaseConfiguration(), TestMigrationConfiguration.class, "migrations.xml");
 
     @Test
     void testRunSubCommand() throws Exception {
-        final String databaseUrl = getDatabaseUrl();
-        final TestMigrationConfiguration conf = createConfiguration(databaseUrl);
+        final String databaseUrl = MigrationTestSupport.getDatabaseUrl();
+        final TestMigrationConfiguration conf = MigrationTestSupport.createConfiguration(databaseUrl);
         dbCommand.run(null, new Namespace(Collections.singletonMap("subcommand", "migrate")), conf);
 
         try (Handle handle = Jdbi.create(databaseUrl, "sa", "").open()) {
@@ -36,7 +36,7 @@ class DbCommandTest extends AbstractMigrationTest {
     @Test
     void testPrintHelp() throws Exception {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        createSubparser(dbCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
+        MigrationTestSupport.createSubparser(dbCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
         assertThat(baos.toString(UTF_8.name())).isEqualTo(String.format(
             "usage: db db [-h]%n" +
                 "          {calculate-checksum,clear-checksums,drop-all,dump,fast-forward,generate-docs,locks,migrate,prepare-rollback,rollback,status,tag,test}%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDropAllCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDropAllCommandTest.java
@@ -15,15 +15,15 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
-class DbDropAllCommandTest extends AbstractMigrationTest {
+class DbDropAllCommandTest {
 
     private final DbDropAllCommand<TestMigrationConfiguration> dropAllCommand = new DbDropAllCommand<>(
         TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations.xml");
 
     @Test
     void testRun() throws Exception {
-        final String databaseUrl = getDatabaseUrl();
-        final TestMigrationConfiguration conf = createConfiguration(databaseUrl);
+        final String databaseUrl = MigrationTestSupport.getDatabaseUrl();
+        final TestMigrationConfiguration conf = MigrationTestSupport.createConfiguration(databaseUrl);
 
         // Create some data
         new DbMigrateCommand<>(
@@ -31,7 +31,7 @@ class DbDropAllCommandTest extends AbstractMigrationTest {
             .run(null, new Namespace(Collections.emptyMap()), conf);
 
         try (Handle handle = Jdbi.create(databaseUrl, "sa", "").open()) {
-            assertThat(tableExists(handle, "PERSONS"))
+            assertThat(MigrationTestSupport.tableExists(handle, "PERSONS"))
                 .isTrue();
         }
 
@@ -39,7 +39,7 @@ class DbDropAllCommandTest extends AbstractMigrationTest {
         dropAllCommand.run(null, new Namespace(Collections.emptyMap()), conf);
 
         try (Handle handle = Jdbi.create(databaseUrl, "sa", "").open()) {
-            assertThat(tableExists(handle, "PERSONS"))
+            assertThat(MigrationTestSupport.tableExists(handle, "PERSONS"))
                 .isFalse();
         }
     }
@@ -47,7 +47,7 @@ class DbDropAllCommandTest extends AbstractMigrationTest {
     @Test
     void testHelpPage() throws Exception {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
-        createSubparser(dropAllCommand).printHelp(new PrintWriter(new OutputStreamWriter(out, UTF_8), true));
+        MigrationTestSupport.createSubparser(dropAllCommand).printHelp(new PrintWriter(new OutputStreamWriter(out, UTF_8), true));
         assertThat(out.toString(UTF_8.name())).isEqualTo(String.format(
             "usage: db drop-all [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
                 "          [--schema SCHEMA] --confirm-delete-everything [file]%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDumpCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDumpCommandTest.java
@@ -31,7 +31,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
-class DbDumpCommandTest extends AbstractMigrationTest {
+class DbDumpCommandTest {
 
     private static final List<String> ATTRIBUTE_NAMES = Arrays.asList("columns", "foreign-keys", "indexes",
             "primary-keys", "sequences", "tables", "unique-constraints", "views");
@@ -51,7 +51,7 @@ class DbDumpCommandTest extends AbstractMigrationTest {
     void setUp() throws Exception {
         final String existedDbPath = getClass().getResource("/test-db.mv.db").getPath();
         final String existedDbUrl = "jdbc:h2:" + existedDbPath.substring(0, existedDbPath.length() - ".mv.db".length());
-        existedDbConf = createConfiguration(existedDbUrl);
+        existedDbConf = MigrationTestSupport.createConfiguration(existedDbUrl);
         dumpCommand.setOutputStream(new PrintStream(baos));
     }
 
@@ -93,7 +93,7 @@ class DbDumpCommandTest extends AbstractMigrationTest {
 
     @Test
     void testHelpPage() throws Exception {
-        createSubparser(dumpCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
+        MigrationTestSupport.createSubparser(dumpCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
         assertThat(baos.toString(UTF_8.name())).isEqualTo(String.format(
                 "usage: db dump [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
                         "          [--schema SCHEMA] [-o OUTPUT] [--tables] [--ignore-tables]%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbFastForwardCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbFastForwardCommandTest.java
@@ -19,7 +19,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
-class DbFastForwardCommandTest extends AbstractMigrationTest {
+class DbFastForwardCommandTest {
 
     private static final Pattern NEWLINE_PATTERN = Pattern.compile(System.lineSeparator());
     private final DbFastForwardCommand<TestMigrationConfiguration> fastForwardCommand = new DbFastForwardCommand<>(
@@ -30,8 +30,8 @@ class DbFastForwardCommandTest extends AbstractMigrationTest {
 
     @BeforeEach
     void setUp() {
-        final String databaseUrl = getDatabaseUrl();
-        conf = createConfiguration(databaseUrl);
+        final String databaseUrl = MigrationTestSupport.getDatabaseUrl();
+        conf = MigrationTestSupport.createConfiguration(databaseUrl);
         dbi = Jdbi.create(databaseUrl, "sa", "");
     }
 
@@ -113,7 +113,7 @@ class DbFastForwardCommandTest extends AbstractMigrationTest {
     @Test
     void testPrintHelp() throws Exception {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        createSubparser(fastForwardCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
+        MigrationTestSupport.createSubparser(fastForwardCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
         assertThat(baos.toString(UTF_8.name())).isEqualTo(String.format(
             "usage: db fast-forward [-h] [--migrations MIGRATIONS-FILE]%n" +
                 "          [--catalog CATALOG] [--schema SCHEMA] [-n] [-a] [-i CONTEXTS]%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbGenerateDocsCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbGenerateDocsCommandTest.java
@@ -15,7 +15,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
-class DbGenerateDocsCommandTest extends AbstractMigrationTest {
+class DbGenerateDocsCommandTest {
 
     private final DbGenerateDocsCommand<TestMigrationConfiguration> generateDocsCommand = new DbGenerateDocsCommand<>(
         TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations.xml");
@@ -30,7 +30,7 @@ class DbGenerateDocsCommandTest extends AbstractMigrationTest {
     @Test
     void testHelpPage() throws Exception {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        createSubparser(generateDocsCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
+        MigrationTestSupport.createSubparser(generateDocsCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
         assertThat(baos.toString(UTF_8.name())).isEqualTo(String.format(
             "usage: db generate-docs [-h] [--migrations MIGRATIONS-FILE]%n" +
                 "          [--catalog CATALOG] [--schema SCHEMA] [file] output%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbLocksCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbLocksCommandTest.java
@@ -16,7 +16,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.*;
 
 @NotThreadSafe
-class DbLocksCommandTest extends AbstractMigrationTest {
+class DbLocksCommandTest {
 
     private final DbLocksCommand<TestMigrationConfiguration> locksCommand = new DbLocksCommand<>(
         TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations.xml");
@@ -61,7 +61,7 @@ class DbLocksCommandTest extends AbstractMigrationTest {
     @Test
     void testPrintHelp() throws Exception {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
-        createSubparser(locksCommand).printHelp(new PrintWriter(new OutputStreamWriter(out, UTF_8), true));
+        MigrationTestSupport.createSubparser(locksCommand).printHelp(new PrintWriter(new OutputStreamWriter(out, UTF_8), true));
         assertThat(out.toString(UTF_8.name())).isEqualTo(String.format(
             "usage: db locks [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
                 "          [--schema SCHEMA] [-l] [-r] [file]%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCommandTest.java
@@ -22,7 +22,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
-class DbMigrateCommandTest extends AbstractMigrationTest {
+class DbMigrateCommandTest {
 
     private final DbMigrateCommand<TestMigrationConfiguration> migrateCommand = new DbMigrateCommand<>(
         TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations.xml");
@@ -31,8 +31,8 @@ class DbMigrateCommandTest extends AbstractMigrationTest {
 
     @BeforeEach
     void setUp() {
-        databaseUrl = getDatabaseUrl();
-        conf = createConfiguration(databaseUrl);
+        databaseUrl = MigrationTestSupport.getDatabaseUrl();
+        conf = MigrationTestSupport.createConfiguration(databaseUrl);
     }
 
     @Test

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCustomSchemaTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCustomSchemaTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
-class DbMigrateCustomSchemaTest extends AbstractMigrationTest {
+class DbMigrateCustomSchemaTest {
 
     private final DbMigrateCommand<TestMigrationConfiguration> migrateCommand = new DbMigrateCommand<>(
         TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations-custom-schema.xml");
@@ -19,8 +19,8 @@ class DbMigrateCustomSchemaTest extends AbstractMigrationTest {
 
     @BeforeEach
     void setUp() {
-        databaseUrl = getDatabaseUrl();
-        conf = createConfiguration(databaseUrl);
+        databaseUrl = MigrationTestSupport.getDatabaseUrl();
+        conf = MigrationTestSupport.createConfiguration(databaseUrl);
     }
 
     @Test

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateDifferentFileCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateDifferentFileCommandTest.java
@@ -13,7 +13,7 @@ import java.util.Collections;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
-class DbMigrateDifferentFileCommandTest extends AbstractMigrationTest {
+class DbMigrateDifferentFileCommandTest {
 
     private final DbMigrateCommand<TestMigrationConfiguration> migrateCommand = new DbMigrateCommand<>(
         TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations-ddl.xml");
@@ -22,8 +22,8 @@ class DbMigrateDifferentFileCommandTest extends AbstractMigrationTest {
 
     @BeforeEach
     void setUp() {
-        databaseUrl = getDatabaseUrl();
-        conf = createConfiguration(databaseUrl);
+        databaseUrl = MigrationTestSupport.getDatabaseUrl();
+        conf = MigrationTestSupport.createConfiguration(databaseUrl);
     }
 
     @Test

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbPrepareRollbackCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbPrepareRollbackCommandTest.java
@@ -15,7 +15,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
-class DbPrepareRollbackCommandTest extends AbstractMigrationTest {
+class DbPrepareRollbackCommandTest {
 
     private final DbPrepareRollbackCommand<TestMigrationConfiguration> prepareRollbackCommand =
         new DbPrepareRollbackCommand<>(new TestMigrationDatabaseConfiguration(), TestMigrationConfiguration.class,
@@ -24,8 +24,8 @@ class DbPrepareRollbackCommandTest extends AbstractMigrationTest {
 
     @BeforeEach
     void setUp() {
-        final String databaseUrl = getDatabaseUrl();
-        conf = createConfiguration(databaseUrl);
+        final String databaseUrl = MigrationTestSupport.getDatabaseUrl();
+        conf = MigrationTestSupport.createConfiguration(databaseUrl);
     }
 
     @Test
@@ -49,7 +49,7 @@ class DbPrepareRollbackCommandTest extends AbstractMigrationTest {
     @Test
     void testPrintHelp() throws Exception {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
-        createSubparser(prepareRollbackCommand).printHelp(new PrintWriter(new OutputStreamWriter(out, UTF_8), true));
+        MigrationTestSupport.createSubparser(prepareRollbackCommand).printHelp(new PrintWriter(new OutputStreamWriter(out, UTF_8), true));
         assertThat(out.toString(UTF_8.name())).isEqualTo(String.format(
             "usage: db prepare-rollback [-h] [--migrations MIGRATIONS-FILE]%n" +
                 "          [--catalog CATALOG] [--schema SCHEMA] [-c COUNT] [-i CONTEXTS]%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbRollbackCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbRollbackCommandTest.java
@@ -19,7 +19,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
-class DbRollbackCommandTest extends AbstractMigrationTest {
+class DbRollbackCommandTest {
 
     private final String migrationsFileName = "migrations-ddl.xml";
     private final DbRollbackCommand<TestMigrationConfiguration> rollbackCommand = new DbRollbackCommand<>(
@@ -32,8 +32,8 @@ class DbRollbackCommandTest extends AbstractMigrationTest {
 
     @BeforeEach
     void setUp() {
-        final String databaseUrl = getDatabaseUrl();
-        conf = createConfiguration(databaseUrl);
+        final String databaseUrl = MigrationTestSupport.getDatabaseUrl();
+        conf = MigrationTestSupport.createConfiguration(databaseUrl);
         dbi = Jdbi.create(databaseUrl, "sa", "");
     }
 
@@ -43,7 +43,7 @@ class DbRollbackCommandTest extends AbstractMigrationTest {
         migrateCommand.run(null, new Namespace(Collections.emptyMap()), conf);
 
         try (Handle handle = dbi.open()) {
-            assertThat(columnExists(handle, "PERSONS", "EMAIL"))
+            assertThat(MigrationTestSupport.columnExists(handle, "PERSONS", "EMAIL"))
                 .isTrue();
         }
 
@@ -51,7 +51,7 @@ class DbRollbackCommandTest extends AbstractMigrationTest {
         rollbackCommand.run(null, new Namespace(Collections.singletonMap("count", 1)), conf);
 
         try (Handle handle = dbi.open()) {
-            assertThat(columnExists(handle, "PERSONS", "EMAIL"))
+            assertThat(MigrationTestSupport.columnExists(handle, "PERSONS", "EMAIL"))
                 .isFalse();
         }
     }
@@ -75,7 +75,7 @@ class DbRollbackCommandTest extends AbstractMigrationTest {
         migrateCommand.run(null, new Namespace(Collections.emptyMap()), conf);
 
         try (Handle handle = dbi.open()) {
-            assertThat(tableExists(handle, "PERSONS"))
+            assertThat(MigrationTestSupport.tableExists(handle, "PERSONS"))
                 .isTrue();
         }
 
@@ -84,7 +84,7 @@ class DbRollbackCommandTest extends AbstractMigrationTest {
             conf);
 
         try (Handle handle = dbi.open()) {
-            assertThat(tableExists(handle, "PERSONS"))
+            assertThat(MigrationTestSupport.tableExists(handle, "PERSONS"))
                 .isFalse();
         }
     }
@@ -117,7 +117,7 @@ class DbRollbackCommandTest extends AbstractMigrationTest {
         tagCommand.run(null, new Namespace(Collections.singletonMap("tag-name", Collections.singletonList("v1"))), conf);
 
         try (Handle handle = dbi.open()) {
-            assertThat(columnExists(handle, "PERSONS", "EMAIL"))
+            assertThat(MigrationTestSupport.columnExists(handle, "PERSONS", "EMAIL"))
                 .isFalse();
         }
 
@@ -125,7 +125,7 @@ class DbRollbackCommandTest extends AbstractMigrationTest {
         migrateCommand.run(null, new Namespace(Collections.emptyMap()), conf);
 
         try (Handle handle = dbi.open()) {
-            assertThat(columnExists(handle, "PERSONS", "EMAIL"))
+            assertThat(MigrationTestSupport.columnExists(handle, "PERSONS", "EMAIL"))
                 .isTrue();
         }
 
@@ -133,7 +133,7 @@ class DbRollbackCommandTest extends AbstractMigrationTest {
         rollbackCommand.run(null, new Namespace(Collections.singletonMap("tag", "v1")), conf);
 
         try (Handle handle = dbi.open()) {
-            assertThat(columnExists(handle, "PERSONS", "EMAIL"))
+            assertThat(MigrationTestSupport.columnExists(handle, "PERSONS", "EMAIL"))
                 .isFalse();
         }
     }
@@ -160,7 +160,7 @@ class DbRollbackCommandTest extends AbstractMigrationTest {
 
     @Test
     void testPrintHelp() throws Exception {
-        createSubparser(rollbackCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
+        MigrationTestSupport.createSubparser(rollbackCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
         assertThat(baos.toString(UTF_8.name())).isEqualTo(String.format(
             "usage: db rollback [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
             "          [--schema SCHEMA] [-n] [-t TAG] [-d DATE] [-c COUNT]%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbStatusCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbStatusCommandTest.java
@@ -15,7 +15,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
-class DbStatusCommandTest extends AbstractMigrationTest {
+class DbStatusCommandTest {
 
     private final DbStatusCommand<TestMigrationConfiguration> statusCommand =
             new DbStatusCommand<>(new TestMigrationDatabaseConfiguration(), TestMigrationConfiguration.class, "migrations.xml");
@@ -24,7 +24,7 @@ class DbStatusCommandTest extends AbstractMigrationTest {
 
     @BeforeEach
     void setUp() {
-        conf = createConfiguration(getDatabaseUrl());
+        conf = MigrationTestSupport.createConfiguration();
 
         statusCommand.setOutputStream(new PrintStream(baos));
     }
@@ -33,7 +33,7 @@ class DbStatusCommandTest extends AbstractMigrationTest {
     void testRunOnMigratedDb() throws Exception {
         final String existedDbPath = getClass().getResource("/test-db.mv.db").getPath();
         final String existedDbUrl = "jdbc:h2:" + existedDbPath.substring(0, existedDbPath.length() - ".mv.db".length());
-        final TestMigrationConfiguration existedDbConf = createConfiguration(existedDbUrl);
+        final TestMigrationConfiguration existedDbConf = MigrationTestSupport.createConfiguration(existedDbUrl);
 
         statusCommand.run(null, new Namespace(Collections.emptyMap()), existedDbConf);
         assertThat(baos.toString(UTF_8.name())).matches("\\S+ is up to date" + System.lineSeparator());
@@ -58,7 +58,7 @@ class DbStatusCommandTest extends AbstractMigrationTest {
 
     @Test
     void testPrintHelp() throws Exception {
-        createSubparser(statusCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
+        MigrationTestSupport.createSubparser(statusCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
         assertThat(baos.toString(UTF_8.name())).isEqualTo(String.format(
                 "usage: db status [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
                         "          [--schema SCHEMA] [-v] [-i CONTEXTS] [file]%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbTagCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbTagCommandTest.java
@@ -13,7 +13,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
-class DbTagCommandTest extends AbstractMigrationTest {
+class DbTagCommandTest {
 
     private final String migrationsFileName = "migrations-ddl.xml";
     private final DbTagCommand<TestMigrationConfiguration> dbTagCommand = new DbTagCommand<>(
@@ -22,7 +22,7 @@ class DbTagCommandTest extends AbstractMigrationTest {
     @Test
     void testRun() throws Exception {
         // Migrate some DDL changes
-        final TestMigrationConfiguration conf = createConfiguration(getDatabaseUrl());
+        final TestMigrationConfiguration conf = MigrationTestSupport.createConfiguration();
         final DbMigrateCommand<TestMigrationConfiguration> dbMigrateCommand = new DbMigrateCommand<>(
             new TestMigrationDatabaseConfiguration(), TestMigrationConfiguration.class, migrationsFileName);
         dbMigrateCommand.run(null, new Namespace(Collections.emptyMap()), conf);
@@ -40,7 +40,7 @@ class DbTagCommandTest extends AbstractMigrationTest {
     @Test
     void testPrintHelp() throws Exception {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        createSubparser(dbTagCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
+        MigrationTestSupport.createSubparser(dbTagCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
         assertThat(baos.toString(UTF_8.name())).isEqualTo(String.format(
             "usage: db tag [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
             "          [--schema SCHEMA] [file] tag-name%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbTestCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbTestCommandTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 @NotThreadSafe
-class DbTestCommandTest extends AbstractMigrationTest {
+class DbTestCommandTest {
 
     private final DbTestCommand<TestMigrationConfiguration> dbTestCommand = new DbTestCommand<>(
         new TestMigrationDatabaseConfiguration(), TestMigrationConfiguration.class, "migrations-ddl.xml");
@@ -22,7 +22,7 @@ class DbTestCommandTest extends AbstractMigrationTest {
     @Test
     void testRun() throws Exception {
         // Apply and rollback some DDL changes
-        final TestMigrationConfiguration conf = createConfiguration(getDatabaseUrl());
+        final TestMigrationConfiguration conf = MigrationTestSupport.createConfiguration();
         assertThatNoException()
             .isThrownBy(() -> dbTestCommand.run(null, new Namespace(Collections.emptyMap()), conf));
     }
@@ -30,7 +30,7 @@ class DbTestCommandTest extends AbstractMigrationTest {
     @Test
     void testPrintHelp() throws Exception {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        createSubparser(dbTestCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
+        MigrationTestSupport.createSubparser(dbTestCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
         assertThat(baos.toString(UTF_8.name())).isEqualTo(String.format(
             "usage: db test [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
                 "          [--schema SCHEMA] [-i CONTEXTS] [file]%n" +

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/LiquibaseScopingTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/LiquibaseScopingTest.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class LiquibaseScopingTest extends AbstractMigrationTest implements CustomTaskChange {
+public class LiquibaseScopingTest implements CustomTaskChange {
     private final DbCommand<TestMigrationConfiguration> dbCommand = new DbCommand<>(
         "db",
         TestMigrationConfiguration::getDataSource,
@@ -42,8 +42,8 @@ public class LiquibaseScopingTest extends AbstractMigrationTest implements Custo
 
     @BeforeEach
     void setUpTest() {
-        databaseUrl = getDatabaseUrl();
-        conf = createConfiguration(databaseUrl);
+        databaseUrl = MigrationTestSupport.getDatabaseUrl();
+        conf = MigrationTestSupport.createConfiguration(databaseUrl);
     }
 
     private static class Person {

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/MigrationTestSupport.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/MigrationTestSupport.java
@@ -1,8 +1,6 @@
 package io.dropwizard.migrations;
 
 import io.dropwizard.db.DataSourceFactory;
-import liquibase.sqlgenerator.SqlGeneratorFactory;
-import liquibase.sqlgenerator.core.AddColumnGeneratorSQLite;
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.Subparser;
 import org.jdbi.v3.core.Handle;
@@ -10,13 +8,9 @@ import org.jdbi.v3.core.Handle;
 import java.sql.SQLException;
 import java.util.UUID;
 
-class AbstractMigrationTest {
+final class MigrationTestSupport {
 
-    static {
-        SqlGeneratorFactory.getInstance().unregister(AddColumnGeneratorSQLite.class);
-    }
-
-    protected static Subparser createSubparser(AbstractLiquibaseCommand<?> command) {
+    static Subparser createSubparser(AbstractLiquibaseCommand<?> command) {
         final Subparser subparser = ArgumentParsers.newFor("db")
             .terminalWidthDetection(false)
             .build()
@@ -27,7 +21,11 @@ class AbstractMigrationTest {
         return subparser;
     }
 
-    protected static TestMigrationConfiguration createConfiguration(String databaseUrl) {
+    static TestMigrationConfiguration createConfiguration() {
+        return createConfiguration(getDatabaseUrl());
+    }
+
+    static TestMigrationConfiguration createConfiguration(String databaseUrl) {
         final DataSourceFactory dataSource = new DataSourceFactory();
         dataSource.setDriverClass("org.h2.Driver");
         dataSource.setUser("sa");
@@ -35,15 +33,15 @@ class AbstractMigrationTest {
         return new TestMigrationConfiguration(dataSource);
     }
 
-    protected static String getDatabaseUrl() {
+    static String getDatabaseUrl() {
         return "jdbc:h2:mem:" + UUID.randomUUID() + ";db_close_delay=-1";
     }
 
-    protected boolean tableExists(final Handle handle, final String tableName) throws SQLException {
+    static boolean tableExists(final Handle handle, final String tableName) throws SQLException {
         return handle.getConnection().getMetaData().getTables(null, null, tableName, null).next();
     }
 
-    protected boolean columnExists(final Handle handle, final String tableName, final String columnName) throws SQLException {
+    static boolean columnExists(final Handle handle, final String tableName, final String columnName) throws SQLException {
         return handle.getConnection().getMetaData().getColumns(null, null, tableName, columnName).next();
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 
 import static io.dropwizard.jackson.Jackson.newObjectMapper;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 class DropwizardTestSupportTest {
     private static final TestServiceListener<TestConfiguration> TEST_SERVICE_LISTENER = new TestServiceListener<>();
@@ -117,11 +118,14 @@ class DropwizardTestSupportTest {
                 FailingApplication.class,
                 config
         );
-        try {
-            support.before();
-        } finally {
-            support.after();
-        }
+
+        assertThatNoException().isThrownBy(() -> {
+            try {
+                support.before();
+            } finally {
+                support.after();
+            }
+        });
     }
 
     public static class FailingApplication extends Application<TestConfiguration> {


### PR DESCRIPTION
Appease some more Sonar grumbles

- Add an assertion to `DropwizardTestSupportTest#isCustomFactoryCalled()`
- Rename `AbstractHttp2Test` to `Http2TestCommon`
- Remove the static initialiser from `AbstractMigrationTest`
- Replace `AbstractMigrationTest` with some static helper methods.

The static initialiser which unregistered `AddColumnGeneratorSQLite.class` no longer seems to be necessary (added in fe842d2fcf13c3d8eb67ad50219f929b0989539b in 2018 as part of the Liquibase 3.6.0 upgrade)