### PR TITLE
Revert "Replace Jackson Afterburner with Blackbird"

### DIFF
--- a/docs/source/manual/upgrade-notes/upgrade-notes-2_1_x.rst
+++ b/docs/source/manual/upgrade-notes/upgrade-notes-2_1_x.rst
@@ -103,7 +103,7 @@ The upgrade of Jersey from version 2.33 to 2.35 introduces a behavior change in 
 If such a parameter is invalid, now a status code ``404`` is returned instead of the former ``400`` status code.
 
 Jackson Blackbird as default
-----------------------------
+============================
 
 Dropwizard is now registering the `Jackson Blackbird`_ module.
 This is the recommended setup for Java 9 and later.

--- a/docs/source/manual/upgrade-notes/upgrade-notes-2_1_x.rst
+++ b/docs/source/manual/upgrade-notes/upgrade-notes-2_1_x.rst
@@ -101,3 +101,23 @@ Upgrade to Jersey 2.35
 ----------------------
 The upgrade of Jersey from version 2.33 to 2.35 introduces a behavior change in the handling of ``Optional<T>`` parameters.
 If such a parameter is invalid, now a status code ``404`` is returned instead of the former ``400`` status code.
+
+Jackson Blackbird as default
+----------------------------
+
+Dropwizard is now registering the `Jackson Blackbird`_ module.
+This is the recommended setup for Java 9 and later.
+
+If the `Jackson Afterburner`_ module is on the class path, it will be preferred over the `Jackson Blackbird`_ module.
+
+.. code-block:: xml
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-afterburner</artifactId>
+      <!-- Unnecessary when using dropwizard-dependencies -->
+      <version>${jackson.version}</version>
+    </dependency>
+
+.. _Jackson Blackbird: https://github.com/FasterXML/jackson-modules-base/tree/jackson-modules-base-2.13.3/blackbird#readme
+.. _Jackson Afterburner: https://github.com/FasterXML/jackson-modules-base/tree/jackson-modules-base-2.13.3/afterburner#readme

--- a/dropwizard-jackson/pom.xml
+++ b/dropwizard-jackson/pom.xml
@@ -55,7 +55,7 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>jackson-module-blackbird</artifactId>
+            <artifactId>jackson-module-afterburner</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/dropwizard-jackson/pom.xml
+++ b/dropwizard-jackson/pom.xml
@@ -56,6 +56,11 @@
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-afterburner</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-blackbird</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.module.blackbird.BlackbirdModule;
+import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 
 import javax.annotation.Nullable;
@@ -60,7 +60,7 @@ public class Jackson {
         mapper.registerModule(new GuavaExtrasModule());
         mapper.registerModule(new CaffeineModule());
         mapper.registerModule(new JodaModule());
-        mapper.registerModule(new BlackbirdModule());
+        mapper.registerModule(new AfterburnerModule());
         mapper.registerModule(new FuzzyEnumModule());
         mapper.registerModule(new ParameterNamesModule());
         mapper.registerModule(new Jdk8Module());

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
@@ -1,17 +1,20 @@
 package io.dropwizard.jackson;
 
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
-
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
+import com.fasterxml.jackson.module.blackbird.BlackbirdModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 
 import javax.annotation.Nullable;
+
+import java.util.List;
+
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 
 /**
  * A utility class for Jackson.
@@ -56,11 +59,19 @@ public class Jackson {
     }
 
     private static ObjectMapper configure(ObjectMapper mapper) {
+        final List<Module> modules = ObjectMapper.findModules();
+
         mapper.registerModule(new GuavaModule());
         mapper.registerModule(new GuavaExtrasModule());
         mapper.registerModule(new CaffeineModule());
         mapper.registerModule(new JodaModule());
-        mapper.registerModule(new AfterburnerModule());
+
+        final Module acceleratorModule = modules.stream()
+                .filter(module -> "AfterburnerModule" .equals(module.getModuleName()))
+                .findFirst()
+                .orElse(new BlackbirdModule());
+
+        mapper.registerModule(acceleratorModule);
         mapper.registerModule(new FuzzyEnumModule());
         mapper.registerModule(new ParameterNamesModule());
         mapper.registerModule(new Jdk8Module());

--- a/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonTest.java
+++ b/dropwizard-jackson/src/test/java/io/dropwizard/jackson/JacksonTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -16,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class JacksonTest {
     @Test
     void objectMapperUsesGivenCustomJsonFactory() {
-        JsonFactory factory = Mockito.mock(JsonFactory.class);
+        JsonFactory factory = new JsonFactory();
 
         ObjectMapper mapper = Jackson.newObjectMapper(factory);
 
@@ -53,6 +52,13 @@ class JacksonTest {
                 .readValue("{\"unknown\": 4711, \"path\": \"/var/log/app/objectMapperIgnoresUnknownProperties.log\"}", LogMetadata.class)
                 .path)
             .hasFileName("objectMapperIgnoresUnknownProperties.log");
+    }
+
+    @Test
+    void objectMapperRegistersAfterburnerButNotBlackbird() {
+        assertThat(Jackson.newObjectMapper().getRegisteredModuleIds())
+                .contains("com.fasterxml.jackson.module.afterburner.AfterburnerModule")
+                .doesNotContain("com.fasterxml.jackson.module.blackbird.BlackbirdModule");
     }
 
     static class LogMetadata {


### PR DESCRIPTION
It turns out that Jackson Blackbird isn't better/faster on Java 11/17/18 right now and Jackson Afterburner still works.

Let's revert the change from Jackson Afterburner to Blackbird in Dropwizard 2.1.x and keep using it in Dropwizard 3.x and later.

This reverts commit c65d010cc05031a6c8efaa380b0d0d123c3234bc.
Refs #3803