### PR TITLE
Remove deprecated methods from `HttpsConnectorFactory` and `DefaultHealthFactory`

### DIFF
--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/Authorizer.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/Authorizer.java
@@ -13,27 +13,13 @@ public interface Authorizer<P extends Principal> {
     /**
      * Decides if access is granted for the given principal in the given role.
      *
-     * @param principal a {@link Principal} object, representing a user
-     * @param role      a user role
-     * @return {@code true}, if the access is granted, {@code false otherwise}
-     * @deprecated Use {@link #authorize(Principal, String, ContainerRequestContext)} instead
-     */
-    @Deprecated
-    boolean authorize(P principal, String role);
-
-    /**
-     * Decides if access is granted for the given principal in the given role.
-     *
      * @param principal      a {@link Principal} object, representing a user
      * @param role           a user role
      * @param requestContext a request context.
      * @return {@code true}, if the access is granted, {@code false otherwise}
      * @since 2.0
      */
-    @SuppressWarnings("deprecation")
-    default boolean authorize(P principal, String role, @Nullable ContainerRequestContext requestContext) {
-        return authorize(principal, role);
-    }
+    boolean authorize(P principal, String role, @Nullable ContainerRequestContext requestContext);
 
     /**
      * Returns an {@link AuthorizationContext} object, to be used in {@link CachingAuthorizer} as cache key.

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/CachingAuthorizer.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/CachingAuthorizer.java
@@ -105,11 +105,6 @@ public class CachingAuthorizer<P extends Principal> implements Authorizer<P> {
     }
 
     @Override
-    public boolean authorize(P principal, String role) {
-        return authorize(principal, role, null);
-    }
-
-    @Override
     public boolean authorize(P principal, String role, @Nullable ContainerRequestContext requestContext) {
         try (Timer.Context context = getsTimer.time()) {
             final AuthorizationContext<P> cacheKey = getAuthorizationContext(principal, role, requestContext);

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/PermitAllAuthorizer.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/PermitAllAuthorizer.java
@@ -1,5 +1,7 @@
 package io.dropwizard.auth;
 
+import javax.annotation.Nullable;
+import javax.ws.rs.container.ContainerRequestContext;
 import java.security.Principal;
 
 /**
@@ -10,7 +12,7 @@ import java.security.Principal;
 public class PermitAllAuthorizer<P extends Principal> implements Authorizer<P> {
 
     @Override
-    public boolean authorize(P principal, String role) {
+    public boolean authorize(P principal, String role, @Nullable ContainerRequestContext ctx) {
         return true;
     }
 }

--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/util/AuthUtil.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/util/AuthUtil.java
@@ -51,7 +51,7 @@ public class AuthUtil {
 
     public static Authorizer<Principal> getTestAuthorizer(final String validUser,
                                                           final String validRole) {
-        return (principal, role) -> principal != null
+        return (principal, role, context) -> principal != null
             && validUser.equals(principal.getName())
             && validRole.equals(role);
     }

--- a/dropwizard-example/src/main/java/com/example/helloworld/auth/ExampleAuthorizer.java
+++ b/dropwizard-example/src/main/java/com/example/helloworld/auth/ExampleAuthorizer.java
@@ -3,10 +3,13 @@ package com.example.helloworld.auth;
 import com.example.helloworld.core.User;
 import io.dropwizard.auth.Authorizer;
 
+import javax.annotation.Nullable;
+import javax.ws.rs.container.ContainerRequestContext;
+
 public class ExampleAuthorizer implements Authorizer<User> {
 
     @Override
-    public boolean authorize(User user, String role) {
+    public boolean authorize(User user, String role, @Nullable ContainerRequestContext ctx) {
         return user.getRoles() != null && user.getRoles().contains(role);
     }
 }

--- a/dropwizard-health/src/main/java/io/dropwizard/health/DefaultHealthFactory.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/DefaultHealthFactory.java
@@ -134,22 +134,6 @@ public class DefaultHealthFactory implements HealthFactory {
         this.healthResponderFactory = healthResponderFactory;
     }
 
-    /**
-     * @deprecated use {@link #getHealthCheckConfigurations()} instead
-     */
-    @Deprecated
-    public List<HealthCheckConfiguration> getHealthChecks() {
-        return healthChecks;
-    }
-
-    /**
-     * @deprecated use {@link #setHealthCheckConfigurations(List)} instead
-     */
-    @Deprecated
-    public void setHealthChecks(List<HealthCheckConfiguration> healthChecks) {
-        this.healthChecks = healthChecks;
-    }
-
     @Override
     public void configure(final LifecycleEnvironment lifecycle, final ServletEnvironment servlets,
                           final JerseyEnvironment jersey, final HealthEnvironment health, final ObjectMapper mapper,
@@ -195,7 +179,7 @@ public class DefaultHealthFactory implements HealthFactory {
         // Set the health state aggregator on the HealthEnvironment
         health.setHealthStateAggregator(healthCheckManager);
 
-        LOGGER.debug("Configured ongoing health check monitoring for healthChecks: {}", getHealthChecks());
+        LOGGER.debug("Configured ongoing health check monitoring for healthChecks: {}", getHealthCheckConfigurations());
     }
 
     private ScheduledExecutorService createScheduledExecutorForHealthChecks(

--- a/dropwizard-health/src/test/java/io/dropwizard/health/DefaultHealthFactoryTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/DefaultHealthFactoryTest.java
@@ -46,8 +46,6 @@ class DefaultHealthFactoryTest {
         assertThat(healthFactory.getShutdownWaitPeriod().toMilliseconds()).isEqualTo(1L);
         assertThat(healthFactory.getHealthCheckUrlPaths()).isEqualTo(singletonList("/health-check"));
 
-        assertThat(healthFactory.getHealthChecks()).isEqualTo(healthFactory.getHealthCheckConfigurations());
-
         assertThat(healthFactory.getHealthCheckConfigurations()
             .stream()
             .map(HealthCheckConfiguration::getName)

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
@@ -13,7 +13,6 @@ import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.SslConnectionFactory;
-import org.eclipse.jetty.util.component.AbstractLifeCycle;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
@@ -635,16 +634,7 @@ public class HttpsConnectorFactory extends HttpConnectorFactory {
      * @since 2.1.0
      */
     protected LifeCycle.Listener logSslParameters(final SslContextFactory sslContextFactory) {
-        // Delegate to the old method as it may have been overridden
-        return logSslInfoOnStart(sslContextFactory);
-    }
-
-    /**
-     * @deprecated Use {@link #logSslParameters(SslContextFactory) instead}
-     */
-    @Deprecated
-    protected AbstractLifeCycle.AbstractLifeCycleListener logSslInfoOnStart(final SslContextFactory sslContextFactory) {
-        return new AbstractLifeCycle.AbstractLifeCycleListener() {
+        return new LifeCycle.Listener() {
             @Override
             public void lifeCycleStarted(LifeCycle event) {
                 logSupportedParameters(sslContextFactory);


### PR DESCRIPTION
Remove the following deprecated methods:

- `Authorizer#authorize(P, String)`
- `HttpsConnectorFactory#logSslInfoOnStart(SslContextFactory)`
- `DefaultHealthFactory#getHealthChecks()`
- `DefaultHealthFactory#setHealthChecks(List<HealthCheckConfiguration>)`
