### PR TITLE
Remove guava from dropwizard-health

### DIFF
--- a/dropwizard-health/pom.xml
+++ b/dropwizard-health/pom.xml
@@ -70,10 +70,6 @@
             <artifactId>jsr305</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>

--- a/dropwizard-health/src/main/java/io/dropwizard/health/DefaultHealthFactory.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/DefaultHealthFactory.java
@@ -7,7 +7,6 @@ import com.codahale.metrics.health.HealthCheckRegistry;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.dropwizard.health.response.HealthResponderFactory;
 import io.dropwizard.health.response.HealthResponseProvider;
 import io.dropwizard.health.response.HealthResponseProviderFactory;
@@ -21,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicLong;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.util.Collections.singletonList;
+import static java.util.concurrent.Executors.defaultThreadFactory;
 
 @JsonTypeName("default")
 public class DefaultHealthFactory implements HealthFactory {
@@ -203,11 +204,16 @@ public class DefaultHealthFactory implements HealthFactory {
             final MetricRegistry metrics,
             final LifecycleEnvironment lifecycle,
             final String fullName) {
-        final ThreadFactory threadFactory = new ThreadFactoryBuilder()
-                .setNameFormat(fullName + "-%d")
-                .setDaemon(true)
-                .setUncaughtExceptionHandler((t, e) -> LOGGER.error("Thread={} died due to uncaught exception", t, e))
-                .build();
+        final AtomicLong threadNum = new AtomicLong(0L);
+        final ThreadFactory defaultThreadFactory = defaultThreadFactory();
+
+        final ThreadFactory threadFactory = (Runnable runnable) -> {
+            Thread thread = defaultThreadFactory.newThread(runnable);
+            thread.setName(String.format("%s-%d", fullName, threadNum.incrementAndGet()));
+            thread.setDaemon(true);
+            thread.setUncaughtExceptionHandler((t, e) -> LOGGER.error("Thread={} died due to uncaught exception", t, e));
+            return thread;
+        };
 
         final InstrumentedThreadFactory instrumentedThreadFactory =
                 new InstrumentedThreadFactory(threadFactory, metrics);


### PR DESCRIPTION
We can construct a `ThreadFactory` without Guava's help.

This also fixes a potential format string injection in the healthcheck thread name.