### PR TITLE
Deprecate `FixtureHelpers`

### DIFF
--- a/docs/source/manual/testing.rst
+++ b/docs/source/manual/testing.rst
@@ -19,8 +19,8 @@ Testing Representations
 
 While Jackson's JSON support is powerful and fairly easy-to-use, you shouldn't just rely on
 eyeballing your representation classes to ensure you're producing the API you think you
-are. By using the helper methods in `FixtureHelpers`, you can add unit tests for serializing and
-deserializing your representation classes to and from JSON.
+are. You can add unit tests for serializing and deserializing your representation classes to and
+from JSON.
 
 Let's assume we have a ``Person`` class which your API uses as both a request entity (e.g., when
 writing via a ``PUT`` request) and a response entity (e.g., when reading via a ``GET`` request):
@@ -89,22 +89,22 @@ Next, write a test for serializing a ``Person`` instance to JSON:
 
 .. code-block:: java
 
-    import static io.dropwizard.testing.FixtureHelpers.*;
-    import static org.assertj.core.api.Assertions.assertThat;
-    import io.dropwizard.jackson.Jackson;
-    import org.junit.jupiter.api.Test;
     import com.fasterxml.jackson.databind.ObjectMapper;
+    import org.junit.jupiter.api.Test;
 
-    public class PersonTest {
+    import static io.dropwizard.jackson.Jackson.newObjectMapper;
+    import static org.assertj.core.api.Assertions.assertThat;
 
-        private static final ObjectMapper MAPPER = Jackson.newObjectMapper();
+    class PersonTest {
+
+        private static final ObjectMapper MAPPER = newObjectMapper();
 
         @Test
-        public void serializesToJSON() throws Exception {
+        void seralizesToJSON() throws Exception {
             final Person person = new Person("Luther Blissett", "lb@example.com");
 
             final String expected = MAPPER.writeValueAsString(
-                    MAPPER.readValue(fixture("fixtures/person.json"), Person.class));
+                    MAPPER.readValue(getClass().getResource("/person.json"), Person.class));
 
             assertThat(MAPPER.writeValueAsString(person)).isEqualTo(expected);
         }

--- a/dropwizard-example/src/test/java/com/example/helloworld/core/PersonTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/core/PersonTest.java
@@ -1,0 +1,25 @@
+package com.example.helloworld.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static io.dropwizard.jackson.Jackson.newObjectMapper;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/*
+ * This test is used as an example in the docs - if you update it, consider
+ * updating the docs too.
+ */
+class PersonTest {
+    private static final ObjectMapper MAPPER = newObjectMapper();
+
+    @Test
+    void serializesToJSON() throws Exception {
+        final Person person = new Person("Luther Blissett", "Lead Tester", 1902);
+
+        final String expected = MAPPER.writeValueAsString(
+            MAPPER.readValue(getClass().getResource("/person.json"), Person.class));
+
+        assertThat(MAPPER.writeValueAsString(person)).isEqualTo(expected);
+    }
+}

--- a/dropwizard-example/src/test/java/com/example/helloworld/resources/PeopleResourceTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/resources/PeopleResourceTest.java
@@ -33,7 +33,7 @@ class PeopleResourceTest {
     public static final ResourceExtension RESOURCES = ResourceExtension.builder()
             .addResource(new PeopleResource(PERSON_DAO))
             .build();
-    private ArgumentCaptor<Person> personCaptor = ArgumentCaptor.forClass(Person.class);
+    private final ArgumentCaptor<Person> personCaptor = ArgumentCaptor.forClass(Person.class);
     private Person person;
 
     @BeforeEach
@@ -86,7 +86,7 @@ class PeopleResourceTest {
     }
 
     @Test
-    void listPeople() throws Exception {
+    void listPeople() {
         final List<Person> people = Collections.singletonList(person);
         when(PERSON_DAO.findAll()).thenReturn(people);
 

--- a/dropwizard-example/src/test/java/com/example/helloworld/resources/PersonResourceTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/resources/PersonResourceTest.java
@@ -5,7 +5,6 @@ import com.example.helloworld.db.PersonDAO;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.testing.junit5.ResourceExtension;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -24,13 +23,6 @@ class PersonResourceTest {
     public static final ResourceExtension RULE = ResourceExtension.builder()
             .addResource(new PersonResource(DAO))
             .build();
-    private Person person;
-
-    @BeforeEach
-    void setup() {
-        person = new Person();
-        person.setId(1L);
-    }
 
     @AfterEach
     void tearDown() {
@@ -39,6 +31,9 @@ class PersonResourceTest {
 
     @Test
     void getPersonSuccess() {
+        final Person person = new Person();
+        person.setId(1L);
+
         when(DAO.findById(1L)).thenReturn(Optional.of(person));
 
         Person found = RULE.target("/people/1").request().get(Person.class);

--- a/dropwizard-example/src/test/resources/person.json
+++ b/dropwizard-example/src/test/resources/person.json
@@ -1,0 +1,6 @@
+{
+    "id": 0,
+    "fullName": "Luther Blissett",
+    "jobTitle": "Lead Tester",
+    "yearBorn": 1902
+}

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/FixtureHelpers.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/FixtureHelpers.java
@@ -11,7 +11,11 @@ import java.nio.charset.StandardCharsets;
 
 /**
  * A set of helper method for fixture files.
+ *
+ * @deprecated use {@link Class#getResource(String)} to obtain a {@link URL} to the resource to use with
+ *             {@link com.fasterxml.jackson.databind.ObjectMapper#readValue(URL, Class)}
  */
+@Deprecated
 public class FixtureHelpers {
     private FixtureHelpers() { /* singleton */ }
 


### PR DESCRIPTION
_Question_ This is a bit speculative - I don't _think_ these helpers seem to offer much value, but maybe you know differently?

Jackson can read directly from `URL`s and `InputStream`s so these helpers don't especially useful.

In addition, Java 9+ has `InputStream#readAllBytes()` which can be combined with `String(byte[])` to parse resources to strings.