### PR TITLE
Deprecate Bytestreams and Maps

### DIFF
--- a/dropwizard-util/src/main/java/io/dropwizard/util/ByteStreams.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/ByteStreams.java
@@ -7,12 +7,18 @@ import java.io.OutputStream;
 
 /**
  * @since 2.0
+ *
+ * @deprecated this class exists for compatibility with Java 8 and will be removed in Dropwizard 3.0.
  */
+@Deprecated
 public final class ByteStreams {
 
     private ByteStreams() {
     }
 
+    /**
+     * @deprecated For users of Java 11+, consider {@link InputStream#readAllBytes()} instead.
+     */
     public static byte[] toByteArray(InputStream in) throws IOException {
         ByteArrayOutputStream to = new ByteArrayOutputStream();
         copyInternal(in, to);
@@ -22,7 +28,6 @@ public final class ByteStreams {
     /**
      * @deprecated this is an internal method to dropwizard-util. Consider apache-commons instead.
      */
-    @Deprecated
     public static void copy(InputStream in, OutputStream to) throws IOException {
         copyInternal(in, to);
     }

--- a/dropwizard-util/src/main/java/io/dropwizard/util/Maps.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Maps.java
@@ -5,7 +5,11 @@ import java.util.Map;
 
 /**
  * @since 2.0
+ *
+ * @deprecated this class exists to help users transition from Guava. It will be removed in Dropwizard 3.0 in favour
+ *             of Java 9+'s JCL Collection methods.
  */
+@Deprecated
 public final class Maps {
     private Maps() {
     }


### PR DESCRIPTION
Deprecate `ByteStreams` and `Maps` as an indicator that they are to be removed in Dropwizard 3.x.

Raised in relation to https://github.com/dropwizard/dropwizard/pull/4914 and https://github.com/dropwizard/dropwizard/pull/4916