### PR TITLE
Support PATCH HTTP method on Java 17

### DIFF
--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/LazyLoadingTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/LazyLoadingTest.java
@@ -59,7 +59,7 @@ class LazyLoadingTest {
 
         // Raf already exists so this should cause a primary key constraint violation
         final Response response = appExtension.client().target("http://localhost:" + appExtension.getLocalPort()).path("/dogs/Raf").request().put(Entity.entity(raf, MediaType.APPLICATION_JSON));
-        assertThat(response.getStatusInfo()).isEqualTo(Response.Status.BAD_REQUEST);
+        assertThat(response.getStatusInfo().toEnum()).isEqualTo(Response.Status.BAD_REQUEST);
         assertThat(response.getHeaderString(HttpHeaders.CONTENT_TYPE)).isEqualTo(MediaType.APPLICATION_JSON);
         assertThat(response.readEntity(ErrorMessage.class).getMessage()).contains("Unique index or primary key violation", "PUBLIC.DOGS(NAME)");
     }

--- a/dropwizard-testing/pom.xml
+++ b/dropwizard-testing/pom.xml
@@ -173,6 +173,10 @@
             <artifactId>jersey-container-servlet-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.jersey.connectors</groupId>
+            <artifactId>jersey-grizzly-connector</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
         </dependency>

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardAppExtension.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardAppExtension.java
@@ -11,8 +11,8 @@ import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.DropwizardTestSupport;
+import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
-import org.glassfish.jersey.client.HttpUrlConnectorProvider;
 import org.glassfish.jersey.client.JerseyClientBuilder;
 
 import javax.annotation.Nullable;
@@ -20,6 +20,8 @@ import javax.ws.rs.client.Client;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+
+import org.glassfish.jersey.grizzly.connector.GrizzlyConnectorProvider;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -275,10 +277,11 @@ public class DropwizardAppExtension<C extends Configuration> implements Dropwiza
     }
 
     protected JerseyClientBuilder clientBuilder() {
-        return new JerseyClientBuilder()
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.connectorProvider(new GrizzlyConnectorProvider())
             .register(new JacksonFeature(getObjectMapper()))
             .property(ClientProperties.CONNECT_TIMEOUT, DEFAULT_CONNECT_TIMEOUT_MS)
-            .property(ClientProperties.READ_TIMEOUT, DEFAULT_READ_TIMEOUT_MS)
-            .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true);
+            .property(ClientProperties.READ_TIMEOUT, DEFAULT_READ_TIMEOUT_MS);
+        return new JerseyClientBuilder().withConfig(clientConfig);
     }
 }


### PR DESCRIPTION
Refs #4404 

###### Problem:
The `JerseyClientBuilder` provided in `DropwizardAppExtension` uses the default connector provider, i.e. `HttpUrlConnectorProvider`. As stated in [this comment](https://github.com/eclipse-ee4j/jersey/issues/4825#issuecomment-925836004), this connector provider will not support the HTTP PATCH method on Java 16+.

###### Solution:
Use an other connector provider, which natively supports the HTTP PATCH method. This PR uses the `GrizzlyConnectorProvider` because it passes most of our tests.

###### Breaking change:
This PR technically is a breaking change, since the obtained client builder is configured differently. But as the HTTP PATCH method will not work on Java 16+, this is a tradeoff IMO. I think we could introduce this change because a different `JerseyClientBuilder` can be obtained easily and hence we should have a client working on Java 16+ as a default.