### PR TITLE
Update maven-enforcer-plugin to v3.1.0

### DIFF
--- a/dropwizard-example/pom.xml
+++ b/dropwizard-example/pom.xml
@@ -198,7 +198,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.4.1</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/dropwizard-hibernate/pom.xml
+++ b/dropwizard-hibernate/pom.xml
@@ -63,7 +63,7 @@
             <exclusions>
                 <exclusion>
                     <groupId>javax.transaction</groupId>
-                    <artifactId>jta</artifactId>
+                    <artifactId>javax.transaction-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
         <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
-        <maven-enforcer-plugin.version>1.4.1</maven-enforcer-plugin.version>
+        <maven-enforcer-plugin.version>3.1.0</maven-enforcer-plugin.version>
         <maven-filtering.version>3.2.0</maven-filtering.version>
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
         <maven-help-plugin.version>3.2.0</maven-help-plugin.version>


### PR DESCRIPTION
`maven-enforcer-plugin` had an issue in v3.0.0 with the `DependencyConvergence` rule. v3.1.0 seems to have that fixed.

Refs #4196 