### PR TITLE
Deprecate Sets, ready for Dropwizard 3.0

### DIFF
--- a/dropwizard-util/src/main/java/io/dropwizard/util/Sets.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Sets.java
@@ -8,7 +8,11 @@ import static java.util.Collections.unmodifiableSet;
 
 /**
  * @since 2.0
+ *
+ * @deprecated this class exists to help users transition from Guava. It will be removed in Dropwizard 3.0 in favour
+ *             of Java 9+'s JCL Collection methods.
  */
+@Deprecated
 public final class Sets {
     private Sets() {
     }


### PR DESCRIPTION
Dropwizard 3.0 will drop support for Java 8 and this class will no longer be necessary.

Mark it as deprecated now, to give users some notice.