### PR TITLE
Change log messages for unhealthy initialized health checks

### DIFF
--- a/dropwizard-health/src/main/java/io/dropwizard/health/HealthCheckManager.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/HealthCheckManager.java
@@ -174,7 +174,14 @@ class HealthCheckManager implements HealthCheckRegistryListener, HealthStatusChe
                     return;
             }
         } else {
-            LOGGER.error("A critical dependency is now unhealthy: name={}, type={}", name, type);
+            ScheduledHealthCheck healthCheck = checks.get(name);
+            HealthCheckConfiguration healthCheckConfiguration = configs.get(name);
+            if (healthCheck != null && healthCheckConfiguration != null
+                && !healthCheckConfiguration.isInitialState() && !healthCheck.isPreviouslyRecovered()) {
+                LOGGER.warn("A critical unhealthy initialized dependency has not yet recovered: name={}, type={}", name, type);
+            } else {
+                LOGGER.error("A critical dependency is now unhealthy: name={}, type={}", name, type);
+            }
             switch (type) {
                 case ALIVE:
                     updateCriticalStatus(isAppAlive, unhealthyCriticalAliveChecks.incrementAndGet());
@@ -196,7 +203,14 @@ class HealthCheckManager implements HealthCheckRegistryListener, HealthStatusChe
         if (isNowHealthy) {
             LOGGER.info("A non-critical dependency is now healthy: name={}, type={}", name, type);
         } else {
-            LOGGER.warn("A non-critical dependency is now unhealthy: name={}, type={}", name, type);
+            ScheduledHealthCheck healthCheck = checks.get(name);
+            HealthCheckConfiguration healthCheckConfiguration = configs.get(name);
+            if (healthCheck != null && healthCheckConfiguration != null
+                && !healthCheckConfiguration.isInitialState() && !healthCheck.isPreviouslyRecovered()) {
+                LOGGER.info("A non-critical unhealthy initialized dependency has not yet recovered: name={}, type={}", name, type);
+            } else {
+                LOGGER.warn("A non-critical dependency is now unhealthy: name={}, type={}", name, type);
+            }
         }
     }
 

--- a/dropwizard-health/src/test/java/io/dropwizard/health/ScheduledHealthCheckTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/ScheduledHealthCheckTest.java
@@ -41,13 +41,17 @@ class ScheduledHealthCheckTest {
 
         final Counter healthyCounter = metrics.counter("test.healthy");
         final Counter unhealthyCounter = metrics.counter("test.unhealthy");
-        final State state = new State(name, schedule.getFailureAttempts(), schedule.getSuccessAttempts(), true, LISTENER);
+        final State state = new State(name, schedule.getFailureAttempts(), schedule.getSuccessAttempts(), false, LISTENER);
         final ScheduledHealthCheck scheduledHealthCheck = new ScheduledHealthCheck(name, HealthCheckType.READY, true,
             healthCheck, schedule, state, healthyCounter, unhealthyCounter);
 
         when(healthCheck.execute()).thenReturn(HealthCheck.Result.healthy());
 
+        assertThat(scheduledHealthCheck.isPreviouslyRecovered()).isFalse();
+
         scheduledHealthCheck.run();
+
+        assertThat(scheduledHealthCheck.isPreviouslyRecovered()).isTrue();
 
         assertThat(scheduledHealthCheck.isHealthy()).isTrue();
         assertThat(healthyCounter.getCount()).isEqualTo(1L);
@@ -62,12 +66,16 @@ class ScheduledHealthCheckTest {
         final String name = "test";
         final Counter healthyCounter = metrics.counter("test.healthy");
         final Counter unhealthyCounter = metrics.counter("test.unhealthy");
-        final State state = new State(name, schedule.getFailureAttempts(), schedule.getSuccessAttempts(), true, LISTENER);
+        final State state = new State(name, schedule.getFailureAttempts(), schedule.getSuccessAttempts(), false, LISTENER);
         final ScheduledHealthCheck scheduledHealthCheck = new ScheduledHealthCheck(name, HealthCheckType.READY, true,
             healthCheck, schedule, state, healthyCounter, unhealthyCounter);
         when(healthCheck.execute()).thenReturn(HealthCheck.Result.unhealthy("something happened"));
 
+        assertThat(scheduledHealthCheck.isPreviouslyRecovered()).isFalse();
+
         scheduledHealthCheck.run();
+
+        assertThat(scheduledHealthCheck.isPreviouslyRecovered()).isFalse();
 
         assertThat(scheduledHealthCheck.isHealthy()).isFalse();
         assertThat(healthyCounter.getCount()).isZero();


### PR DESCRIPTION
Closes #4944 

This PR maintains a flag in a `SchaduledHealthCheck`, if the check already had recovered. This provides the ability to display a better log message, if the check was initialized as unhealthy.
