### PR TITLE
Remove guava as a dependency of dropwizard-auth

### DIFF
--- a/dropwizard-auth/pom.xml
+++ b/dropwizard-auth/pom.xml
@@ -46,10 +46,6 @@
             <artifactId>jsr305</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/CachingAuthorizer.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/CachingAuthorizer.java
@@ -9,7 +9,6 @@ import com.github.benmanes.caffeine.cache.CaffeineSpec;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import com.github.benmanes.caffeine.cache.stats.StatsCounter;
-import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.util.Sets;
 
 import javax.annotation.Nullable;
@@ -48,7 +47,6 @@ public class CachingAuthorizer<P extends Principal> implements Authorizer<P> {
     // thus result in read through to the underlying `Authorizer`.
     //
     // Field is package-private to be visible for unit tests
-    @VisibleForTesting
     final LoadingCache<AuthorizationContext<P>, Boolean> cache;
 
     /**


### PR DESCRIPTION
This was only here in order to annotate a field as `@VisibleForTesting`