### PR TITLE
Wrap exceptions thrown by beforeStart with MappableException

### DIFF
--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkApplicationListener.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkApplicationListener.java
@@ -73,13 +73,17 @@ public class UnitOfWorkApplicationListener implements ApplicationEventListener {
         public void onEvent(RequestEvent event) {
             final RequestEvent.Type eventType = event.getType();
             if (eventType == RequestEvent.Type.RESOURCE_METHOD_START) {
-                methodMap
-                    .computeIfAbsent(event.getUriInfo().getMatchedResourceMethod(), UnitOfWorkEventListener::registerUnitOfWorkAnnotations)
-                    .forEach(unitOfWork ->
-                        unitOfWorkAspects
-                            .computeIfAbsent(unitOfWork.value(), hibernateName -> new UnitOfWorkAspect(sessionFactories))
-                            .beforeStart(unitOfWork)
-                );
+                try {
+                    methodMap
+                        .computeIfAbsent(event.getUriInfo().getMatchedResourceMethod(), UnitOfWorkEventListener::registerUnitOfWorkAnnotations)
+                        .forEach(unitOfWork ->
+                            unitOfWorkAspects
+                                .computeIfAbsent(unitOfWork.value(), hibernateName -> new UnitOfWorkAspect(sessionFactories))
+                                .beforeStart(unitOfWork)
+                    );
+                } catch (Exception e) {
+                    throw new MappableException(e);
+                }
             } else if (eventType == RequestEvent.Type.RESP_FILTERS_START) {
                 try {
                     unitOfWorkAspects

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/JerseyIntegrationTest.java
@@ -13,6 +13,7 @@ import io.dropwizard.logging.common.BootstrapLogging;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.test.JerseyTest;
+import org.h2.tools.Server;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
@@ -32,9 +33,11 @@ import javax.ws.rs.core.Application;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.sql.SQLException;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -87,6 +90,9 @@ class JerseyIntegrationTest extends JerseyTest {
     @Nullable
     private SessionFactory sessionFactory;
 
+    @Nullable
+    private Server h2Server;
+
     @Override
     @BeforeEach
     public void setUp() throws Exception {
@@ -100,6 +106,9 @@ class JerseyIntegrationTest extends JerseyTest {
 
         if (sessionFactory != null) {
             sessionFactory.close();
+        }
+        if (h2Server != null) {
+            h2Server.stop();
         }
     }
 
@@ -116,7 +125,14 @@ class JerseyIntegrationTest extends JerseyTest {
         when(environment.lifecycle()).thenReturn(lifecycleEnvironment);
         when(environment.metrics()).thenReturn(metricRegistry);
 
-        dbConfig.setUrl("jdbc:h2:mem:DbTest-" + System.nanoTime());
+        try {
+            h2Server = Server.createTcpServer("-ifNotExists");
+            h2Server.start();
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to start the H2 TCP Server during test configuration", e);
+        }
+
+        dbConfig.setUrl("jdbc:h2:" + h2Server.getURL() + "/mem:DbTest-" + System.nanoTime());
         dbConfig.setUser("sa");
         dbConfig.setDriverClass("org.h2.Driver");
         dbConfig.setValidationQuery("SELECT 1");
@@ -144,6 +160,7 @@ class JerseyIntegrationTest extends JerseyTest {
         config.register(new PersistenceExceptionMapper());
         config.register(new JacksonFeature(Jackson.newObjectMapper()));
         config.register(new DataExceptionMapper());
+        config.register(new SQLNonTransientConnectionExceptionMapper());
         config.register(new EmptyOptionalExceptionMapper());
 
         return config;
@@ -199,9 +216,20 @@ class JerseyIntegrationTest extends JerseyTest {
                 .isEqualTo(person.getBirthday());
     }
 
+    @Test
+    void testSqlExceptionIsHandledBeforeStart() {
+        Objects.requireNonNull(h2Server).stop();
+
+        final Response response = target("/people/Jeff").request().
+            get();
+
+        assertThat(response.getStatusInfo()).isEqualTo(Response.Status.SERVICE_UNAVAILABLE);
+        assertThat(response.getHeaderString(HttpHeaders.CONTENT_TYPE)).isEqualTo(MediaType.APPLICATION_JSON);
+        assertThat(response.readEntity(ErrorMessage.class).getMessage()).isEqualTo("Connection not available");
+    }
 
     @Test
-    void testSqlExceptionIsHandled() {
+    void testSqlExceptionIsHandledAfterEnd() {
         final Person person = new Person();
         person.setName("Jeff");
         person.setEmail("jeff.hammersmith@targetprocessinc.com");

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SQLNonTransientConnectionExceptionMapper.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/SQLNonTransientConnectionExceptionMapper.java
@@ -1,0 +1,19 @@
+package io.dropwizard.hibernate;
+
+import io.dropwizard.jersey.errors.ErrorMessage;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import java.sql.SQLNonTransientConnectionException;
+
+@Provider
+public class SQLNonTransientConnectionExceptionMapper implements ExceptionMapper<SQLNonTransientConnectionException> {
+    @Override
+    public Response toResponse(SQLNonTransientConnectionException e) {
+        return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                       .entity(new ErrorMessage(Response.Status.BAD_REQUEST.getStatusCode(), "Connection not available"))
+                       .build();
+
+    }
+}


### PR DESCRIPTION
###### Problem:

We have a custom `HibernateBundle` that provides multi-tenancy and must support the case where tenant database instances are offline. We'd like to handle the errors caused by an offline tenant using `ExceptionMapper` as well, but that's impossible because exceptions thrown during the `beforeStart` phase are not wrapped in `MappableException`. (See #5501.)

This is similar to issue https://github.com/dropwizard/dropwizard/issues/949. Back in those good old times, it was impossible to create `ExceptionMapper`s to handle persistence exceptions thrown during the `afterEnd` phase of the unit of work. The fix in PR https://github.com/dropwizard/dropwizard/pull/958 wraps the exception with Jersey's `MappableException`before rethrowing.

[This gist](https://gist.github.com/andref/9869a3c483b57eb8bf1f145740fe5c71) is a minimal test case.

###### Solution:

* Exceptions thrown by `UnitOfWorkAspect.beforeStart` are wrapped in `MappableException`. 
* I'm unsure about the test: I had to config the H2 TCP server, so that I could turn it off and trigger an error during beforeStart. That might not be appropriate in the project's build infrastructure.
* It might be sensible to wrap any exception thrown by the `UnitOfWorkEventListener`. I didn't do that though.

###### Result:

If an exception is thrown during the `beforeStart` stage, the user can create an `ExceptionMapper` to produce a web response in a way similar to what is already possible during the `afterEnd` stage.
