### PR TITLE
Properly stop threads of `LogbackAccessRequestLog`

### DIFF
--- a/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/LogbackAccessRequestLog.java
+++ b/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/LogbackAccessRequestLog.java
@@ -1,12 +1,13 @@
 package io.dropwizard.request.logging;
 
 import ch.qos.logback.access.jetty.RequestLogImpl;
+import org.eclipse.jetty.util.component.LifeCycle;
 
 /**
  * The Dropwizard request log uses logback-access, but we override it to remove the requirement for logback-access.xml
  * based configuration.
  */
-public class LogbackAccessRequestLog extends RequestLogImpl {
+public class LogbackAccessRequestLog extends RequestLogImpl implements LifeCycle {
     @Override
     public void configure() {
         setName("LogbackAccessRequestLog");


### PR DESCRIPTION
Closes #3226 

`LogbackAccessRequestLog` is registered as a bean, but [doesn't implement `LifeCycle`](https://github.com/qos-ch/logback/pull/269). As this PR is open for over 6 years, I'd suggest to fix this on our side.

If we manually implement `LifeCycle`, which the `RequestLogImpl` actually does with its methods, the component is registered as a managed object rather then a POJO and therefore is started and stopped by the Jetty server.