### PR TITLE
Fix tests

### DIFF
--- a/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbStatusCommandTest.java
+++ b/dropwizard-migrations/src/test/java/io/dropwizard/migrations/DbStatusCommandTest.java
@@ -45,14 +45,14 @@ class DbStatusCommandTest {
     void testRun() throws Exception {
         statusCommand.run(null, new Namespace(Collections.emptyMap()), MigrationTestSupport.createConfiguration());
         assertThat(baos.toString(UTF_8.name())).matches(
-                "3 change sets have not been applied to \\S+\\R");
+                "3 changesets have not been applied to \\S+\\R");
     }
 
     @Test
     void testVerbose() throws Exception {
         statusCommand.run(null, new Namespace(Collections.singletonMap("verbose", true)), MigrationTestSupport.createConfiguration());
         assertThat(baos.toString(UTF_8.name())).matches(
-                "3 change sets have not been applied to \\S+\\R" +
+                "3 changesets have not been applied to \\S+\\R" +
                         "\\s*migrations\\.xml::1::db_dev\\R" +
                         "\\s*migrations\\.xml::2::db_dev\\R" +
                         "\\s*migrations\\.xml::3::db_dev\\R");

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardAppExtension.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardAppExtension.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
+import org.glassfish.jersey.client.RequestEntityProcessing;
 import org.glassfish.jersey.grizzly.connector.GrizzlyConnectorProvider;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -281,7 +282,8 @@ public class DropwizardAppExtension<C extends Configuration> implements Dropwiza
         clientConfig.connectorProvider(new GrizzlyConnectorProvider())
             .register(new JacksonFeature(getObjectMapper()))
             .property(ClientProperties.CONNECT_TIMEOUT, DEFAULT_CONNECT_TIMEOUT_MS)
-            .property(ClientProperties.READ_TIMEOUT, DEFAULT_READ_TIMEOUT_MS);
+            .property(ClientProperties.READ_TIMEOUT, DEFAULT_READ_TIMEOUT_MS)
+            .property(ClientProperties.REQUEST_ENTITY_PROCESSING, RequestEntityProcessing.BUFFERED);
         return new JerseyClientBuilder().withConfig(clientConfig);
     }
 }


### PR DESCRIPTION
This PR provides fixes for failing tests:
 - Liquibase 4.14.0 introduced a wording change from "change set" to "changeset", which breaks a test in the `dropwizard-migrations` module
 - the introduction of the Grizzly connector in Dropwizard 2.1.1 broke some tests on Windows with the message "Remotely closed". This seems to be related to the `ClientProperties.REQUEST_ENTITY_PROCESSING` property, which was set to `RequestEntityProcessing.BUFFERED` while using the `HttpUrlConnectorProvider` and is now set to `RequestEntityProcessing.CHUNKED` in the `GrizzlyConnectorProvider`.