### PR TITLE
Make `LocalIpFilter` and `NetUtil` package-private

### DIFF
--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/LocalIpFilter.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/LocalIpFilter.java
@@ -21,11 +21,7 @@ import java.net.SocketException;
 
 /**
  * @see <a href="https://github.com/apache/curator/blob/master/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/LocalIpFilter.java">LocalIpFilter</a>
- *
- * @deprecated This interface is intended for internal use and should be treated as
- *             package-private.
  */
-@Deprecated
-public interface LocalIpFilter {
+interface LocalIpFilter {
     boolean use(NetworkInterface networkInterface, InetAddress address) throws SocketException;
 }

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/NetUtil.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/NetUtil.java
@@ -40,13 +40,9 @@ import static java.util.Objects.requireNonNull;
  *
  * The {@link #getAllLocalIPs()} method was taken from the Apache Curator project
  * which is also under the Apache 2.0 license.
- *
- * @deprecated This class is intended for internal use and should be treated as
- *             package-private.
  */
 
-@Deprecated
-public class NetUtil {
+class NetUtil {
     public static final int DEFAULT_TCP_BACKLOG_WINDOWS = 200;
     public static final int DEFAULT_TCP_BACKLOG_LINUX = 128;
     public static final String TCP_BACKLOG_SETTING_LOCATION = "/proc/sys/net/core/somaxconn";


### PR DESCRIPTION
These were unintentionally public in previous versions and had a deprecation warning saying they would be made package-private.

Make them package-private.