### PR TITLE
Add toJavaDuration to Duration

### DIFF
--- a/dropwizard-util/src/main/java/io/dropwizard/util/Duration.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Duration.java
@@ -137,6 +137,10 @@ public class Duration implements Comparable<Duration>, Serializable {
         return TimeUnit.DAYS.convert(count, unit);
     }
 
+    public java.time.Duration toJavaDuration() {
+        return java.time.Duration.ofNanos(toNanoseconds());
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {

--- a/dropwizard-util/src/test/java/io/dropwizard/util/DurationTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/DurationTest.java
@@ -2,12 +2,15 @@ package io.dropwizard.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.time.temporal.ChronoUnit;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -887,5 +890,36 @@ class DurationTest {
                     .isInstanceOf(Duration.class)
                     .isEqualTo(duration);
         }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "1 nanosecond, 1, NANOS",
+        "1000 nanoseconds, 1000, NANOS",
+        "200000 nanoseconds, 200000, NANOS",
+        "1 microsecond, 1, MICROS",
+        "500 microseconds, 500, MICROS",
+        "75000 microseconds, 75000, MICROS",
+        "1 millisecond, 1, MILLIS",
+        "42000 milliseconds, 42000, MILLIS",
+        "500000 milliseconds, 500000, MILLIS",
+        "1 second, 1, SECONDS",
+        "420 seconds, 420, SECONDS",
+        "86400 seconds, 86400, SECONDS",
+        "1 minute, 1, MINUTES",
+        "84 minutes, 84, MINUTES",
+        "1440 minutes, 1440, MINUTES",
+        "1 hours, 1, HOURS",
+        "42 hours, 42, HOURS",
+        "8760 hours, 8760, HOURS",
+        "1 day, 1, DAYS",
+        "252 days, 252, DAYS",
+        "36500 days, 36500, DAYS"
+    })
+    void convertsToJavaDuration(String durationSpec, long amount, ChronoUnit unit) {
+        Duration duration = Duration.parse(durationSpec);
+
+        assertThat(duration.toJavaDuration())
+            .isEqualTo(java.time.Duration.of(amount, unit));
     }
 }


### PR DESCRIPTION
###### Problem:
As discussed in #5534 it is sometimes necessary to convert a Dropwizard `Duration` to a Java `java.time.Duration`.

###### Solution:
This PR adds the `toJavaDuration()` method to the Dropwizard `io.dropwizard.util.Duration` class.

###### Result:
It's now really easy to convert a Dropwizard `Duration` to a `java.time.Duration`

Closes #5534