### PR TITLE
Replace JAX-RS ClientBuilder with Jersey's JerseyClientBuilder

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/JerseyClientBuilder.java
@@ -24,7 +24,6 @@ import javax.annotation.Nullable;
 import javax.net.ssl.HostnameVerifier;
 import javax.validation.Validator;
 import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.RxInvokerProvider;
 import javax.ws.rs.core.Configuration;
 import java.util.ArrayList;
@@ -369,7 +368,7 @@ public class JerseyClientBuilder {
             apacheHttpClientBuilder.disableContentCompression(true);
         }
 
-        final Client client = ClientBuilder.newClient(buildConfig(name, threadPool, objectMapper, validator));
+        final Client client = org.glassfish.jersey.client.JerseyClientBuilder.createClient(buildConfig(name, threadPool, objectMapper, validator));
         client.register(new JerseyIgnoreRequestUserAgentHeaderFilter());
 
         // Tie the client to server lifecycle

--- a/dropwizard-health/src/main/java/io/dropwizard/health/check/http/HttpHealthCheck.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/check/http/HttpHealthCheck.java
@@ -2,12 +2,12 @@ package io.dropwizard.health.check.http;
 
 import com.codahale.metrics.health.HealthCheck;
 import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.JerseyClientBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Response;
 import java.time.Duration;
 import java.util.Objects;
@@ -32,7 +32,7 @@ public class HttpHealthCheck extends HealthCheck {
         if (readTimeout.toMillis() <= 0L || connectionTimeout.toMillis() <= 0L) {
             throw new IllegalStateException();
         }
-        this.client = ClientBuilder.newClient()
+        this.client = JerseyClientBuilder.createClient()
             .property(ClientProperties.CONNECT_TIMEOUT, (int) connectionTimeout.toMillis())
             .property(ClientProperties.READ_TIMEOUT, (int) readTimeout.toMillis());
     }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportTest.java
@@ -13,12 +13,12 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.app.TestConfiguration;
 import io.dropwizard.validation.BaseValidator;
+import org.glassfish.jersey.client.JerseyClientBuilder;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import javax.validation.Validator;
-import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import java.io.PrintWriter;
@@ -58,7 +58,7 @@ class DropwizardTestSupportTest {
 
     @Test
     void canGetExpectedResourceOverHttp() {
-        final String content = ClientBuilder.newClient().target(
+        final String content = JerseyClientBuilder.createClient().target(
                 "http://localhost:" + TEST_SUPPORT.getLocalPort() + "/test").request().get(String.class);
 
         assertThat(content).isEqualTo("Yes, it's here");
@@ -85,7 +85,7 @@ class DropwizardTestSupportTest {
     @Test
     void canPerformAdminTask() {
         final String response
-                = ClientBuilder.newClient().target("http://localhost:"
+                = JerseyClientBuilder.createClient().target("http://localhost:"
                 + TEST_SUPPORT.getAdminPort() + "/tasks/hello?name=test_user")
                 .request()
                 .post(Entity.entity("", MediaType.TEXT_PLAIN), String.class);
@@ -96,7 +96,7 @@ class DropwizardTestSupportTest {
     @Test
     void canPerformAdminTaskWithPostBody() {
         final String response
-                = ClientBuilder.newClient().target("http://localhost:"
+                = JerseyClientBuilder.createClient().target("http://localhost:"
                 + TEST_SUPPORT.getAdminPort() + "/tasks/echo")
                 .request()
                 .post(Entity.entity("Custom message", MediaType.TEXT_PLAIN), String.class);

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit/DropwizardAppRuleTest.java
@@ -7,7 +7,6 @@ import io.dropwizard.testing.app.TestConfiguration;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 
@@ -21,7 +20,7 @@ public class DropwizardAppRuleTest {
 
     @Test
     public void canGetExpectedResourceOverHttp() {
-        final String content = ClientBuilder.newClient().target(
+        final String content = RULE.client().target(
             "http://localhost:" + RULE.getLocalPort() + "/test").request().get(String.class);
 
         assertThat(content).isEqualTo("Yes, it's here");

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/AbstractDropwizardAppExtensionTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/AbstractDropwizardAppExtensionTest.java
@@ -6,9 +6,10 @@ import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.app.DropwizardTestApplication;
 import io.dropwizard.testing.app.TestConfiguration;
 import java.util.Optional;
-import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
+
+import org.glassfish.jersey.client.JerseyClientBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -16,7 +17,7 @@ abstract class AbstractDropwizardAppExtensionTest {
 
     @Test
     void canGetExpectedResourceOverHttp() {
-        final String content = ClientBuilder.newClient().target(
+        final String content = JerseyClientBuilder.createClient().target(
                 "http://localhost:" + getExtension().getLocalPort() + "/test").request().get(String.class);
 
         assertThat(content).isEqualTo("Yes, it's here");


### PR DESCRIPTION
Refs #3847 

`dropwizard-testing` mostly already uses the `JerseyClientBuilder`, the remaining changes are added for consistency.

`HttpHealthCheck` doesn't expose the `Client`, so the change is unproblematic too.

Only the client used in `dropwizard-client` gets exposed to the user. But as `JerseyIgnoreRequestUserAgentHeaderFilter` relies on a Jersey `ClientRequest` and is registered by default, other implementations would probably fail. So the change to `JerseyClientBuilder` should be reasonable to provide a working instance for every user.