### PR TITLE
Change access modifier of `@UnitsOfWork` to public

### DIFF
--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitsOfWork.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitsOfWork.java
@@ -13,6 +13,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(METHOD)
 @Retention(RUNTIME)
 @Documented
-@interface UnitsOfWork {
+public @interface UnitsOfWork {
     UnitOfWork[] value();
 }


### PR DESCRIPTION
###### Problem:
When using multiple `@UnitOfWork` annotations, the compiler complains that the `@UnitsOfWork` container annotation cannot be found.

###### Solution:
Change the access modifier of the `@UnitsOfWork` annotation to public.
