### PR TITLE
Health check configurable to run on admin servlet

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -1293,6 +1293,7 @@ Health
         type: json
       responder:
         type: servlet
+      onAdminServlet: false
 
 
 ============================== =======================  ====================================================================================================
@@ -1306,6 +1307,7 @@ healthChecks                   []                       A list of configured hea
 initialOverallState            true                     Flag indicating whether the overall health state of the application should start as healthy or unhealthy. A value of ``true`` indicates an initial state of healthy while a value of ``false`` indicates an initial state of unhealthy.
 responseProvider               json                     The health response provider that is used to respond to generate responses to return to health check requests. This can be implemented using Jersey, Jetty, or other technologies if desired. See the :ref:`detailed JSON health response provider section <man-configuration-health-responseprovider>` for more details.
 responder                      servlet                  The health responder that is used to respond to health check requests. This can be implemented using Jersey, Jetty, or other technologies if desired. See the :ref:`servlet health responder section <man-configuration-health-responder>` for more details.
+onAdminServlet                 false                    Flag indicating whether to run the health check endpoint on the admin servlet instead of the default application servlet.
 ============================== =======================  ====================================================================================================
 
 

--- a/dropwizard-core/src/main/java/io/dropwizard/cli/EnvironmentCommand.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/EnvironmentCommand.java
@@ -16,6 +16,7 @@ import javax.annotation.Nullable;
  */
 public abstract class EnvironmentCommand<T extends Configuration> extends ConfiguredCommand<T> {
     private final Application<T> application;
+
     @Nullable
     private Environment environment;
 
@@ -57,7 +58,7 @@ public abstract class EnvironmentCommand<T extends Configuration> extends Config
         configuration.getServerFactory().configure(environment);
         configuration.getHealthFactory().ifPresent(health -> health.configure(
                 environment.lifecycle(),
-                environment.servlets(),
+                health.isOnAdminServlet() ? environment.admin() : environment.servlets(),
                 environment.jersey(),
                 environment.health(),
                 environment.getObjectMapper(),

--- a/dropwizard-core/src/test/java/io/dropwizard/cli/EnvironmentCommandTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/cli/EnvironmentCommandTest.java
@@ -12,7 +12,7 @@ import io.dropwizard.jetty.setup.ServletEnvironment;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import net.sourceforge.argparse4j.inf.Namespace;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/dropwizard-core/src/test/java/io/dropwizard/cli/EnvironmentCommandTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/cli/EnvironmentCommandTest.java
@@ -1,0 +1,117 @@
+package io.dropwizard.cli;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Set;
+
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.jetty.setup.ServletEnvironment;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import net.sourceforge.argparse4j.inf.Namespace;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EnvironmentCommandTest
+{
+    @SuppressWarnings("NullAway")
+    private class TestApplication<T extends Configuration>
+        extends Application<T>
+    {
+        Environment environment;
+
+        @Override
+        protected void addDefaultCommands(Bootstrap<T> bootstrap) {
+            ServerCommand serverCommand = new ServerCommand<T>(this)
+            {
+                @Override
+                protected void run(Bootstrap<T> bootstrap, Namespace namespace, T configuration) throws Exception {
+                    super.run(bootstrap, namespace, configuration);
+                    TestApplication.this.environment = this.getEnvironment();
+                }
+
+                @Override
+                public void onError(Cli cli, Namespace namespace, Throwable t) {
+                    throw new IllegalStateException("Fatal error trying to start server", t);
+                }
+            };
+            bootstrap.addCommand(serverCommand);
+        }
+
+        @Override
+        public void run(final T configuration, final Environment environment) throws Exception {
+        }
+
+        public Environment getEnvironment() {
+            return this.environment;
+        }
+    }
+
+    @Test
+    public void testHealthCheckOnAdminServlet() throws Exception {
+        File configFile = File.createTempFile("env-cmd-test", ".yml");
+        try {
+            Files.write(configFile.toPath(), Arrays.asList(
+                "health:",
+                "  onAdminServlet: true",
+                "server:",
+                "  applicationConnectors:",
+                "    - type: http",
+                "      port: 0",
+                "  adminConnectors:",
+                "    - type: http",
+                "      port: 0"
+            ));
+            TestApplication testApplication = new TestApplication();
+            testApplication.run("server", configFile.getAbsolutePath());
+            ServletEnvironment adminEnvironment = testApplication.getEnvironment().admin();
+            Set<String> servlets = getServletNames(adminEnvironment);
+            assertThat(servlets).contains("health-check-TestApplication-servlet");
+            ServletEnvironment servletEnvironment = testApplication.getEnvironment().servlets();
+            servlets = getServletNames(servletEnvironment);
+            assertThat(servlets).doesNotContain("health-check-TestApplication-servlet");
+        }
+        finally {
+            configFile.delete();
+        }
+    }
+
+    @Test
+    public void testHealthCheckOnApplicationServlet() throws Exception {
+        File configFile = File.createTempFile("env-cmd-test", ".yml");
+        try {
+            Files.write(configFile.toPath(), Arrays.asList(
+                "health:",
+                "  onAdminServlet: false",
+                "server:",
+                "  applicationConnectors:",
+                "    - type: http",
+                "      port: 0",
+                "  adminConnectors:",
+                "    - type: http",
+                "      port: 0"
+            ));
+            TestApplication testApplication = new TestApplication();
+            testApplication.run("server", configFile.getAbsolutePath());
+            ServletEnvironment adminEnvironment = testApplication.getEnvironment().admin();
+            Set<String> servlets = getServletNames(adminEnvironment);
+            assertThat(servlets).doesNotContain("health-check-TestApplication-servlet");
+            ServletEnvironment servletEnvironment = testApplication.getEnvironment().servlets();
+            servlets = getServletNames(servletEnvironment);
+            assertThat(servlets).contains("health-check-TestApplication-servlet");
+        }
+        finally {
+            configFile.delete();
+        }
+    }
+
+    private Set<String> getServletNames(ServletEnvironment environment) throws Exception {
+        Field servletsField = ServletEnvironment.class.getDeclaredField("servlets");
+        servletsField.setAccessible(true);
+        return (Set<String>) servletsField.get(environment);
+    }
+}

--- a/dropwizard-health/src/main/java/io/dropwizard/health/DefaultHealthFactory.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/DefaultHealthFactory.java
@@ -51,6 +51,9 @@ public class DefaultHealthFactory implements HealthFactory {
     @JsonProperty
     private boolean delayedShutdownHandlerEnabled = false;
 
+    @JsonProperty
+    private boolean onAdminServlet = false;
+
     @NotNull
     @JsonProperty
     private Duration shutdownWaitPeriod = Duration.seconds(15);
@@ -134,6 +137,16 @@ public class DefaultHealthFactory implements HealthFactory {
     public void setHealthResponderFactory(HealthResponderFactory healthResponderFactory) {
         this.healthResponderFactory = healthResponderFactory;
     }
+
+    @Override
+    public boolean isOnAdminServlet() {
+        return onAdminServlet;
+    }
+
+    public void setOnAdminServlet(final boolean onAdminServlet) {
+        this.onAdminServlet = onAdminServlet;
+    }
+
 
     /**
      * @deprecated use {@link #getHealthCheckConfigurations()} instead

--- a/dropwizard-health/src/main/java/io/dropwizard/health/HealthFactory.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/HealthFactory.java
@@ -11,4 +11,5 @@ import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 public interface HealthFactory extends Discoverable {
     void configure(LifecycleEnvironment lifecycle, ServletEnvironment servlets, JerseyEnvironment jersey,
                    HealthEnvironment health, ObjectMapper mapper, String name);
+    boolean isOnAdminServlet();
 }

--- a/dropwizard-health/src/test/java/io/dropwizard/health/DefaultHealthFactoryTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/DefaultHealthFactoryTest.java
@@ -45,6 +45,7 @@ class DefaultHealthFactoryTest {
         assertThat(healthFactory.isInitialOverallState()).isTrue();
         assertThat(healthFactory.getShutdownWaitPeriod().toMilliseconds()).isEqualTo(1L);
         assertThat(healthFactory.getHealthCheckUrlPaths()).isEqualTo(singletonList("/health-check"));
+        assertThat(healthFactory.isOnAdminServlet()).isTrue();
 
         assertThat(healthFactory.getHealthChecks()).isEqualTo(healthFactory.getHealthCheckConfigurations());
 

--- a/dropwizard-health/src/test/resources/yml/health.yml
+++ b/dropwizard-health/src/test/resources/yml/health.yml
@@ -11,3 +11,4 @@ delayedShutdownHandlerEnabled: true
 shutdownWaitPeriod: 1ms
 servletFactory:
   type: default
+onAdminServlet: true


### PR DESCRIPTION
###### Problem:
The health check under the `health` section is hard-coded to run always on the application servlet. We don't always wish to expose this endpoint to the outside world. Although we can configure the load balancer to block the access from external, having it running on the admin servlet and exposing only the application port would be easier.

###### Solution:
Make it configurable by adding a new `onAdminServlet` option. When set to `true`, the `/health-check' endpoint will be on the admin servlet, just like the `/healthcheck`.

###### Result:
The default behavior is not changed, the health check still runs on the application servlet if not configured otherwise.