### PR TITLE
Support for customizing the application's ObjectMapper

### DIFF
--- a/docs/source/manual/internals.rst
+++ b/docs/source/manual/internals.rst
@@ -40,7 +40,7 @@ Startup Sequence
 
 	Bootstrap(application: Application<T>) {
 	  this.application = application;
-	  this.objectMapper = Jackson.newObjectMapper();
+	  this.objectMapper = new DefaultObjectMapperFactory().newObjectMapper();
 	  this.bundles = new ArrayList<>();
 	  this.configuredBundles = new ArrayList<>();
 	  this.commands = new ArrayList<>();

--- a/docs/source/manual/testing.rst
+++ b/docs/source/manual/testing.rst
@@ -568,7 +568,7 @@ assert the expected widget is deserialized based on the ``type`` field.
 
     public class WidgetFactoryTest {
 
-        private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+        private final ObjectMapper objectMapper = new DefaultObjectMapperFactory().newObjectMapper();
         private final Validator validator = Validators.newValidator();
         private final YamlConfigurationFactory<WidgetFactory> factory =
                 new YamlConfigurationFactory<>(WidgetFactory.class, validator, objectMapper, "dw");
@@ -611,7 +611,7 @@ In order to test this, we would require the following in our test class:
 
     public class WidgetFactoryTest {
 
-        private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+        private final ObjectMapper objectMapper = new DefaultObjectMapperFactory().newObjectMapper();
         private final Validator validator = Validators.newValidator();
         private final YamlConfigurationFactory<WidgetFactory> factory =
                 new YamlConfigurationFactory<>(WidgetFactory.class, validator, objectMapper, "dw");

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientConfigurationTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientConfigurationTest.java
@@ -2,7 +2,7 @@ package io.dropwizard.client;
 
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jersey.validation.Validators;
 import org.junit.jupiter.api.Test;
 
@@ -13,7 +13,7 @@ class JerseyClientConfigurationTest {
     @Test
     void testBasicJerseyClient() throws Exception {
         final JerseyClientConfiguration configuration = new YamlConfigurationFactory<>(JerseyClientConfiguration.class,
-                Validators.newValidator(), Jackson.newObjectMapper(), "dw")
+                Validators.newValidator(), new DefaultObjectMapperFactory().newObjectMapper(), "dw")
                 .build(new ResourceConfigurationSourceProvider(), "yaml/jersey-client.yml");
         assertThat(configuration.getMinThreads()).isEqualTo(8);
         assertThat(configuration.getMaxThreads()).isEqualTo(64);

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientIntegrationTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientIntegrationTest.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.util.Duration;
 import org.apache.http.client.HttpRequestRetryHandler;
 import org.apache.http.protocol.HttpContext;
@@ -49,7 +49,7 @@ class JerseyClientIntegrationTest {
     private static final String TRANSFER_ENCODING = "Transfer-Encoding";
     private static final String CHUNKED = "chunked";
     private static final String GZIP = "gzip";
-    private static final ObjectMapper JSON_MAPPER = Jackson.newObjectMapper();
+    private static final ObjectMapper JSON_MAPPER = new DefaultObjectMapperFactory().newObjectMapper();
     private static final String GZIP_DEFLATE = "gzip,deflate";
     private static final String JSON_TOKEN = JSON_MAPPER.createObjectNode()
             .put("id", 214)

--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyIgnoreRequestUserAgentHeaderFilterTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyIgnoreRequestUserAgentHeaderFilterTest.java
@@ -3,7 +3,7 @@ package io.dropwizard.client;
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
@@ -37,7 +37,7 @@ class JerseyIgnoreRequestUserAgentHeaderFilterTest {
         clientConfiguration.setTimeout(Duration.milliseconds(2500L));
         clientBuilder = new JerseyClientBuilder(new MetricRegistry())
             .using(clientConfiguration)
-            .using(Executors.newSingleThreadExecutor(), Jackson.newObjectMapper());
+            .using(Executors.newSingleThreadExecutor(), new DefaultObjectMapperFactory().newObjectMapper());
     }
 
     @Test

--- a/dropwizard-client/src/test/java/io/dropwizard/client/proxy/HttpClientConfigurationTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/proxy/HttpClientConfigurationTest.java
@@ -6,7 +6,7 @@ import io.dropwizard.configuration.ConfigurationParsingException;
 import io.dropwizard.configuration.ConfigurationValidationException;
 import io.dropwizard.configuration.DefaultConfigurationFactoryFactory;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jersey.validation.Validators;
 import org.junit.jupiter.api.Test;
 
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class HttpClientConfigurationTest {
 
-    private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+    private final ObjectMapper objectMapper = new DefaultObjectMapperFactory().newObjectMapper();
     private HttpClientConfiguration configuration = new HttpClientConfiguration();
 
     private void load(String configLocation) throws Exception {

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/BaseConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/BaseConfigurationFactoryTest.java
@@ -1,8 +1,9 @@
 package io.dropwizard.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.CaffeineSpec;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.util.Maps;
 import io.dropwizard.validation.BaseValidator;
 import org.assertj.core.api.ThrowableAssertAlternative;
@@ -26,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 public abstract class BaseConfigurationFactoryTest {
+    protected final ObjectMapper objectMapper = new DefaultObjectMapperFactory().newObjectMapper();
 
     @SuppressWarnings("UnusedDeclaration")
     public static class ExampleServer {
@@ -167,7 +169,7 @@ public abstract class BaseConfigurationFactoryTest {
     @Test
     void usesDefaultedCacheBuilderSpec() throws Exception {
         final ExampleWithDefaults example =
-            new YamlConfigurationFactory<>(ExampleWithDefaults.class, validator, Jackson.newObjectMapper(), "dw")
+            new YamlConfigurationFactory<>(ExampleWithDefaults.class, validator, objectMapper, "dw")
                 .build();
         assertThat(example.cacheBuilderSpec)
             .isNotNull()
@@ -366,7 +368,7 @@ public abstract class BaseConfigurationFactoryTest {
         System.setProperty("dw.servers[2].port", "8092");
 
         final ExampleWithDefaults example =
-                new YamlConfigurationFactory<>(ExampleWithDefaults.class, validator, Jackson.newObjectMapper(), "dw")
+                new YamlConfigurationFactory<>(ExampleWithDefaults.class, validator, objectMapper, "dw")
                         .build();
 
         assertThat(example)
@@ -384,7 +386,7 @@ public abstract class BaseConfigurationFactoryTest {
     @Test
     void handleDefaultConfigurationWithoutOverriding() throws Exception {
         final ExampleWithDefaults example =
-                new YamlConfigurationFactory<>(ExampleWithDefaults.class, validator, Jackson.newObjectMapper(), "dw")
+                new YamlConfigurationFactory<>(ExampleWithDefaults.class, validator, objectMapper, "dw")
                         .build();
 
         assertThat(example)
@@ -401,7 +403,7 @@ public abstract class BaseConfigurationFactoryTest {
     void throwsAnExceptionIfDefaultConfigurationCantBeInstantiated() {
         System.setProperty("dw.name", "Coda Hale Overridden");
         final YamlConfigurationFactory<NonInstantiableExample> factory =
-            new YamlConfigurationFactory<>(NonInstantiableExample.class, validator, Jackson.newObjectMapper(), "dw");
+            new YamlConfigurationFactory<>(NonInstantiableExample.class, validator, objectMapper, "dw");
         assertThatIllegalArgumentException()
             .isThrownBy(factory::build)
             .withMessage("Unable to create an instance of the configuration class: " +

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationFactoryFactoryTest.java
@@ -3,9 +3,8 @@ package io.dropwizard.configuration;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.configuration.BaseConfigurationFactoryTest.Example;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.validation.BaseValidator;
-
 import org.junit.jupiter.api.Test;
 
 import javax.validation.Validator;
@@ -19,12 +18,13 @@ class ConfigurationFactoryFactoryTest {
     private final ConfigurationSourceProvider configurationSourceProvider = new ResourceConfigurationSourceProvider();
     private final ConfigurationFactoryFactory<Example> factoryFactory = new DefaultConfigurationFactoryFactory<>();
     private final Validator validator = BaseValidator.newValidator();
+    private final ObjectMapper objectMapper = new DefaultObjectMapperFactory().newObjectMapper();
 
     @Test
     void createDefaultFactory() throws Exception {
         String validFile = "factory-test-valid.yml";
         ConfigurationFactory<Example> factory =
-            factoryFactory.create(Example.class, validator, Jackson.newObjectMapper(), "dw");
+            factoryFactory.create(Example.class, validator, objectMapper, "dw");
         final Example example = factory.build(configurationSourceProvider, validFile);
         assertThat(example.getName())
             .isEqualTo("Coda Hale");
@@ -34,7 +34,7 @@ class ConfigurationFactoryFactoryTest {
     void createDefaultFactoryFailsUnknownProperty() {
         String validFileWithUnknownProp = "factory-test-unknown-property.yml";
         ConfigurationFactory<Example> factory =
-            factoryFactory.create(Example.class, validator, Jackson.newObjectMapper(), "dw");
+            factoryFactory.create(Example.class, validator, objectMapper, "dw");
 
         assertThatExceptionOfType(ConfigurationException.class)
             .isThrownBy(() -> factory.build(configurationSourceProvider, validFileWithUnknownProp))
@@ -49,7 +49,7 @@ class ConfigurationFactoryFactoryTest {
             customFactory.create(
                 Example.class,
                 validator,
-                Jackson.newObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES),
+                objectMapper.copy().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES),
                 "dw");
         Example example = factory.build(configurationSourceProvider, validFileWithUnknownProp);
         assertThat(example.getName())

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationMetadataTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationMetadataTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 class ConfigurationMetadataTest {
+    private final ObjectMapper objectMapper = new DefaultObjectMapperFactory().newObjectMapper();
 
     @SuppressWarnings("UnusedDeclaration")
     public static class ExampleConfiguration {
@@ -141,7 +142,7 @@ class ConfigurationMetadataTest {
                                         boolean isCollectionOrArrayType,
                                         Class<?> klass) {
         final ConfigurationMetadata metadata = new ConfigurationMetadata(
-                Jackson.newObjectMapper(), ExampleConfiguration.class);
+                objectMapper, ExampleConfiguration.class);
 
         assertThat(metadata.fields.get(name)).isNotNull().satisfies((f) -> {
             assertThat(f.isPrimitive()).isEqualTo(isPrimitive);
@@ -173,7 +174,7 @@ class ConfigurationMetadataTest {
     @MethodSource("provideArgsForIsCollectionOfStringsShouldWork")
     void isCollectionOfStringsShouldWork(String name, boolean isCollectionOfStrings) {
         final ConfigurationMetadata metadata = new ConfigurationMetadata(
-                Jackson.newObjectMapper(), ExampleConfiguration.class);
+                objectMapper, ExampleConfiguration.class);
 
         assertThat(metadata.isCollectionOfStrings(name)).isEqualTo(isCollectionOfStrings);
     }
@@ -197,13 +198,13 @@ class ConfigurationMetadataTest {
     @Test
     void issue3528ShouldNotProduceOutOfMemoryError() {
         assertThatNoException().isThrownBy(
-                () -> new ConfigurationMetadata(Jackson.newObjectMapper(), Issue3528Configuration.class));
+                () -> new ConfigurationMetadata(objectMapper, Issue3528Configuration.class));
     }
 
     @Test
     void fieldsAnnotatedWithJsonIgnoreShouldBeIgnored() {
         final ConfigurationMetadata metadata =
-                new ConfigurationMetadata(Jackson.newObjectMapper(), SelfReferencingIgnoredConfiguration.class);
+                new ConfigurationMetadata(objectMapper, SelfReferencingIgnoredConfiguration.class);
 
         assertThat(metadata.fields).containsOnlyKeys("str", "number");
     }
@@ -211,7 +212,7 @@ class ConfigurationMetadataTest {
     @Test
     void selfReferencingConfigurationShouldNotLoop() {
         final ConfigurationMetadata metadata =
-                new ConfigurationMetadata(Jackson.newObjectMapper(), SelfReferencingConfiguration.class);
+                new ConfigurationMetadata(objectMapper, SelfReferencingConfiguration.class);
 
         assertThat(metadata.fields).containsOnlyKeys("selfReferencingConfiguration.str", "str");
     }

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/Issue3796Test.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/Issue3796Test.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.node.TextNode;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.validation.BaseValidator;
 import org.junit.jupiter.api.Test;
 
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class Issue3796Test {
     @Test
     void configurationWithCustomDeserializerCanBeRead() throws IOException, ConfigurationException {
-        final ConfigurationFactory<CustomConfiguration> factory = new YamlConfigurationFactory<>(CustomConfiguration.class, BaseValidator.newValidator(), Jackson.newObjectMapper(), "dw");
+        final ConfigurationFactory<CustomConfiguration> factory = new YamlConfigurationFactory<>(CustomConfiguration.class, BaseValidator.newValidator(), new DefaultObjectMapperFactory().newObjectMapper(), "dw");
         final CustomConfiguration testObject = factory.build(new ResourceConfigurationSourceProvider(), "issue-3796.yml");
 
         assertThat(testObject).isNotNull();

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/JsonConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/JsonConfigurationFactoryTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static io.dropwizard.jackson.Jackson.newObjectMapper;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -17,7 +16,7 @@ class JsonConfigurationFactoryTest extends BaseConfigurationFactoryTest {
 
     @BeforeEach
     void setUp() {
-        this.factory = new JsonConfigurationFactory<>(Example.class, validator, newObjectMapper(), "dw");
+        this.factory = new JsonConfigurationFactory<>(Example.class, validator, objectMapper, "dw");
         this.malformedFile = "factory-test-malformed.json";
         this.malformedFileError = "* Malformed JSON at line:";
         this.emptyFile = "factory-test-empty.json";
@@ -43,7 +42,7 @@ class JsonConfigurationFactoryTest extends BaseConfigurationFactoryTest {
 
     @Test
     void configuredMapperAllowsComment() throws IOException, ConfigurationException {
-        ObjectMapper mapper = newObjectMapper()
+        ObjectMapper mapper = objectMapper.copy()
             .configure(Feature.ALLOW_COMMENTS, true);
 
         JsonConfigurationFactory<Example> factory = new JsonConfigurationFactory<>(Example.class, validator, mapper, "dw");

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/YamlConfigurationFactoryTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/YamlConfigurationFactoryTest.java
@@ -2,13 +2,11 @@ package io.dropwizard.configuration;
 
 import org.junit.jupiter.api.BeforeEach;
 
-import static io.dropwizard.jackson.Jackson.newObjectMapper;
-
 public class YamlConfigurationFactoryTest extends BaseConfigurationFactoryTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        this.factory = new YamlConfigurationFactory<>(Example.class, validator, newObjectMapper(), "dw");
+        this.factory = new YamlConfigurationFactory<>(Example.class, validator, objectMapper, "dw");
         this.malformedFile = "factory-test-malformed.yml";
         this.malformedFileError = " * Failed to parse configuration; Cannot construct instance of `io.dropwizard.configuration.BaseConfigurationFactoryTest$Example`";
         this.emptyFile = "factory-test-empty.yml";

--- a/dropwizard-core/src/main/java/io/dropwizard/Application.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/Application.java
@@ -4,11 +4,15 @@ import ch.qos.logback.classic.Level;
 import io.dropwizard.cli.CheckCommand;
 import io.dropwizard.cli.Cli;
 import io.dropwizard.cli.ServerCommand;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
+import io.dropwizard.jackson.ObjectMapperFactory;
 import io.dropwizard.logging.BootstrapLogging;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Generics;
 import io.dropwizard.util.JarLocation;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * The base class for Dropwizard applications.
@@ -22,8 +26,25 @@ import io.dropwizard.util.JarLocation;
  * @param <T> the type of configuration class for this application
  */
 public abstract class Application<T extends Configuration> {
+
+    private ObjectMapperFactory objectMapperFactory;
+
     protected Application() {
+        this(new DefaultObjectMapperFactory());
+    }
+
+    protected Application(ObjectMapperFactory objectMapperFactory) {
         bootstrapLogging();
+        this.objectMapperFactory = requireNonNull(objectMapperFactory, "objectMapperFactory");
+    }
+
+    public ObjectMapperFactory getObjectMapperFactory() {
+        return objectMapperFactory;
+    }
+
+    public Application<T> setObjectMapperFactory(ObjectMapperFactory objectMapperFactory) {
+        this.objectMapperFactory = requireNonNull(objectMapperFactory, "objectMapperFactory");
+        return this;
     }
 
     /**

--- a/dropwizard-core/src/main/java/io/dropwizard/cli/ConfiguredCommand.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/ConfiguredCommand.java
@@ -91,7 +91,8 @@ public abstract class ConfiguredCommand<T extends Configuration> extends Command
 
         try {
             if (configuration != null) {
-                configuration.getLoggingFactory().configure(bootstrap.getMetricRegistry(),
+                configuration.getLoggingFactory().configure(bootstrap.getObjectMapper(),
+                                                            bootstrap.getMetricRegistry(),
                                                             bootstrap.getApplication().getName());
             }
 

--- a/dropwizard-core/src/main/java/io/dropwizard/setup/Bootstrap.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/Bootstrap.java
@@ -20,7 +20,6 @@ import io.dropwizard.configuration.ConfigurationFactoryFactory;
 import io.dropwizard.configuration.ConfigurationSourceProvider;
 import io.dropwizard.configuration.DefaultConfigurationFactoryFactory;
 import io.dropwizard.configuration.FileConfigurationSourceProvider;
-import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.validation.Validators;
 
 import javax.annotation.Nullable;
@@ -61,7 +60,7 @@ public class Bootstrap<T extends Configuration> {
      */
     public Bootstrap(Application<T> application) {
         this.application = application;
-        this.objectMapper = Jackson.newObjectMapper();
+        this.objectMapper = application.getObjectMapperFactory().newObjectMapper();
         this.configuredBundles = new ArrayList<>();
         this.commands = new ArrayList<>();
         this.validatorFactory = Validators.newValidatorFactory();
@@ -83,7 +82,7 @@ public class Bootstrap<T extends Configuration> {
 
         getMetricRegistry().register("jvm.attribute", new JvmAttributeGaugeSet());
         getMetricRegistry().register("jvm.buffers", new BufferPoolMetricSet(ManagementFactory
-                                                                               .getPlatformMBeanServer()));
+                .getPlatformMBeanServer()));
         getMetricRegistry().register("jvm.classloader", new ClassLoadingGaugeSet());
         getMetricRegistry().register("jvm.filedescriptor", new FileDescriptorRatioGauge());
         getMetricRegistry().register("jvm.gc", new GarbageCollectorMetricSet());
@@ -178,8 +177,8 @@ public class Bootstrap<T extends Configuration> {
 
     /**
      * Sets the given {@link ObjectMapper} to the bootstrap.
-     * <p<b>WARNING:</b> The mapper should be created by {@link Jackson#newMinimalObjectMapper()}
-     * or {@link Jackson#newObjectMapper()}, otherwise it will not work with Dropwizard.</p>
+     * <p<b>WARNING:</b> The mapper should be created by {@link io.dropwizard.jackson.DefaultObjectMapperFactory#newObjectMapper()},
+     * otherwise it will not work with Dropwizard.
      *
      * @param objectMapper an {@link ObjectMapper}
      */

--- a/dropwizard-core/src/main/java/io/dropwizard/setup/Environment.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/Environment.java
@@ -7,7 +7,7 @@ import com.codahale.metrics.health.SharedHealthCheckRegistries;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.Configuration;
 import io.dropwizard.health.HealthEnvironment;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.setup.JerseyContainerHolder;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
@@ -131,7 +131,7 @@ public class Environment {
      * @since 2.0
      */
     public Environment(String name) {
-        this(name, Jackson.newObjectMapper(), Validators.newValidatorFactory(), new MetricRegistry(), ClassLoader.getSystemClassLoader(), new HealthCheckRegistry(), new Configuration());
+        this(name, new DefaultObjectMapperFactory().newObjectMapper(), Validators.newValidatorFactory(), new MetricRegistry(), ClassLoader.getSystemClassLoader(), new HealthCheckRegistry(), new Configuration());
     }
 
     /**

--- a/dropwizard-core/src/test/java/io/dropwizard/ConfigurationTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/ConfigurationTest.java
@@ -1,7 +1,7 @@
 package io.dropwizard;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jetty.ConnectorFactory;
 import io.dropwizard.logging.AppenderFactory;
 import org.junit.jupiter.api.Test;
@@ -29,7 +29,7 @@ class ConfigurationTest {
 
     @Test
     void ensureConfigSerializable() throws Exception {
-        final ObjectMapper mapper = Jackson.newObjectMapper();
+        final ObjectMapper mapper = new DefaultObjectMapperFactory().newObjectMapper();
         Class<?>[] dummyArray = {};
 
         mapper.getSubtypeResolver()

--- a/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
@@ -6,8 +6,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.configuration.ConfigurationException;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
-import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jetty.HttpConnectorFactory;
 import io.dropwizard.jetty.ServerPushFilterFactory;
 import io.dropwizard.logging.ConsoleAppenderFactory;
@@ -27,8 +27,8 @@ import org.junit.jupiter.api.Test;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import java.io.InputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
@@ -44,12 +44,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class DefaultServerFactoryTest {
     private final Environment environment = new Environment("test");
+    private final ObjectMapper objectMapper = new DefaultObjectMapperFactory().newObjectMapper();
     private DefaultServerFactory http;
 
     @BeforeEach
     void setUp() throws Exception {
-
-        final ObjectMapper objectMapper = Jackson.newObjectMapper();
         objectMapper.getSubtypeResolver().registerSubtypes(ConsoleAppenderFactory.class,
                                                            FileAppenderFactory.class,
                                                            SyslogAppenderFactory.class,
@@ -245,13 +244,13 @@ class DefaultServerFactoryTest {
 
     @Test
     void testDeserializeWithoutJsonAutoDetect() throws ConfigurationException, IOException {
-        final ObjectMapper objectMapper = Jackson.newObjectMapper()
+        final ObjectMapper mapper = objectMapper.copy()
             .setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE);
 
         assertThat(new YamlConfigurationFactory<>(
                 DefaultServerFactory.class,
                 BaseValidator.newValidator(),
-                objectMapper,
+                mapper,
                 "dw"
                 ).build(new ResourceConfigurationSourceProvider(), "yaml/server.yml")
                 .getMaxThreads())

--- a/dropwizard-core/src/test/java/io/dropwizard/server/SimpleServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/SimpleServerFactoryTest.java
@@ -6,8 +6,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.configuration.ConfigurationException;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
-import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jetty.HttpConnectorFactory;
 import io.dropwizard.logging.ConsoleAppenderFactory;
 import io.dropwizard.logging.FileAppenderFactory;
@@ -25,8 +25,8 @@ import javax.validation.Validator;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import java.io.InputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -103,7 +103,7 @@ public class SimpleServerFactoryTest {
 
     @Test
     void testDeserializeWithoutJsonAutoDetect() throws ConfigurationException, IOException {
-        final ObjectMapper objectMapper = Jackson.newObjectMapper()
+        final ObjectMapper objectMapper = new DefaultObjectMapperFactory().newObjectMapper()
             .setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE);
 
         assertThat(new YamlConfigurationFactory<>(

--- a/dropwizard-core/src/test/java/io/dropwizard/setup/BootstrapTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/setup/BootstrapTest.java
@@ -9,7 +9,6 @@ import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.configuration.DefaultConfigurationFactoryFactory;
 import io.dropwizard.configuration.FileConfigurationSourceProvider;
-import io.dropwizard.jackson.Jackson;
 import org.hibernate.validator.HibernateValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -115,7 +114,7 @@ class BootstrapTest {
 
     @Test
     void canUseCustomObjectMapper() {
-        final ObjectMapper minimalObjectMapper = Jackson.newMinimalObjectMapper();
+        final ObjectMapper minimalObjectMapper = new ObjectMapper();
         bootstrap.setObjectMapper(minimalObjectMapper);
         assertThat(bootstrap.getObjectMapper()).isSameAs(minimalObjectMapper);
     }

--- a/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceConfigurationTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceConfigurationTest.java
@@ -2,7 +2,7 @@ package io.dropwizard.db;
 
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.util.Duration;
 import org.junit.jupiter.api.Test;
@@ -121,7 +121,7 @@ class DataSourceConfigurationTest {
 
     private DataSourceFactory getDataSourceFactory(String resourceName) throws Exception {
         return new YamlConfigurationFactory<>(DataSourceFactory.class,
-                Validators.newValidator(), Jackson.newObjectMapper(), "dw")
+                Validators.newValidator(), new DefaultObjectMapperFactory().newObjectMapper(), "dw")
                 .build(new ResourceConfigurationSourceProvider(), resourceName);
     }
 }

--- a/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceFactoryTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/DataSourceFactoryTest.java
@@ -4,7 +4,7 @@ import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.util.Duration;
 import io.dropwizard.validation.BaseValidator;
 import org.apache.tomcat.jdbc.pool.interceptor.ConnectionState;
@@ -138,7 +138,7 @@ class DataSourceFactoryTest {
     @Test
     void createDefaultFactory() throws Exception {
         final DataSourceFactory factory = new YamlConfigurationFactory<>(DataSourceFactory.class,
-            BaseValidator.newValidator(), Jackson.newObjectMapper(), "dw")
+            BaseValidator.newValidator(), new DefaultObjectMapperFactory().newObjectMapper(), "dw")
             .build(new ResourceConfigurationSourceProvider(), "yaml/minimal_db_pool.yml");
 
         assertThat(factory.getDriverClass()).isEqualTo("org.postgresql.Driver");

--- a/dropwizard-e2e/src/test/java/com/example/app1/App1Test.java
+++ b/dropwizard-e2e/src/test/java/com/example/app1/App1Test.java
@@ -4,7 +4,7 @@ import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.util.Duration;
@@ -41,7 +41,7 @@ public class App1Test {
         // Avoid flakiness with default timeouts in CI builds
         config.setTimeout(Duration.seconds(5));
         client = new JerseyClientBuilder(RULE.getEnvironment())
-            .withProvider(new CustomJsonProvider(Jackson.newObjectMapper()))
+            .withProvider(new CustomJsonProvider(new DefaultObjectMapperFactory().newObjectMapper()))
             .using(config)
             .build("test client");
     }

--- a/dropwizard-e2e/src/test/java/com/example/validation/BeanValidatorTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/validation/BeanValidatorTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.Configuration;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.assertj.core.api.AbstractListAssert;
@@ -34,7 +34,7 @@ public class BeanValidatorTest {
     public static final DropwizardAppExtension<Configuration> APP = new DropwizardAppExtension<>(
         DefaultValidatorApp.class, "app1/config.yml", new ResourceConfigurationSourceProvider());
 
-    private final ObjectMapper mapper = Jackson.newMinimalObjectMapper();
+    private final ObjectMapper mapper = new DefaultObjectMapperFactory().newObjectMapper();
     private WebTarget target;
 
     @BeforeEach

--- a/dropwizard-example/src/test/java/com/example/helloworld/core/PersonTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/core/PersonTest.java
@@ -1,9 +1,9 @@
 package com.example.helloworld.core;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import org.junit.jupiter.api.Test;
 
-import static io.dropwizard.jackson.Jackson.newObjectMapper;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /*
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * updating the docs too.
  */
 class PersonTest {
-    private static final ObjectMapper MAPPER = newObjectMapper();
+    private static final ObjectMapper MAPPER = new DefaultObjectMapperFactory().newObjectMapper();
 
     @Test
     void serializesToJSON() throws Exception {

--- a/dropwizard-health/src/test/java/io/dropwizard/health/DefaultHealthFactoryTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/DefaultHealthFactoryTest.java
@@ -7,7 +7,7 @@ import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.health.response.ServletHealthResponder;
 import io.dropwizard.health.response.ServletHealthResponderFactory;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
 import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.jetty.setup.ServletEnvironment;
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class DefaultHealthFactoryTest {
-    private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+    private final ObjectMapper objectMapper = new DefaultObjectMapperFactory().newObjectMapper();
     private final Validator validator = Validators.newValidator();
     private final YamlConfigurationFactory<DefaultHealthFactory> configFactory =
         new YamlConfigurationFactory<>(DefaultHealthFactory.class, validator, objectMapper, "dw");

--- a/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckConfigurationTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckConfigurationTest.java
@@ -3,7 +3,7 @@ package io.dropwizard.health;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jersey.validation.Validators;
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +12,7 @@ import javax.validation.Validator;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class HealthCheckConfigurationTest {
-    private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+    private final ObjectMapper objectMapper = new DefaultObjectMapperFactory().newObjectMapper();
     private final Validator validator = Validators.newValidator();
     private final YamlConfigurationFactory<HealthCheckConfiguration> configFactory =
         new YamlConfigurationFactory<>(HealthCheckConfiguration.class, validator, objectMapper, "dw");

--- a/dropwizard-health/src/test/java/io/dropwizard/health/ScheduleTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/ScheduleTest.java
@@ -3,7 +3,7 @@ package io.dropwizard.health;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jersey.validation.Validators;
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +12,7 @@ import javax.validation.Validator;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ScheduleTest {
-    private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+    private final ObjectMapper objectMapper = new DefaultObjectMapperFactory().newObjectMapper();
     private final Validator validator = Validators.newValidator();
     private final YamlConfigurationFactory<Schedule> configFactory =
         new YamlConfigurationFactory<>(Schedule.class, validator, objectMapper, "dw");

--- a/dropwizard-health/src/test/java/io/dropwizard/health/response/JsonHealthResponseProviderFactoryTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/response/JsonHealthResponseProviderFactoryTest.java
@@ -5,17 +5,19 @@ import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.health.HealthStateAggregator;
 import io.dropwizard.health.HealthStatusChecker;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
-import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.validation.Validators;
-import java.util.Collections;
-import java.util.List;
-import javax.validation.Validator;
-import javax.ws.rs.core.MediaType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.validation.Validator;
+import javax.ws.rs.core.MediaType;
+import java.util.Collections;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -23,7 +25,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class JsonHealthResponseProviderFactoryTest {
-    private final ObjectMapper mapper = Jackson.newObjectMapper();
+    private final ObjectMapper mapper = new DefaultObjectMapperFactory().newObjectMapper();
     private final Validator validator = Validators.newValidator();
     private final YamlConfigurationFactory<HealthResponseProviderFactory> configFactory =
             new YamlConfigurationFactory<>(HealthResponseProviderFactory.class, validator, mapper, "dw");

--- a/dropwizard-health/src/test/java/io/dropwizard/health/response/JsonHealthResponseProviderTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/response/JsonHealthResponseProviderTest.java
@@ -6,7 +6,7 @@ import io.dropwizard.health.HealthCheckType;
 import io.dropwizard.health.HealthStateAggregator;
 import io.dropwizard.health.HealthStateView;
 import io.dropwizard.health.HealthStatusChecker;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.util.ByteStreams;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class JsonHealthResponseProviderTest {
-    private final ObjectMapper mapper = Jackson.newObjectMapper();
+    private final ObjectMapper mapper = new DefaultObjectMapperFactory().newObjectMapper();
     @Mock
     private HealthStatusChecker healthStatusChecker;
     @Mock

--- a/dropwizard-health/src/test/java/io/dropwizard/health/response/ServletHealthResponderFactoryTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/response/ServletHealthResponderFactoryTest.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.health.HealthEnvironment;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
-import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
 import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.jetty.setup.ServletEnvironment;
@@ -43,7 +43,7 @@ class ServletHealthResponderFactoryTest {
     private static final HealthResponse FAIL = new HealthResponse(false, "unhealthy", MediaType.TEXT_PLAIN,
         Response.SC_SERVICE_UNAVAILABLE);
 
-    private final ObjectMapper mapper = Jackson.newObjectMapper();
+    private final ObjectMapper mapper = new DefaultObjectMapperFactory().newObjectMapper();
     private final Validator validator = Validators.newValidator();
     private final YamlConfigurationFactory<HealthResponderFactory> configFactory =
         new YamlConfigurationFactory<>(HealthResponderFactory.class, validator, mapper, "dw");

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
@@ -2,7 +2,7 @@ package io.dropwizard.hibernate;
 
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.db.DataSourceFactory;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.errors.ErrorMessage;
 import io.dropwizard.jersey.jackson.JacksonFeature;
@@ -15,9 +15,6 @@ import org.glassfish.jersey.test.JerseyTest;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
-
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,6 +32,8 @@ import javax.ws.rs.core.Application;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.Optional;
 
@@ -143,7 +142,7 @@ class JerseyIntegrationTest extends JerseyTest {
         config.register(new UnitOfWorkApplicationListener("hr-db", sessionFactory));
         config.register(new PersonResource(new PersonDAO(sessionFactory)));
         config.register(new PersistenceExceptionMapper());
-        config.register(new JacksonFeature(Jackson.newObjectMapper()));
+        config.register(new JacksonFeature(new DefaultObjectMapperFactory().newObjectMapper()));
         config.register(new DataExceptionMapper());
         config.register(new EmptyOptionalExceptionMapper());
 
@@ -152,7 +151,7 @@ class JerseyIntegrationTest extends JerseyTest {
 
     @Override
     protected void configureClient(ClientConfig config) {
-        config.register(new JacksonFeature(Jackson.newObjectMapper()));
+        config.register(new JacksonFeature(new DefaultObjectMapperFactory().newObjectMapper()));
     }
 
     @Test

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/BaseObjectMapperFactory.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/BaseObjectMapperFactory.java
@@ -1,0 +1,77 @@
+package io.dropwizard.jackson;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+
+import javax.annotation.Nullable;
+
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+
+/**
+ * Base class for a factory for creating instances of the {@link ObjectMapper} instances for Dropwizard.
+ *
+ * @since 2.1.1
+ */
+public abstract class BaseObjectMapperFactory implements ObjectMapperFactory {
+    /**
+     * Creates a new {@link ObjectMapper} with a custom {@link JsonFactory}
+     * with Guava, Logback, and Joda Time support, as well as support for {@link JsonSnakeCase}.
+     * Also includes all {@link Discoverable} interface implementations.
+     */
+    @Override
+    public ObjectMapper newObjectMapper() {
+        return configure(new ObjectMapper());
+    }
+
+    /**
+     * Creates a new {@link ObjectMapper} with a custom {@link JsonFactory}
+     * with Guava, Logback, and Joda Time support, as well as support for {@link JsonSnakeCase}.
+     * Also includes all {@link Discoverable} interface implementations.
+     *
+     * @param jsonFactory instance of {@link JsonFactory} to use
+     *                    for the created {@link ObjectMapper} instance.
+     */
+    @Override
+    public ObjectMapper newObjectMapper(@Nullable JsonFactory jsonFactory) {
+        return configure(new ObjectMapper(jsonFactory));
+    }
+
+    /**
+     * Creates a new minimal {@link ObjectMapper} that will work with Dropwizard out of box.
+     * <p><b>NOTE:</b> Use it, if the default Dropwizard's {@link ObjectMapper}, created in
+     * {@link #newObjectMapper()}, is too aggressive for you.</p>
+     */
+    public ObjectMapper newMinimalObjectMapper() {
+        return new ObjectMapper()
+                .registerModule(new GuavaModule())
+                .setSubtypeResolver(new DiscoverableSubtypeResolver())
+                .disable(FAIL_ON_UNKNOWN_PROPERTIES);
+    }
+
+    /**
+     * Configure the provided {@link ObjectMapper} instance.
+     *
+     * @param mapper The {@link ObjectMapper} instance to customize.
+     * @return The customized {@link ObjectMapper} instance.
+     */
+    protected ObjectMapper configure(ObjectMapper mapper) {
+        mapper.registerModule(new GuavaModule());
+        mapper.registerModule(new GuavaExtrasModule());
+        mapper.registerModule(new CaffeineModule());
+        mapper.registerModule(new JodaModule());
+        mapper.registerModule(new FuzzyEnumModule());
+        mapper.registerModule(new ParameterNamesModule());
+        mapper.registerModule(new Jdk8Module());
+        mapper.registerModule(new JavaTimeModule());
+        mapper.setPropertyNamingStrategy(new AnnotationSensitivePropertyNamingStrategy());
+        mapper.setSubtypeResolver(new DiscoverableSubtypeResolver());
+        mapper.disable(FAIL_ON_UNKNOWN_PROPERTIES);
+
+        return mapper;
+    }
+}

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/DefaultObjectMapperFactory.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/DefaultObjectMapperFactory.java
@@ -1,0 +1,18 @@
+package io.dropwizard.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.blackbird.BlackbirdModule;
+
+/**
+ * Factory for creating instances of the default {@link ObjectMapper} instances for Dropwizard including the
+ * <a href="https://github.com/FasterXML/jackson-modules-base/tree/jackson-modules-base-2.13.3/blackbird#readme">Jackson Blackbird module</a>.
+ *
+ * @see BaseObjectMapperFactory
+ * @since 2.1.1
+ */
+public class DefaultObjectMapperFactory extends BaseObjectMapperFactory {
+    @Override
+    protected ObjectMapper configure(ObjectMapper mapper) {
+        return super.configure(mapper).registerModule(new BlackbirdModule());
+    }
+}

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
@@ -1,46 +1,47 @@
 package io.dropwizard.jackson;
 
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
-
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.joda.JodaModule;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.module.blackbird.BlackbirdModule;
-import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 
 import javax.annotation.Nullable;
 
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+
 /**
  * A utility class for Jackson.
+ *
+ * @deprecated See {@link DefaultObjectMapperFactory}.
  */
+@Deprecated
 public class Jackson {
+    private static final ObjectMapperFactory FACTORY = new DefaultObjectMapperFactory();
+
     private Jackson() { /* singleton */ }
 
     /**
-     * Creates a new {@link ObjectMapper} with Guava, Logback, and Joda Time support, as well as
+     * Creates a new {@link ObjectMapper} with Guava, Logback, and Joda-Time support, as well as
      * support for {@link JsonSnakeCase}. Also includes all {@link Discoverable} interface implementations.
+     *
+     * @deprecated Use {@link ObjectMapperFactory#newObjectMapper()}.
      */
+    @Deprecated
     public static ObjectMapper newObjectMapper() {
-        final ObjectMapper mapper = new ObjectMapper();
-
-        return configure(mapper);
+        return FACTORY.newObjectMapper();
     }
 
     /**
      * Creates a new {@link ObjectMapper} with a custom {@link com.fasterxml.jackson.core.JsonFactory}
-     * with Guava, Logback, and Joda Time support, as well as support for {@link JsonSnakeCase}.
+     * with Guava, Logback, and Joda-Time support, as well as support for {@link JsonSnakeCase}.
      * Also includes all {@link Discoverable} interface implementations.
      *
      * @param jsonFactory instance of {@link com.fasterxml.jackson.core.JsonFactory} to use
      *                    for the created {@link com.fasterxml.jackson.databind.ObjectMapper} instance.
+     * @deprecated Use {@link ObjectMapperFactory#newObjectMapper(JsonFactory)}.
      */
+    @Deprecated
     public static ObjectMapper newObjectMapper(@Nullable JsonFactory jsonFactory) {
-        final ObjectMapper mapper = new ObjectMapper(jsonFactory);
-
-        return configure(mapper);
+        return FACTORY.newObjectMapper(jsonFactory);
     }
 
     /**
@@ -48,27 +49,11 @@ public class Jackson {
      * <p><b>NOTE:</b> Use it, if the default Dropwizard's {@link ObjectMapper}, created in
      * {@link #newObjectMapper()}, is too aggressive for you.</p>
      */
+    @Deprecated
     public static ObjectMapper newMinimalObjectMapper() {
         return new ObjectMapper()
                 .registerModule(new GuavaModule())
                 .setSubtypeResolver(new DiscoverableSubtypeResolver())
                 .disable(FAIL_ON_UNKNOWN_PROPERTIES);
-    }
-
-    private static ObjectMapper configure(ObjectMapper mapper) {
-        mapper.registerModule(new GuavaModule());
-        mapper.registerModule(new GuavaExtrasModule());
-        mapper.registerModule(new CaffeineModule());
-        mapper.registerModule(new JodaModule());
-        mapper.registerModule(new BlackbirdModule());
-        mapper.registerModule(new FuzzyEnumModule());
-        mapper.registerModule(new ParameterNamesModule());
-        mapper.registerModule(new Jdk8Module());
-        mapper.registerModule(new JavaTimeModule());
-        mapper.setPropertyNamingStrategy(new AnnotationSensitivePropertyNamingStrategy());
-        mapper.setSubtypeResolver(new DiscoverableSubtypeResolver());
-        mapper.disable(FAIL_ON_UNKNOWN_PROPERTIES);
-
-        return mapper;
     }
 }

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/ObjectMapperFactory.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/ObjectMapperFactory.java
@@ -1,0 +1,28 @@
+package io.dropwizard.jackson;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.annotation.Nullable;
+
+/**
+ * Factory for creating instances of Jackson's {@link ObjectMapper}.
+ *
+ * @since 2.1
+ */
+public interface ObjectMapperFactory {
+    /**
+     * Creates a new {@link ObjectMapper}.
+     *
+     * @since 2.1
+     */
+    ObjectMapper newObjectMapper();
+
+    /**
+     * Creates a new {@link ObjectMapper} with a custom {@link JsonFactory}.
+     *
+     * @param jsonFactory instance of {@link JsonFactory} to use for the created {@link ObjectMapper} instance.
+     * @since 2.1
+     */
+    ObjectMapper newObjectMapper(@Nullable JsonFactory jsonFactory);
+}

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/DefaultObjectMapperFactoryTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/DefaultObjectMapperFactoryTest.java
@@ -1,0 +1,16 @@
+package io.dropwizard.jackson;
+
+import com.fasterxml.jackson.module.blackbird.BlackbirdModule;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DefaultObjectMapperFactoryTest {
+    private final ObjectMapperFactory objectMapperFactory = new DefaultObjectMapperFactory();
+
+    @Test
+    void objectMapperFactoryRegistersBlackbird() {
+        assertThat(objectMapperFactory.newObjectMapper().getRegisteredModuleIds())
+                .contains(BlackbirdModule.class.getCanonicalName());
+    }
+}

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonDeserializationOfBigNumbersToDurationTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonDeserializationOfBigNumbersToDurationTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTimeout;
 
 class JacksonDeserializationOfBigNumbersToDurationTest {
 
-    private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+    private final ObjectMapper objectMapper = new DefaultObjectMapperFactory().newObjectMapper();
 
     @Test
     void testDoesNotAttemptToDeserializeExtremelyBigNumbers() throws Exception {

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonDeserializationOfBigNumbersToInstantTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonDeserializationOfBigNumbersToInstantTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTimeout;
 
 class JacksonDeserializationOfBigNumbersToInstantTest {
 
-    private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+    private final ObjectMapper objectMapper = new DefaultObjectMapperFactory().newObjectMapper();
 
     @Test
     void testDoesNotAttemptToDeserializeExtremelBigNumbers() throws Exception {

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/DefaultJacksonMessageBodyProvider.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/errors/DefaultJacksonMessageBodyProvider.java
@@ -1,6 +1,6 @@
 package io.dropwizard.jersey.errors;
 
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
 
 import javax.ws.rs.ext.Provider;
@@ -8,6 +8,6 @@ import javax.ws.rs.ext.Provider;
 @Provider
 public class DefaultJacksonMessageBodyProvider extends JacksonMessageBodyProvider {
     public DefaultJacksonMessageBodyProvider() {
-        super(Jackson.newObjectMapper());
+        super(new DefaultObjectMapperFactory().newObjectMapper());
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/DefaultJacksonMessageBodyProvider.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/DefaultJacksonMessageBodyProvider.java
@@ -1,12 +1,12 @@
 package io.dropwizard.jersey.jackson;
 
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 
 import javax.ws.rs.ext.Provider;
 
 @Provider
 public class DefaultJacksonMessageBodyProvider extends JacksonMessageBodyProvider {
     public DefaultJacksonMessageBodyProvider() {
-        super(Jackson.newObjectMapper());
+        super(new DefaultObjectMapperFactory().newObjectMapper());
     }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProviderTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/jackson/JacksonMessageBodyProviderTest.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.validation.Validated;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
@@ -35,7 +35,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unchecked")
@@ -100,7 +99,7 @@ public class JacksonMessageBodyProviderTest {
 
     }
 
-    private final ObjectMapper mapper = spy(Jackson.newObjectMapper());
+    private final ObjectMapper mapper = new DefaultObjectMapperFactory().newObjectMapper();
     private final JacksonMessageBodyProvider provider =
             new JacksonMessageBodyProvider(mapper);
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/DefaultJacksonMessageBodyProvider.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/DefaultJacksonMessageBodyProvider.java
@@ -1,6 +1,6 @@
 package io.dropwizard.jersey.validation;
 
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
 
 import javax.ws.rs.ext.Provider;
@@ -8,7 +8,7 @@ import javax.ws.rs.ext.Provider;
 @Provider
 public class DefaultJacksonMessageBodyProvider extends JacksonMessageBodyProvider {
     public DefaultJacksonMessageBodyProvider() {
-        super(Jackson.newObjectMapper());
+        super(new DefaultObjectMapperFactory().newObjectMapper());
     }
 }
 

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/GzipHandlerFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/GzipHandlerFactoryTest.java
@@ -2,7 +2,7 @@ package io.dropwizard.jetty;
 
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.util.DataSize;
 import io.dropwizard.util.Sets;
 import io.dropwizard.validation.BaseValidator;
@@ -23,7 +23,7 @@ class GzipHandlerFactoryTest {
     @BeforeEach
     void setUp() throws Exception {
         this.gzip = new YamlConfigurationFactory<>(GzipHandlerFactory.class,
-                BaseValidator.newValidator(), Jackson.newObjectMapper(), "dw")
+                BaseValidator.newValidator(), new DefaultObjectMapperFactory().newObjectMapper(), "dw")
                 .build(new ResourceConfigurationSourceProvider(),"yaml/gzip.yml");
     }
 
@@ -71,7 +71,7 @@ class GzipHandlerFactoryTest {
     @Test
     void testBuildDefault() throws Exception {
         final GzipHandler handler = new YamlConfigurationFactory<>(GzipHandlerFactory.class,
-                BaseValidator.newValidator(), Jackson.newObjectMapper(), "dw")
+                BaseValidator.newValidator(), new DefaultObjectMapperFactory().newObjectMapper(), "dw")
                 .build(new ResourceConfigurationSourceProvider(), "yaml/default_gzip.yml")
                 .build(null);
 

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
@@ -5,8 +5,8 @@ import com.codahale.metrics.jetty9.InstrumentedConnectionFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
-import io.dropwizard.jackson.Jackson;
 import io.dropwizard.logging.ConsoleAppenderFactory;
 import io.dropwizard.logging.FileAppenderFactory;
 import io.dropwizard.logging.SyslogAppenderFactory;
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.verify;
 
 class HttpConnectorFactoryTest {
 
-    private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+    private final ObjectMapper objectMapper = new DefaultObjectMapperFactory().newObjectMapper();
     private final Validator validator = BaseValidator.newValidator();
 
     @BeforeEach

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpsConnectorFactoryTest.java
@@ -4,8 +4,8 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.jetty9.InstrumentedConnectionFactory;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
-import io.dropwizard.jackson.Jackson;
 import io.dropwizard.validation.BaseValidator;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.eclipse.jetty.server.ConnectionFactory;
@@ -61,7 +61,7 @@ class HttpsConnectorFactoryTest {
     @Test
     void testParsingConfiguration() throws Exception {
         HttpsConnectorFactory https = new YamlConfigurationFactory<>(HttpsConnectorFactory.class, validator,
-                Jackson.newObjectMapper(), "dw-https")
+                new DefaultObjectMapperFactory().newObjectMapper(), "dw-https")
                 .build(new ResourceConfigurationSourceProvider(), "yaml/https-connector.yml");
 
         assertThat(https.getPort()).isEqualTo(8443);

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/ServerPushFilterFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/ServerPushFilterFactoryTest.java
@@ -2,7 +2,7 @@ package io.dropwizard.jetty;
 
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.util.Duration;
 import io.dropwizard.validation.BaseValidator;
 import org.eclipse.jetty.servlet.ServletContextHandler;
@@ -26,7 +26,7 @@ class ServerPushFilterFactoryTest {
     void testLoadConfiguration() throws Exception {
         final ServerPushFilterFactory serverPush = new YamlConfigurationFactory<>(
                 ServerPushFilterFactory.class, BaseValidator.newValidator(),
-                Jackson.newObjectMapper(), "dw-server-push")
+                new DefaultObjectMapperFactory().newObjectMapper(), "dw-server-push")
                 .build(new ResourceConfigurationSourceProvider(), "yaml/server-push.yml");
         assertThat(serverPush.isEnabled()).isTrue();
         assertThat(serverPush.getAssociatePeriod()).isEqualTo(Duration.seconds(5));

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/AbstractJsonLayoutBaseFactory.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/AbstractJsonLayoutBaseFactory.java
@@ -2,7 +2,8 @@ package io.dropwizard.logging.json;
 
 import ch.qos.logback.core.spi.DeferredProcessingAware;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.dropwizard.jackson.Jackson;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.logging.json.layout.JsonFormatter;
 import io.dropwizard.logging.json.layout.TimestampFormatter;
 import io.dropwizard.logging.layout.DiscoverableLayoutFactory;
@@ -116,7 +117,11 @@ public abstract class AbstractJsonLayoutBaseFactory<E extends DeferredProcessing
     }
 
     protected JsonFormatter createDropwizardJsonFormatter() {
-        return new JsonFormatter(Jackson.newObjectMapper(), isPrettyPrint(), isAppendLineSeparator());
+        return createDropwizardJsonFormatter(new DefaultObjectMapperFactory().newObjectMapper());
+    }
+
+    protected JsonFormatter createDropwizardJsonFormatter(ObjectMapper objectMapper) {
+        return new JsonFormatter(objectMapper, isPrettyPrint(), isAppendLineSeparator());
     }
 
     protected TimestampFormatter createTimestampFormatter(TimeZone timeZone) {

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.logging.BootstrapLogging;
 import io.dropwizard.logging.ConsoleAppenderFactory;
 import io.dropwizard.logging.DefaultLoggingFactory;
@@ -43,7 +43,7 @@ class LayoutIntegrationTests {
         BootstrapLogging.bootstrap(Level.INFO, new EventJsonLayoutBaseFactory());
     }
 
-    private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+    private final ObjectMapper objectMapper = new DefaultObjectMapperFactory().newObjectMapper();
 
     @SuppressWarnings("rawtypes")
     private final YamlConfigurationFactory<ConsoleAppenderFactory> yamlFactory = new YamlConfigurationFactory<>(

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/AccessJsonLayoutTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/AccessJsonLayoutTest.java
@@ -3,7 +3,7 @@ package io.dropwizard.logging.json.layout;
 import ch.qos.logback.access.spi.IAccessEvent;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.logging.json.AccessAttribute;
 import io.dropwizard.util.Maps;
 import io.dropwizard.util.Sets;
@@ -38,7 +38,7 @@ class AccessJsonLayoutTest {
     private IAccessEvent event = Mockito.mock(IAccessEvent.class);
 
     private TimestampFormatter timestampFormatter = new TimestampFormatter("yyyy-MM-dd'T'HH:mm:ss.SSSZ", ZoneId.of("UTC"));
-    private ObjectMapper objectMapper = Jackson.newObjectMapper();
+    private ObjectMapper objectMapper = new DefaultObjectMapperFactory().newObjectMapper();
     private JsonFormatter jsonFormatter = new JsonFormatter(objectMapper, false, true);
     private Set<AccessAttribute> includes = EnumSet.of(AccessAttribute.REMOTE_ADDRESS,
         AccessAttribute.REMOTE_USER, AccessAttribute.REQUEST_TIME, AccessAttribute.REQUEST_URI,

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/EventJsonLayoutTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/EventJsonLayoutTest.java
@@ -5,7 +5,7 @@ import ch.qos.logback.classic.pattern.ThrowableProxyConverter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggerContextVO;
 import ch.qos.logback.classic.spi.ThrowableProxyVO;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.logging.json.EventAttribute;
 import io.dropwizard.util.Maps;
 import io.dropwizard.util.Sets;
@@ -46,7 +46,7 @@ class EventJsonLayoutTest {
             EventAttribute.CALLER_DATA));
 
     private final TimestampFormatter timestampFormatter = new TimestampFormatter("yyyy-MM-dd'T'HH:mm:ss.SSSZ", ZoneId.of("UTC"));
-    private final JsonFormatter jsonFormatter = new JsonFormatter(Jackson.newObjectMapper(), false, true);
+    private final JsonFormatter jsonFormatter = new JsonFormatter(new DefaultObjectMapperFactory().newObjectMapper(), false, true);
     private ThrowableProxyConverter throwableProxyConverter = Mockito.mock(ThrowableProxyConverter.class);
     private ILoggingEvent event = Mockito.mock(ILoggingEvent.class);
     private Marker marker = Mockito.mock(Marker.class);

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/JsonFormatterTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/JsonFormatterTest.java
@@ -1,6 +1,7 @@
 package io.dropwizard.logging.json.layout;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.util.Maps;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -10,7 +11,6 @@ import java.util.Arrays;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import static io.dropwizard.jackson.Jackson.newObjectMapper;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class JsonFormatterTest {
@@ -18,7 +18,7 @@ class JsonFormatterTest {
     private final SortedMap<String, Object> map = new TreeMap<>(Maps.of(
             "name", "Jim",
             "hobbies", Arrays.asList("Reading", "Biking", "Snorkeling")));
-    private final ObjectMapper objectMapper = newObjectMapper();
+    private final ObjectMapper objectMapper = new DefaultObjectMapperFactory().newObjectMapper();
 
     @ParameterizedTest
     @ValueSource(booleans={true, false})

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/ExternalLoggingFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/ExternalLoggingFactory.java
@@ -1,6 +1,5 @@
 package io.dropwizard.logging;
 
-import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 /**
@@ -8,12 +7,6 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  */
 @JsonTypeName("external")
 public class ExternalLoggingFactory implements LoggingFactory {
-
-    @Override
-    public void configure(MetricRegistry metricRegistry, String name) {
-        // Do nothing
-    }
-
     @Override
     public void stop() {
         // Do nothing

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/LoggingFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/LoggingFactory.java
@@ -2,11 +2,17 @@ package io.dropwizard.logging;
 
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Discoverable;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = DefaultLoggingFactory.class)
 public interface LoggingFactory extends Discoverable {
-    void configure(MetricRegistry metricRegistry, String name);
+    default void configure(MetricRegistry metricRegistry, String name) {
+    }
+
+    default void configure(ObjectMapper objectMapper, MetricRegistry metricRegistry, String name) {
+        configure(metricRegistry, name);
+    }
 
     /** Should flush all log messages but not disable logging */
     void stop();

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/AppenderFactoryCustomLayoutTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/AppenderFactoryCustomLayoutTest.java
@@ -9,7 +9,7 @@ import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.logging.TestPatternLayoutFactory.TestPatternLayout;
 import io.dropwizard.logging.async.AsyncLoggingEventAppenderFactory;
 import io.dropwizard.logging.filter.NullLevelFilterFactory;
@@ -27,7 +27,7 @@ class AppenderFactoryCustomLayoutTest {
         BootstrapLogging.bootstrap();
     }
 
-    private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+    private final ObjectMapper objectMapper = new DefaultObjectMapperFactory().newObjectMapper();
     @SuppressWarnings("rawtypes")
     private final YamlConfigurationFactory<ConsoleAppenderFactory> factory = new YamlConfigurationFactory<>(
         ConsoleAppenderFactory.class, BaseValidator.newValidator(), objectMapper, "dw-layout");

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/AppenderFactoryCustomTimeZoneTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/AppenderFactoryCustomTimeZoneTest.java
@@ -9,7 +9,7 @@ import ch.qos.logback.core.pattern.PatternLayoutBase;
 import io.dropwizard.configuration.ConfigurationSourceProvider;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.logging.async.AsyncLoggingEventAppenderFactory;
 import io.dropwizard.logging.filter.NullLevelFilterFactory;
 import io.dropwizard.logging.layout.DropwizardLayoutFactory;
@@ -32,7 +32,7 @@ class AppenderFactoryCustomTimeZoneTest {
 
     @SuppressWarnings("rawtypes")
     private final YamlConfigurationFactory<ConsoleAppenderFactory> factory = new YamlConfigurationFactory<>(
-        ConsoleAppenderFactory.class, BaseValidator.newValidator(), Jackson.newObjectMapper(), "dw");
+        ConsoleAppenderFactory.class, BaseValidator.newValidator(), new DefaultObjectMapperFactory().newObjectMapper(), "dw");
 
     @ParameterizedTest
     @CsvSource({

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/DefaultLoggingFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/DefaultLoggingFactoryTest.java
@@ -14,7 +14,7 @@ import io.dropwizard.configuration.ConfigurationSourceProvider;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.util.Maps;
 import io.dropwizard.validation.BaseValidator;
 import org.apache.commons.text.StringSubstitutor;
@@ -31,7 +31,7 @@ import java.nio.file.Path;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class DefaultLoggingFactoryTest {
-    private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+    private final ObjectMapper objectMapper = new DefaultObjectMapperFactory().newObjectMapper();
     private final ConfigurationSourceProvider configurationSourceProvider = new ResourceConfigurationSourceProvider();
     private final YamlConfigurationFactory<DefaultLoggingFactory> factory = new YamlConfigurationFactory<>(
             DefaultLoggingFactory.class,

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/ExternalLoggingFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/ExternalLoggingFactoryTest.java
@@ -2,8 +2,8 @@ package io.dropwizard.logging;
 
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
-import io.dropwizard.jackson.Jackson;
 import io.dropwizard.validation.BaseValidator;
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +14,7 @@ class ExternalLoggingFactoryTest {
     @Test
     void canBeDeserialized() throws Exception {
         LoggingFactory externalRequestLogFactory = new YamlConfigurationFactory<>(LoggingFactory.class,
-            BaseValidator.newValidator(), Jackson.newObjectMapper(), "dw")
+            BaseValidator.newValidator(), new DefaultObjectMapperFactory().newObjectMapper(), "dw")
             .build(new ResourceConfigurationSourceProvider(), "yaml/logging_external.yml");
         assertThat(externalRequestLogFactory)
             .isNotNull()

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/FileAppenderFactoryTest.java
@@ -17,8 +17,8 @@ import io.dropwizard.configuration.ConfigurationException;
 import io.dropwizard.configuration.ConfigurationValidationException;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
-import io.dropwizard.jackson.Jackson;
 import io.dropwizard.logging.async.AsyncLoggingEventAppenderFactory;
 import io.dropwizard.logging.filter.NullLevelFilterFactory;
 import io.dropwizard.logging.layout.DropwizardLayoutFactory;
@@ -45,7 +45,7 @@ class FileAppenderFactoryTest {
         BootstrapLogging.bootstrap();
     }
 
-    private final ObjectMapper mapper = Jackson.newObjectMapper();
+    private final ObjectMapper mapper = new DefaultObjectMapperFactory().newObjectMapper();
     private final Validator validator = BaseValidator.newValidator();
 
     @Test

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/TcpSocketAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/TcpSocketAppenderFactoryTest.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.util.DataSize;
 import io.dropwizard.util.Duration;
 import io.dropwizard.validation.BaseValidator;
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class TcpSocketAppenderFactoryTest {
 
-    private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+    private final ObjectMapper objectMapper = new DefaultObjectMapperFactory().newObjectMapper();
     private final YamlConfigurationFactory<DefaultLoggingFactory> yamlConfigurationFactory = new YamlConfigurationFactory<>(
         DefaultLoggingFactory.class, BaseValidator.newValidator(), objectMapper, "dw-tcp");
 

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/TlsSocketAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/TlsSocketAppenderFactoryTest.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.util.Maps;
 import io.dropwizard.validation.BaseValidator;
 import org.apache.commons.text.StringSubstitutor;
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class TlsSocketAppenderFactoryTest {
 
-    private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+    private final ObjectMapper objectMapper = new DefaultObjectMapperFactory().newObjectMapper();
     private final YamlConfigurationFactory<DefaultLoggingFactory> yamlConfigurationFactory = new YamlConfigurationFactory<>(
         DefaultLoggingFactory.class, BaseValidator.newValidator(), objectMapper, "dw-ssl");
 

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/UdpSocketAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/UdpSocketAppenderFactoryTest.java
@@ -4,7 +4,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.validation.BaseValidator;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -26,7 +26,7 @@ class UdpSocketAppenderFactoryTest {
     @Test
     void testSendLogsByTcp() throws Exception {
         final int messageCount = 100;
-        ObjectMapper objectMapper = Jackson.newObjectMapper();
+        ObjectMapper objectMapper = new DefaultObjectMapperFactory().newObjectMapper();
         objectMapper.getSubtypeResolver().registerSubtypes(UdpSocketAppenderFactory.class);
 
         try (DatagramSocket datagramSocket = new DatagramSocket(UDP_PORT); UdpServer udpServer = new UdpServer(datagramSocket, messageCount)) {

--- a/dropwizard-metrics-graphite/src/test/java/io/dropwizard/metrics/graphite/GraphiteReporterFactoryTest.java
+++ b/dropwizard-metrics-graphite/src/test/java/io/dropwizard/metrics/graphite/GraphiteReporterFactoryTest.java
@@ -5,8 +5,8 @@ import com.codahale.metrics.graphite.Graphite;
 import com.codahale.metrics.graphite.GraphiteReporter;
 import com.codahale.metrics.graphite.GraphiteUDP;
 import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
-import io.dropwizard.jackson.Jackson;
 import io.dropwizard.validation.BaseValidator;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -35,7 +35,7 @@ class GraphiteReporterFactoryTest {
     @Test
     void createDefaultFactory() throws Exception {
         final GraphiteReporterFactory factory = new YamlConfigurationFactory<>(GraphiteReporterFactory.class,
-             BaseValidator.newValidator(), Jackson.newObjectMapper(), "dw")
+             BaseValidator.newValidator(), new DefaultObjectMapperFactory().newObjectMapper(), "dw")
             .build();
         assertThat(factory.getFrequency()).isNotPresent();
     }

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/CsvReporterFactoryTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/CsvReporterFactoryTest.java
@@ -4,8 +4,8 @@ import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
-import io.dropwizard.jackson.Jackson;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import io.dropwizard.validation.BaseValidator;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,7 +16,7 @@ import java.io.File;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class CsvReporterFactoryTest {
-    private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+    private final ObjectMapper objectMapper = new DefaultObjectMapperFactory().newObjectMapper();
     private final YamlConfigurationFactory<MetricsFactory> factory =
             new YamlConfigurationFactory<>(MetricsFactory.class,
                                            BaseValidator.newValidator(),

--- a/dropwizard-metrics/src/test/java/io/dropwizard/metrics/MetricsFactoryTest.java
+++ b/dropwizard-metrics/src/test/java/io/dropwizard/metrics/MetricsFactoryTest.java
@@ -4,7 +4,7 @@ import com.codahale.metrics.MetricAttribute;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.logging.BootstrapLogging;
 import io.dropwizard.util.Duration;
 import io.dropwizard.validation.BaseValidator;
@@ -21,7 +21,7 @@ class MetricsFactoryTest {
         BootstrapLogging.bootstrap();
     }
 
-    private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+    private final ObjectMapper objectMapper = new DefaultObjectMapperFactory().newObjectMapper();
     private final YamlConfigurationFactory<MetricsFactory> factory = new YamlConfigurationFactory<>(
         MetricsFactory.class, BaseValidator.newValidator(), objectMapper, "dw");
     private MetricsFactory config;

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/ExternalRequestLogFactoryTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/ExternalRequestLogFactoryTest.java
@@ -2,8 +2,8 @@ package io.dropwizard.request.logging;
 
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
-import io.dropwizard.jackson.Jackson;
 import io.dropwizard.logging.BootstrapLogging;
 import io.dropwizard.validation.BaseValidator;
 import org.junit.jupiter.api.Test;
@@ -19,7 +19,7 @@ class ExternalRequestLogFactoryTest {
     @Test
     void canBeDeserialized() throws Exception {
         RequestLogFactory<?> externalRequestLogFactory = new YamlConfigurationFactory<>(RequestLogFactory.class,
-            BaseValidator.newValidator(), Jackson.newObjectMapper(), "dw")
+            BaseValidator.newValidator(), new DefaultObjectMapperFactory().newObjectMapper(), "dw")
             .build(new ResourceConfigurationSourceProvider(), "yaml/externalRequestLog.yml");
         assertThat(externalRequestLogFactory)
             .isNotNull()

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/RequestLogFactoryTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/RequestLogFactoryTest.java
@@ -3,8 +3,8 @@ package io.dropwizard.request.logging;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
-import io.dropwizard.jackson.Jackson;
 import io.dropwizard.logging.ConsoleAppenderFactory;
 import io.dropwizard.logging.FileAppenderFactory;
 import io.dropwizard.logging.SyslogAppenderFactory;
@@ -19,7 +19,7 @@ class RequestLogFactoryTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        final ObjectMapper objectMapper = Jackson.newObjectMapper();
+        final ObjectMapper objectMapper = new DefaultObjectMapperFactory().newObjectMapper();
         objectMapper.getSubtypeResolver().registerSubtypes(ConsoleAppenderFactory.class,
                                                            FileAppenderFactory.class,
                                                            SyslogAppenderFactory.class);

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/old/LogbackClassicRequestLogFactoryTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/old/LogbackClassicRequestLogFactoryTest.java
@@ -5,8 +5,8 @@ import ch.qos.logback.core.Appender;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
-import io.dropwizard.jackson.Jackson;
 import io.dropwizard.logging.BootstrapLogging;
 import io.dropwizard.logging.ConsoleAppenderFactory;
 import io.dropwizard.logging.FileAppenderFactory;
@@ -42,7 +42,7 @@ class LogbackClassicRequestLogFactoryTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        final ObjectMapper objectMapper = Jackson.newObjectMapper();
+        final ObjectMapper objectMapper = new DefaultObjectMapperFactory().newObjectMapper();
         objectMapper.getSubtypeResolver().registerSubtypes(ConsoleAppenderFactory.class, FileAppenderFactory.class,
             SyslogAppenderFactory.class);
         this.requestLog = new YamlConfigurationFactory<>(RequestLogFactory.class,

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/POJOConfigurationFactory.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/POJOConfigurationFactory.java
@@ -1,20 +1,25 @@
 package io.dropwizard.testing;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.Configuration;
 import io.dropwizard.configuration.ConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 
 import java.io.File;
 
 public class POJOConfigurationFactory<C extends Configuration>
     extends YamlConfigurationFactory<C> {
     protected final C configuration;
+    
+    public POJOConfigurationFactory(C cfg) {
+        this(cfg, new DefaultObjectMapperFactory().newObjectMapper());
+    }
 
     @SuppressWarnings("unchecked")
-    public POJOConfigurationFactory(C cfg) {
-        super((Class<C>) cfg.getClass(), null, Jackson.newObjectMapper(), "dw");
+    public POJOConfigurationFactory(C cfg, ObjectMapper objectMapper) {
+        super((Class<C>) cfg.getClass(), null, objectMapper, "dw");
         configuration = cfg;
     }
 

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/common/Resource.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/common/Resource.java
@@ -3,7 +3,7 @@ package io.dropwizard.testing.common;
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.logging.BootstrapLogging;
 import io.dropwizard.testing.junit5.ResourceExtension;
@@ -43,7 +43,7 @@ public class Resource {
         private final Set<Class<?>> providers = new HashSet<>();
         private final Map<String, Object> properties = new HashMap<>();
         private MetricRegistry metricRegistry = new MetricRegistry();
-        private ObjectMapper mapper = Jackson.newObjectMapper();
+        private ObjectMapper mapper = new DefaultObjectMapperFactory().newObjectMapper();
         private Validator validator = Validators.newValidator();
         private Consumer<ClientConfig> clientConfigurator = c -> {
         };

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportTest.java
@@ -6,6 +6,7 @@ import io.dropwizard.Configuration;
 import io.dropwizard.configuration.JsonConfigurationFactory;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.servlets.tasks.PostBodyTask;
 import io.dropwizard.servlets.tasks.Task;
@@ -26,7 +27,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static io.dropwizard.jackson.Jackson.newObjectMapper;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
@@ -110,7 +110,7 @@ class DropwizardTestSupportTest {
         TestConfiguration config = new YamlConfigurationFactory<>(
                 TestConfiguration.class,
                 BaseValidator.newValidator(),
-                newObjectMapper(),
+                new DefaultObjectMapperFactory().newObjectMapper(),
                 "dw"
         ).build(new ResourceConfigurationSourceProvider(), "test-config.yaml");
 

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResourceExceptionMapperTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResourceExceptionMapperTest.java
@@ -2,7 +2,7 @@ package io.dropwizard.testing.app;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jersey.validation.JerseyViolationException;
 import io.dropwizard.testing.junit.ResourceTestRule;
 import org.glassfish.jersey.spi.ExtendedExceptionMapper;
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.mock;
 public class PersonResourceExceptionMapperTest {
     private static final PeopleStore PEOPLE_STORE = mock(PeopleStore.class);
 
-    private static final ObjectMapper OBJECT_MAPPER = Jackson.newObjectMapper()
+    private static final ObjectMapper OBJECT_MAPPER = new DefaultObjectMapperFactory().newObjectMapper()
         .registerModule(new GuavaModule());
 
     @SuppressWarnings("deprecation")

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/PersonResourceExceptionMapperTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/PersonResourceExceptionMapperTest.java
@@ -2,7 +2,7 @@ package io.dropwizard.testing.junit5;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jersey.validation.JerseyViolationException;
 import io.dropwizard.testing.app.PeopleStore;
 import io.dropwizard.testing.app.PersonResource;
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.mock;
 @ExtendWith(DropwizardExtensionsSupport.class)
 class PersonResourceExceptionMapperTest {
 
-    private static final ObjectMapper OBJECT_MAPPER = Jackson.newObjectMapper()
+    private static final ObjectMapper OBJECT_MAPPER = new DefaultObjectMapperFactory().newObjectMapper()
         .registerModule(new GuavaModule());
 
     private PeopleStore peopleStore = mock(PeopleStore.class);

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/PersonResourceTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/PersonResourceTest.java
@@ -2,7 +2,7 @@ package io.dropwizard.testing.junit5;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.testing.app.PeopleStore;
 import io.dropwizard.testing.app.Person;
 import io.dropwizard.testing.app.PersonResource;
@@ -34,7 +34,7 @@ class PersonResourceTest {
         }
     }
 
-    private static final ObjectMapper OBJECT_MAPPER = Jackson.newObjectMapper()
+    private static final ObjectMapper OBJECT_MAPPER = new DefaultObjectMapperFactory().newObjectMapper()
         .registerModule(new GuavaModule());
 
     private final PeopleStore peopleStore = mock(PeopleStore.class);

--- a/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/MultipleContentTypeTest.java
+++ b/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/MultipleContentTypeTest.java
@@ -2,7 +2,7 @@ package io.dropwizard.views.freemarker;
 
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jackson.DefaultObjectMapperFactory;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.logging.BootstrapLogging;
 import io.dropwizard.views.View;
@@ -182,7 +182,7 @@ class MultipleContentTypeTest extends JerseyTest {
         public void writeTo(Info info, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
                             MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream)
                 throws IOException, WebApplicationException {
-            Jackson.newObjectMapper().writeValue(entityStream, info);
+            new DefaultObjectMapperFactory().newObjectMapper().writeValue(entityStream, info);
         }
     }
 }


### PR DESCRIPTION
Some users of Dropwizard 2.x and Java 8 want to be able to customize the application's `ObjectMapper` instance in a more granular way than it was possible before.

This change set adds the `ObjectMapperFactory` interface and a default implementation which replaces the existing `Jackson` class which offered only static methods to construct a preconfigured `ObjectMapper` instance.

Refs https://github.com/dropwizard/dropwizard/discussions/5319