### PR TITLE
Add deprecation annotation for ByteStreams#toByteArray method

### DIFF
--- a/dropwizard-util/src/main/java/io/dropwizard/util/ByteStreams.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/ByteStreams.java
@@ -13,6 +13,10 @@ public final class ByteStreams {
     private ByteStreams() {
     }
 
+    /**
+     * @deprecated use {@link InputStream#readAllBytes()} instead
+     */
+    @Deprecated
     public static byte[] toByteArray(InputStream in) throws IOException {
         ByteArrayOutputStream to = new ByteArrayOutputStream();
         copyInternal(in, to);


### PR DESCRIPTION
Add deprecation annotation to remove `ByteStreams#toByteArray` in DW 3. Related to #4916 