### PR TITLE
Make better use of AssertJ's string matchers

### DIFF
--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/BaseConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/BaseConfigurationFactoryTest.java
@@ -27,8 +27,6 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 
 public abstract class BaseConfigurationFactoryTest {
 
-    private static final String NEWLINE = System.lineSeparator();
-
     @SuppressWarnings("UnusedDeclaration")
     public static class ExampleServer {
 
@@ -414,8 +412,8 @@ public abstract class BaseConfigurationFactoryTest {
     void incorrectTypeIsFound() {
         assertThatExceptionOfType(ConfigurationParsingException.class)
             .isThrownBy(() -> factory.build(configurationSourceProvider, wrongTypeFile))
-            .withMessage(String.format("%s has an error:" + NEWLINE +
-                "  * Incorrect type of value at: age; is of type: String, expected: int" + NEWLINE, wrongTypeFile));
+            .withMessage("%s has an error:%n" +
+                "  * Incorrect type of value at: age; is of type: String, expected: int%n", wrongTypeFile);
     }
 
     @Test

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationValidationExceptionTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationValidationExceptionTest.java
@@ -24,7 +24,7 @@ class ConfigurationValidationExceptionTest {
     private ConfigurationValidationException e;
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         assumeThat(Locale.getDefault().getLanguage()).isEqualTo("en");
 
         final Validator validator = BaseValidator.newValidator();
@@ -35,10 +35,9 @@ class ConfigurationValidationExceptionTest {
     @Test
     void formatsTheViolationsIntoAHumanReadableMessage() {
         assertThat(e.getMessage())
-                .isEqualTo(String.format(
-                        "config.yml has an error:%n" +
-                                "  * woo must not be null%n"
-                ));
+            .isEqualToNormalizingNewlines(
+                "config.yml has an error:\n" +
+                "  * woo must not be null\n");
     }
 
     @Test

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/JsonFormatterTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/JsonFormatterTest.java
@@ -44,18 +44,20 @@ class JsonFormatterTest {
     @Test
     void testPrettyPrintWithLineSeparator() {
         JsonFormatter formatter = new JsonFormatter(objectMapper, true, true);
-        assertThat(formatter.toJson(map)).isEqualTo(String.format("{%n" +
-                "  \"hobbies\" : [ \"Reading\", \"Biking\", \"Snorkeling\" ],%n" +
-                "  \"name\" : \"Jim\"%n" +
-                "}%n"));
+        assertThat(formatter.toJson(map)).isEqualToNormalizingNewlines(
+                "{\n" +
+                "  \"hobbies\" : [ \"Reading\", \"Biking\", \"Snorkeling\" ],\n" +
+                "  \"name\" : \"Jim\"\n" +
+                "}\n");
     }
 
     @Test
     void testPrettyPrintNoLineSeparator() {
         JsonFormatter formatter = new JsonFormatter(objectMapper, true, false);
-        assertThat(formatter.toJson(map)).isEqualTo(String.format("{%n" +
-                "  \"hobbies\" : [ \"Reading\", \"Biking\", \"Snorkeling\" ],%n" +
-                "  \"name\" : \"Jim\"%n" +
-                "}"));
+        assertThat(formatter.toJson(map)).isEqualToNormalizingNewlines(
+                "{\n" +
+                "  \"hobbies\" : [ \"Reading\", \"Biking\", \"Snorkeling\" ],\n" +
+                "  \"name\" : \"Jim\"\n" +
+                "}");
     }
 }

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/ResilientSocketOutputStreamTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/ResilientSocketOutputStreamTest.java
@@ -49,8 +49,8 @@ class ResilientSocketOutputStreamTest {
     void testGetDescription() throws IOException {
         try (ServerSocket ss = new ServerSocket(0); ResilientSocketOutputStream resilientSocketOutputStream = new ResilientSocketOutputStream("localhost", ss.getLocalPort(),
             1024, 500, SocketFactory.getDefault())) {
-            assertThat(resilientSocketOutputStream.getDescription()).isEqualTo(String.format("tcp [localhost:%d]",
-                ss.getLocalPort()));
+            assertThat(resilientSocketOutputStream.getDescription())
+                .isEqualTo("tcp [localhost:%d]", ss.getLocalPort());
         }
     }
 }

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbCalculateChecksumCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbCalculateChecksumCommandTest.java
@@ -39,25 +39,25 @@ class DbCalculateChecksumCommandTest {
     void testHelpPage() throws Exception {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         MigrationTestSupport.createSubparser(migrateCommand).printHelp(new PrintWriter(new OutputStreamWriter(out, UTF_8), true));
-        assertThat(out.toString(UTF_8.name())).isEqualTo(String.format(
-            "usage: db calculate-checksum [-h] [--migrations MIGRATIONS-FILE]%n" +
-                "          [--catalog CATALOG] [--schema SCHEMA] [file] id author%n" +
-                "%n" +
-                "Calculates and prints a checksum for a change set%n" +
-                "%n" +
-                "positional arguments:%n" +
-                "  file                   application configuration file%n" +
-                "  id                     change set id%n" +
-                "  author                 author name%n" +
-                "%n" +
-                "named arguments:%n" +
-                "  -h, --help             show this help message and exit%n" +
-                "  --migrations MIGRATIONS-FILE%n" +
-                "                         the file containing  the  Liquibase migrations for%n" +
-                "                         the application%n" +
-                "  --catalog CATALOG      Specify  the   database   catalog   (use  database%n" +
-                "                         default if omitted)%n" +
-                "  --schema SCHEMA        Specify the database schema  (use database default%n" +
-                "                         if omitted)%n"));
+        assertThat(out.toString(UTF_8.name())).isEqualToNormalizingNewlines(
+            "usage: db calculate-checksum [-h] [--migrations MIGRATIONS-FILE]\n" +
+                "          [--catalog CATALOG] [--schema SCHEMA] [file] id author\n" +
+                "\n" +
+                "Calculates and prints a checksum for a change set\n" +
+                "\n" +
+                "positional arguments:\n" +
+                "  file                   application configuration file\n" +
+                "  id                     change set id\n" +
+                "  author                 author name\n" +
+                "\n" +
+                "named arguments:\n" +
+                "  -h, --help             show this help message and exit\n" +
+                "  --migrations MIGRATIONS-FILE\n" +
+                "                         the file containing  the  Liquibase migrations for\n" +
+                "                         the application\n" +
+                "  --catalog CATALOG      Specify  the   database   catalog   (use  database\n" +
+                "                         default if omitted)\n" +
+                "  --schema SCHEMA        Specify the database schema  (use database default\n" +
+                "                         if omitted)\n");
     }
 }

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbClearChecksumsCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbClearChecksumsCommandTest.java
@@ -31,23 +31,23 @@ class DbClearChecksumsCommandTest {
     void testHelpPage() throws Exception {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         MigrationTestSupport.createSubparser(clearChecksums).printHelp(new PrintWriter(new OutputStreamWriter(out, UTF_8), true));
-        assertThat(out.toString(UTF_8.name())).isEqualTo(String.format(
-            "usage: db clear-checksums [-h] [--migrations MIGRATIONS-FILE]%n" +
-                "          [--catalog CATALOG] [--schema SCHEMA] [file]%n" +
-                "%n" +
-                "Removes all saved checksums from the database log%n" +
-                "%n" +
-                "positional arguments:%n" +
-                "  file                   application configuration file%n" +
-                "%n" +
-                "named arguments:%n" +
-                "  -h, --help             show this help message and exit%n" +
-                "  --migrations MIGRATIONS-FILE%n" +
-                "                         the file containing  the  Liquibase migrations for%n" +
-                "                         the application%n" +
-                "  --catalog CATALOG      Specify  the   database   catalog   (use  database%n" +
-                "                         default if omitted)%n" +
-                "  --schema SCHEMA        Specify the database schema  (use database default%n" +
-                "                         if omitted)%n"));
+        assertThat(out.toString(UTF_8.name())).isEqualToNormalizingNewlines(
+            "usage: db clear-checksums [-h] [--migrations MIGRATIONS-FILE]\n" +
+                "          [--catalog CATALOG] [--schema SCHEMA] [file]\n" +
+                "\n" +
+                "Removes all saved checksums from the database log\n" +
+                "\n" +
+                "positional arguments:\n" +
+                "  file                   application configuration file\n" +
+                "\n" +
+                "named arguments:\n" +
+                "  -h, --help             show this help message and exit\n" +
+                "  --migrations MIGRATIONS-FILE\n" +
+                "                         the file containing  the  Liquibase migrations for\n" +
+                "                         the application\n" +
+                "  --catalog CATALOG      Specify  the   database   catalog   (use  database\n" +
+                "                         default if omitted)\n" +
+                "  --schema SCHEMA        Specify the database schema  (use database default\n" +
+                "                         if omitted)\n");
     }
 }

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbCommandTest.java
@@ -37,17 +37,17 @@ class DbCommandTest {
     void testPrintHelp() throws Exception {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         MigrationTestSupport.createSubparser(dbCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
-        assertThat(baos.toString(UTF_8.name())).isEqualTo(String.format(
-            "usage: db db [-h]%n" +
-                "          {calculate-checksum,clear-checksums,drop-all,dump,fast-forward,generate-docs,locks,migrate,prepare-rollback,rollback,status,tag,test}%n" +
-                "          ...%n" +
-                "%n" +
-                "Run database migration tasks%n" +
-                "%n" +
-                "positional arguments:%n" +
-                "  {calculate-checksum,clear-checksums,drop-all,dump,fast-forward,generate-docs,locks,migrate,prepare-rollback,rollback,status,tag,test}%n" +
-                "%n" +
-                "named arguments:%n" +
-                "  -h, --help             show this help message and exit%n"));
+        assertThat(baos.toString(UTF_8.name())).isEqualToNormalizingNewlines(
+            "usage: db db [-h]\n" +
+                "          {calculate-checksum,clear-checksums,drop-all,dump,fast-forward,generate-docs,locks,migrate,prepare-rollback,rollback,status,tag,test}\n" +
+                "          ...\n" +
+                "\n" +
+                "Run database migration tasks\n" +
+                "\n" +
+                "positional arguments:\n" +
+                "  {calculate-checksum,clear-checksums,drop-all,dump,fast-forward,generate-docs,locks,migrate,prepare-rollback,rollback,status,tag,test}\n" +
+                "\n" +
+                "named arguments:\n" +
+                "  -h, --help             show this help message and exit\n");
     }
 }

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDropAllCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDropAllCommandTest.java
@@ -48,26 +48,26 @@ class DbDropAllCommandTest {
     void testHelpPage() throws Exception {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         MigrationTestSupport.createSubparser(dropAllCommand).printHelp(new PrintWriter(new OutputStreamWriter(out, UTF_8), true));
-        assertThat(out.toString(UTF_8.name())).isEqualTo(String.format(
-            "usage: db drop-all [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
-                "          [--schema SCHEMA] --confirm-delete-everything [file]%n" +
-                "%n" +
-                "Delete all user-owned objects from the database.%n" +
-                "%n" +
-                "positional arguments:%n" +
-                "  file                   application configuration file%n" +
-                "%n" +
-                "named arguments:%n" +
-                "  -h, --help             show this help message and exit%n" +
-                "  --migrations MIGRATIONS-FILE%n" +
-                "                         the file containing  the  Liquibase migrations for%n" +
-                "                         the application%n" +
-                "  --catalog CATALOG      Specify  the   database   catalog   (use  database%n" +
-                "                         default if omitted)%n" +
-                "  --schema SCHEMA        Specify the database schema  (use database default%n" +
-                "                         if omitted)%n" +
-                "  --confirm-delete-everything%n" +
-                "                         indicate you  understand  this  deletes everything%n" +
-                "                         in your database%n"));
+        assertThat(out.toString(UTF_8.name())).isEqualToNormalizingNewlines(
+            "usage: db drop-all [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]\n" +
+                "          [--schema SCHEMA] --confirm-delete-everything [file]\n" +
+                "\n" +
+                "Delete all user-owned objects from the database.\n" +
+                "\n" +
+                "positional arguments:\n" +
+                "  file                   application configuration file\n" +
+                "\n" +
+                "named arguments:\n" +
+                "  -h, --help             show this help message and exit\n" +
+                "  --migrations MIGRATIONS-FILE\n" +
+                "                         the file containing  the  Liquibase migrations for\n" +
+                "                         the application\n" +
+                "  --catalog CATALOG      Specify  the   database   catalog   (use  database\n" +
+                "                         default if omitted)\n" +
+                "  --schema SCHEMA        Specify the database schema  (use database default\n" +
+                "                         if omitted)\n" +
+                "  --confirm-delete-everything\n" +
+                "                         indicate you  understand  this  deletes everything\n" +
+                "                         in your database\n");
     }
 }

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDumpCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDumpCommandTest.java
@@ -98,70 +98,70 @@ class DbDumpCommandTest {
     @Test
     void testHelpPage() throws Exception {
         MigrationTestSupport.createSubparser(dumpCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
-        assertThat(baos.toString(UTF_8.name())).isEqualTo(String.format(
-                "usage: db dump [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
-                        "          [--schema SCHEMA] [-o OUTPUT] [--tables] [--ignore-tables]%n" +
-                        "          [--columns] [--ignore-columns] [--views] [--ignore-views]%n" +
-                        "          [--primary-keys] [--ignore-primary-keys] [--unique-constraints]%n" +
-                        "          [--ignore-unique-constraints] [--indexes] [--ignore-indexes]%n" +
-                        "          [--foreign-keys] [--ignore-foreign-keys] [--sequences]%n" +
-                        "          [--ignore-sequences] [--data] [--ignore-data] [file]%n" +
-                        "%n" +
-                        "Generate a dump of the existing database state.%n" +
-                        "%n" +
-                        "positional arguments:%n" +
-                        "  file                   application configuration file%n" +
-                        "%n" +
-                        "named arguments:%n" +
-                        "  -h, --help             show this help message and exit%n" +
-                        "  --migrations MIGRATIONS-FILE%n" +
-                        "                         the file containing  the  Liquibase migrations for%n" +
-                        "                         the application%n" +
-                        "  --catalog CATALOG      Specify  the   database   catalog   (use  database%n" +
-                        "                         default if omitted)%n" +
-                        "  --schema SCHEMA        Specify the database schema  (use database default%n" +
-                        "                         if omitted)%n" +
-                        "  -o OUTPUT, --output OUTPUT%n" +
-                        "                         Write output to <file> instead of stdout%n" +
-                        "%n" +
-                        "Tables:%n" +
-                        "  --tables               Check for added or removed tables (default)%n" +
-                        "  --ignore-tables        Ignore tables%n" +
-                        "%n" +
-                        "Columns:%n" +
-                        "  --columns              Check for  added,  removed,  or  modified  columns%n" +
-                        "                         (default)%n" +
-                        "  --ignore-columns       Ignore columns%n" +
-                        "%n" +
-                        "Views:%n" +
-                        "  --views                Check  for  added,  removed,   or  modified  views%n" +
-                        "                         (default)%n" +
-                        "  --ignore-views         Ignore views%n" +
-                        "%n" +
-                        "Primary Keys:%n" +
-                        "  --primary-keys         Check for changed primary keys (default)%n" +
-                        "  --ignore-primary-keys  Ignore primary keys%n" +
-                        "%n" +
-                        "Unique Constraints:%n" +
-                        "  --unique-constraints   Check for changed unique constraints (default)%n" +
-                        "  --ignore-unique-constraints%n" +
-                        "                         Ignore unique constraints%n" +
-                        "%n" +
-                        "Indexes:%n" +
-                        "  --indexes              Check for changed indexes (default)%n" +
-                        "  --ignore-indexes       Ignore indexes%n" +
-                        "%n" +
-                        "Foreign Keys:%n" +
-                        "  --foreign-keys         Check for changed foreign keys (default)%n" +
-                        "  --ignore-foreign-keys  Ignore foreign keys%n" +
-                        "%n" +
-                        "Sequences:%n" +
-                        "  --sequences            Check for changed sequences (default)%n" +
-                        "  --ignore-sequences     Ignore sequences%n" +
-                        "%n" +
-                        "Data:%n" +
-                        "  --data                 Check for changed data%n" +
-                        "  --ignore-data          Ignore data (default)%n"));
+        assertThat(baos.toString(UTF_8.name())).isEqualToNormalizingNewlines(
+                "usage: db dump [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]\n" +
+                        "          [--schema SCHEMA] [-o OUTPUT] [--tables] [--ignore-tables]\n" +
+                        "          [--columns] [--ignore-columns] [--views] [--ignore-views]\n" +
+                        "          [--primary-keys] [--ignore-primary-keys] [--unique-constraints]\n" +
+                        "          [--ignore-unique-constraints] [--indexes] [--ignore-indexes]\n" +
+                        "          [--foreign-keys] [--ignore-foreign-keys] [--sequences]\n" +
+                        "          [--ignore-sequences] [--data] [--ignore-data] [file]\n" +
+                        "\n" +
+                        "Generate a dump of the existing database state.\n" +
+                        "\n" +
+                        "positional arguments:\n" +
+                        "  file                   application configuration file\n" +
+                        "\n" +
+                        "named arguments:\n" +
+                        "  -h, --help             show this help message and exit\n" +
+                        "  --migrations MIGRATIONS-FILE\n" +
+                        "                         the file containing  the  Liquibase migrations for\n" +
+                        "                         the application\n" +
+                        "  --catalog CATALOG      Specify  the   database   catalog   (use  database\n" +
+                        "                         default if omitted)\n" +
+                        "  --schema SCHEMA        Specify the database schema  (use database default\n" +
+                        "                         if omitted)\n" +
+                        "  -o OUTPUT, --output OUTPUT\n" +
+                        "                         Write output to <file> instead of stdout\n" +
+                        "\n" +
+                        "Tables:\n" +
+                        "  --tables               Check for added or removed tables (default)\n" +
+                        "  --ignore-tables        Ignore tables\n" +
+                        "\n" +
+                        "Columns:\n" +
+                        "  --columns              Check for  added,  removed,  or  modified  columns\n" +
+                        "                         (default)\n" +
+                        "  --ignore-columns       Ignore columns\n" +
+                        "\n" +
+                        "Views:\n" +
+                        "  --views                Check  for  added,  removed,   or  modified  views\n" +
+                        "                         (default)\n" +
+                        "  --ignore-views         Ignore views\n" +
+                        "\n" +
+                        "Primary Keys:\n" +
+                        "  --primary-keys         Check for changed primary keys (default)\n" +
+                        "  --ignore-primary-keys  Ignore primary keys\n" +
+                        "\n" +
+                        "Unique Constraints:\n" +
+                        "  --unique-constraints   Check for changed unique constraints (default)\n" +
+                        "  --ignore-unique-constraints\n" +
+                        "                         Ignore unique constraints\n" +
+                        "\n" +
+                        "Indexes:\n" +
+                        "  --indexes              Check for changed indexes (default)\n" +
+                        "  --ignore-indexes       Ignore indexes\n" +
+                        "\n" +
+                        "Foreign Keys:\n" +
+                        "  --foreign-keys         Check for changed foreign keys (default)\n" +
+                        "  --ignore-foreign-keys  Ignore foreign keys\n" +
+                        "\n" +
+                        "Sequences:\n" +
+                        "  --sequences            Check for changed sequences (default)\n" +
+                        "  --ignore-sequences     Ignore sequences\n" +
+                        "\n" +
+                        "Data:\n" +
+                        "  --data                 Check for changed data\n" +
+                        "  --ignore-data          Ignore data (default)\n");
     }
 
 

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbFastForwardCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbFastForwardCommandTest.java
@@ -114,29 +114,29 @@ class DbFastForwardCommandTest {
     void testPrintHelp() throws Exception {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         MigrationTestSupport.createSubparser(fastForwardCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
-        assertThat(baos.toString(UTF_8.name())).isEqualTo(String.format(
-            "usage: db fast-forward [-h] [--migrations MIGRATIONS-FILE]%n" +
-                "          [--catalog CATALOG] [--schema SCHEMA] [-n] [-a] [-i CONTEXTS]%n" +
-                "          [file]%n" +
-                "%n" +
-                "Mark the next pending change set as applied without running it%n" +
-                "%n" +
-                "positional arguments:%n" +
-                "  file                   application configuration file%n" +
-                "%n" +
-                "named arguments:%n" +
-                "  -h, --help             show this help message and exit%n" +
-                "  --migrations MIGRATIONS-FILE%n" +
-                "                         the file containing  the  Liquibase migrations for%n" +
-                "                         the application%n" +
-                "  --catalog CATALOG      Specify  the   database   catalog   (use  database%n" +
-                "                         default if omitted)%n" +
-                "  --schema SCHEMA        Specify the database schema  (use database default%n" +
-                "                         if omitted)%n" +
-                "  -n, --dry-run          output the DDL to stdout, don't run it%n" +
-                "  -a, --all              mark all pending change sets as applied%n" +
-                "  -i CONTEXTS, --include CONTEXTS%n" +
-                "                         include change sets from the given context%n"));
+        assertThat(baos.toString(UTF_8.name())).isEqualToNormalizingNewlines(
+            "usage: db fast-forward [-h] [--migrations MIGRATIONS-FILE]\n" +
+                "          [--catalog CATALOG] [--schema SCHEMA] [-n] [-a] [-i CONTEXTS]\n" +
+                "          [file]\n" +
+                "\n" +
+                "Mark the next pending change set as applied without running it\n" +
+                "\n" +
+                "positional arguments:\n" +
+                "  file                   application configuration file\n" +
+                "\n" +
+                "named arguments:\n" +
+                "  -h, --help             show this help message and exit\n" +
+                "  --migrations MIGRATIONS-FILE\n" +
+                "                         the file containing  the  Liquibase migrations for\n" +
+                "                         the application\n" +
+                "  --catalog CATALOG      Specify  the   database   catalog   (use  database\n" +
+                "                         default if omitted)\n" +
+                "  --schema SCHEMA        Specify the database schema  (use database default\n" +
+                "                         if omitted)\n" +
+                "  -n, --dry-run          output the DDL to stdout, don't run it\n" +
+                "  -a, --all              mark all pending change sets as applied\n" +
+                "  -i CONTEXTS, --include CONTEXTS\n" +
+                "                         include change sets from the given context\n");
 
     }
 }

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbGenerateDocsCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbGenerateDocsCommandTest.java
@@ -31,24 +31,24 @@ class DbGenerateDocsCommandTest {
     void testHelpPage() throws Exception {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         MigrationTestSupport.createSubparser(generateDocsCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
-        assertThat(baos.toString(UTF_8.name())).isEqualTo(String.format(
-            "usage: db generate-docs [-h] [--migrations MIGRATIONS-FILE]%n" +
-                "          [--catalog CATALOG] [--schema SCHEMA] [file] output%n" +
-                "%n" +
-                "Generate documentation about the database state.%n" +
-                "%n" +
-                "positional arguments:%n" +
-                "  file                   application configuration file%n" +
-                "  output                 output directory%n" +
-                "%n" +
-                "named arguments:%n" +
-                "  -h, --help             show this help message and exit%n" +
-                "  --migrations MIGRATIONS-FILE%n" +
-                "                         the file containing  the  Liquibase migrations for%n" +
-                "                         the application%n" +
-                "  --catalog CATALOG      Specify  the   database   catalog   (use  database%n" +
-                "                         default if omitted)%n" +
-                "  --schema SCHEMA        Specify the database schema  (use database default%n" +
-                "                         if omitted)%n"));
+        assertThat(baos.toString(UTF_8.name())).isEqualToNormalizingNewlines(
+            "usage: db generate-docs [-h] [--migrations MIGRATIONS-FILE]\n" +
+                "          [--catalog CATALOG] [--schema SCHEMA] [file] output\n" +
+                "\n" +
+                "Generate documentation about the database state.\n" +
+                "\n" +
+                "positional arguments:\n" +
+                "  file                   application configuration file\n" +
+                "  output                 output directory\n" +
+                "\n" +
+                "named arguments:\n" +
+                "  -h, --help             show this help message and exit\n" +
+                "  --migrations MIGRATIONS-FILE\n" +
+                "                         the file containing  the  Liquibase migrations for\n" +
+                "                         the application\n" +
+                "  --catalog CATALOG      Specify  the   database   catalog   (use  database\n" +
+                "                         default if omitted)\n" +
+                "  --schema SCHEMA        Specify the database schema  (use database default\n" +
+                "                         if omitted)\n");
     }
 }

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbLocksCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbLocksCommandTest.java
@@ -62,25 +62,25 @@ class DbLocksCommandTest {
     void testPrintHelp() throws Exception {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         MigrationTestSupport.createSubparser(locksCommand).printHelp(new PrintWriter(new OutputStreamWriter(out, UTF_8), true));
-        assertThat(out.toString(UTF_8.name())).isEqualTo(String.format(
-            "usage: db locks [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
-                "          [--schema SCHEMA] [-l] [-r] [file]%n" +
-                "%n" +
-                "Manage database migration locks%n" +
-                "%n" +
-                "positional arguments:%n" +
-                "  file                   application configuration file%n" +
-                "%n" +
-                "named arguments:%n" +
-                "  -h, --help             show this help message and exit%n" +
-                "  --migrations MIGRATIONS-FILE%n" +
-                "                         the file containing  the  Liquibase migrations for%n" +
-                "                         the application%n" +
-                "  --catalog CATALOG      Specify  the   database   catalog   (use  database%n" +
-                "                         default if omitted)%n" +
-                "  --schema SCHEMA        Specify the database schema  (use database default%n" +
-                "                         if omitted)%n" +
-                "  -l, --list             list all open locks%n" +
-                "  -r, --force-release    forcibly release all open locks%n"));
+        assertThat(out.toString(UTF_8.name())).isEqualToNormalizingNewlines(
+            "usage: db locks [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]\n" +
+                "          [--schema SCHEMA] [-l] [-r] [file]\n" +
+                "\n" +
+                "Manage database migration locks\n" +
+                "\n" +
+                "positional arguments:\n" +
+                "  file                   application configuration file\n" +
+                "\n" +
+                "named arguments:\n" +
+                "  -h, --help             show this help message and exit\n" +
+                "  --migrations MIGRATIONS-FILE\n" +
+                "                         the file containing  the  Liquibase migrations for\n" +
+                "                         the application\n" +
+                "  --catalog CATALOG      Specify  the   database   catalog   (use  database\n" +
+                "                         default if omitted)\n" +
+                "  --schema SCHEMA        Specify the database schema  (use database default\n" +
+                "                         if omitted)\n" +
+                "  -l, --list             list all open locks\n" +
+                "  -r, --force-release    forcibly release all open locks\n");
     }
 }

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCommandTest.java
@@ -79,28 +79,28 @@ class DbMigrateCommandTest {
 
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         subparser.printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
-        assertThat(baos.toString(UTF_8.name())).isEqualTo(String.format(
-                        "usage: db migrate [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
-                        "          [--schema SCHEMA] [-n] [-c COUNT] [-i CONTEXTS] [file]%n" +
-                        "%n" +
-                        "Apply all pending change sets.%n" +
-                        "%n" +
-                        "positional arguments:%n" +
-                        "  file                   application configuration file%n" +
-                        "%n" +
-                        "named arguments:%n" +
-                        "  -h, --help             show this help message and exit%n" +
-                        "  --migrations MIGRATIONS-FILE%n" +
-                        "                         the file containing  the  Liquibase migrations for%n" +
-                        "                         the application%n" +
-                        "  --catalog CATALOG      Specify  the   database   catalog   (use  database%n" +
-                        "                         default if omitted)%n" +
-                        "  --schema SCHEMA        Specify the database schema  (use database default%n" +
-                        "                         if omitted)%n" +
-                        "  -n, --dry-run          output the DDL to stdout, don't run it%n" +
-                        "  -c COUNT, --count COUNT%n" +
-                        "                         only apply the next N change sets%n" +
-                        "  -i CONTEXTS, --include CONTEXTS%n" +
-                        "                         include change sets from the given context%n"));
+        assertThat(baos.toString(UTF_8.name())).isEqualToNormalizingNewlines(
+                        "usage: db migrate [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]\n" +
+                        "          [--schema SCHEMA] [-n] [-c COUNT] [-i CONTEXTS] [file]\n" +
+                        "\n" +
+                        "Apply all pending change sets.\n" +
+                        "\n" +
+                        "positional arguments:\n" +
+                        "  file                   application configuration file\n" +
+                        "\n" +
+                        "named arguments:\n" +
+                        "  -h, --help             show this help message and exit\n" +
+                        "  --migrations MIGRATIONS-FILE\n" +
+                        "                         the file containing  the  Liquibase migrations for\n" +
+                        "                         the application\n" +
+                        "  --catalog CATALOG      Specify  the   database   catalog   (use  database\n" +
+                        "                         default if omitted)\n" +
+                        "  --schema SCHEMA        Specify the database schema  (use database default\n" +
+                        "                         if omitted)\n" +
+                        "  -n, --dry-run          output the DDL to stdout, don't run it\n" +
+                        "  -c COUNT, --count COUNT\n" +
+                        "                         only apply the next N change sets\n" +
+                        "  -i CONTEXTS, --include CONTEXTS\n" +
+                        "                         include change sets from the given context\n");
     }
 }

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbPrepareRollbackCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbPrepareRollbackCommandTest.java
@@ -50,29 +50,29 @@ class DbPrepareRollbackCommandTest {
     void testPrintHelp() throws Exception {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         MigrationTestSupport.createSubparser(prepareRollbackCommand).printHelp(new PrintWriter(new OutputStreamWriter(out, UTF_8), true));
-        assertThat(out.toString(UTF_8.name())).isEqualTo(String.format(
-            "usage: db prepare-rollback [-h] [--migrations MIGRATIONS-FILE]%n" +
-                "          [--catalog CATALOG] [--schema SCHEMA] [-c COUNT] [-i CONTEXTS]%n" +
-                "          [file]%n" +
-                "%n" +
-                "Generate rollback DDL scripts for pending change sets.%n" +
-                "%n" +
-                "positional arguments:%n" +
-                "  file                   application configuration file%n" +
-                "%n" +
-                "named arguments:%n" +
-                "  -h, --help             show this help message and exit%n" +
-                "  --migrations MIGRATIONS-FILE%n" +
-                "                         the file containing  the  Liquibase migrations for%n" +
-                "                         the application%n" +
-                "  --catalog CATALOG      Specify  the   database   catalog   (use  database%n" +
-                "                         default if omitted)%n" +
-                "  --schema SCHEMA        Specify the database schema  (use database default%n" +
-                "                         if omitted)%n" +
-                "  -c COUNT, --count COUNT%n" +
-                "                         limit script to  the  specified  number of pending%n" +
-                "                         change sets%n" +
-                "  -i CONTEXTS, --include CONTEXTS%n" +
-                "                         include change sets from the given context%n"));
+        assertThat(out.toString(UTF_8.name())).isEqualToNormalizingNewlines(
+            "usage: db prepare-rollback [-h] [--migrations MIGRATIONS-FILE]\n" +
+                "          [--catalog CATALOG] [--schema SCHEMA] [-c COUNT] [-i CONTEXTS]\n" +
+                "          [file]\n" +
+                "\n" +
+                "Generate rollback DDL scripts for pending change sets.\n" +
+                "\n" +
+                "positional arguments:\n" +
+                "  file                   application configuration file\n" +
+                "\n" +
+                "named arguments:\n" +
+                "  -h, --help             show this help message and exit\n" +
+                "  --migrations MIGRATIONS-FILE\n" +
+                "                         the file containing  the  Liquibase migrations for\n" +
+                "                         the application\n" +
+                "  --catalog CATALOG      Specify  the   database   catalog   (use  database\n" +
+                "                         default if omitted)\n" +
+                "  --schema SCHEMA        Specify the database schema  (use database default\n" +
+                "                         if omitted)\n" +
+                "  -c COUNT, --count COUNT\n" +
+                "                         limit script to  the  specified  number of pending\n" +
+                "                         change sets\n" +
+                "  -i CONTEXTS, --include CONTEXTS\n" +
+                "                         include change sets from the given context\n");
     }
 }

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbRollbackCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbRollbackCommandTest.java
@@ -161,31 +161,31 @@ class DbRollbackCommandTest {
     @Test
     void testPrintHelp() throws Exception {
         MigrationTestSupport.createSubparser(rollbackCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
-        assertThat(baos.toString(UTF_8.name())).isEqualTo(String.format(
-            "usage: db rollback [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
-            "          [--schema SCHEMA] [-n] [-t TAG] [-d DATE] [-c COUNT]%n" +
-            "          [-i CONTEXTS] [file]%n" +
-            "%n" +
-            "Rollback the database schema to a previous version.%n" +
-            "%n" +
-            "positional arguments:%n" +
-            "  file                   application configuration file%n" +
-            "%n" +
-            "named arguments:%n" +
-            "  -h, --help             show this help message and exit%n" +
-            "  --migrations MIGRATIONS-FILE%n" +
-            "                         the file containing  the  Liquibase migrations for%n" +
-            "                         the application%n" +
-            "  --catalog CATALOG      Specify  the   database   catalog   (use  database%n" +
-            "                         default if omitted)%n" +
-            "  --schema SCHEMA        Specify the database schema  (use database default%n" +
-            "                         if omitted)%n" +
-            "  -n, --dry-run          Output the DDL to stdout, don't run it%n" +
-            "  -t TAG, --tag TAG      Rollback to the given tag%n" +
-            "  -d DATE, --date DATE   Rollback to the given date%n" +
-            "  -c COUNT, --count COUNT%n" +
-            "                         Rollback the specified number of change sets%n" +
-            "  -i CONTEXTS, --include CONTEXTS%n" +
-            "                         include change sets from the given context%n"));
+        assertThat(baos.toString(UTF_8.name())).isEqualToNormalizingNewlines(
+            "usage: db rollback [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]\n" +
+            "          [--schema SCHEMA] [-n] [-t TAG] [-d DATE] [-c COUNT]\n" +
+            "          [-i CONTEXTS] [file]\n" +
+            "\n" +
+            "Rollback the database schema to a previous version.\n" +
+            "\n" +
+            "positional arguments:\n" +
+            "  file                   application configuration file\n" +
+            "\n" +
+            "named arguments:\n" +
+            "  -h, --help             show this help message and exit\n" +
+            "  --migrations MIGRATIONS-FILE\n" +
+            "                         the file containing  the  Liquibase migrations for\n" +
+            "                         the application\n" +
+            "  --catalog CATALOG      Specify  the   database   catalog   (use  database\n" +
+            "                         default if omitted)\n" +
+            "  --schema SCHEMA        Specify the database schema  (use database default\n" +
+            "                         if omitted)\n" +
+            "  -n, --dry-run          Output the DDL to stdout, don't run it\n" +
+            "  -t TAG, --tag TAG      Rollback to the given tag\n" +
+            "  -d DATE, --date DATE   Rollback to the given date\n" +
+            "  -c COUNT, --count COUNT\n" +
+            "                         Rollback the specified number of change sets\n" +
+            "  -i CONTEXTS, --include CONTEXTS\n" +
+            "                         include change sets from the given context\n");
     }
 }

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbStatusCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbStatusCommandTest.java
@@ -63,26 +63,26 @@ class DbStatusCommandTest {
     @Test
     void testPrintHelp() throws Exception {
         MigrationTestSupport.createSubparser(statusCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
-        assertThat(baos.toString(UTF_8.name())).isEqualTo(String.format(
-                "usage: db status [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
-                        "          [--schema SCHEMA] [-v] [-i CONTEXTS] [file]%n" +
-                        "%n" +
-                        "Check for pending change sets.%n" +
-                        "%n" +
-                        "positional arguments:%n" +
-                        "  file                   application configuration file%n" +
-                        "%n" +
-                        "named arguments:%n" +
-                        "  -h, --help             show this help message and exit%n" +
-                        "  --migrations MIGRATIONS-FILE%n" +
-                        "                         the file containing  the  Liquibase migrations for%n" +
-                        "                         the application%n" +
-                        "  --catalog CATALOG      Specify  the   database   catalog   (use  database%n" +
-                        "                         default if omitted)%n" +
-                        "  --schema SCHEMA        Specify the database schema  (use database default%n" +
-                        "                         if omitted)%n" +
-                        "  -v, --verbose          Output verbose information%n" +
-                        "  -i CONTEXTS, --include CONTEXTS%n" +
-                        "                         include change sets from the given context%n"));
+        assertThat(baos.toString(UTF_8.name())).isEqualToNormalizingNewlines(
+                "usage: db status [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]\n" +
+                        "          [--schema SCHEMA] [-v] [-i CONTEXTS] [file]\n" +
+                        "\n" +
+                        "Check for pending change sets.\n" +
+                        "\n" +
+                        "positional arguments:\n" +
+                        "  file                   application configuration file\n" +
+                        "\n" +
+                        "named arguments:\n" +
+                        "  -h, --help             show this help message and exit\n" +
+                        "  --migrations MIGRATIONS-FILE\n" +
+                        "                         the file containing  the  Liquibase migrations for\n" +
+                        "                         the application\n" +
+                        "  --catalog CATALOG      Specify  the   database   catalog   (use  database\n" +
+                        "                         default if omitted)\n" +
+                        "  --schema SCHEMA        Specify the database schema  (use database default\n" +
+                        "                         if omitted)\n" +
+                        "  -v, --verbose          Output verbose information\n" +
+                        "  -i CONTEXTS, --include CONTEXTS\n" +
+                        "                         include change sets from the given context\n");
     }
 }

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbTagCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbTagCommandTest.java
@@ -41,24 +41,24 @@ class DbTagCommandTest {
     void testPrintHelp() throws Exception {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         MigrationTestSupport.createSubparser(dbTagCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
-        assertThat(baos.toString(UTF_8.name())).isEqualTo(String.format(
-            "usage: db tag [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
-            "          [--schema SCHEMA] [file] tag-name%n" +
-            "%n" +
-            "Tag the database schema.%n" +
-            "%n" +
-            "positional arguments:%n" +
-            "  file                   application configuration file%n" +
-            "  tag-name               The tag name%n" +
-            "%n" +
-            "named arguments:%n" +
-            "  -h, --help             show this help message and exit%n" +
-            "  --migrations MIGRATIONS-FILE%n" +
-            "                         the file containing  the  Liquibase migrations for%n" +
-            "                         the application%n" +
-            "  --catalog CATALOG      Specify  the   database   catalog   (use  database%n" +
-            "                         default if omitted)%n" +
-            "  --schema SCHEMA        Specify the database schema  (use database default%n" +
-            "                         if omitted)%n"));
+        assertThat(baos.toString(UTF_8.name())).isEqualToNormalizingNewlines(
+            "usage: db tag [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]\n" +
+            "          [--schema SCHEMA] [file] tag-name\n" +
+            "\n" +
+            "Tag the database schema.\n" +
+            "\n" +
+            "positional arguments:\n" +
+            "  file                   application configuration file\n" +
+            "  tag-name               The tag name\n" +
+            "\n" +
+            "named arguments:\n" +
+            "  -h, --help             show this help message and exit\n" +
+            "  --migrations MIGRATIONS-FILE\n" +
+            "                         the file containing  the  Liquibase migrations for\n" +
+            "                         the application\n" +
+            "  --catalog CATALOG      Specify  the   database   catalog   (use  database\n" +
+            "                         default if omitted)\n" +
+            "  --schema SCHEMA        Specify the database schema  (use database default\n" +
+            "                         if omitted)\n");
     }
 }

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbTestCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbTestCommandTest.java
@@ -31,25 +31,25 @@ class DbTestCommandTest {
     void testPrintHelp() throws Exception {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         MigrationTestSupport.createSubparser(dbTestCommand).printHelp(new PrintWriter(new OutputStreamWriter(baos, UTF_8), true));
-        assertThat(baos.toString(UTF_8.name())).isEqualTo(String.format(
-            "usage: db test [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]%n" +
-                "          [--schema SCHEMA] [-i CONTEXTS] [file]%n" +
-                "%n" +
-                "Apply and rollback pending change sets.%n" +
-                "%n" +
-                "positional arguments:%n" +
-                "  file                   application configuration file%n" +
-                "%n" +
-                "named arguments:%n" +
-                "  -h, --help             show this help message and exit%n" +
-                "  --migrations MIGRATIONS-FILE%n" +
-                "                         the file containing  the  Liquibase migrations for%n" +
-                "                         the application%n" +
-                "  --catalog CATALOG      Specify  the   database   catalog   (use  database%n" +
-                "                         default if omitted)%n" +
-                "  --schema SCHEMA        Specify the database schema  (use database default%n" +
-                "                         if omitted)%n" +
-                "  -i CONTEXTS, --include CONTEXTS%n" +
-                "                         include change sets from the given context%n"));
+        assertThat(baos.toString(UTF_8.name())).isEqualToNormalizingNewlines(
+            "usage: db test [-h] [--migrations MIGRATIONS-FILE] [--catalog CATALOG]\n" +
+                "          [--schema SCHEMA] [-i CONTEXTS] [file]\n" +
+                "\n" +
+                "Apply and rollback pending change sets.\n" +
+                "\n" +
+                "positional arguments:\n" +
+                "  file                   application configuration file\n" +
+                "\n" +
+                "named arguments:\n" +
+                "  -h, --help             show this help message and exit\n" +
+                "  --migrations MIGRATIONS-FILE\n" +
+                "                         the file containing  the  Liquibase migrations for\n" +
+                "                         the application\n" +
+                "  --catalog CATALOG      Specify  the   database   catalog   (use  database\n" +
+                "                         default if omitted)\n" +
+                "  --schema SCHEMA        Specify the database schema  (use database default\n" +
+                "                         if omitted)\n" +
+                "  -i CONTEXTS, --include CONTEXTS\n" +
+                "                         include change sets from the given context\n");
     }
 }


### PR DESCRIPTION
Where we are using `String#format(...)` to deal with platform-specific line endings, we can instead use `isEqualToNormalizingNewlines`.

We can also replace some calls to `String#format(String...)` with AssertJ's built-in support for format strings.
