### PR TITLE
Add notes for breaking changes in Jersey and Liquibase

### DIFF
--- a/docs/source/manual/upgrade-notes/upgrade-notes-2_1_x.rst
+++ b/docs/source/manual/upgrade-notes/upgrade-notes-2_1_x.rst
@@ -57,3 +57,47 @@ Changed Configuration Options
 -----------------------------
 * ``delayedShutdownHandlerEnabled`` default value changed to ``false``.
 * ``servlet`` removed in favor of the new ``responder`` and ``responseProvider`` factories.
+
+.. _upgrade-notes-dropwizard-2_1_x-breaking-changes:
+
+Changes in versioning
+=====================
+Although Dropwizard tries to postpone big changes to major releases, some breaking changes had to be introduced into Dropwizard 2.1. This change is necessary due to new versioning of Dropwizard releases.
+The Dropwizard 2.x releases will stay on a Java 8 baseline and the ``javax`` namespace.
+Dropwizard 3.x will stay on the ``javax`` namespace too, but will drop support for Java 8 and upgrade to Java 11 instead.
+Dropwizard 4.x will eventually mirror the 3.x versions on the ``jakarta`` namespace and maybe introduce some more changes.
+
+Therefore major updates for the Java 8 baseline have to be brought to minor releases on the 2.x branch. The major changes introduced in 2.1 are the following:
+
+.. include:: <isonum.txt>
+
+=================== ====================
+Library             Version change
+=================== ====================
+argparse            0.8.x |rarr| 0.9.x
+
+Hibernate Validator 6.1.x |rarr| 6.2.x
+
+Jackson             2.10.x |rarr| 2.13.x
+
+Jersey              2.33 |rarr| 2.35
+
+Liquibase           3.10.x |rarr| 4.9.x
+
+Dropwizard Metrics  4.1.x |rarr| 4.2.x
+=================== ====================
+
+Upgrade to Liquibase 4.x
+------------------------
+Most of the updates come with low migration cost, but Liquibase gets a major version upgrade and needs some attention.
+
+Liquibase 4.x changes the way it finds files. This means previously recognized migration files could be reported as missing.
+Liquibase lets users of the library specify paths, where it should search for files.
+Dropwizard therefore adds the file system specific roots to these ``root paths``, as well as the code location (of the current JAR).
+
+This essentially means migration files now must be specified with absolute paths or be located under ``src/main/resources`` and specified relative to that path.
+
+Upgrade to Jersey 2.35
+----------------------
+The upgrade of Jersey from version 2.33 to 2.35 introduces a behavior change in the handling of ``Optional<T>`` parameters.
+If such a parameter is invalid, now a status code ``404`` is returned instead of the former ``400`` status code.


### PR DESCRIPTION
This PR adds some details for the upcoming versioning change and for the breaking changes the upgrades of Liquibase and Jersey introduce for the migration towards Dropwizard 2.1.
