### PR TITLE
Migrations file handling

### DIFF
--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibaseWithFileSystemMigrationsFile.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/CloseableLiquibaseWithFileSystemMigrationsFile.java
@@ -7,7 +7,11 @@ import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.LiquibaseException;
 import liquibase.resource.FileSystemResourceAccessor;
 
+import java.io.File;
+import java.net.URISyntaxException;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class CloseableLiquibaseWithFileSystemMigrationsFile extends CloseableLiquibase implements AutoCloseable {
 
@@ -17,9 +21,25 @@ public class CloseableLiquibaseWithFileSystemMigrationsFile extends CloseableLiq
         String file
     ) throws LiquibaseException, SQLException {
         super(file,
-              new FileSystemResourceAccessor(),
-              database,
-              dataSource);
+            new FileSystemResourceAccessor(getRootPaths().toArray(new File[0])),
+            database,
+            dataSource);
+    }
+
+    private static List<File> getRootPaths() {
+        List<File> rootPaths = new ArrayList<>();
+        boolean isWindows = System.getProperty("os.name", "").toLowerCase().contains("win");
+        if (isWindows) {
+            rootPaths.add(new File("C:\\"));
+        } else {
+            rootPaths.add(new File("/"));
+        }
+        try {
+            rootPaths.add(new File(CloseableLiquibase.class.getProtectionDomain().getCodeSource().getLocation().toURI()));
+        } catch (URISyntaxException ignored) {
+            // if we cannot acquire the path of the executing jar, skip it
+        }
+        return rootPaths;
     }
 
     public CloseableLiquibaseWithFileSystemMigrationsFile(

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateDifferentFileCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbMigrateDifferentFileCommandTest.java
@@ -4,7 +4,6 @@ import net.sourceforge.argparse4j.inf.Namespace;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 
@@ -37,7 +36,6 @@ class DbMigrateDifferentFileCommandTest {
     }
 
     @Test
-    @Disabled("Ignored until https://liquibase.jira.com/browse/CORE-3262 has been solved")
     void testRunForFileFromFilesystem() throws Exception {
         final String migrationsPath = getClass().getResource("/migrations.xml").getPath();
         migrateCommand.run(null, new Namespace(Collections.singletonMap("migrations-file", migrationsPath)), conf);


### PR DESCRIPTION
###### Problem:
Liquibase 4.x.x changed its file finding and handling. Therefore migration files in the `dropwizard-migrations` module were not found.

###### Solution:
Add root paths to the `FileSystemResourceAccessor`. Liquibase suggests adding the path `'/'` as a fix when migrating to 4.x.x. This seems to work on Linux, but not on Windows. So this PR adds the operating system specific root path (`C:\` for Windows and `/` otherwise). Additionally, the location of the code source is added (acquired through the `CloseableLiquibase` class).

This allows finding files with an absolute path and files located under `src/main/resources`, that are packaged into the jar as resources. Previously, it was possible to provide paths relative to the root folder of the project, which now isn't possible any more. However, the sources are unlikely to be deployed, so this should be enough in my opinion, when adding this behavior change to the migration guide. This also includes changes to be made to `.xml` files including other ones, as the include mechanism uses the same resolving strategy.

###### Result:
Users can specify custom files to the `dropwizard-migrations` module instead of using the default `migrations.xml`.

Resolves #5150 
