### PR TITLE
Fix CycloneDX execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -352,6 +352,14 @@
                     <plugin>
                         <groupId>org.cyclonedx</groupId>
                         <artifactId>cyclonedx-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>makeAggregateBom</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Seems like the CycloneDX execution was skipped for the release of 2.0.30. I've tested this locally and somehow the plugin only gets invoked, if the `executions` section is specified. 