### PR TITLE
Deprecate `EnvironmentVariableLookup`

### DIFF
--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/EnvironmentVariableLookup.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/EnvironmentVariableLookup.java
@@ -5,9 +5,8 @@ import org.apache.commons.text.lookup.StringLookup;
 /**
  * A custom {@link StringLookup} implementation using environment variables as lookup source.
  *
- * @deprecated Use a method reference to @link{System#getenv()} directly instead.
+ * @deprecated Use a method reference to {@link System#getenv()} directly instead.
  */
-
 @Deprecated
 public class EnvironmentVariableLookup implements StringLookup {
     /**

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/EnvironmentVariableLookup.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/EnvironmentVariableLookup.java
@@ -4,7 +4,11 @@ import org.apache.commons.text.lookup.StringLookup;
 
 /**
  * A custom {@link StringLookup} implementation using environment variables as lookup source.
+ *
+ * @deprecated Use a method reference to @link{System#getenv()} directly instead.
  */
+
+@Deprecated
 public class EnvironmentVariableLookup implements StringLookup {
     /**
      * {@inheritDoc}

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/EnvironmentVariableSubstitutor.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/EnvironmentVariableSubstitutor.java
@@ -22,7 +22,7 @@ public class EnvironmentVariableSubstitutor extends StringSubstitutor {
      * @see org.apache.commons.text.StringSubstitutor#setEnableSubstitutionInVariables(boolean)
      */
     public EnvironmentVariableSubstitutor(boolean strict, boolean substitutionInVariables) {
-        super(new EnvironmentVariableLookup());
+        super(System::getenv);
         this.setEnableUndefinedVariableException(strict);
         this.setEnableSubstitutionInVariables(substitutionInVariables);
     }

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/EnvironmentVariableSubstitutorTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/EnvironmentVariableSubstitutorTest.java
@@ -29,12 +29,6 @@ class EnvironmentVariableSubstitutorTest {
     }
 
     @Test
-    void substitutorUsesEnvironmentVariableLookup() {
-        EnvironmentVariableSubstitutor substitutor = new EnvironmentVariableSubstitutor();
-        assertThat(substitutor.getStringLookup()).isInstanceOf(EnvironmentVariableLookup.class);
-    }
-
-    @Test
     void substitutorReplacesWithEnvironmentVariables() {
         EnvironmentVariableSubstitutor substitutor = new EnvironmentVariableSubstitutor(false);
 


### PR DESCRIPTION
`StringLookup` is a functional interface and so `EnvironmentVariableLookup` can be implemented as a direct method reference to `System#getenv()`.