### PR TITLE
Simplify `Optional` handling in dropwizard-jersey

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalDoubleMessageBodyWriter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalDoubleMessageBodyWriter.java
@@ -9,8 +9,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.nio.charset.StandardCharsets;
 import java.util.OptionalDouble;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
 
 @Provider
 @Produces(MediaType.WILDCARD)
@@ -34,10 +35,7 @@ public class OptionalDoubleMessageBodyWriter implements MessageBodyWriter<Option
                         MediaType mediaType,
                         MultivaluedMap<String, Object> httpHeaders,
                         OutputStream entityStream) throws IOException {
-        if (!entity.isPresent()) {
-            throw EmptyOptionalException.INSTANCE;
-        }
-
-        entityStream.write(Double.toString(entity.getAsDouble()).getBytes(StandardCharsets.US_ASCII));
+        final String body = Double.toString(entity.orElseThrow(() -> EmptyOptionalException.INSTANCE));
+        entityStream.write(body.getBytes(US_ASCII));
     }
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalIntMessageBodyWriter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalIntMessageBodyWriter.java
@@ -9,8 +9,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.nio.charset.StandardCharsets;
 import java.util.OptionalInt;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
 
 @Provider
 @Produces(MediaType.WILDCARD)
@@ -34,10 +35,7 @@ public class OptionalIntMessageBodyWriter implements MessageBodyWriter<OptionalI
                         MediaType mediaType,
                         MultivaluedMap<String, Object> httpHeaders,
                         OutputStream entityStream) throws IOException {
-        if (!entity.isPresent()) {
-            throw EmptyOptionalException.INSTANCE;
-        }
-
-        entityStream.write(Integer.toString(entity.getAsInt()).getBytes(StandardCharsets.US_ASCII));
+        final String body = Integer.toString(entity.orElseThrow(() -> EmptyOptionalException.INSTANCE));
+        entityStream.write(body.getBytes(US_ASCII));
     }
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalLongMessageBodyWriter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalLongMessageBodyWriter.java
@@ -9,8 +9,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.nio.charset.StandardCharsets;
 import java.util.OptionalLong;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
 
 @Provider
 @Produces(MediaType.WILDCARD)
@@ -34,10 +35,7 @@ public class OptionalLongMessageBodyWriter implements MessageBodyWriter<Optional
                         MediaType mediaType,
                         MultivaluedMap<String, Object> httpHeaders,
                         OutputStream entityStream) throws IOException {
-        if (!entity.isPresent()) {
-            throw EmptyOptionalException.INSTANCE;
-        }
-
-        entityStream.write(Long.toString(entity.getAsLong()).getBytes(StandardCharsets.US_ASCII));
+        final String body = Long.toString(entity.orElseThrow(() -> EmptyOptionalException.INSTANCE));
+        entityStream.write(body.getBytes(US_ASCII));
     }
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalMessageBodyWriter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalMessageBodyWriter.java
@@ -49,16 +49,14 @@ public class OptionalMessageBodyWriter implements MessageBodyWriter<Optional<?>>
                         MultivaluedMap<String, Object> httpHeaders,
                         OutputStream entityStream)
             throws IOException {
-        if (!entity.isPresent()) {
-            throw EmptyOptionalException.INSTANCE;
-        }
+        final Object entityObj = entity.orElseThrow(() -> EmptyOptionalException.INSTANCE);
 
         final Type innerGenericType = (genericType instanceof ParameterizedType) ?
-            ((ParameterizedType) genericType).getActualTypeArguments()[0] : entity.get().getClass();
+            ((ParameterizedType) genericType).getActualTypeArguments()[0] : entityObj.getClass();
 
-        final MessageBodyWriter writer = requireNonNull(mbw).get().getMessageBodyWriter(entity.get().getClass(),
+        final MessageBodyWriter writer = requireNonNull(mbw).get().getMessageBodyWriter(entityObj.getClass(),
             innerGenericType, annotations, mediaType);
-        writer.writeTo(entity.get(), entity.get().getClass(),
+        writer.writeTo(entityObj, entityObj.getClass(),
             innerGenericType, annotations, mediaType, httpHeaders, entityStream);
     }
 


### PR DESCRIPTION
We can use `Optional#orElseThrow(Supplier<? extends Throwable>)` instead of explicitly checking for `Optional#isPresent()` here.