### PR TITLE
Use Jetty's `Resource` to locate truststore in `Http2TestCommon`

### DIFF
--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2TestCommon.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2TestCommon.java
@@ -16,8 +16,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.jetty.util.resource.Resource.newResource;
 
 /**
  * Common code for HTTP/2 connector tests
@@ -34,7 +34,7 @@ class Http2TestCommon {
 
     @BeforeEach
     void setUp() throws Exception {
-        sslContextFactory.setTrustStorePath(resourceFilePath("stores/http2_client.jts"));
+        sslContextFactory.setTrustStoreResource(newResource(getClass().getResource("/stores/http2_client.jts")));
         sslContextFactory.setTrustStorePassword("http2_client");
         sslContextFactory.start();
 


### PR DESCRIPTION
Instead of using our own `ResourceHelpers` class, since `SslContextFactory` is a jetty util class, use the Jetty util class `Resource` to load our test truststore from the classpath.

This reduces our usage of `ResourceHelpers` to be obtaining absolute paths to files in order to supply config overrides or to pass to `Application#run()`