### PR TITLE
Properly handle `null` in PortRangeValidator

### DIFF
--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/PortRangeValidator.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/PortRangeValidator.java
@@ -19,6 +19,6 @@ public class PortRangeValidator implements ConstraintValidator<PortRange, Intege
 
     @Override
     public boolean isValid(Integer value, ConstraintValidatorContext context) {
-        return value == 0 || (value >= min && value <= max);
+        return value == null || value == 0 || (value >= min && value <= max);
     }
 }

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/PortRangeValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/PortRangeValidatorTest.java
@@ -86,7 +86,7 @@ public class PortRangeValidatorTest {
 
     @Test
     @SuppressWarnings("NullAway")
-    void rejectsNull() {
+    void acceptsNull() {
         example.nullablePort = null;
         assertThat(ConstraintViolations.format(validator.validate(example)))
             .isEmpty();

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/PortRangeValidatorTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/PortRangeValidatorTest.java
@@ -21,6 +21,9 @@ public class PortRangeValidatorTest {
         @PortRange(min = 10000, max = 15000)
         public int otherPort = 10001;
 
+        @PortRange
+        public Integer nullablePort = 1;
+
         @Valid
         List<@PortRange Integer> ports = Collections.emptyList();
     }
@@ -79,5 +82,13 @@ public class PortRangeValidatorTest {
         example.ports = Collections.singletonList(-1);
         assertThat(ConstraintViolations.format(validator.validate(example)))
             .containsOnly("ports[0].<list element> must be between 1 and 65535");
+    }
+
+    @Test
+    @SuppressWarnings("NullAway")
+    void rejectsNull() {
+        example.nullablePort = null;
+        assertThat(ConstraintViolations.format(validator.validate(example)))
+            .isEmpty();
     }
 }


### PR DESCRIPTION
The `PortRangeValidator` will now ignore `null` values of `Integer` fields and treat them as valid, similar to other validators are working.

If a port range should be mandatory consider using a primitive `int` or mark the `Integer` field as `@NotNull`.

Fixes #5684