### PR TITLE
Clean up some multiline string behaviour

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
@@ -50,7 +50,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.URL;
 import java.util.EnumSet;
 import java.util.Optional;
 import java.util.Set;
@@ -705,17 +704,17 @@ public abstract class AbstractServerFactory implements ServerFactory {
     @SuppressWarnings("Slf4jFormatShouldBeConst")
     protected void printBanner(String name) {
         String msg = "Starting " + name;
-        final URL resource = Thread.currentThread().getContextClassLoader().getResource("banner.txt");
-        if (resource != null) {
-            try (final InputStream resourceStream = resource.openStream();
-                 final InputStreamReader inputStreamReader = new InputStreamReader(resourceStream);
-                 final BufferedReader bufferedReader = new BufferedReader(inputStreamReader)) {
-                final String banner = bufferedReader
+        try (final InputStream resourceStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("banner.txt")) {
+            if (resourceStream != null) {
+                try (final InputStreamReader inputStreamReader = new InputStreamReader(resourceStream);
+                     final BufferedReader bufferedReader = new BufferedReader(inputStreamReader)) {
+                    final String banner = bufferedReader
                         .lines()
                         .collect(Collectors.joining(System.lineSeparator()));
-                msg = String.format("Starting %s%n%s", name, banner);
-            } catch (IllegalArgumentException | IOException ignored) {
+                    msg = String.format("Starting %s%n%s", name, banner);
+                }
             }
+        } catch (IllegalArgumentException | IOException ignored) {
         }
         LOGGER.info(msg);
     }

--- a/dropwizard-json-logging/pom.xml
+++ b/dropwizard-json-logging/pom.xml
@@ -98,6 +98,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/JsonFormatterTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/JsonFormatterTest.java
@@ -1,16 +1,16 @@
 package io.dropwizard.logging.json.layout;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.dropwizard.jackson.Jackson;
 import io.dropwizard.util.Maps;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import static io.dropwizard.jackson.Jackson.newObjectMapper;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class JsonFormatterTest {
@@ -18,46 +18,32 @@ class JsonFormatterTest {
     private final SortedMap<String, Object> map = new TreeMap<>(Maps.of(
             "name", "Jim",
             "hobbies", Arrays.asList("Reading", "Biking", "Snorkeling")));
-    private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+    private final ObjectMapper objectMapper = newObjectMapper();
 
-    @Test
-    void testNoPrettyPrintNoLineSeparator() throws IOException {
-        JsonFormatter formatter = new JsonFormatter(objectMapper, false, false);
-
-        final JsonNode actual = objectMapper.readTree(formatter.toJson(map));
-        final JsonNode expected = objectMapper.readTree("{\"name\":\"Jim\",\"hobbies\":[\"Reading\",\"Biking\",\"Snorkeling\"]}");
-        assertThat(actual).isEqualTo(expected);
-    }
-
-
-    @Test
-    void testNoPrettyPrintWithLineSeparator() throws IOException {
-        JsonFormatter formatter = new JsonFormatter(objectMapper, false, true);
+    @ParameterizedTest
+    @ValueSource(booleans={true, false})
+    void testNoPrettyPrint(boolean appendLineSeparator) throws IOException {
+        JsonFormatter formatter = new JsonFormatter(objectMapper, false, appendLineSeparator);
 
         final String content = formatter.toJson(map);
-        assertThat(content).endsWith(System.lineSeparator());
-        final JsonNode actual = objectMapper.readTree(content);
-        final JsonNode expected = objectMapper.readTree("{\"name\":\"Jim\",\"hobbies\":[\"Reading\",\"Biking\",\"Snorkeling\"]}");
-        assertThat(actual).isEqualTo(expected);
+        if (appendLineSeparator) {
+            assertThat(content).endsWith(System.lineSeparator());
+        } else {
+            assertThat(content).doesNotEndWith(System.lineSeparator());
+        }
+
+        assertThat(objectMapper.readTree(content))
+            .isEqualTo(objectMapper.readTree("{\"name\":\"Jim\",\"hobbies\":[\"Reading\",\"Biking\",\"Snorkeling\"]}"));
     }
 
-    @Test
-    void testPrettyPrintWithLineSeparator() {
-        JsonFormatter formatter = new JsonFormatter(objectMapper, true, true);
+    @ParameterizedTest
+    @ValueSource(booleans={true, false})
+    void testPrettyPrint(boolean appendLineSeparator) {
+        JsonFormatter formatter = new JsonFormatter(objectMapper, true, appendLineSeparator);
         assertThat(formatter.toJson(map)).isEqualToNormalizingNewlines(
                 "{\n" +
                 "  \"hobbies\" : [ \"Reading\", \"Biking\", \"Snorkeling\" ],\n" +
                 "  \"name\" : \"Jim\"\n" +
-                "}\n");
-    }
-
-    @Test
-    void testPrettyPrintNoLineSeparator() {
-        JsonFormatter formatter = new JsonFormatter(objectMapper, true, false);
-        assertThat(formatter.toJson(map)).isEqualToNormalizingNewlines(
-                "{\n" +
-                "  \"hobbies\" : [ \"Reading\", \"Biking\", \"Snorkeling\" ],\n" +
-                "  \"name\" : \"Jim\"\n" +
-                "}");
+                "}" + (appendLineSeparator ? "\n" : ""));
     }
 }

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/PrefixedRootCauseFirstThrowableProxyConverterTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/PrefixedRootCauseFirstThrowableProxyConverterTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.regex.Pattern;
@@ -63,9 +62,9 @@ class PrefixedRootCauseFirstThrowableProxyConverterTest {
 
     @Test
     void prefixesExceptionsWithExclamationMarks()  {
-        assertThat(Arrays.stream(converter.throwableProxyToString(proxy).split(System.lineSeparator()))
-                .filter(Objects::nonNull)
-                .filter(s -> !s.isEmpty()))
+        assertThat(converter.throwableProxyToString(proxy).split("\\R"))
+                .filteredOn(Objects::nonNull)
+                .filteredOn(s -> !s.isEmpty())
                 .isNotEmpty()
                 .allSatisfy(line -> assertThat(line).startsWith("!"));
     }

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbFastForwardCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbFastForwardCommandTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 @Execution(SAME_THREAD)
 class DbFastForwardCommandTest {
 
-    private static final Pattern NEWLINE_PATTERN = Pattern.compile(System.lineSeparator());
+    private static final Pattern NEWLINE_PATTERN = Pattern.compile("\\R");
     private final DbFastForwardCommand<TestMigrationConfiguration> fastForwardCommand = new DbFastForwardCommand<>(
         TestMigrationConfiguration::getDataSource, TestMigrationConfiguration.class, "migrations.xml");
     private TestMigrationConfiguration conf;

--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbStatusCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbStatusCommandTest.java
@@ -24,12 +24,9 @@ class DbStatusCommandTest {
     private final DbStatusCommand<TestMigrationConfiguration> statusCommand =
             new DbStatusCommand<>(new TestMigrationDatabaseConfiguration(), TestMigrationConfiguration.class, "migrations.xml");
     private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    private TestMigrationConfiguration conf;
 
     @BeforeEach
     void setUp() {
-        conf = MigrationTestSupport.createConfiguration();
-
         statusCommand.setOutputStream(new PrintStream(baos));
     }
 
@@ -41,24 +38,24 @@ class DbStatusCommandTest {
         final TestMigrationConfiguration existedDbConf = MigrationTestSupport.createConfiguration(existedDbUrl);
 
         statusCommand.run(null, new Namespace(Collections.emptyMap()), existedDbConf);
-        assertThat(baos.toString(UTF_8.name())).matches("\\S+ is up to date" + System.lineSeparator());
+        assertThat(baos.toString(UTF_8.name())).matches("\\S+ is up to date\\R");
     }
 
     @Test
     void testRun() throws Exception {
-        statusCommand.run(null, new Namespace(Collections.emptyMap()), conf);
+        statusCommand.run(null, new Namespace(Collections.emptyMap()), MigrationTestSupport.createConfiguration());
         assertThat(baos.toString(UTF_8.name())).matches(
-                "3 change sets have not been applied to \\S+" + System.lineSeparator());
+                "3 change sets have not been applied to \\S+\\R");
     }
 
     @Test
     void testVerbose() throws Exception {
-        statusCommand.run(null, new Namespace(Collections.singletonMap("verbose", true)), conf);
+        statusCommand.run(null, new Namespace(Collections.singletonMap("verbose", true)), MigrationTestSupport.createConfiguration());
         assertThat(baos.toString(UTF_8.name())).matches(
-                "3 change sets have not been applied to \\S+" + System.lineSeparator() +
-                        "\\s*migrations\\.xml::1::db_dev"  + System.lineSeparator() +
-                        "\\s*migrations\\.xml::2::db_dev"  + System.lineSeparator() +
-                        "\\s*migrations\\.xml::3::db_dev" + System.lineSeparator());
+                "3 change sets have not been applied to \\S+\\R" +
+                        "\\s*migrations\\.xml::1::db_dev\\R" +
+                        "\\s*migrations\\.xml::2::db_dev\\R" +
+                        "\\s*migrations\\.xml::3::db_dev\\R");
     }
 
     @Test


### PR DESCRIPTION
- Rely on `\R` in regexes to match newlines, reducing the need to reference `System.lineSeparator()` so much.
- Parameterise some tests in `dropwizard-json-logging` to reduce duplication and make it clearer what is being tested.
- Use `Class#getResourceAsStream(String)` when loading the banner