### PR TITLE
Remove commons-lang3 as a dependency

### DIFF
--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -25,7 +25,6 @@
         <checker-qual.version>3.21.3</checker-qual.version>
         <classmate.version>1.5.1</classmate.version>
         <commons-codec.version>1.15</commons-codec.version>
-        <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-text.version>1.9</commons-text.version>
         <conscrypt-openjdk-uber.version>2.5.2</conscrypt-openjdk-uber.version>
         <error_prone.version>2.10.0</error_prone.version>
@@ -91,11 +90,6 @@
                 <version>${jackson.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>${commons-lang3.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/dropwizard-e2e/pom.xml
+++ b/dropwizard-e2e/pom.xml
@@ -110,10 +110,6 @@
             <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-io</artifactId>
         </dependency>

--- a/dropwizard-e2e/src/main/java/com/example/app1/App1.java
+++ b/dropwizard-e2e/src/main/java/com/example/app1/App1.java
@@ -7,13 +7,14 @@ import io.dropwizard.jersey.optional.EmptyOptionalNoContentExceptionMapper;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.eclipse.jetty.io.EofException;
 import org.glassfish.jersey.spi.ExtendedExceptionMapper;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
+
+import static io.dropwizard.util.Throwables.findThrowableInChain;
 
 public class App1 extends Application<Configuration> {
     public volatile boolean wasEofExceptionHit = false;
@@ -50,7 +51,7 @@ public class App1 extends Application<Configuration> {
 
             @Override
             public boolean isMappable(WebApplicationException e) {
-                return ExceptionUtils.indexOfThrowable(e, MustacheNotFoundException.class) != -1;
+                return findThrowableInChain(t -> t.getClass() == MustacheNotFoundException.class, e).isPresent();
             }
         });
 

--- a/dropwizard-jetty/pom.xml
+++ b/dropwizard-jetty/pom.xml
@@ -60,10 +60,6 @@
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-io</artifactId>
         </dependency>

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/ZipExceptionHandlingGzipHandler.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/ZipExceptionHandlingGzipHandler.java
@@ -1,6 +1,5 @@
 package io.dropwizard.jetty;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.Request;
@@ -11,7 +10,10 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.EOFException;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.zip.ZipException;
+
+import static io.dropwizard.util.Throwables.findThrowableInChain;
 
 /**
  * This customization of Jetty's {@link GzipHandler} catches {@link ZipException}s and {@link EOFException}s to properly return an
@@ -23,11 +25,14 @@ class ZipExceptionHandlingGzipHandler extends GzipHandler {
         try {
             super.handle(target, baseRequest, request, response);
         } catch (Exception ex) {
-            Throwable rootCause = ExceptionUtils.getRootCause(ex);
-            if (rootCause instanceof ZipException || rootCause instanceof EOFException) {
-                throw new BadMessageException(HttpStatus.BAD_REQUEST_400, rootCause.getMessage(), rootCause);
+            Optional<BadMessageException> badMessageException = findThrowableInChain(t -> t.getCause() == null && (t instanceof ZipException || t instanceof EOFException), ex)
+                .map(e -> new BadMessageException(HttpStatus.BAD_REQUEST_400, e.getMessage(), e));
+
+            if (badMessageException.isPresent()) {
+                throw badMessageException.get();
+            } else {
+                throw ex;
             }
-            throw ex;
         }
     }
 }

--- a/dropwizard-util/src/main/java/io/dropwizard/util/Throwables.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Throwables.java
@@ -1,11 +1,14 @@
 package io.dropwizard.util;
 
+import javax.annotation.Nullable;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+
 /**
  * @since 2.0
- *
- * @deprecated consider using Apache commons-lang3 ExceptionUtils instead
  */
-@Deprecated
 public final class Throwables {
     private Throwables() {
     }
@@ -19,7 +22,9 @@ public final class Throwables {
      * </pre>
      *
      * @throws IllegalArgumentException if there is a loop in the causal chain
+     * @deprecated consider using Apache commons-lang3 ExceptionUtils instead
      */
+    @Deprecated
     public static Throwable getRootCause(Throwable throwable) {
         // Keep a second pointer that slowly walks the causal chain. If the fast pointer ever catches
         // the slower pointer, then there's a loop.
@@ -39,5 +44,26 @@ public final class Throwables {
             advanceSlowPointer = !advanceSlowPointer; // only advance every other iteration
         }
         return throwable;
+    }
+
+    /**
+     * Search an exception chain for an exception matching a given condition.
+     *
+     * @param condition The condition to match on
+     * @param t The head of the exception chain
+     * @return An {@link Optional} containing the first match in the chain, starting from the head, or empty if no
+     *         matching exception was found
+     * @since 2.1.0
+     */
+    public static Optional<Throwable> findThrowableInChain(Predicate<Throwable> condition, @Nullable Throwable t) {
+        final Set<Throwable> seen = new HashSet<>();
+        while (t != null && !seen.contains(t)) {
+            if (condition.test(t)) {
+                return Optional.of(t);
+            }
+            seen.add(t);
+            t = t.getCause();
+        }
+        return Optional.empty();
     }
 }

--- a/dropwizard-util/src/test/java/io/dropwizard/util/ThrowablesTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/ThrowablesTest.java
@@ -1,0 +1,82 @@
+package io.dropwizard.util;
+
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
+
+import static io.dropwizard.util.Throwables.findThrowableInChain;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ThrowablesTest {
+    @Test
+    void findsNothingFromNull() {
+        assertThat(findThrowableInChain(t -> true, null)).isEmpty();
+    }
+
+    @Test
+    void findsSimpleException() {
+        final RuntimeException e = new RuntimeException();
+
+        assertThat(findThrowableInChain(t -> t instanceof RuntimeException, e)).contains(e);
+        assertThat(findThrowableInChain(t -> false, e)).isEmpty();
+    }
+
+    @Test
+    void findsChainedException() {
+        final RuntimeException first = new RuntimeException("first");
+        final RuntimeException second = new RuntimeException("second", first);
+        final RuntimeException third = new RuntimeException("third", second);
+
+        assertThat(findThrowableInChain(t -> "third".equals(t.getMessage()), third)).contains(third);
+        assertThat(findThrowableInChain(t -> "second".equals(t.getMessage()), third)).contains(second);
+        assertThat(findThrowableInChain(t -> "first".equals(t.getMessage()), third)).contains(first);
+        assertThat(findThrowableInChain(t -> false, third)).isEmpty();
+    }
+
+    @Test
+    void ignoresCircularChains() {
+        // fifth -> fourth -> third -> second -> first
+        //                      ^                  /
+        //                       \-----------------
+        final LateBoundCauseException first = new LateBoundCauseException("first");
+        final RuntimeException second = new RuntimeException("second", first);
+        final RuntimeException third = new RuntimeException("third", second);
+        first.setCause(third);
+        final RuntimeException fourth = new RuntimeException("fourth", third);
+        final RuntimeException fifth = new RuntimeException("fifth", fourth);
+
+        assertThat(findThrowableInChain(t -> "fifth".equals(t.getMessage()), fifth)).contains(fifth);
+        assertThat(findThrowableInChain(t -> "fourth".equals(t.getMessage()), fifth)).contains(fourth);
+        assertThat(findThrowableInChain(t -> "third".equals(t.getMessage()), fifth)).contains(third);
+        assertThat(findThrowableInChain(t -> "second".equals(t.getMessage()), fifth)).contains(second);
+        assertThat(findThrowableInChain(t -> "first".equals(t.getMessage()), fifth)).contains(first);
+        assertThat(findThrowableInChain(t -> false, fifth)).isEmpty();
+
+        // Starting in the loop
+        assertThat(findThrowableInChain(t -> "third".equals(t.getMessage()), second)).contains(third);
+        assertThat(findThrowableInChain(t -> "fourth".equals(t.getMessage()), second)).isEmpty();
+    }
+
+    /**
+     * An Exception which allows the cause to be overridden after creation
+     */
+    private static class LateBoundCauseException extends RuntimeException {
+        @Nullable
+        private Throwable cause;
+
+        LateBoundCauseException(@Nullable String message) {
+            super(message);
+        }
+
+        void setCause(@Nullable Throwable cause) {
+            this.cause = cause;
+        }
+
+        @Override
+        @Nullable
+        public Throwable getCause() {
+            return cause;
+        }
+    }
+
+}

--- a/dropwizard-views/pom.xml
+++ b/dropwizard-views/pom.xml
@@ -46,10 +46,6 @@
             <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-common</artifactId>
         </dependency>

--- a/dropwizard-views/src/main/java/io/dropwizard/views/ViewRenderExceptionMapper.java
+++ b/dropwizard-views/src/main/java/io/dropwizard/views/ViewRenderExceptionMapper.java
@@ -5,10 +5,11 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.glassfish.jersey.spi.ExtendedExceptionMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static io.dropwizard.util.Throwables.findThrowableInChain;
 
 /**
  * An {@link ExtendedExceptionMapper} that returns a 500 error response with a generic
@@ -41,6 +42,6 @@ public class ViewRenderExceptionMapper implements ExtendedExceptionMapper<WebApp
 
     @Override
     public boolean isMappable(WebApplicationException e) {
-        return ExceptionUtils.indexOfThrowable(e, ViewRenderException.class) != -1;
+        return findThrowableInChain(t -> t.getClass() == ViewRenderException.class, e).isPresent();
     }
 }


### PR DESCRIPTION
commons-lang3 was only used for `ExceptionUtils` in order to navigate exception chains.

Add a helper method to dropwizard-util `Throwables` to perform the same task.