### PR TITLE
Change access modifier to methods of AuthorizationContext

### DIFF
--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthorizationContext.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthorizationContext.java
@@ -12,21 +12,21 @@ public abstract class AuthorizationContext<P extends Principal> {
     private final @Nullable
     ContainerRequestContext requestContext;
 
-    protected AuthorizationContext(P principal, String role, @Nullable ContainerRequestContext requestContext) {
+    public AuthorizationContext(P principal, String role, @Nullable ContainerRequestContext requestContext) {
         this.principal = principal;
         this.role = role;
         this.requestContext = requestContext;
     }
 
-    protected P getPrincipal() {
+    public P getPrincipal() {
         return principal;
     }
 
-    protected String getRole() {
+    public String getRole() {
         return role;
     }
 
-    @Nullable protected ContainerRequestContext getRequestContext() {
+    @Nullable public ContainerRequestContext getRequestContext() {
         return requestContext;
     }
 


### PR DESCRIPTION
###### Problem:

Having `AuthorizationContext` functions as protected is fairly impractical when trying to use it.

###### Solution:

Make its functions public, which [I should have done from the start](https://github.com/dropwizard/dropwizard/pull/3725#discussion_r596225170) 😞

Sorry for not catching that earlier.
