### PR TITLE
Add ability to configure the ObjectMapper

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/Application.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/Application.java
@@ -1,14 +1,18 @@
 package io.dropwizard;
 
 import ch.qos.logback.classic.Level;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.cli.CheckCommand;
 import io.dropwizard.cli.Cli;
 import io.dropwizard.cli.ServerCommand;
+import io.dropwizard.jackson.Jackson;
 import io.dropwizard.logging.BootstrapLogging;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Generics;
 import io.dropwizard.util.JarLocation;
+
+import java.util.function.Consumer;
 
 /**
  * The base class for Dropwizard applications.
@@ -55,6 +59,16 @@ public abstract class Application<T extends Configuration> {
      */
     public String getName() {
         return getClass().getSimpleName();
+    }
+
+    /**
+     * Returns a {@link Consumer} instance used from the {@link Bootstrap} to configure the application's {@link ObjectMapper}.
+     * Defaults to {@link Jackson#configure(ObjectMapper)}.
+     *
+     * @return the {@link Consumer} to configure the {@link ObjectMapper}
+     */
+    public Consumer<ObjectMapper> getObjectMapperConfigurer() {
+        return Jackson::configure;
     }
 
     /**

--- a/dropwizard-core/src/main/java/io/dropwizard/setup/Bootstrap.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/Bootstrap.java
@@ -61,7 +61,7 @@ public class Bootstrap<T extends Configuration> {
      */
     public Bootstrap(Application<T> application) {
         this.application = application;
-        this.objectMapper = Jackson.newObjectMapper();
+        this.objectMapper = Jackson.newObjectMapper(application.getObjectMapperConfigurer());
         this.configuredBundles = new ArrayList<>();
         this.commands = new ArrayList<>();
         this.validatorFactory = Validators.newValidatorFactory();

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.module.blackbird.BlackbirdModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 
 import javax.annotation.Nullable;
+import java.util.function.Consumer;
 
 /**
  * A utility class for Jackson.
@@ -24,9 +25,18 @@ public class Jackson {
      * support for {@link JsonSnakeCase}. Also includes all {@link Discoverable} interface implementations.
      */
     public static ObjectMapper newObjectMapper() {
-        final ObjectMapper mapper = new ObjectMapper();
+        return newObjectMapper(Jackson::configure);
+    }
 
-        return configure(mapper);
+    /**
+     * Creates a new {@link ObjectMapper} configured with the given {@link Consumer} instance.
+     *
+     * @param configurer the {@link Consumer} to configure the {@link ObjectMapper}
+     */
+    public static ObjectMapper newObjectMapper(Consumer<ObjectMapper> configurer) {
+        final ObjectMapper mapper = new ObjectMapper();
+        configurer.accept(mapper);
+        return mapper;
     }
 
     /**
@@ -38,9 +48,20 @@ public class Jackson {
      *                    for the created {@link com.fasterxml.jackson.databind.ObjectMapper} instance.
      */
     public static ObjectMapper newObjectMapper(@Nullable JsonFactory jsonFactory) {
-        final ObjectMapper mapper = new ObjectMapper(jsonFactory);
+        return newObjectMapper(jsonFactory, Jackson::configure);
+    }
 
-        return configure(mapper);
+    /**
+     * Creates a new {@link ObjectMapper} with a custom {@link JsonFactory} configured with the given {@link Consumer} instance.
+     *
+     * @param jsonFactory instance of {@link com.fasterxml.jackson.core.JsonFactory} to use
+     *                    for the created {@link com.fasterxml.jackson.databind.ObjectMapper} instance.
+     * @param configurer the {@link Consumer} to configure the {@link ObjectMapper}
+     */
+    public static ObjectMapper newObjectMapper(@Nullable JsonFactory jsonFactory, Consumer<ObjectMapper> configurer) {
+        final ObjectMapper mapper = new ObjectMapper(jsonFactory);
+        configurer.accept(mapper);
+        return mapper;
     }
 
     /**
@@ -55,7 +76,7 @@ public class Jackson {
                 .disable(FAIL_ON_UNKNOWN_PROPERTIES);
     }
 
-    private static ObjectMapper configure(ObjectMapper mapper) {
+    public static ObjectMapper configure(ObjectMapper mapper) {
         mapper.registerModule(new GuavaModule());
         mapper.registerModule(new GuavaExtrasModule());
         mapper.registerModule(new CaffeineModule());

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonTest.java
@@ -25,7 +25,7 @@ class JacksonTest {
 
     @Test
     void objectMapperCanHandleNullInsteadOfCustomJsonFactory() {
-        ObjectMapper mapper = Jackson.newObjectMapper(null);
+        ObjectMapper mapper = Jackson.newObjectMapper((JsonFactory) null);
 
         assertThat(mapper.getFactory()).isNotNull();
     }


### PR DESCRIPTION
Follow up for #5472.

This is just a basic implementation for my idea mentioned in the referenced PR.

Further considerations:
 1. Propagate the created `ObjectMapper` to e.g. the `dropwizard-logging` module
 2. Change the return type of `Jackson#configure(ObjectMapper)` to `void`
 3. Add a section in the upgrade notes on how to disable Blackbird