### PR TITLE
Remove deprecated `Throwables#getRootCause(Throwable)`

### DIFF
--- a/dropwizard-util/src/main/java/io/dropwizard/util/Throwables.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Throwables.java
@@ -14,39 +14,6 @@ public final class Throwables {
     }
 
     /**
-     * Returns the innermost cause of {@code throwable}. The first throwable in a chain provides
-     * context from when the error or exception was initially detected. Example usage:
-     *
-     * <pre>
-     * assertEquals("Unable to assign a customer id", Throwables.getRootCause(e).getMessage());
-     * </pre>
-     *
-     * @throws IllegalArgumentException if there is a loop in the causal chain
-     * @deprecated consider using Apache commons-lang3 ExceptionUtils instead
-     */
-    @Deprecated
-    public static Throwable getRootCause(Throwable throwable) {
-        // Keep a second pointer that slowly walks the causal chain. If the fast pointer ever catches
-        // the slower pointer, then there's a loop.
-        Throwable slowPointer = throwable;
-        boolean advanceSlowPointer = false;
-
-        Throwable cause;
-        while ((cause = throwable.getCause()) != null) {
-            throwable = cause;
-
-            if (throwable == slowPointer) {
-                throw new IllegalArgumentException("Loop in causal chain detected.", throwable);
-            }
-            if (advanceSlowPointer) {
-                slowPointer = slowPointer.getCause();
-            }
-            advanceSlowPointer = !advanceSlowPointer; // only advance every other iteration
-        }
-        return throwable;
-    }
-
-    /**
      * Search an exception chain for an exception matching a given condition.
      *
      * @param condition The condition to match on


### PR DESCRIPTION
This was deprecated in 2.1.x and is not used by Dropwizard.