### PR TITLE
Remove unused parts of `NetUtil`

### DIFF
--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/NetUtil.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/NetUtil.java
@@ -19,37 +19,20 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.net.InetAddress;
-import java.net.NetworkInterface;
-import java.net.SocketException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Enumeration;
-import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.atomic.AtomicReference;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * This class is taken from the Netty project, and all credit goes to them.
  * It has been modified, to remove dependencies on other classes, and to convert to methods, rather than a
  * static value.
- *
- * The {@link #getAllLocalIPs()} method was taken from the Apache Curator project
- * which is also under the Apache 2.0 license.
  */
 
 class NetUtil {
-    public static final int DEFAULT_TCP_BACKLOG_WINDOWS = 200;
-    public static final int DEFAULT_TCP_BACKLOG_LINUX = 128;
-    public static final String TCP_BACKLOG_SETTING_LOCATION = "/proc/sys/net/core/somaxconn";
-
-    private static final AtomicReference<LocalIpFilter> LOCAL_IP_FILTER = new AtomicReference<>((nif, adr) ->
-        (adr != null) && !adr.isLoopbackAddress() && (nif.isPointToPoint() || !adr.isLinkLocalAddress())
-    );
+    static final int DEFAULT_TCP_BACKLOG_WINDOWS = 200;
+    static final int DEFAULT_TCP_BACKLOG_LINUX = 128;
+    static final String TCP_BACKLOG_SETTING_LOCATION = "/proc/sys/net/core/somaxconn";
 
     /**
      * The SOMAXCONN value of the current machine.  If failed to get the value,  {@code 200}  is used as a
@@ -59,11 +42,7 @@ class NetUtil {
         return getTcpBacklog(getDefaultTcpBacklog());
     }
 
-    /**
-     * The SOMAXCONN value of the current machine.  If failed to get the value, <code>defaultBacklog</code> argument is
-     * used
-     */
-    public static int getTcpBacklog(int tcpBacklog) {
+    static int getTcpBacklog(int tcpBacklog) {
         // Taken from netty.
 
         // As a SecurityManager may prevent reading the somaxconn file we wrap this in a privileged block.
@@ -84,72 +63,11 @@ class NetUtil {
 
     }
 
-    public static boolean isWindows() {
+    private static boolean isWindows() {
         return System.getProperty("os.name", "").toLowerCase(Locale.US).contains("win");
     }
 
-    public static int getDefaultTcpBacklog() {
+    private static int getDefaultTcpBacklog() {
         return isWindows() ? DEFAULT_TCP_BACKLOG_WINDOWS : DEFAULT_TCP_BACKLOG_LINUX;
-    }
-
-    /**
-     * Replace the default local ip filter used by {@link #getAllLocalIPs()}
-     *
-     * @param newLocalIpFilter the new local ip filter
-     */
-    public static void setLocalIpFilter(LocalIpFilter newLocalIpFilter) {
-        requireNonNull(newLocalIpFilter);
-        LOCAL_IP_FILTER.set(newLocalIpFilter);
-    }
-
-    /**
-     * Return the current local ip filter used by {@link #getAllLocalIPs()}
-     *
-     * @return ip filter
-     */
-    public static LocalIpFilter getLocalIpFilter() {
-        return requireNonNull(LOCAL_IP_FILTER.get());
-    }
-
-    /**
-     * based on http://pastebin.com/5X073pUc
-     * <p>
-     *
-     * Returns all available IP addresses.
-     * <p>
-     * In error case or if no network connection is established, we return
-     * an empty list here.
-     * <p>
-     * Loopback addresses are excluded - so 127.0.0.1 will not be never
-     * returned.
-     * <p>
-     * The "primary" IP might not be the first one in the returned list.
-     *
-     * @return  Returns all IP addresses (can be an empty list in error case
-     *          or if network connection is missing).
-     * @see <a href="http://pastebin.com/5X073pUc">getAllLocalIPs</a>
-     * @see <a href="https://github.com/apache/curator/blob/master/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/ServiceInstanceBuilder.java">ServiceInstanceBuilder.java</a>
-     * @throws SocketException errors
-     */
-    public static Collection<InetAddress> getAllLocalIPs() throws SocketException {
-        final List<InetAddress> listAdr = new ArrayList<>();
-        final Enumeration<NetworkInterface> nifs = NetworkInterface.getNetworkInterfaces();
-        if (nifs == null) {
-            return listAdr;
-        }
-
-        while (nifs.hasMoreElements()) {
-            final NetworkInterface nif = nifs.nextElement();
-            // We ignore subinterfaces - as not yet needed.
-
-            final Enumeration<InetAddress> adrs = nif.getInetAddresses();
-            while (adrs.hasMoreElements()) {
-                final InetAddress adr = adrs.nextElement();
-                if (getLocalIpFilter().use(nif, adr)) {
-                    listAdr.add(adr);
-                }
-            }
-        }
-        return listAdr;
     }
 }

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NetUtilTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NetUtilTest.java
@@ -3,7 +3,6 @@ package io.dropwizard.jetty;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
-import java.net.InetAddress;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
@@ -55,23 +54,6 @@ class NetUtilTest {
         assertThat(NetUtil.getTcpBacklog())
             .as("NetUtil should read more than the first character of somaxconn")
             .isGreaterThan(2);
-    }
-
-    @Test
-    void testAllLocalIps() throws Exception {
-        NetUtil.setLocalIpFilter((nif, adr) ->
-            (adr != null) && !adr.isLoopbackAddress() && (nif.isPointToPoint() || !adr.isLinkLocalAddress()));
-        assertThat(NetUtil.getAllLocalIPs())
-                .isNotEmpty()
-                .doesNotContain(InetAddress.getLoopbackAddress());
-    }
-
-    @Test
-    void testLocalIpsWithLocalFilter() throws Exception {
-        NetUtil.setLocalIpFilter((inf, adr) -> adr != null);
-        assertThat(NetUtil.getAllLocalIPs())
-                .isNotEmpty()
-                .contains(InetAddress.getLoopbackAddress());
     }
 
     private boolean isTcpBacklogSettingReadable() {


### PR DESCRIPTION
Remove unused methods from `NetUtil` and tighten access modifiers for the remainder.

`NetUtil#getLocalIpFilter()` was added in 02ae4b77610e6d05595e04e007f6b9282a2b22e6 but never seems to have been used.