### PR TITLE
Remove guava exclusion from mustache dependency

### DIFF
--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -304,12 +304,6 @@
                 <groupId>com.github.spullara.mustache.java</groupId>
                 <artifactId>compiler</artifactId>
                 <version>${mustache-compiler.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.google.guava</groupId>
-                        <artifactId>guava</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.freemarker</groupId>


### PR DESCRIPTION
Guava hasn't been a dependency of mustache since 0.9.0, released in 2015 so we don't need to exclude it.

See https://mvnrepository.com/artifact/com.github.spullara.mustache.java/compiler/0.9.10

It was there in 0.8.18: https://mvnrepository.com/artifact/com.github.spullara.mustache.java/compiler/0.8.18
but gone in 0.9.0: https://mvnrepository.com/artifact/com.github.spullara.mustache.java/compiler/0.9.0

Removed in commit https://github.com/spullara/mustache.java/commit/f8e148f09bc5e9035ea32ee30c7a2adaeddc4f23