### PR TITLE
Append value of counter instead of toString output

### DIFF
--- a/dropwizard-health/src/main/java/io/dropwizard/health/ScheduledHealthCheck.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/ScheduledHealthCheck.java
@@ -111,9 +111,13 @@ class ScheduledHealthCheck implements Runnable {
         sb.append(", healthCheck=").append(healthCheck);
         sb.append(", schedule=").append(schedule);
         sb.append(", state=").append(state);
-        sb.append(", healthyCheckCounter=").append(healthyCheckCounter);
-        sb.append(", unhealthyCheckCounter=").append(unhealthyCheckCounter);
+        sb.append(", healthyCheckCounter=").append(getCounterString(healthyCheckCounter));
+        sb.append(", unhealthyCheckCounter=").append(getCounterString(unhealthyCheckCounter));
         sb.append('}');
         return sb.toString();
+    }
+
+    private String getCounterString(Counter counter) {
+        return Counter.class.equals(counter.getClass()) ? String.valueOf(counter.getCount()) : counter.toString();
     }
 }


### PR DESCRIPTION
Closes #4943 

This outputs the value of the `Counter` except when the `Counter` is overridden. If a user provides a custom implementation of a `toString` method, probably that one should be used.
