### PR TITLE
Rework logging reset

### DIFF
--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/DefaultLoggingFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/DefaultLoggingFactory.java
@@ -202,7 +202,6 @@ public class DefaultLoggingFactory implements LoggingFactory {
             // sane default.
             loggerContext.stop();
             final Logger logger = loggerContext.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
-            logger.detachAndStopAllAppenders();
             final DropwizardLayout formatter = new DropwizardLayout(loggerContext, TimeZone.getDefault());
             formatter.start();
             final LayoutWrappingEncoder<ILoggingEvent> layoutEncoder = new LayoutWrappingEncoder<>();

--- a/dropwizard-testing/pom.xml
+++ b/dropwizard-testing/pom.xml
@@ -86,10 +86,6 @@
             <artifactId>jsr305</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
         </dependency>

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
@@ -18,7 +18,6 @@ import net.sourceforge.argparse4j.inf.Namespace;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
@@ -263,11 +262,8 @@ public class DropwizardTestSupport<C extends Configuration> {
         }
 
         // Don't leak logging appenders into other test cases
-        if (configuration != null) {
-            configuration.getLoggingFactory().reset();
-        } else {
-            LoggingUtil.getLoggerContext().getLogger(Logger.ROOT_LOGGER_NAME).detachAndStopAllAppenders();
-        }
+        // Therefore stop the LoggerContext to detach all appenders
+        LoggingUtil.getLoggerContext().stop();
     }
 
     private void applyConfigOverrides() {


### PR DESCRIPTION
Raised as a discussion base regarding #5479.

If an integration test is run, the logging configuration gets overridden. Since the state of the loggers gets modified, the previous state cannot be reconstructed.

At the moment, the logger objects all get reset and a new `ConsoleAppender` gets registered. If no integration test is run at all, the `bootstrapLogging()` method won't get invoked and no appender is registered by default. So the logging reset modifies the state of the default configuration.

This PR just stops the `LoggerContext` to disable logging, as this is the default state before an integration test gets executed.

Additionally, there is a redundant call to `detachAndStopAllAppenders()` on the root logger in `DefaultLoggingFactory#reset()`, which gets executed through the recursive reset of the loggers at `LoggerContext#stop()`.