### PR TITLE
Replace `assumeThat` with jUnit 5 `DisabledIf` et al

### DIFF
--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationValidationExceptionTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationValidationExceptionTest.java
@@ -3,6 +3,7 @@ package io.dropwizard.configuration;
 import io.dropwizard.validation.BaseValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 
 import javax.annotation.Nullable;
 import javax.validation.ConstraintViolation;
@@ -12,8 +13,8 @@ import java.util.Locale;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
+@EnabledIf("isDefaultLocaleEnglish")
 class ConfigurationValidationExceptionTest {
     private static class Example {
         @NotNull
@@ -25,8 +26,6 @@ class ConfigurationValidationExceptionTest {
 
     @BeforeEach
     void setUp() {
-        assumeThat(Locale.getDefault().getLanguage()).isEqualTo("en");
-
         final Validator validator = BaseValidator.newValidator();
         final Set<ConstraintViolation<Example>> violations = validator.validate(new Example());
         this.e = new ConfigurationValidationException("config.yml", violations);
@@ -44,5 +43,9 @@ class ConfigurationValidationExceptionTest {
     void retainsTheSetOfExceptions() {
         assertThat(e.getConstraintViolations())
                 .isNotEmpty();
+    }
+
+    private static boolean isDefaultLocaleEnglish() {
+        return "en".equals(Locale.getDefault().getLanguage());
     }
 }

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/EnvironmentVariableSubstitutorTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/EnvironmentVariableSubstitutorTest.java
@@ -2,9 +2,9 @@ package io.dropwizard.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 class EnvironmentVariableSubstitutorTest {
 
@@ -15,9 +15,8 @@ class EnvironmentVariableSubstitutorTest {
     }
 
     @Test
+    @DisabledIfEnvironmentVariable(named = "DOES_NOT_EXIST", matches = ".*")
     void defaultConstructorEnablesStrict() {
-        assumeThat(System.getenv("DOES_NOT_EXIST")).isNull();
-
         assertThatExceptionOfType(UndefinedEnvironmentVariableException.class).isThrownBy(() ->
             new EnvironmentVariableSubstitutor().replace("${DOES_NOT_EXIST}"));
     }
@@ -49,16 +48,15 @@ class EnvironmentVariableSubstitutorTest {
     }
 
     @Test
+    @DisabledIfEnvironmentVariable(named = "DOES_NOT_EXIST", matches = ".*")
     void substitutorStrictRecurse() {
-        assumeThat(System.getenv("DOES_NOT_EXIST")).isNull();
         EnvironmentVariableSubstitutor substitutor = new EnvironmentVariableSubstitutor(true, true);
         assertThat(substitutor.replace("${DOES_NOT_EXIST:-${TEST}}")).isEqualTo(System.getenv("TEST"));
     }
 
     @Test
+    @DisabledIfEnvironmentVariable(named = "DOES_NOT_EXIST", matches = ".*")
     void substitutorThrowsExceptionInStrictMode() {
-        assumeThat(System.getenv("DOES_NOT_EXIST")).isNull();
-
         assertThatExceptionOfType(UndefinedEnvironmentVariableException.class).isThrownBy(() ->
             new EnvironmentVariableSubstitutor(true).replace("${DOES_NOT_EXIST}"));
     }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProviderTest.java
@@ -7,8 +7,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.validation.Validated;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 
 import javax.annotation.Nullable;
 import javax.validation.Valid;
@@ -33,13 +33,13 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unchecked")
+@EnabledIf("isDefaultLocaleEnglish")
 public class JacksonMessageBodyProviderTest {
     private static final Annotation[] NONE = new Annotation[0];
 
@@ -103,11 +103,6 @@ public class JacksonMessageBodyProviderTest {
     private final ObjectMapper mapper = spy(Jackson.newObjectMapper());
     private final JacksonMessageBodyProvider provider =
             new JacksonMessageBodyProvider(mapper);
-
-    @BeforeEach
-    void setUp() throws Exception {
-        assumeThat(Locale.getDefault().getLanguage()).isEqualTo("en");
-    }
 
     @Test
     void readsDeserializableTypes() {
@@ -289,4 +284,7 @@ public class JacksonMessageBodyProviderTest {
         assertThat((Iterable<Example>) obj).extracting(item -> item.id).contains(1 , 2);
     }
 
+    private static boolean isDefaultLocaleEnglish() {
+        return "en".equals(Locale.getDefault().getLanguage());
+    }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
@@ -7,7 +7,6 @@ import io.dropwizard.jersey.jackson.JacksonMessageBodyProviderTest.ListExample;
 import io.dropwizard.jersey.jackson.JacksonMessageBodyProviderTest.PartialExample;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.client.Entity;
@@ -23,7 +22,6 @@ import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
 class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     private static final Locale DEFAULT_LOCALE = Locale.getDefault();
@@ -45,12 +43,6 @@ class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     @AfterAll
     static void shutdown() {
         Locale.setDefault(DEFAULT_LOCALE);
-    }
-
-    @BeforeEach
-    public void setUp() throws Exception {
-        assumeThat(Locale.getDefault().getLanguage()).isEqualTo("en");
-        super.setUp();
     }
 
     @Test

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NetUtilTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/NetUtilTest.java
@@ -1,6 +1,10 @@
 package io.dropwizard.jetty;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import java.io.File;
 import java.net.InetAddress;
@@ -8,49 +12,34 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
 class NetUtilTest {
 
-    private static final String OS_NAME_PROPERTY = "os.name";
-
-    /**
-     * Assuming Windows
-     */
     @Test
+    @EnabledOnOs(OS.WINDOWS)
+    @DisabledIf("isTcpBacklogSettingReadable")
     void testDefaultTcpBacklogForWindows() {
-        assumeThat(System.getProperty(OS_NAME_PROPERTY)).contains("win");
-        assumeThat(isTcpBacklogSettingReadable()).isFalse();
         assertThat(NetUtil.getTcpBacklog()).isEqualTo(NetUtil.DEFAULT_TCP_BACKLOG_WINDOWS);
     }
 
-    /**
-     * Assuming Mac (which does not have /proc)
-     */
     @Test
+    @DisabledIf("isTcpBacklogSettingReadable")
+    @EnabledOnOs(OS.MAC)
     void testNonWindowsDefaultTcpBacklog() {
-        assumeThat(System.getProperty(OS_NAME_PROPERTY)).contains("Mac OS X");
-        assumeThat(isTcpBacklogSettingReadable()).isFalse();
         assertThat(NetUtil.getTcpBacklog()).isEqualTo(NetUtil.DEFAULT_TCP_BACKLOG_LINUX);
     }
 
-    /**
-     * Assuming Mac (which does not have /proc)
-     */
     @Test
+    @DisabledIf("isTcpBacklogSettingReadable")
+    @EnabledOnOs(OS.MAC)
     void testNonWindowsSpecifiedTcpBacklog() {
-        assumeThat(System.getProperty(OS_NAME_PROPERTY)).contains("Mac OS X");
-        assumeThat(isTcpBacklogSettingReadable()).isFalse();
         assertThat(NetUtil.getTcpBacklog(100)).isEqualTo(100);
     }
 
-    /**
-     * Assuming Linux (which has /proc)
-     */
     @Test
-    void testOsSetting() {
-        assumeThat(System.getProperty(OS_NAME_PROPERTY)).contains("Linux");
-        assumeThat(isTcpBacklogSettingReadable()).isTrue();
+    @EnabledIf("isTcpBacklogSettingReadable")
+    @EnabledOnOs(OS.LINUX)
+    void testOsTcpBackloc() {
         assertThat(NetUtil.getTcpBacklog(-1)).isNotEqualTo(-1);
         assertThat(NetUtil.getTcpBacklog())
             .as("NetUtil should read more than the first character of somaxconn")
@@ -74,7 +63,7 @@ class NetUtilTest {
                 .contains(InetAddress.getLoopbackAddress());
     }
 
-    private boolean isTcpBacklogSettingReadable() {
+    private static boolean isTcpBacklogSettingReadable() {
         return AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
             try {
                 File f = new File(NetUtil.TCP_BACKLOG_SETTING_LOCATION);
@@ -82,7 +71,6 @@ class NetUtilTest {
             } catch (Exception e) {
                 return false;
             }
-
         });
     }
 }

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/PortRangeValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/PortRangeValidatorTest.java
@@ -1,7 +1,7 @@
 package io.dropwizard.validation;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 
 import javax.validation.Valid;
 import javax.validation.Validator;
@@ -10,8 +10,8 @@ import java.util.List;
 import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
+@EnabledIf("isDefaultLocaleEnglish")
 class PortRangeValidatorTest {
     @SuppressWarnings("PublicField")
     public static class Example {
@@ -29,13 +29,8 @@ class PortRangeValidatorTest {
     private final Validator validator = BaseValidator.newValidator();
     private final Example example = new Example();
 
-    @BeforeEach
-    void setUp() throws Exception {
-        assumeThat(Locale.getDefault().getLanguage()).isEqualTo("en");
-    }
-
     @Test
-    void acceptsNonPrivilegedPorts() throws Exception {
+    void acceptsNonPrivilegedPorts() {
         example.port = 2048;
 
         assertThat(validator.validate(example))
@@ -43,7 +38,7 @@ class PortRangeValidatorTest {
     }
 
     @Test
-    void acceptsDynamicPorts() throws Exception {
+    void acceptsDynamicPorts() {
         example.port = 0;
 
         assertThat(validator.validate(example))
@@ -51,7 +46,7 @@ class PortRangeValidatorTest {
     }
 
     @Test
-    void rejectsNegativePorts() throws Exception {
+    void rejectsNegativePorts() {
         example.port = -1;
 
         assertThat(ConstraintViolations.format(validator.validate(example)))
@@ -59,7 +54,7 @@ class PortRangeValidatorTest {
     }
 
     @Test
-    void allowsForCustomMinimumPorts() throws Exception {
+    void allowsForCustomMinimumPorts() {
         example.otherPort = 8080;
 
         assertThat(ConstraintViolations.format(validator.validate(example)))
@@ -67,7 +62,7 @@ class PortRangeValidatorTest {
     }
 
     @Test
-    void allowsForCustomMaximumPorts() throws Exception {
+    void allowsForCustomMaximumPorts() {
         example.otherPort = 16000;
 
         assertThat(ConstraintViolations.format(validator.validate(example)))
@@ -79,5 +74,9 @@ class PortRangeValidatorTest {
         example.ports = Collections.singletonList(-1);
         assertThat(ConstraintViolations.format(validator.validate(example)))
             .containsOnly("ports[0].<list element> must be between 1 and 65535");
+    }
+
+    private static boolean isDefaultLocaleEnglish() {
+        return "en".equals(Locale.getDefault().getLanguage());
     }
 }


### PR DESCRIPTION
jUnit 5 introduces `DisabledIf` and `EnabledIf`, allowing tests or entire test classes to be disabled based on arbitrary conditions.

Replace use of `assumeThat` with this newer mechanism.

I'm not completely convinced, personally - it's not as type-safe (although IntelliJ IDEA knows about it).

For the tests where we did `assumeThat` in a `BeforeEach`, this should be more performant I suppose, but the rest are much of a muchness I think.

See what you think...

For `dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java` I just removed the `assumeThat` since the test explicitly changes the locale anyway (which is probably bad?!).