### PR TITLE
Revert "Update dependency org.glassfish.jersey:jersey-bom to v3.0.6 (release/4.0.x)"

### DIFF
--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -47,7 +47,7 @@
         <javassist.version>3.29.1-GA</javassist.version>
         <jaxb-api.version>4.0.0</jaxb-api.version>
         <jdbi3.version>3.32.0</jdbi3.version>
-        <jersey.version>3.0.6</jersey.version>
+        <jersey.version>3.0.5</jersey.version>
         <jetty-setuid-java.version>1.0.4</jetty-setuid-java.version>
         <jetty.version>11.0.11</jetty.version>
         <liquibase-core.version>4.15.0</liquibase-core.version>


### PR DESCRIPTION
Reverts dropwizard/dropwizard#5686

Our tests with the Jetty test framework provider fail with Jersey 3.0.6. There seems to be an issue in the release process of 3.0.6 (see this [issue](https://github.com/eclipse-ee4j/jersey/issues/5130)).