### PR TITLE
Use Byte Buddy instead of Javassist  in UnitOfWorkAwareProxyFactory

### DIFF
--- a/dropwizard-hibernate/pom.xml
+++ b/dropwizard-hibernate/pom.xml
@@ -114,8 +114,8 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.javassist</groupId>
-            <artifactId>javassist</artifactId>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jadira.usertype</groupId>


### PR DESCRIPTION
As Hibernate uses Byte Buddy internally to create proxies, this allows removal of the dependency on Javassist.