### PR TITLE
Update link to Apache HttpClient's docs

### DIFF
--- a/docs/source/manual/client.rst
+++ b/docs/source/manual/client.rst
@@ -25,7 +25,7 @@ Apache HttpClient
 The underlying library for ``dropwizard-client`` is  Apache's HttpClient_, a full-featured,
 well-tested HTTP client library.
 
-.. _HttpClient: http://hc.apache.org/httpcomponents-core-4.3.x/index.html
+.. _HttpClient: https://hc.apache.org/httpcomponents-client-4.5.x/index.html
 
 To create a :ref:`managed <man-core-managed>`, instrumented ``HttpClient`` instance, your
 :ref:`configuration class <man-core-configuration>` needs an :ref:`http client configuration <man-configuration-clients-http>` instance:


### PR DESCRIPTION
###### Problem:
The link to the HttpClient docs are incorrectly pointing to the HttpCore docs and a no longer published version of those docs.

###### Solution:
Update the docs to point to the HttpClient docs for (the current version)[https://github.com/dropwizard/dropwizard/blob/0d46d5e5c830057095fae2cdf88f339d9086bd3c/dropwizard-dependencies/pom.xml#L36]

###### Result:
Docs link to HttpClient version 4.5 docs.