### PR TITLE
Replace `@NotThreadSafe` with jUnit 5 `Execution(SAME_THREAD)`

### DIFF
--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -45,7 +45,6 @@
         <javassist.version>3.28.0-GA</javassist.version>
         <javax.persistence-api.version>2.2</javax.persistence-api.version>
         <jaxb-api.version>2.3.3</jaxb-api.version>
-        <jcip-annotations.version>1.0</jcip-annotations.version>
         <jdbi3.version>3.28.0</jdbi3.version>
         <jersey.version>2.35</jersey.version>
         <jetty-setuid-java.version>1.0.4</jetty-setuid-java.version>
@@ -294,11 +293,6 @@
                         <artifactId>liquibase-core</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>net.jcip</groupId>
-                <artifactId>jcip-annotations</artifactId>
-                <version>${jcip-annotations.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.github.spullara.mustache.java</groupId>

--- a/dropwizard-migrations/pom.xml
+++ b/dropwizard-migrations/pom.xml
@@ -95,11 +95,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>net.jcip</groupId>
-            <artifactId>jcip-annotations</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-jdbc</artifactId>
             <scope>test</scope>

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/CloseableLiquibaseTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/CloseableLiquibaseTest.java
@@ -3,14 +3,15 @@ package io.dropwizard.migrations;
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.db.ManagedPooledDataSource;
-import net.jcip.annotations.NotThreadSafe;
 import org.apache.tomcat.jdbc.pool.ConnectionPool;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
-@NotThreadSafe
+@Execution(SAME_THREAD)
 class CloseableLiquibaseTest {
 
     CloseableLiquibase liquibase;

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbCalculateChecksumCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbCalculateChecksumCommandTest.java
@@ -2,9 +2,9 @@ package io.dropwizard.migrations;
 
 import io.dropwizard.util.Maps;
 import liquibase.change.CheckSum;
-import net.jcip.annotations.NotThreadSafe;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
@@ -14,8 +14,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
-@NotThreadSafe
+@Execution(SAME_THREAD)
 class DbCalculateChecksumCommandTest {
 
     private final DbCalculateChecksumCommand<TestMigrationConfiguration> migrateCommand = new DbCalculateChecksumCommand<>(

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbClearChecksumsCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbClearChecksumsCommandTest.java
@@ -1,9 +1,9 @@
 package io.dropwizard.migrations;
 
 import liquibase.Liquibase;
-import net.jcip.annotations.NotThreadSafe;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 import org.mockito.Mockito;
 
 import java.io.ByteArrayOutputStream;
@@ -13,8 +13,9 @@ import java.util.Collections;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
-@NotThreadSafe
+@Execution(SAME_THREAD)
 class DbClearChecksumsCommandTest {
 
     private final DbClearChecksumsCommand<TestMigrationConfiguration> clearChecksums = new DbClearChecksumsCommand<>(

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbCommandTest.java
@@ -1,10 +1,10 @@
 package io.dropwizard.migrations;
 
-import net.jcip.annotations.NotThreadSafe;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
@@ -13,8 +13,9 @@ import java.util.Collections;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
-@NotThreadSafe
+@Execution(SAME_THREAD)
 class DbCommandTest {
 
     private final DbCommand<TestMigrationConfiguration> dbCommand = new DbCommand<>("db",

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDropAllCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDropAllCommandTest.java
@@ -1,10 +1,10 @@
 package io.dropwizard.migrations;
 
-import net.jcip.annotations.NotThreadSafe;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
@@ -13,8 +13,9 @@ import java.util.Collections;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
-@NotThreadSafe
+@Execution(SAME_THREAD)
 class DbDropAllCommandTest {
 
     private final DbDropAllCommand<TestMigrationConfiguration> dropAllCommand = new DbDropAllCommand<>(

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDumpCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbDumpCommandTest.java
@@ -1,10 +1,10 @@
 package io.dropwizard.migrations;
 
-import net.jcip.annotations.NotThreadSafe;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -32,8 +32,9 @@ import java.util.stream.Stream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
-@NotThreadSafe
+@Execution(SAME_THREAD)
 class DbDumpCommandTest {
 
     private static final List<String> ATTRIBUTE_NAMES = Arrays.asList("columns", "foreign-keys", "indexes",

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbFastForwardCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbFastForwardCommandTest.java
@@ -1,12 +1,12 @@
 package io.dropwizard.migrations;
 
 import io.dropwizard.util.Maps;
-import net.jcip.annotations.NotThreadSafe;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
@@ -17,8 +17,9 @@ import java.util.regex.Pattern;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
-@NotThreadSafe
+@Execution(SAME_THREAD)
 class DbFastForwardCommandTest {
 
     private static final Pattern NEWLINE_PATTERN = Pattern.compile(System.lineSeparator());

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbGenerateDocsCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbGenerateDocsCommandTest.java
@@ -1,9 +1,9 @@
 package io.dropwizard.migrations;
 
 import liquibase.Liquibase;
-import net.jcip.annotations.NotThreadSafe;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 import org.mockito.Mockito;
 
 import java.io.ByteArrayOutputStream;
@@ -13,8 +13,9 @@ import java.util.Collections;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
-@NotThreadSafe
+@Execution(SAME_THREAD)
 class DbGenerateDocsCommandTest {
 
     private final DbGenerateDocsCommand<TestMigrationConfiguration> generateDocsCommand = new DbGenerateDocsCommand<>(

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbLocksCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbLocksCommandTest.java
@@ -2,9 +2,9 @@ package io.dropwizard.migrations;
 
 import io.dropwizard.util.Maps;
 import liquibase.Liquibase;
-import net.jcip.annotations.NotThreadSafe;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 import org.mockito.Mockito;
 
 import java.io.ByteArrayOutputStream;
@@ -14,8 +14,9 @@ import java.io.PrintWriter;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
-@NotThreadSafe
+@Execution(SAME_THREAD)
 class DbLocksCommandTest {
 
     private final DbLocksCommand<TestMigrationConfiguration> locksCommand = new DbLocksCommand<>(

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCommandTest.java
@@ -1,7 +1,6 @@
 package io.dropwizard.migrations;
 
 import io.dropwizard.util.Maps;
-import net.jcip.annotations.NotThreadSafe;
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
@@ -10,6 +9,7 @@ import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.result.ResultIterable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
@@ -20,8 +20,9 @@ import java.util.Map;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
-@NotThreadSafe
+@Execution(SAME_THREAD)
 class DbMigrateCommandTest {
 
     private final DbMigrateCommand<TestMigrationConfiguration> migrateCommand = new DbMigrateCommand<>(

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCustomSchemaTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateCustomSchemaTest.java
@@ -1,15 +1,16 @@
 package io.dropwizard.migrations;
 
 import io.dropwizard.util.Maps;
-import net.jcip.annotations.NotThreadSafe;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
-@NotThreadSafe
+@Execution(SAME_THREAD)
 class DbMigrateCustomSchemaTest {
 
     private final DbMigrateCommand<TestMigrationConfiguration> migrateCommand = new DbMigrateCommand<>(

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateDifferentFileCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateDifferentFileCommandTest.java
@@ -1,18 +1,19 @@
 package io.dropwizard.migrations;
 
-import net.jcip.annotations.NotThreadSafe;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
-@NotThreadSafe
+@Execution(SAME_THREAD)
 class DbMigrateDifferentFileCommandTest {
 
     private final DbMigrateCommand<TestMigrationConfiguration> migrateCommand = new DbMigrateCommand<>(

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbPrepareRollbackCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbPrepareRollbackCommandTest.java
@@ -1,9 +1,9 @@
 package io.dropwizard.migrations;
 
-import net.jcip.annotations.NotThreadSafe;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
@@ -13,8 +13,9 @@ import java.util.Collections;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
-@NotThreadSafe
+@Execution(SAME_THREAD)
 class DbPrepareRollbackCommandTest {
 
     private final DbPrepareRollbackCommand<TestMigrationConfiguration> prepareRollbackCommand =

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbRollbackCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbRollbackCommandTest.java
@@ -1,12 +1,12 @@
 package io.dropwizard.migrations;
 
 import io.dropwizard.util.Maps;
-import net.jcip.annotations.NotThreadSafe;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
@@ -17,8 +17,9 @@ import java.util.Date;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
-@NotThreadSafe
+@Execution(SAME_THREAD)
 class DbRollbackCommandTest {
 
     private final String migrationsFileName = "migrations-ddl.xml";

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbStatusCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbStatusCommandTest.java
@@ -1,9 +1,9 @@
 package io.dropwizard.migrations;
 
-import net.jcip.annotations.NotThreadSafe;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
@@ -16,8 +16,9 @@ import java.util.Objects;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
-@NotThreadSafe
+@Execution(SAME_THREAD)
 class DbStatusCommandTest {
 
     private final DbStatusCommand<TestMigrationConfiguration> statusCommand =

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbTagCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbTagCommandTest.java
@@ -1,8 +1,8 @@
 package io.dropwizard.migrations;
 
-import net.jcip.annotations.NotThreadSafe;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
@@ -11,8 +11,9 @@ import java.util.Collections;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
-@NotThreadSafe
+@Execution(SAME_THREAD)
 class DbTagCommandTest {
 
     private final String migrationsFileName = "migrations-ddl.xml";

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbTestCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbTestCommandTest.java
@@ -1,8 +1,8 @@
 package io.dropwizard.migrations;
 
-import net.jcip.annotations.NotThreadSafe;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
@@ -12,8 +12,9 @@ import java.util.Collections;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
-@NotThreadSafe
+@Execution(SAME_THREAD)
 class DbTestCommandTest {
 
     private final DbTestCommand<TestMigrationConfiguration> dbTestCommand = new DbTestCommand<>(


### PR DESCRIPTION
This allows us to drop a dependency on jcip-annnotations