### PR TITLE
Modification to show issue for target property of logging appender

### DIFF
--- a/dropwizard-example/example.yml
+++ b/dropwizard-example/example.yml
@@ -69,6 +69,8 @@ logging:
 
   appenders:
     - type: console
+      # add target for test
+      target: stdout
     - type: file
       threshold: INFO
       logFormat: "%-6level [%d{HH:mm:ss.SSS}] [%t] %logger{5} - %X{code} %msg %n"

--- a/dropwizard-example/pom.xml
+++ b/dropwizard-example/pom.xml
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>${junit5.version}</version>
+            <version>5.7.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/dropwizard-example/src/main/java/com/example/helloworld/HelloWorldApplication.java
+++ b/dropwizard-example/src/main/java/com/example/helloworld/HelloWorldApplication.java
@@ -16,6 +16,7 @@ import com.example.helloworld.resources.PersonResource;
 import com.example.helloworld.resources.ProtectedResource;
 import com.example.helloworld.resources.ViewResource;
 import com.example.helloworld.tasks.EchoTask;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import io.dropwizard.Application;
 import io.dropwizard.assets.AssetsBundle;
 import io.dropwizard.auth.AuthDynamicFeature;
@@ -60,6 +61,10 @@ public class HelloWorldApplication extends Application<HelloWorldConfiguration> 
                         new EnvironmentVariableSubstitutor(false)
                 )
         );
+        // Using customized JSON Deserialization Settings
+        bootstrap.getObjectMapper()
+              //  .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL)
+        .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
 
         bootstrap.addCommand(new RenderCommand());
         bootstrap.addBundle(new AssetsBundle());

--- a/dropwizard-example/src/main/java/com/example/helloworld/db/PersonDAO.java
+++ b/dropwizard-example/src/main/java/com/example/helloworld/db/PersonDAO.java
@@ -3,7 +3,9 @@ package com.example.helloworld.db;
 import com.example.helloworld.core.Person;
 import io.dropwizard.hibernate.AbstractDAO;
 
+import org.hibernate.Criteria;
 import org.hibernate.SessionFactory;
+import org.hibernate.query.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -22,6 +24,6 @@ public class PersonDAO extends AbstractDAO<Person> {
     }
 
     public List<Person> findAll() {
-        return list(namedTypedQuery("com.example.helloworld.core.Person.findAll"));
+        return list((Query<Person>) namedQuery("com.example.helloworld.core.Person.findAll"));
     }
 }

--- a/dropwizard-example/src/test/java/com/example/helloworld/DockerIntegrationTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/DockerIntegrationTest.java
@@ -128,21 +128,21 @@ public class DockerIntegrationTest {
                 .readEntity(Person.class);
     }
 
-    @Test
-    void testLogFileWritten() {
-        // The log file is using a size and time based policy, which used to silently
-        // fail (and not write to a log file). This test ensures not only that the
-        // log file exists, but also contains the log line that jetty prints on startup
-        assertThat(new File(CURRENT_LOG.get()))
-            .exists()
-            .content()
-            .contains("Starting hello-world",
-                "Started application@",
-                "0.0.0.0:" + APP.getLocalPort(),
-                "Started admin@",
-                "0.0.0.0:" + APP.getAdminPort())
-            .doesNotContain("ERROR", "FATAL", "Exception");
-    }
+//    @Test
+//    void testLogFileWritten() {
+//        // The log file is using a size and time based policy, which used to silently
+//        // fail (and not write to a log file). This test ensures not only that the
+//        // log file exists, but also contains the log line that jetty prints on startup
+//        assertThat(new File(CURRENT_LOG.get()))
+//            .exists()
+//            .content()
+//            .contains("Starting hello-world",
+//                "Started application@",
+//                "0.0.0.0:" + APP.getLocalPort(),
+//                "Started admin@",
+//                "0.0.0.0:" + APP.getAdminPort())
+//            .doesNotContain("ERROR", "FATAL", "Exception");
+//    }
 
     @Test
     void healthCheckShouldSucceed() {

--- a/dropwizard-example/src/test/java/com/example/helloworld/IntegrationTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/IntegrationTest.java
@@ -115,27 +115,27 @@ class IntegrationTest {
                 .readEntity(Person.class);
     }
 
-    @Test
-    void testLogFileWritten() {
-        // The log file is using a size and time based policy, which used to silently
-        // fail (and not write to a log file). This test ensures not only that the
-        // log file exists, but also contains the log line that jetty prints on startup
-        assertThat(new File(CURRENT_LOG.get()))
-            .exists()
-            .content()
-            .contains("0.0.0.0:" + APP.getLocalPort(), "Starting hello-world", "Started application", "Started admin")
-            .doesNotContain("Exception", "ERROR", "FATAL");
-    }
+//    @Test
+//    void testLogFileWritten() {
+//        // The log file is using a size and time based policy, which used to silently
+//        // fail (and not write to a log file). This test ensures not only that the
+//        // log file exists, but also contains the log line that jetty prints on startup
+//        assertThat(new File(CURRENT_LOG.get()))
+//            .exists()
+//            .content()
+//            .contains("0.0.0.0:" + APP.getLocalPort(), "Starting hello-world", "Started application", "Started admin")
+//            .doesNotContain("Exception", "ERROR", "FATAL");
+//    }
 
-    @Test
-    void healthCheckShouldSucceed() {
-        final Response healthCheckResponse =
-                APP.client().target("http://localhost:" + APP.getLocalPort() + "/health-check")
-                .request()
-                .get();
-
-        assertThat(healthCheckResponse)
-                .extracting(Response::getStatus)
-                .isEqualTo(Response.Status.OK.getStatusCode());
-    }
+//    @Test
+//    void healthCheckShouldSucceed() {
+//        final Response healthCheckResponse =
+//                APP.client().target("http://localhost:" + APP.getLocalPort() + "/health-check")
+//                .request()
+//                .get();
+//
+//        assertThat(healthCheckResponse)
+//                .extracting(Response::getStatus)
+//                .isEqualTo(Response.Status.OK.getStatusCode());
+//    }
 }

--- a/dropwizard-example/src/test/resources/test-example.yml
+++ b/dropwizard-example/src/test/resources/test-example.yml
@@ -20,6 +20,8 @@ logging:
   level: INFO
   appenders:
     - type: console
+     # add target for test
+      target: stdout
     - type: file
       currentLogFilename: './logs/application.log'
       archivedLogFilenamePattern: './logs/application-%d-%i.log.gz'
@@ -28,18 +30,18 @@ logging:
       maxFileSize: '1MiB'
 
 # Health settings
-health:
-  delayedShutdownHandlerEnabled: true
-  shutdownWaitPeriod: 1s
-  healthChecks:
-    - name: deadlocks
-      type: alive
-    - name: hibernate
-      type: ready
-      critical: true
-    - name: template
-      type: ready
-      critical: true
-      schedule:
-        checkInterval: 1s
-        downtimeInterval: 2s
+#health:
+#  delayedShutdownHandlerEnabled: true
+#  shutdownWaitPeriod: 1s
+#  healthChecks:
+#    - name: deadlocks
+#      type: alive
+#    - name: hibernate
+#      type: ready
+#      critical: true
+#    - name: template
+#      type: ready
+#      critical: true
+#      schedule:
+#        checkInterval: 1s
+#        downtimeInterval: 2s


### PR DESCRIPTION
This PR is to modify this dropwizard-example to expose the issue.

When setting "target: stdout" in the test-example.yml and setting bootstrap.getObjectMapper().enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
it will show that the lowercase setting "stdout" for the target property of Logging appender is not accepted. 