### PR TITLE
Make ConfigurationFactoryFactory#create public

### DIFF
--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationFactoryFactory.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationFactoryFactory.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import javax.validation.Validator;
 
 public interface ConfigurationFactoryFactory<T> {
-    ConfigurationFactory<T> create(Class<T> klass,
+    public ConfigurationFactory<T> create(Class<T> klass,
             Validator validator,
             ObjectMapper objectMapper,
             String propertyPrefix);


### PR DESCRIPTION
###### Problem:
In its current state, the `ConfigurationFactoryFactory`'s `create` method cannot be inherited outside the package (e.g. by a third-party plugin). This makes it impossible to build and configure a custom ConfigurationFactory, as the method to create a configuration factory can't be overridden.

###### Solution:
Make `create` on `ConfigurationFactoryFactory` public, giving external libraries the ability to inherit/override if necessary.

###### Result:
All unit tests still pass, and increasing the visibility on the method does not cause any regression issues. This will simply increase the extensibility/inheritability of Dropwizard as a whole.