### PR TITLE
add feature to allow adding custom liveness paths to dropwizard health

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -491,6 +491,37 @@ Define the following health check configurations in your `config.yml` file:
         - name: user-cache
           critical: false
 
+For a full list of configuration options see the following snippet
+
+.. code-block: yaml
+    health:
+      enabled: true
+      delayedShutdownHandlerEnabled: true
+      shutdownWaitPeriod: 10s
+      initialOverallState: true
+      healthCheckUrlPaths: ["/alive/health", "/alive/health/readiness"]
+      responseProvider:
+        type: json
+      responder:
+        type: servlet
+        cacheControlEnabled: true
+        cacheControlValue: "no-store"
+        livenessCheckUrlPaths: ["/alive/health/liveness"]
+      healthChecks:
+        - name: ready-check
+          critical: false
+          initialState: true
+          type: ready
+          schedule:
+            checkInterval: 2500ms
+            downtimeInterval: 10s
+            failureAttempts: 2
+            successAttempts: 1
+        - name: alive-check
+          critical: false
+          initialState: true
+          type: alive
+
 .. note::
 
     This behavior was integrated from the `Dropwizard Health module`_. If you are migrating from that module

--- a/dropwizard-health/src/test/resources/yml/servlet-responder-factory-liveness-configured.yml
+++ b/dropwizard-health/src/test/resources/yml/servlet-responder-factory-liveness-configured.yml
@@ -1,0 +1,2 @@
+type: servlet
+livenessCheckUrlPaths: ["/alive","/probes/liveness"]


### PR DESCRIPTION
###### Problem:
This is written up in https://github.com/dropwizard/dropwizard/issues/5518

TLDR:
Need a way to break up alive and readiness checks on separate URL's

###### Solution:
This solution modifies the `ServletHealthResponderFactory.java` to have a new optional configurable field `livenessCheckUrlPaths`. This field is a list of string URLS that should only return the results of the alive checks. This makes it a non breaking change as the probably better solution would be to add the field to the `DefaultHealthFactory` and rename the `healthCheckUrlPaths` to be more clear. However, this change would be breaking and probably best served for the 3.x or 4.x release. 

###### Result:
There is now a new option to give consumers further control of their health checks. 
