### PR TITLE
Fix logging of query parameters for classic request logging

### DIFF
--- a/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/old/ClassicLogFormat.java
+++ b/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/old/ClassicLogFormat.java
@@ -16,6 +16,6 @@ public class ClassicLogFormat {
         // `AbstractNCSARequestLog`, and this is the best approximation
         // of that class
         return "%{client}a - %u %{dd/MMM/yyyy:HH:mm:ss Z|" + tz.getID()
-            + "}t \"%m %U %H\" %s %O \"%{Referer}i\" \"%{User-Agent}i\" %{ms}T";
+            + "}t \"%r\" %s %O \"%{Referer}i\" \"%{User-Agent}i\" %{ms}T";
     }
 }

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/old/LogbackClassicRequestLogFactoryTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/old/LogbackClassicRequestLogFactoryTest.java
@@ -84,6 +84,7 @@ class LogbackClassicRequestLogFactoryTest {
             // isn't a way for us to set our own clock
             when(request.getTimeStamp()).thenReturn(System.currentTimeMillis());
             when(request.getMethod()).thenReturn("GET");
+            when(request.getOriginalURI()).thenReturn("/test/things?yay");
             when(request.getRequestURI()).thenReturn("/test/things");
             when(request.getProtocol()).thenReturn("HTTP/1.1");
             when(request.getHttpChannelState()).thenReturn(channelState);
@@ -101,7 +102,7 @@ class LogbackClassicRequestLogFactoryTest {
             assertThat(event.getFormattedMessage())
                 .startsWith("10.0.0.1")
                 .doesNotContain("%")
-                .contains("\"GET /test/things HTTP/1.1\"")
+                .contains("\"GET /test/things?yay HTTP/1.1\"")
                 .contains("-0500");
         } catch (Exception e) {
             if (logger != null) {


### PR DESCRIPTION
###### Problem:
We are using classic type request logging through syslog. After upgrading to 2.x the query parameters are no longer getting logged in the access logs.

###### Solution:
Updated the pattern in io.dropwizard.request.logging.old.ClassicLogFormat.

###### Result:
