### PR TITLE
JavaDoc enhancements

### DIFF
--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/BaseConfigurationFactory.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/BaseConfigurationFactory.java
@@ -43,6 +43,9 @@ public abstract class BaseConfigurationFactory<T> implements ConfigurationFactor
 
     private final Class<T> klass;
     private final String propertyPrefix;
+    /**
+     * The object mapper to use for mapping configuration files to objects.
+     */
     protected final ObjectMapper mapper;
     private final ConfigurationMetadata configurationMetadata;
 
@@ -59,6 +62,7 @@ public abstract class BaseConfigurationFactory<T> implements ConfigurationFactor
      * @param formatName     the name of the format parsed by this factory (used in exceptions)
      * @param klass          the configuration class
      * @param validator      the validator to use
+     * @param objectMapper   the object mapper to use
      * @param propertyPrefix the system property name prefix used by overrides
      */
     public BaseConfigurationFactory(JsonFactory parserFactory,
@@ -98,6 +102,13 @@ public abstract class BaseConfigurationFactory<T> implements ConfigurationFactor
         }
     }
 
+    /**
+     * Constructs a {@link JsonParser} to parse the contents of the provided {@link InputStream}.
+     *
+     * @param input the input to parse
+     * @return the JSON parser for the given input
+     * @throws IOException if the parser creation fails due to an I/O error
+     */
     protected JsonParser createParser(InputStream input) throws IOException {
         return parserFactory.createParser(input);
     }
@@ -115,6 +126,15 @@ public abstract class BaseConfigurationFactory<T> implements ConfigurationFactor
         }
     }
 
+    /**
+     * Loads, parses, binds, and validates a configuration object for a given {@link JsonNode}.
+     *
+     * @param node the json node to parse the configuration from
+     * @param path the path of the configuration file
+     * @return a validated configuration object
+     * @throws IOException if there is an error reading the file
+     * @throws ConfigurationException if there is an error parsing or validating the file
+     */
     protected T build(JsonNode node, String path) throws IOException, ConfigurationException {
         for (Map.Entry<Object, Object> pref : System.getProperties().entrySet()) {
             final String prefName = (String) pref.getKey();
@@ -158,6 +178,13 @@ public abstract class BaseConfigurationFactory<T> implements ConfigurationFactor
         }
     }
 
+    /**
+     * Applies an override to a given {@link JsonNode}.
+     *
+     * @param root the node to apply the override to
+     * @param name the key of the override
+     * @param value the new value
+     */
     protected void addOverride(JsonNode root, String name, String value) {
         JsonNode node = root;
         final List<String> parts = Arrays.stream(ESCAPED_DOT_SPLIT_PATTERN.split(name))

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationException.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationException.java
@@ -4,7 +4,7 @@ import java.util.Collection;
 
 /**
  * Base class for problems with a Configuration object.
- * <p/>
+ * <br/>
  * Refer to the implementations for different classes of problems:
  * <ul>
  *     <li>Parsing errors: {@link ConfigurationParsingException}</li>
@@ -17,8 +17,14 @@ public abstract class ConfigurationException extends Exception {
      */
     private static final long serialVersionUID = 7596147083618606385L;
 
+    /**
+     * A constant representing a newline sequence.
+     */
     protected static final String NEWLINE = String.format("%n");
 
+    /**
+     * The configuration related errors.
+     */
     private final Collection<String> errors;
 
     /**
@@ -44,10 +50,22 @@ public abstract class ConfigurationException extends Exception {
         this.errors = errors;
     }
 
+    /**
+     * Returns the configuration errors.
+     *
+     * @return a collection of strings representing the configuration errors
+     */
     public Collection<String> getErrors() {
         return errors;
     }
 
+    /**
+     * Formats a message for the exception reporting the errors that occurred related to the configuration.
+     *
+     * @param file the configuration file
+     * @param errors the configuration errors
+     * @return the formatted message
+     */
     protected static String formatMessage(String file, Collection<String> errors) {
         final StringBuilder msg = new StringBuilder(file);
         msg.append(errors.size() == 1 ? " has an error:" : " has the following errors:").append(NEWLINE);

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationFactory.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationFactory.java
@@ -3,6 +3,11 @@ package io.dropwizard.configuration;
 import java.io.File;
 import java.io.IOException;
 
+/**
+ * A generic interface for constructing a configuration object.
+ *
+ * @param <T> the type of the configuration objects to produce
+ */
 public interface ConfigurationFactory<T> {
 
     /**

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationFactoryFactory.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationFactoryFactory.java
@@ -4,7 +4,21 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import javax.validation.Validator;
 
+/**
+ * A generic interface for constructing a configuration factory that can create configuration objects.
+ *
+ * @param <T> the type of the configuration objects to produce
+ */
 public interface ConfigurationFactoryFactory<T> {
+    /**
+     * Creates a new configuration factory for the given class.
+     *
+     * @param klass          the configuration class
+     * @param validator      the validator to use
+     * @param objectMapper   the Jackson {@link ObjectMapper} to use
+     * @param propertyPrefix the system property name prefix used by overrides
+     * @return the new configuration factory
+     */
     ConfigurationFactory<T> create(Class<T> klass,
             Validator validator,
             ObjectMapper objectMapper,

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationMetadata.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationMetadata.java
@@ -26,7 +26,7 @@ import java.util.Set;
  *     &#064;NotNull
  *     private String name;
  *
- *     private List&lt;String&gt names = Collections.emptyList();
+ *     private List&lt;String&gt; names = Collections.emptyList();
  *
  *     &#064;JsonProperty
  *     public String getName() {

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationParsingException.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationParsingException.java
@@ -305,6 +305,9 @@ public class ConfigurationParsingException extends ConfigurationException {
             private static final long serialVersionUID = 1L;
             private static final LevenshteinDistance LEVENSHTEIN_DISTANCE = new LevenshteinDistance();
 
+            /**
+             * The base string for the levenshtein comparator.
+             */
             private String base;
 
             public LevenshteinComparator(String base) {
@@ -340,10 +343,23 @@ public class ConfigurationParsingException extends ConfigurationException {
                     LEVENSHTEIN_DISTANCE.apply(b, base));
             }
 
+            /**
+             * Serializes this comparator to the given {@link ObjectOutputStream}.
+             *
+             * @param stream the stream to serialize to
+             * @throws IOException if I/O errors occur while writing to the stream
+             */
             private void writeObject(ObjectOutputStream stream) throws IOException {
                 stream.defaultWriteObject();
             }
 
+            /**
+             * Deserializes this comparator from a given {@link ObjectInputStream}.
+             *
+             * @param stream the stream to deserialize from
+             * @throws IOException if I/O errors occur while reading from the stream
+             * @throws ClassNotFoundException if the class of a serialized object could not be found
+             */
             private void readObject(ObjectInputStream stream) throws IOException, ClassNotFoundException {
                 stream.defaultReadObject();
             }

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationValidationException.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/ConfigurationValidationException.java
@@ -11,6 +11,9 @@ import java.util.Set;
 public class ConfigurationValidationException extends ConfigurationException {
     private static final long serialVersionUID = 5325162099634227047L;
 
+    /**
+     * The constraint violation occurred during configuration validation.
+     */
     private final Set<ConstraintViolation<?>> constraintViolations;
 
     /**
@@ -18,6 +21,7 @@ public class ConfigurationValidationException extends ConfigurationException {
      *
      * @param path      the bad configuration path
      * @param errors    the errors in the path
+     * @param <T> the type of the root bean of a constraint violation
      */
     public <T> ConfigurationValidationException(String path, Set<ConstraintViolation<T>> errors) {
         super(path, ConstraintViolations.format(errors));

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/DefaultConfigurationFactoryFactory.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/DefaultConfigurationFactoryFactory.java
@@ -5,6 +5,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import javax.validation.Validator;
 
+/**
+ * The default implementation for the {@link ConfigurationFactoryFactory} interface. An instance of this class constructs a new {@link YamlConfigurationFactory}.
+ *
+ * @param <T> the type of the configuration objects to produce
+ */
 public class DefaultConfigurationFactoryFactory<T> implements ConfigurationFactoryFactory<T> {
     @Override
     public ConfigurationFactory<T> create(

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/EnvironmentVariableSubstitutor.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/EnvironmentVariableSubstitutor.java
@@ -7,15 +7,25 @@ import org.apache.commons.text.TextStringBuilder;
  * A custom {@link StringSubstitutor} using environment variables as lookup source.
  */
 public class EnvironmentVariableSubstitutor extends StringSubstitutor {
+    /**
+     * Constructs a new environment variable substitutor with strict checking and no substitution done in variables.
+     */
     public EnvironmentVariableSubstitutor() {
         this(true, false);
     }
 
+    /**
+     * Constructs a new environment variable substitutor with no substitution done in variables.
+     *
+     * @param strict whether to use strict variable checking
+     */
     public EnvironmentVariableSubstitutor(boolean strict) {
         this(strict, false);
     }
 
     /**
+     * Constructs a new environment variable substitutor.
+     *
      * @param strict                  {@code true} if looking up undefined environment variables should throw a
      *                                {@link UndefinedEnvironmentVariableException}, {@code false} otherwise.
      * @param substitutionInVariables a flag whether substitution is done in variable names.

--- a/dropwizard-configuration/src/main/java/io/dropwizard/configuration/UndefinedEnvironmentVariableException.java
+++ b/dropwizard-configuration/src/main/java/io/dropwizard/configuration/UndefinedEnvironmentVariableException.java
@@ -1,8 +1,16 @@
 package io.dropwizard.configuration;
 
+/**
+ * An exception thrown, if a variable cannot be replaced by an {@link EnvironmentVariableSubstitutor} because no value is provided.
+ */
 public class UndefinedEnvironmentVariableException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Constructs a new exception with the given error message.
+     *
+     * @param errorMessage the error message
+     */
     public UndefinedEnvironmentVariableException(String errorMessage) {
         super(errorMessage);
     }

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/AnnotationSensitivePropertyNamingStrategy.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/AnnotationSensitivePropertyNamingStrategy.java
@@ -16,6 +16,9 @@ import com.fasterxml.jackson.databind.introspect.AnnotatedParameter;
 public class AnnotationSensitivePropertyNamingStrategy extends PropertyNamingStrategy {
     private static final long serialVersionUID = -1372862028366311230L;
 
+    /**
+     * The snake case naming strategy to use, if a class is annotated with {@link JsonSnakeCase}.
+     */
     private final PropertyNamingStrategy snakeCase = new PropertyNamingStrategies.SnakeCaseStrategy();
 
     @Override

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/CaffeineModule.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/CaffeineModule.java
@@ -20,6 +20,8 @@ import com.github.benmanes.caffeine.cache.CaffeineSpec;
 import java.io.IOException;
 
 /**
+ * A Jackson module that can (de)serialize {@link CaffeineSpec CaffeineSpecs}.
+ *
  * @since 2.0
  */
 public class CaffeineModule extends Module {

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/DiscoverableSubtypeResolver.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/DiscoverableSubtypeResolver.java
@@ -23,12 +23,23 @@ public class DiscoverableSubtypeResolver extends StdSubtypeResolver {
     private static final long serialVersionUID = 1L;
     private static final Logger LOGGER = LoggerFactory.getLogger(DiscoverableSubtypeResolver.class);
 
+    /**
+     * The list of discovered subtypes.
+     */
     private final List<Class<?>> discoveredSubtypes;
 
+    /**
+     * Constructs a subtype resolver which scans for subtypes of {@link Discoverable}.
+     */
     public DiscoverableSubtypeResolver() {
         this(Discoverable.class);
     }
 
+    /**
+     * Constructs a subtype resolver which scans for subtypes of the provided class.
+     *
+     * @param rootKlass the class to choose the correct {@code META-INF/services} file from
+     */
     public DiscoverableSubtypeResolver(Class<?> rootKlass) {
         final List<Class<?>> subtypes = new ArrayList<>();
         for (Class<?> klass : discoverServices(rootKlass)) {
@@ -40,14 +51,30 @@ public class DiscoverableSubtypeResolver extends StdSubtypeResolver {
         this.discoveredSubtypes = subtypes;
     }
 
+    /**
+     * Returns the subtypes discovered from the {@code META-INF} configuration file.
+     *
+     * @return a list of {@link Class} objects representing the subtypes
+     */
     public List<Class<?>> getDiscoveredSubtypes() {
         return discoveredSubtypes;
     }
 
+    /**
+     * Returns a {@link ClassLoader} from the current class.
+     *
+     * @return the current {@link ClassLoader}
+     */
     protected ClassLoader getClassLoader() {
         return this.getClass().getClassLoader();
     }
 
+    /**
+     * Discovers the services in the {@code META-INF/services} folder for the provided class.
+     *
+     * @param klass the class to lookup services
+     * @return the discovered services
+     */
     protected List<Class<?>> discoverServices(Class<?> klass) {
         final List<Class<?>> serviceClasses = new ArrayList<>();
         try {
@@ -77,6 +104,13 @@ public class DiscoverableSubtypeResolver extends StdSubtypeResolver {
         return serviceClasses;
     }
 
+    /**
+     * Loads a class discovered from a service file without throwing a {@link ClassNotFoundException},
+     * if the class' implementation isn't found.
+     *
+     * @param line the string line with the class name
+     * @return the {@link Class} instance or {@code null}, if the class was not found
+     */
     @Nullable
     private Class<?> loadClass(String line) {
         try {

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/FuzzyEnumModule.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/FuzzyEnumModule.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 /**
  * A module for deserializing enums that is more permissive than the default.
- * <p/>
+ * <br/>
  * This deserializer is more permissive in the following ways:
  * <ul>
  * <li>Whitespace is permitted but stripped from the input.</li>

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/GuavaExtrasModule.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/GuavaExtrasModule.java
@@ -19,6 +19,9 @@ import com.google.common.cache.CacheBuilderSpec;
 
 import java.io.IOException;
 
+/**
+ * A Jackson module that can (de)serialize {@link CacheBuilderSpec CacheBuilderSpecs}.
+ */
 public class GuavaExtrasModule extends Module {
     private static class CacheBuilderSpecDeserializer extends JsonDeserializer<CacheBuilderSpec> {
         @Override

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
@@ -25,6 +25,8 @@ public class Jackson {
     /**
      * Creates a new {@link ObjectMapper} with Guava, Logback, and Joda Time support, as well as
      * support for {@link JsonSnakeCase}. Also includes all {@link Discoverable} interface implementations.
+     *
+     * @return the configured {@link ObjectMapper}
      */
     public static ObjectMapper newObjectMapper() {
         final ObjectMapper mapper = new ObjectMapper();
@@ -39,6 +41,7 @@ public class Jackson {
      *
      * @param jsonFactory instance of {@link com.fasterxml.jackson.core.JsonFactory} to use
      *                    for the created {@link com.fasterxml.jackson.databind.ObjectMapper} instance.
+     * @return the configured {@link ObjectMapper}
      */
     public static ObjectMapper newObjectMapper(@Nullable JsonFactory jsonFactory) {
         final ObjectMapper mapper = new ObjectMapper(jsonFactory);
@@ -50,6 +53,8 @@ public class Jackson {
      * Creates a new minimal {@link ObjectMapper} that will work with Dropwizard out of box.
      * <p><b>NOTE:</b> Use it, if the default Dropwizard's {@link ObjectMapper}, created in
      * {@link #newObjectMapper()}, is too aggressive for you.</p>
+     *
+     * @return the configured {@link ObjectMapper}
      */
     public static ObjectMapper newMinimalObjectMapper() {
         return new ObjectMapper()
@@ -58,6 +63,12 @@ public class Jackson {
                 .disable(FAIL_ON_UNKNOWN_PROPERTIES);
     }
 
+    /**
+     * Configures an {@link ObjectMapper} with a set of common modules and properties.
+     *
+     * @param mapper the {@link ObjectMapper} to configure
+     * @return the configured {@link ObjectMapper}
+     */
     private static ObjectMapper configure(ObjectMapper mapper) {
         final List<Module> modules = ObjectMapper.findModules();
 

--- a/dropwizard-util/src/main/java/io/dropwizard/util/ByteStreams.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/ByteStreams.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 /**
+ * Provides helper methods for easier conversions of streams.
  * @since 2.0
  *
  * @deprecated this class exists for compatibility with Java 8 and will be removed in Dropwizard 3.0.
@@ -17,6 +18,11 @@ public final class ByteStreams {
     }
 
     /**
+     * Converts an {@link InputStream} to a {@code byte[]}.
+     *
+     * @param in the {@link InputStream} to convert
+     * @return the {@code byte[]} representing the contents of the {@link InputStream}
+     * @throws IOException If an I/O error occurs
      * @deprecated For users of Java 11+, consider {@link InputStream#readAllBytes()} instead.
      */
     public static byte[] toByteArray(InputStream in) throws IOException {
@@ -26,6 +32,11 @@ public final class ByteStreams {
     }
 
     /**
+     * Copies the contents from an {@link InputStream} to an {@link OutputStream}.
+     *
+     * @param in the source stream
+     * @param to the target stream
+     * @throws IOException If an I/O error occurs
      * @deprecated this is an internal method to dropwizard-util. Consider apache-commons instead.
      */
     public static void copy(InputStream in, OutputStream to) throws IOException {

--- a/dropwizard-util/src/main/java/io/dropwizard/util/CharStreams.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/CharStreams.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.Reader;
 
 /**
+ * Provides helper methods to work with character streams.
  * @since 2.0
  */
 @Deprecated
@@ -12,6 +13,13 @@ public final class CharStreams {
     private CharStreams() {
     }
 
+    /**
+     * Constructs a string from the contents of the given {@link Reader}.
+     *
+     * @param reader the source {@link Reader}
+     * @return a string representing the concatenation of the chars of the {@link Reader}
+     * @throws IOException If an I/O error occurs
+     */
     public static String toString(Reader reader) throws IOException {
         final StringBuilder builder = new StringBuilder();
         char[] buffer = new char[4096];

--- a/dropwizard-util/src/main/java/io/dropwizard/util/DataSize.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/DataSize.java
@@ -69,55 +69,137 @@ public class DataSize implements Comparable<DataSize>, Serializable {
         SUFFIXES = Collections.unmodifiableSortedMap(suffixes);
     }
 
+    /**
+     * Constructs a new {@link DataSize} object representing the specified amount of bytes.
+     *
+     * @param count the amount of bytes
+     * @return the newly created {@link DataSize} object
+     */
     public static DataSize bytes(long count) {
         return new DataSize(count, DataSizeUnit.BYTES);
     }
 
+    /**
+     * Constructs a new {@link DataSize} object representing the specified amount of kilobytes.
+     *
+     * @param count the amount of kilobytes
+     * @return the newly created {@link DataSize} object
+     */
     public static DataSize kilobytes(long count) {
         return new DataSize(count, DataSizeUnit.KILOBYTES);
     }
 
+    /**
+     * Constructs a new {@link DataSize} object representing the specified amount of megabytes.
+     *
+     * @param count the amount of megabytes
+     * @return the newly created {@link DataSize} object
+     */
     public static DataSize megabytes(long count) {
         return new DataSize(count, DataSizeUnit.MEGABYTES);
     }
 
+    /**
+     * Constructs a new {@link DataSize} object representing the specified amount of gigabytes.
+     *
+     * @param count the amount of gigabytes
+     * @return the newly created {@link DataSize} object
+     */
     public static DataSize gigabytes(long count) {
         return new DataSize(count, DataSizeUnit.GIGABYTES);
     }
 
+    /**
+     * Constructs a new {@link DataSize} object representing the specified amount of terabytes.
+     *
+     * @param count the amount of terabytes
+     * @return the newly created {@link DataSize} object
+     */
     public static DataSize terabytes(long count) {
         return new DataSize(count, DataSizeUnit.TERABYTES);
     }
 
+    /**
+     * Constructs a new {@link DataSize} object representing the specified amount of petabytes.
+     *
+     * @param count the amount of petabytes
+     * @return the newly created {@link DataSize} object
+     */
     public static DataSize petabytes(long count) {
         return new DataSize(count, DataSizeUnit.PETABYTES);
     }
 
+    /**
+     * Constructs a new {@link DataSize} object representing the specified amount of kibibytes.
+     *
+     * @param count the amount of kibibytes
+     * @return the newly created {@link DataSize} object
+     */
     public static DataSize kibibytes(long count) {
         return new DataSize(count, DataSizeUnit.KIBIBYTES);
     }
 
+    /**
+     * Constructs a new {@link DataSize} object representing the specified amount of mebibytes.
+     *
+     * @param count the amount of mebibytes
+     * @return the newly created {@link DataSize} object
+     */
     public static DataSize mebibytes(long count) {
         return new DataSize(count, DataSizeUnit.MEBIBYTES);
     }
 
+    /**
+     * Constructs a new {@link DataSize} object representing the specified amount of gibibytes.
+     *
+     * @param count the amount of gibibytes
+     * @return the newly created {@link DataSize} object
+     */
     public static DataSize gibibytes(long count) {
         return new DataSize(count, DataSizeUnit.GIBIBYTES);
     }
 
+    /**
+     * Constructs a new {@link DataSize} object representing the specified amount of tebibytes.
+     *
+     * @param count the amount of tebibytes
+     * @return the newly created {@link DataSize} object
+     */
     public static DataSize tebibytes(long count) {
         return new DataSize(count, DataSizeUnit.TEBIBYTES);
     }
 
+    /**
+     * Constructs a new {@link DataSize} object representing the specified amount of pebibytes.
+     *
+     * @param count the amount of pebibytes
+     * @return the newly created {@link DataSize} object
+     */
     public static DataSize pebibytes(long count) {
         return new DataSize(count, DataSizeUnit.PEBIBYTES);
     }
 
+    /**
+     * Parses a given {@link CharSequence} to a {@link DataSize} object.
+     * If no unit is provided by the input sequence, a default unit of {@link DataSizeUnit#BYTES} is used.
+     *
+     * @param size the string representation of the {@link DataSize} to parse
+     * @return a valid new {@link DataSize} object representing the parsed string
+     */
     @JsonCreator
     public static DataSize parse(CharSequence size) {
         return parse(size, DataSizeUnit.BYTES);
     }
 
+    /**
+     * Parses a given {@link CharSequence} to a {@link DataSize} object.
+     * If no unit is provided by the input sequence, the default unit parameter is used.
+     *
+     * @param size the string representation of the {@link DataSize} to parse
+     * @param defaultUnit the fallback default unit to use for the newly created {@link DataSize}
+     * @return a valid new {@link DataSize} object representing the parsed string
+     * @throws IllegalArgumentException if the input sequence cannot be parsed correctly
+     */
     public static DataSize parse(CharSequence size, DataSizeUnit defaultUnit) {
         final Matcher matcher = SIZE_PATTERN.matcher(size);
         if (!matcher.matches()) {
@@ -134,7 +216,14 @@ public class DataSize implements Comparable<DataSize>, Serializable {
         return new DataSize(count, dataSizeUnit);
     }
 
+    /**
+     * The quantity of the current data size
+     */
     private final long count;
+
+    /**
+     * The unit of the current data size
+     */
     private final DataSizeUnit unit;
 
     private DataSize(long count, DataSizeUnit unit) {
@@ -142,58 +231,126 @@ public class DataSize implements Comparable<DataSize>, Serializable {
         this.unit = requireNonNull(unit);
     }
 
+    /**
+     * Gets the quantity of the current {@link DataSize} object.
+     *
+     * @return the quantity of the current data size
+     */
     public long getQuantity() {
         return count;
     }
 
+    /**
+     * Returns the {@link DataSizeUnit data size unit} of the current {@link DataSize} object.
+     *
+     * @return the unit of the current data size
+     */
     public DataSizeUnit getUnit() {
         return unit;
     }
 
+    /**
+     * Returns the quantity of the current {@link DataSize} object in bytes.
+     *
+     * @return the converted quantity
+     */
     public long toBytes() {
         return DataSizeUnit.BYTES.convert(count, unit);
     }
 
+    /**
+     * Returns the quantity of the current {@link DataSize} object in kilobytes.
+     *
+     * @return the converted quantity
+     */
     public long toKilobytes() {
         return DataSizeUnit.KILOBYTES.convert(count, unit);
     }
 
+    /**
+     * Returns the quantity of the current {@link DataSize} object in megabytes.
+     *
+     * @return the converted quantity
+     */
     public long toMegabytes() {
         return DataSizeUnit.MEGABYTES.convert(count, unit);
     }
 
+    /**
+     * Returns the quantity of the current {@link DataSize} object in gigabytes.
+     *
+     * @return the converted quantity
+     */
     public long toGigabytes() {
         return DataSizeUnit.GIGABYTES.convert(count, unit);
     }
 
+    /**
+     * Returns the quantity of the current {@link DataSize} object in terabytes.
+     *
+     * @return the converted quantity
+     */
     public long toTerabytes() {
         return DataSizeUnit.TERABYTES.convert(count, unit);
     }
 
+    /**
+     * Returns the quantity of the current {@link DataSize} object in petabytes.
+     *
+     * @return the converted quantity
+     */
     public long toPetabytes() {
         return DataSizeUnit.PETABYTES.convert(count, unit);
     }
 
+    /**
+     * Returns the quantity of the current {@link DataSize} object in kibibytes.
+     *
+     * @return the converted quantity
+     */
     public long toKibibytes() {
         return DataSizeUnit.KIBIBYTES.convert(count, unit);
     }
 
+    /**
+     * Returns the quantity of the current {@link DataSize} object in mebibytes.
+     *
+     * @return the converted quantity
+     */
     public long toMebibytes() {
         return DataSizeUnit.MEBIBYTES.convert(count, unit);
     }
 
+    /**
+     * Returns the quantity of the current {@link DataSize} object in gibibytes.
+     *
+     * @return the converted quantity
+     */
     public long toGibibytes() {
         return DataSizeUnit.GIBIBYTES.convert(count, unit);
     }
 
+    /**
+     * Returns the quantity of the current {@link DataSize} object in gebibytes.
+     *
+     * @return the converted quantity
+     */
     public long toTebibytes() {
         return DataSizeUnit.TEBIBYTES.convert(count, unit);
     }
 
+    /**
+     * Returns the quantity of the current {@link DataSize} object in pebibytes.
+     *
+     * @return the converted quantity
+     */
     public long toPebibytes() {
         return DataSizeUnit.PEBIBYTES.convert(count, unit);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -206,11 +363,17 @@ public class DataSize implements Comparable<DataSize>, Serializable {
         return (count == size.count) && (unit == size.unit);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int hashCode() {
         return (31 * (int) (count ^ (count >>> 32))) + unit.hashCode();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     @JsonValue
     public String toString() {
@@ -221,6 +384,9 @@ public class DataSize implements Comparable<DataSize>, Serializable {
         return Long.toString(count) + ' ' + units;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int compareTo(DataSize other) {
         if (unit == other.unit) {
@@ -233,6 +399,7 @@ public class DataSize implements Comparable<DataSize>, Serializable {
     /**
      * Construct an equivalent {@link Size} object from this {@link DataSize}
      *
+     * @return the converted {@link Size} object
      * @deprecated {@link Size} is deprecated in favour of {@link DataSize}
      */
     @Deprecated
@@ -265,6 +432,8 @@ public class DataSize implements Comparable<DataSize>, Serializable {
     /**
      * Construct an equivalent {@link DataSize} object from a {@link Size} object
      *
+     * @param size the {@link Size} to convert
+     * @return the converted {@link DataSize} object
      * @deprecated {@link Size} is deprecated in favour of {@link DataSize}
      */
     @Deprecated

--- a/dropwizard-util/src/main/java/io/dropwizard/util/DirectExecutorService.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/DirectExecutorService.java
@@ -7,6 +7,8 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
 /**
+ * An implementation of an {@link java.util.concurrent.ExecutorService} which directly executes a task, if the service has not shut down already.
+ *
  * @since 2.0
  */
 public class DirectExecutorService extends AbstractExecutorService {

--- a/dropwizard-util/src/main/java/io/dropwizard/util/Duration.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Duration.java
@@ -14,6 +14,9 @@ import java.util.regex.Pattern;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * This class provides helper methods for parsing human-readable duration values.
+ */
 public class Duration implements Comparable<Duration>, Serializable {
     private static final long serialVersionUID = 1445611723318059801L;
 
@@ -49,34 +52,83 @@ public class Duration implements Comparable<Duration>, Serializable {
 
     }
 
+    /**
+     * Constructs a new {@link Duration} object representing the specified amount of nanoseconds.
+     *
+     * @param count the amount of nanoseconds
+     * @return the newly created {@link Duration} object
+     */
     public static Duration nanoseconds(long count) {
         return new Duration(count, TimeUnit.NANOSECONDS);
     }
 
+    /**
+     * Constructs a new {@link Duration} object representing the specified amount of microseconds.
+     *
+     * @param count the amount of microseconds
+     * @return the newly created {@link Duration} object
+     */
     public static Duration microseconds(long count) {
         return new Duration(count, TimeUnit.MICROSECONDS);
     }
 
+    /**
+     * Constructs a new {@link Duration} object representing the specified amount of milliseconds.
+     *
+     * @param count the amount of milliseconds
+     * @return the newly created {@link Duration} object
+     */
     public static Duration milliseconds(long count) {
         return new Duration(count, TimeUnit.MILLISECONDS);
     }
 
+    /**
+     * Constructs a new {@link Duration} object representing the specified amount of seconds.
+     *
+     * @param count the amount of seconds
+     * @return the newly created {@link Duration} object
+     */
     public static Duration seconds(long count) {
         return new Duration(count, TimeUnit.SECONDS);
     }
 
+    /**
+     * Constructs a new {@link Duration} object representing the specified amount of minutes.
+     *
+     * @param count the amount of minutes
+     * @return the newly created {@link Duration} object
+     */
     public static Duration minutes(long count) {
         return new Duration(count, TimeUnit.MINUTES);
     }
 
+    /**
+     * Constructs a new {@link Duration} object representing the specified amount of hours.
+     *
+     * @param count the amount of hours
+     * @return the newly created {@link Duration} object
+     */
     public static Duration hours(long count) {
         return new Duration(count, TimeUnit.HOURS);
     }
 
+    /**
+     * Constructs a new {@link Duration} object representing the specified amount of days.
+     *
+     * @param count the amount of days
+     * @return the newly created {@link Duration} object
+     */
     public static Duration days(long count) {
         return new Duration(count, TimeUnit.DAYS);
     }
 
+    /**
+     * Parses a given input string to a {@link Duration}.
+     *
+     * @param duration the string to parse
+     * @return a valid {@link Duration} representing the parsed input string
+     * @throws IllegalArgumentException if the given input string cannot be parsed correctly
+     */
     @JsonCreator
     public static Duration parse(String duration) {
         final Matcher matcher = DURATION_PATTERN.matcher(duration);
@@ -93,7 +145,14 @@ public class Duration implements Comparable<Duration>, Serializable {
         return new Duration(count, unit);
     }
 
+    /**
+     * The quantity of the current duration
+     */
     private final long count;
+
+    /**
+     * The time unit of the current duration
+     */
     private final TimeUnit unit;
 
     private Duration(long count, TimeUnit unit) {
@@ -101,46 +160,99 @@ public class Duration implements Comparable<Duration>, Serializable {
         this.unit = requireNonNull(unit);
     }
 
+    /**
+     * Gets the quantity of the current {@link Duration} object.
+     *
+     * @return the quantity of the current duration
+     */
     public long getQuantity() {
         return count;
     }
 
+    /**
+     * Returns the {@link TimeUnit time unit} of the current {@link Duration} object.
+     *
+     * @return the unit of the current duration
+     */
     public TimeUnit getUnit() {
         return unit;
     }
 
+    /**
+     * Returns the quantity of the current {@link Duration} object in nanoseconds.
+     *
+     * @return the converted quantity
+     */
     public long toNanoseconds() {
         return TimeUnit.NANOSECONDS.convert(count, unit);
     }
 
+    /**
+     * Returns the quantity of the current {@link Duration} object in microseconds.
+     *
+     * @return the converted quantity
+     */
     public long toMicroseconds() {
         return TimeUnit.MICROSECONDS.convert(count, unit);
     }
 
+    /**
+     * Returns the quantity of the current {@link Duration} object in milliseconds.
+     *
+     * @return the converted quantity
+     */
     public long toMilliseconds() {
         return TimeUnit.MILLISECONDS.convert(count, unit);
     }
 
+    /**
+     * Returns the quantity of the current {@link Duration} object in seconds.
+     *
+     * @return the converted quantity
+     */
     public long toSeconds() {
         return TimeUnit.SECONDS.convert(count, unit);
     }
 
+    /**
+     * Returns the quantity of the current {@link Duration} object in minutes.
+     *
+     * @return the converted quantity
+     */
     public long toMinutes() {
         return TimeUnit.MINUTES.convert(count, unit);
     }
 
+    /**
+     * Returns the quantity of the current {@link Duration} object in hours.
+     *
+     * @return the converted quantity
+     */
     public long toHours() {
         return TimeUnit.HOURS.convert(count, unit);
     }
 
+    /**
+     * Returns the quantity of the current {@link Duration} object in days.
+     *
+     * @return the converted quantity
+     */
     public long toDays() {
         return TimeUnit.DAYS.convert(count, unit);
     }
 
+    /**
+     * Constructs a {@code java.time.Duration} from the current {@link Duration} object.
+     *
+     * @return the {@code java.time.Duration} representation
+     */
     public java.time.Duration toJavaDuration() {
         return java.time.Duration.ofNanos(toNanoseconds());
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -154,11 +266,17 @@ public class Duration implements Comparable<Duration>, Serializable {
 
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int hashCode() {
         return (31 * (int) (count ^ (count >>> 32))) + unit.hashCode();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     @JsonValue
     public String toString() {
@@ -169,6 +287,9 @@ public class Duration implements Comparable<Duration>, Serializable {
         return Long.toString(count) + ' ' + units;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int compareTo(Duration other) {
         if (unit == other.unit) {

--- a/dropwizard-util/src/main/java/io/dropwizard/util/Enums.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Enums.java
@@ -9,7 +9,7 @@ public class Enums {
 
     /**
      * Convert a string to an enum with more permissive rules than {@link Enum} valueOf().
-     * <p/>
+     * <br/>
      * This method is more permissive in the following ways:
      * <ul>
      * <li>Whitespace is permitted but stripped from the input.</li>

--- a/dropwizard-util/src/main/java/io/dropwizard/util/JarLocation.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/JarLocation.java
@@ -11,15 +11,28 @@ import java.util.Optional;
 public class JarLocation {
     private final Class<?> klass;
 
+    /**
+     * Constructs a new {@link JarLocation} object which gets access to the code source with the provided parameter.
+     *
+     * @param klass the class to access the code source from
+     */
     public JarLocation(Class<?> klass) {
         this.klass = klass;
     }
 
+    /**
+     * Returns the version of the current jar holding the provided {@code klass}.
+     *
+     * @return the version representation
+     */
     public Optional<String> getVersion() {
         return Optional.ofNullable(klass.getPackage())
             .map(Package::getImplementationVersion);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String toString() {
         final URL location = klass.getProtectionDomain().getCodeSource().getLocation();

--- a/dropwizard-util/src/main/java/io/dropwizard/util/JavaVersion.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/JavaVersion.java
@@ -3,12 +3,18 @@ package io.dropwizard.util;
 import javax.annotation.Nullable;
 
 /**
+ * Provides helper methods related to the version of the executing java platform.
  * @since 2.0
  */
 public final class JavaVersion {
     private JavaVersion() {
     }
 
+    /**
+     * Checks, if the execution platform is running a JRE 8.
+     *
+     * @return if the current Java version is 1.8
+     */
     public static boolean isJava8() {
         final String specVersion = getJavaSpecVersion();
         return specVersion != null && specVersion.startsWith("1.8");

--- a/dropwizard-util/src/main/java/io/dropwizard/util/Lists.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Lists.java
@@ -7,6 +7,7 @@ import java.util.List;
 import static java.util.Collections.unmodifiableList;
 
 /**
+ * Helper methods to construct {@link List} instances.
  * @since 2.0
  *
  * @deprecated use Java 8+ JCL methods instead
@@ -17,6 +18,13 @@ public final class Lists {
     private Lists() {
     }
 
+    /**
+     * Constructs an unmodifiable {@link List} of an {@link Iterable} of elements.
+     *
+     * @param elements the elements to construct the list of
+     * @return the list containing the given elements
+     * @param <T> the type of the list elements
+     */
     public static <T> List<T> of(Iterable<T> elements) {
         final List<T> list = new ArrayList<>();
         for (T element : elements) {
@@ -25,6 +33,13 @@ public final class Lists {
         return unmodifiableList(list);
     }
 
+    /**
+     * Constructs an unmodifiable {@link List} of an {@link Iterator} of elements.
+     *
+     * @param it the elements to construct the list of
+     * @return the list containing the given elements
+     * @param <T> the type of the list elements
+     */
     public static <T> List<T> of(Iterator<T> it) {
         final List<T> list = new ArrayList<>();
         while (it.hasNext()) {

--- a/dropwizard-util/src/main/java/io/dropwizard/util/Maps.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Maps.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
+ * Helper methods to construct {@link Map} instances.
  * @since 2.0
  *
  * @deprecated this class exists to help users transition from Guava. It will be removed in Dropwizard 3.0 in favour
@@ -14,6 +15,17 @@ public final class Maps {
     private Maps() {
     }
 
+    /**
+     * Construct a {@link Map} of two keys and corresponding values.
+     *
+     * @param k1 the first key
+     * @param v1 the first value
+     * @param k2 the second key
+     * @param v2 the second value
+     * @return a new {@link Map} containing the specified elements
+     * @param <K> the type of the key elements
+     * @param <V> the type of the value elements
+     */
     public static <K, V> Map<K, V> of(K k1, V v1, K k2, V v2) {
         final Map<K, V> map = new HashMap<>();
         map.put(k1, v1);
@@ -21,6 +33,19 @@ public final class Maps {
         return map;
     }
 
+    /**
+     * Construct a {@link Map} of three keys and corresponding values.
+     *
+     * @param k1 the first key
+     * @param v1 the first value
+     * @param k2 the second key
+     * @param v2 the second value
+     * @param k3 the third key
+     * @param v3 the third value
+     * @return a new {@link Map} containing the specified elements
+     * @param <K> the type of the key elements
+     * @param <V> the type of the value elements
+     */
     public static <K, V> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3) {
         final Map<K, V> map = new HashMap<>();
         map.put(k1, v1);
@@ -29,6 +54,21 @@ public final class Maps {
         return map;
     }
 
+    /**
+     * Construct a {@link Map} of four keys and corresponding values.
+     *
+     * @param k1 the first key
+     * @param v1 the first value
+     * @param k2 the second key
+     * @param v2 the second value
+     * @param k3 the third key
+     * @param v3 the third value
+     * @param k4 the fourth key
+     * @param v4 the fourth value
+     * @return a new {@link Map} containing the specified elements
+     * @param <K> the type of the key elements
+     * @param <V> the type of the value elements
+     */
     public static <K, V> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4) {
         final Map<K, V> map = new HashMap<>();
         map.put(k1, v1);
@@ -38,6 +78,23 @@ public final class Maps {
         return map;
     }
 
+    /**
+     * Construct a {@link Map} of five keys and corresponding values.
+     *
+     * @param k1 the first key
+     * @param v1 the first value
+     * @param k2 the second key
+     * @param v2 the second value
+     * @param k3 the third key
+     * @param v3 the third value
+     * @param k4 the fourth key
+     * @param v4 the fourth value
+     * @param k5 the fifth key
+     * @param v5 the fifth value
+     * @return a new {@link Map} containing the specified elements
+     * @param <K> the type of the key elements
+     * @param <V> the type of the value elements
+     */
     public static <K, V> Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5) {
         final Map<K, V> map = new HashMap<>();
         map.put(k1, v1);

--- a/dropwizard-util/src/main/java/io/dropwizard/util/Optionals.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Optionals.java
@@ -3,6 +3,8 @@ package io.dropwizard.util;
 import java.util.Optional;
 
 /**
+ * Helper methods to convert between {@code java.util.Optional} and {@code com.google.common.base.Optional} instances.
+ *
  * @deprecated prefer using {@link java.util.Optional} directly
  */
 @Deprecated
@@ -12,6 +14,7 @@ public abstract class Optionals {
      *
      * @param guavaOptional The Guava {@link com.google.common.base.Optional}
      * @return An equivalent {@link Optional}
+     * @param <T> the value type of the optional
      */
     public static <T> Optional<T> fromGuavaOptional(final com.google.common.base.Optional<T> guavaOptional) {
         return Optional.ofNullable(guavaOptional.orNull());
@@ -22,6 +25,7 @@ public abstract class Optionals {
      *
      * @param optional The {@link Optional}
      * @return An equivalent Guava {@link com.google.common.base.Optional}
+     * @param <T> the value type of the optional
      */
     public static <T> com.google.common.base.Optional<T> toGuavaOptional(final Optional<T> optional) {
         return com.google.common.base.Optional.fromNullable(optional.orElse(null));

--- a/dropwizard-util/src/main/java/io/dropwizard/util/Resources.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Resources.java
@@ -7,6 +7,8 @@ import java.net.URL;
 import java.nio.charset.Charset;
 
 /**
+ * Provides helper methods to work with resources.
+ *
  * @since 2.0
  */
 public final class Resources {
@@ -23,6 +25,8 @@ public final class Resources {
      * <p>In the unusual case where the context class loader is null, the class loader that loaded
      * this class ({@code Resources}) will be used instead.
      *
+     * @param resourceName the name of the resource
+     * @return the {@link URL} of the resource
      * @throws IllegalArgumentException if the resource is not found
      */
     public static URL getResource(String resourceName) {

--- a/dropwizard-util/src/main/java/io/dropwizard/util/Sets.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Sets.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import static java.util.Collections.unmodifiableSet;
 
 /**
+ * Provides helper methods to create {@link Set} instances
  * @since 2.0
  *
  * @deprecated this class exists to help users transition from Guava. It will be removed in Dropwizard 3.0 in favour
@@ -17,6 +18,14 @@ public final class Sets {
     private Sets() {
     }
 
+    /**
+     * Constructs an unmodifiable {@link Set} of two elements.
+     *
+     * @param e1 the first element
+     * @param e2 the second element
+     * @return the new {@link Set} instance containing the given elements
+     * @param <T> the type of the set elements
+     */
     public static <T> Set<T> of(T e1, T e2) {
         final Set<T> set = new HashSet<>(2);
         set.add(e1);
@@ -24,6 +33,15 @@ public final class Sets {
         return unmodifiableSet(set);
     }
 
+    /**
+     * Constructs an unmodifiable {@link Set} of three elements.
+     *
+     * @param e1 the first element
+     * @param e2 the second element
+     * @param e3 the third element
+     * @return the new {@link Set} instance containing the given elements
+     * @param <T> the type of the set elements
+     */
     public static <T> Set<T> of(T e1, T e2, T e3) {
         final Set<T> set = new HashSet<>(3);
         set.add(e1);
@@ -32,6 +50,16 @@ public final class Sets {
         return unmodifiableSet(set);
     }
 
+    /**
+     * Constructs an unmodifiable {@link Set} of four elements.
+     *
+     * @param e1 the first element
+     * @param e2 the second element
+     * @param e3 the third element
+     * @param e4 the fourth element
+     * @return the new {@link Set} instance containing the given elements
+     * @param <T> the type of the set elements
+     */
     public static <T> Set<T> of(T e1, T e2, T e3, T e4) {
         final Set<T> set = new HashSet<>(4);
         set.add(e1);
@@ -41,6 +69,17 @@ public final class Sets {
         return unmodifiableSet(set);
     }
 
+    /**
+     * Constructs an unmodifiable {@link Set} of five elements.
+     *
+     * @param e1 the first element
+     * @param e2 the second element
+     * @param e3 the third element
+     * @param e4 the fourth element
+     * @param e5 the fifth element
+     * @return the new {@link Set} instance containing the given elements
+     * @param <T> the type of the set elements
+     */
     public static <T> Set<T> of(T e1, T e2, T e3, T e4, T e5) {
         final Set<T> set = new HashSet<>(5);
         set.add(e1);
@@ -51,6 +90,13 @@ public final class Sets {
         return unmodifiableSet(set);
     }
 
+    /**
+     * Constructs an unmodifiable {@link Set} of a variable number of elements.
+     *
+     * @param elements the elements to create the set of
+     * @return the new {@link Set} instance containing the given elements
+     * @param <T> the type of the set elements
+     */
     @SafeVarargs
     public static <T> Set<T> of(T... elements) {
         final Set<T> set = new HashSet<>(elements.length);
@@ -58,6 +104,13 @@ public final class Sets {
         return unmodifiableSet(set);
     }
 
+    /**
+     * Constructs an unmodifiable {@link Set} of an {@link Iterable} of elements.
+     *
+     * @param elements the elements to create the set of
+     * @return the new {@link Set} instance containing the given elements
+     * @param <T> the type of the set elements
+     */
     public static <T> Set<T> of(Iterable<T> elements) {
         final Set<T> set = new HashSet<>();
         for (T element : elements) {

--- a/dropwizard-util/src/main/java/io/dropwizard/util/Size.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Size.java
@@ -51,26 +51,63 @@ public class Size implements Comparable<Size>, Serializable {
         SUFFIXES = Collections.unmodifiableSortedMap(suffixes);
     }
 
+    /**
+     * Constructs a new {@link Size} object representing the specified amount of bytes.
+     *
+     * @param count the amount of bytes
+     * @return the newly created {@link Size} object
+     */
     public static Size bytes(long count) {
         return new Size(count, SizeUnit.BYTES);
     }
 
+    /**
+     * Constructs a new {@link Size} object representing the specified amount of kilobytes.
+     *
+     * @param count the amount of kilobytes
+     * @return the newly created {@link Size} object
+     */
     public static Size kilobytes(long count) {
         return new Size(count, SizeUnit.KILOBYTES);
     }
 
+    /**
+     * Constructs a new {@link Size} object representing the specified amount of megabytes.
+     *
+     * @param count the amount of megabytes
+     * @return the newly created {@link Size} object
+     */
     public static Size megabytes(long count) {
         return new Size(count, SizeUnit.MEGABYTES);
     }
 
+    /**
+     * Constructs a new {@link Size} object representing the specified amount of gigabytes.
+     *
+     * @param count the amount of gigabytes
+     * @return the newly created {@link Size} object
+     */
     public static Size gigabytes(long count) {
         return new Size(count, SizeUnit.GIGABYTES);
     }
 
+    /**
+     * Constructs a new {@link Size} object representing the specified amount of terabytes.
+     *
+     * @param count the amount of terabytes
+     * @return the newly created {@link Size} object
+     */
     public static Size terabytes(long count) {
         return new Size(count, SizeUnit.TERABYTES);
     }
 
+    /**
+     * Constructs a {@link Size} object from the given string representation.
+     *
+     * @param size the string representation to parse
+     * @return the newly created {@link Size} object
+     * @throws IllegalArgumentException if the input string cannot be parsed correctly
+     */
     @JsonCreator
     public static Size parse(String size) {
         final Matcher matcher = SIZE_PATTERN.matcher(size);
@@ -87,7 +124,14 @@ public class Size implements Comparable<Size>, Serializable {
         return new Size(count, unit);
     }
 
+    /**
+     * The quantity of the current size
+     */
     private final long count;
+
+    /**
+     * The unit of the current size
+     */
     private final SizeUnit unit;
 
     private Size(long count, SizeUnit unit) {
@@ -95,34 +139,72 @@ public class Size implements Comparable<Size>, Serializable {
         this.unit = requireNonNull(unit);
     }
 
+    /**
+     * Gets the quantity of the current {@link Size} object.
+     *
+     * @return the quantity of the current size
+     */
     public long getQuantity() {
         return count;
     }
 
+    /**
+     * Returns the {@link SizeUnit size unit} of the current {@link Size} object.
+     *
+     * @return the unit of the current size
+     */
     public SizeUnit getUnit() {
         return unit;
     }
 
+    /**
+     * Returns the quantity of the current {@link Size} object in bytes.
+     *
+     * @return the converted quantity
+     */
     public long toBytes() {
         return SizeUnit.BYTES.convert(count, unit);
     }
 
+    /**
+     * Returns the quantity of the current {@link Size} object in kilobytes.
+     *
+     * @return the converted quantity
+     */
     public long toKilobytes() {
         return SizeUnit.KILOBYTES.convert(count, unit);
     }
 
+    /**
+     * Returns the quantity of the current {@link Size} object in megabytes.
+     *
+     * @return the converted quantity
+     */
     public long toMegabytes() {
         return SizeUnit.MEGABYTES.convert(count, unit);
     }
 
+    /**
+     * Returns the quantity of the current {@link Size} object in gigabytes.
+     *
+     * @return the converted quantity
+     */
     public long toGigabytes() {
         return SizeUnit.GIGABYTES.convert(count, unit);
     }
 
+    /**
+     * Returns the quantity of the current {@link Size} object in terabytes.
+     *
+     * @return the converted quantity
+     */
     public long toTerabytes() {
         return SizeUnit.TERABYTES.convert(count, unit);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -135,11 +217,17 @@ public class Size implements Comparable<Size>, Serializable {
         return this.compareTo(size) == 0;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int hashCode() {
         return (31 * (int) (count ^ (count >>> 32))) + unit.hashCode();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     @JsonValue
     public String toString() {
@@ -150,6 +238,9 @@ public class Size implements Comparable<Size>, Serializable {
         return Long.toString(count) + ' ' + units;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int compareTo(Size other) {
         if (unit == other.unit) {
@@ -160,6 +251,9 @@ public class Size implements Comparable<Size>, Serializable {
     }
 
     /**
+     * Converts the current {@link Size} to a representation of the newer {@link DataSize} class.
+     *
+     * @return the converted {@link DataSize} instance
      * @since 2.0
      */
     public DataSize toDataSize() {
@@ -180,6 +274,10 @@ public class Size implements Comparable<Size>, Serializable {
     }
 
     /**
+     * Constructs a {@link Size} object from a given {@link DataSize} instance.
+     *
+     * @param dataSize the data size object to convert
+     * @return the converted {@link Size} object
      * @since 2.0
      */
     public static Size fromDataSize(DataSize dataSize) {

--- a/dropwizard-util/src/main/java/io/dropwizard/util/Strings.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Strings.java
@@ -5,9 +5,11 @@ import javax.annotation.Nullable;
 import static java.util.Objects.requireNonNull;
 
 /**
+ * Provides helper methods to work with {@link String} objects.
+ *
  * @since 2.0
  *
- * @deprecated 
+ * @deprecated The class was intended for internal use only. If you need those methods, simply copy them into your project.
  */
 @Deprecated
 public final class Strings {

--- a/dropwizard-util/src/main/java/io/dropwizard/util/Throwables.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Throwables.java
@@ -7,6 +7,8 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 /**
+ * Provides helper methods to work with {@link Throwable} objects.
+ *
  * @since 2.0
  */
 public final class Throwables {
@@ -21,6 +23,8 @@ public final class Throwables {
      * assertEquals("Unable to assign a customer id", Throwables.getRootCause(e).getMessage());
      * </pre>
      *
+     * @param throwable the throwable to obtain the root cause from
+     * @return the root cause
      * @throws IllegalArgumentException if there is a loop in the causal chain
      * @deprecated consider using Apache commons-lang3 ExceptionUtils instead
      */

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/BaseValidator.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/BaseValidator.java
@@ -7,11 +7,16 @@ import org.hibernate.validator.HibernateValidatorConfiguration;
 import javax.validation.Validation;
 import javax.validation.Validator;
 
+/**
+ * This class provides static methods to obtain configured {@link Validator} instances.
+ */
 public class BaseValidator {
     private BaseValidator() { /* singleton */ }
 
     /**
-     * Creates a new {@link Validator} based on {@link #newConfiguration()}
+     * Creates a new {@link Validator} based on {@link #newConfiguration()}.
+     *
+     * @return the new {@link Validator} instance
      */
     public static Validator newValidator() {
         return newConfiguration().buildValidatorFactory().getValidator();
@@ -19,6 +24,8 @@ public class BaseValidator {
 
     /**
      * Creates a new {@link HibernateValidatorConfiguration} with the base custom unwrappers registered.
+     *
+     * @return the configured {@link HibernateValidatorConfiguration}
      */
     public static HibernateValidatorConfiguration newConfiguration() {
         return Validation

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/ConstraintViolations.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/ConstraintViolations.java
@@ -7,9 +7,19 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+/**
+ * This class provides static methods to work with constraint violations.
+ */
 public class ConstraintViolations {
     private ConstraintViolations() { /* singleton */ }
 
+    /**
+     * Computes a string representation from a {@link ConstraintViolation}.
+     *
+     * @param v the constraint violation
+     * @return the formatted message
+     * @param <T> the generic type of the constraint violation
+     */
     public static <T> String format(ConstraintViolation<T> v) {
         if (v.getConstraintDescriptor().getAnnotation() instanceof ValidationMethod) {
             return v.getMessage();
@@ -18,6 +28,13 @@ public class ConstraintViolations {
         }
     }
 
+    /**
+     * Computes a set of formatted messages from the given typed set of {@link ConstraintViolation ConstraintViolations}.
+     *
+     * @param violations the constraint violations to format
+     * @return a new set containing the formatted messages
+     * @param <T> the generic type of the constraint violations
+     */
     public static <T> Collection<String> format(Set<ConstraintViolation<T>> violations) {
         final SortedSet<String> errors = new TreeSet<>();
         for (ConstraintViolation<?> v : violations) {
@@ -26,6 +43,12 @@ public class ConstraintViolations {
         return errors;
     }
 
+    /**
+     * Computes a set of formatted messages from the given untyped set of {@link ConstraintViolation ConstraintViolations}.
+     *
+     * @param violations the constraint violations to format
+     * @return a new set containing the formatted messages
+     */
     public static Collection<String> formatUntyped(Set<ConstraintViolation<?>> violations) {
         final SortedSet<String> errors = new TreeSet<>();
         for (ConstraintViolation<?> v : violations) {
@@ -34,6 +57,13 @@ public class ConstraintViolations {
         return errors;
     }
 
+    /**
+     * Copies a set of {@link ConstraintViolation ConstraintViolations}.
+     *
+     * @param violations the source set
+     * @return a new {@link HashSet} containing the violations from the source set
+     * @param <T> the generic type of the constraint violations
+     */
     public static <T> Set<ConstraintViolation<?>> copyOf(Set<ConstraintViolation<T>> violations) {
         return new HashSet<>(violations);
     }

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/DataSizeRange.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/DataSizeRange.java
@@ -32,29 +32,64 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @MaxDataSize(value = Long.MAX_VALUE, unit = DataSizeUnit.PEBIBYTES)
 @ReportAsSingleViolation
 public @interface DataSizeRange {
+    /**
+     * The minimum value of the range the validated {@link io.dropwizard.util.DataSize} must be in.
+     *
+     * @return the minimum value
+     */
     @OverridesAttribute(constraint = MinDataSize.class, name = "value")
     long min() default 0;
 
+    /**
+     * The maximum value of the range the validated {@link io.dropwizard.util.DataSize} must be in.
+     *
+     * @return the maximum value
+     */
     @OverridesAttribute(constraint = MaxDataSize.class, name = "value")
     long max() default Long.MAX_VALUE;
 
+    /**
+     * The unit of the validated range.
+     *
+     * @return the {@link DataSizeUnit}
+     */
     @OverridesAttribute(constraint = MinDataSize.class, name = "unit")
     @OverridesAttribute(constraint = MaxDataSize.class, name = "unit")
     DataSizeUnit unit() default DataSizeUnit.BYTES;
 
+    /**
+     * The validation message for this constraint.
+     *
+     * @return the message
+     */
     String message() default "must be between {min} {unit} and {max} {unit}";
 
+    /**
+     * The groups the constraint belongs to.
+     *
+     * @return an array of classes representing the groups
+     */
     Class<?>[] groups() default { };
 
+    /**
+     * The payloads of this constraint.
+     *
+     * @return the array of payload classes
+     */
     @SuppressWarnings("UnusedDeclaration") Class<? extends Payload>[] payload() default { };
 
     /**
-     * Defines several {@code @SizeRange} annotations on the same element.
+     * Defines several {@code @DataSizeRange} annotations on the same element.
      */
     @Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
     @Retention(RUNTIME)
     @Documented
     @interface List {
+        /**
+         * The annotation's value.
+         *
+         * @return the array of {@link DataSizeRange} annotations this container annotation holds
+         */
         DataSizeRange[] value();
     }
 }

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/DurationRange.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/DurationRange.java
@@ -29,20 +29,50 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @MaxDuration(value = Long.MAX_VALUE, unit = TimeUnit.DAYS)
 @ReportAsSingleViolation
 public @interface DurationRange {
+    /**
+     * The minimum value of the range the validated {@link io.dropwizard.util.Duration} must be in.
+     *
+     * @return the minimum value
+     */
     @OverridesAttribute(constraint = MinDuration.class, name = "value")
     long min() default 0;
 
+    /**
+     * The maximum value of the range the validated {@link io.dropwizard.util.Duration} must be in.
+     *
+     * @return the maximum value
+     */
     @OverridesAttribute(constraint = MaxDuration.class, name = "value")
     long max() default Long.MAX_VALUE;
 
+    /**
+     * The unit of the validated range.
+     *
+     * @return the {@link TimeUnit}
+     */
     @OverridesAttribute(constraint = MinDuration.class, name = "unit")
     @OverridesAttribute(constraint = MaxDuration.class, name = "unit")
     TimeUnit unit() default TimeUnit.SECONDS;
 
+    /**
+     * The validation message for this constraint.
+     *
+     * @return the message
+     */
     String message() default "must be between {min} {unit} and {max} {unit}";
 
+    /**
+     * The groups the constraint belongs to.
+     *
+     * @return an array of classes representing the groups
+     */
     Class<?>[] groups() default { };
 
+    /**
+     * The payloads of this constraint.
+     *
+     * @return the array of payload classes
+     */
     @SuppressWarnings("UnusedDeclaration") Class<? extends Payload>[] payload() default { };
 
     /**
@@ -51,7 +81,12 @@ public @interface DurationRange {
     @Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
     @Retention(RUNTIME)
     @Documented
-    public @interface List {
+    @interface List {
+        /**
+         * The annotation's value.
+         *
+         * @return the array of {@link DurationRange} annotations this container annotation holds
+         */
         DurationRange[] value();
     }
 }

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/InterpolationHelper.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/InterpolationHelper.java
@@ -18,9 +18,21 @@ import java.util.regex.Pattern;
  */
 public final class InterpolationHelper {
 
+    /**
+     * A constant representing the '&#123;' character.
+     */
     public static final char BEGIN_TERM = '{';
+    /**
+     * A constant representing the '&#125;' character.
+     */
     public static final char END_TERM = '}';
+    /**
+     * A constant representing the '&#36;' character.
+     */
     public static final char EL_DESIGNATOR = '$';
+    /**
+     * A constant representing the '&#92;' character.
+     */
     public static final char ESCAPE_CHARACTER = '\\';
 
     private static final Pattern ESCAPE_MESSAGE_PARAMETER_PATTERN = Pattern.compile("([\\" + ESCAPE_CHARACTER + BEGIN_TERM + END_TERM + EL_DESIGNATOR + "])");
@@ -28,6 +40,12 @@ public final class InterpolationHelper {
     private InterpolationHelper() {
     }
 
+    /**
+     * Escapes a string with the {@link #ESCAPE_MESSAGE_PARAMETER_PATTERN}.
+     *
+     * @param messageParameter the string to escape
+     * @return the escaped string or {@code null}, if the input was {@code null}
+     */
     @Nullable
     public static String escapeMessageParameter(@Nullable String messageParameter) {
         if (messageParameter == null) {

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/MaxDataSize.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/MaxDataSize.java
@@ -19,7 +19,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * The annotated element must be a {@link io.dropwizard.util.DataSize}
  * whose value must be less than or equal to the specified maximum.
- * <p/>
+ * <br/>
  * <code>null</code> elements are considered valid
  *
  * @since 2.0
@@ -29,18 +29,37 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Documented
 @Constraint(validatedBy = MaxDataSizeValidator.class)
 public @interface MaxDataSize {
+    /**
+     * The validation message for this constraint.
+     *
+     * @return the message
+     */
     String message() default "must be less than or equal to {value} {unit}";
 
+    /**
+     * The groups the constraint belongs to.
+     *
+     * @return an array of classes representing the groups
+     */
     Class<?>[] groups() default {};
 
+    /**
+     * The payloads of this constraint.
+     *
+     * @return the array of payload classes
+     */
     @SuppressWarnings("UnusedDeclaration") Class<? extends Payload>[] payload() default {};
 
     /**
+     * The annotation's value.
+     *
      * @return value the element must be less than or equal to
      */
     long value();
 
     /**
+     * The unit of the annotation.
+     *
      * @return unit of the value the element must be less than or equal to
      */
     DataSizeUnit unit() default DataSizeUnit.BYTES;

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/MaxDuration.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/MaxDuration.java
@@ -18,7 +18,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * The annotated element must be a {@link io.dropwizard.util.Duration}
  * whose value must be higher or equal to the specified minimum.
- * <p/>
+ * <br/>
  * <code>null</code> elements are considered valid
  */
 @Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
@@ -26,23 +26,44 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Documented
 @Constraint(validatedBy = MaxDurationValidator.class)
 public @interface MaxDuration {
+    /**
+     * The validation message for this constraint.
+     *
+     * @return the message
+     */
     String message() default "must be less than ${inclusive == true ? 'or equal to ' : ''}{value} {unit}";
 
+    /**
+     * The groups the constraint belongs to.
+     *
+     * @return an array of classes representing the groups
+     */
     Class<?>[] groups() default { };
 
+    /**
+     * The payloads of this constraint.
+     *
+     * @return the array of payload classes
+     */
     @SuppressWarnings("UnusedDeclaration") Class<? extends Payload>[] payload() default { };
 
     /**
-     * @return value the element must be higher or equal to
+     * The annotation's value.
+     *
+     * @return value the element must be less than or equal to
      */
     long value();
 
     /**
+     * The unit of the annotation.
+     *
      * @return unit of the value the element must be higher or equal to
      */
     TimeUnit unit() default TimeUnit.SECONDS;
 
     /**
+     * If the boundary value is inclusive or not.
+     *
      * @return {@code true} if the validation is to allow values equal to {@link #value()}.
      * False if the validation is to be exclusive.
      * Defaults to {@code true}.

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/MaxSize.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/MaxSize.java
@@ -19,7 +19,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * The annotated element must be a {@link io.dropwizard.util.Size}
  * whose value must be less than or equal to the specified maximum.
- * <p/>
+ * <br/>
  * <code>null</code> elements are considered valid
  *
  * @deprecated Use {@link MaxDataSize} for correct SI and IEC prefixes.
@@ -30,18 +30,37 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Documented
 @Constraint(validatedBy = MaxSizeValidator.class)
 public @interface MaxSize {
+    /**
+     * The validation message for this constraint.
+     *
+     * @return the message
+     */
     String message() default "must be less than or equal to {value} {unit}";
 
+    /**
+     * The groups the constraint belongs to.
+     *
+     * @return an array of classes representing the groups
+     */
     Class<?>[] groups() default { };
 
+    /**
+     * The payloads of this constraint.
+     *
+     * @return the array of payload classes
+     */
     @SuppressWarnings("UnusedDeclaration") Class<? extends Payload>[] payload() default { };
 
     /**
+     * The annotation's value.
+     *
      * @return value the element must be less than or equal to
      */
     long value();
 
     /**
+     * The unit of the annotation.
+     *
      * @return unit of the value the element must be less than or equal to
      */
     SizeUnit unit() default SizeUnit.BYTES;

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/MinDataSize.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/MinDataSize.java
@@ -19,7 +19,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * The annotated element must be a {@link io.dropwizard.util.DataSize}
  * whose value must be higher or equal to the specified minimum.
- * <p/>
+ * <br/>
  * <code>null</code> elements are considered valid
  *
  * @since 2.0
@@ -29,18 +29,37 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Documented
 @Constraint(validatedBy = MinDataSizeValidator.class)
 public @interface MinDataSize {
+    /**
+     * The validation message for this constraint.
+     *
+     * @return the message
+     */
     String message() default "must be greater than or equal to {value} {unit}";
 
+    /**
+     * The groups the constraint belongs to.
+     *
+     * @return an array of classes representing the groups
+     */
     Class<?>[] groups() default {};
 
+    /**
+     * The payloads of this constraint.
+     *
+     * @return the array of payload classes
+     */
     @SuppressWarnings("UnusedDeclaration") Class<? extends Payload>[] payload() default {};
 
     /**
+     * The annotation's value.
+     *
      * @return value the element must be higher or equal to
      */
     long value();
 
     /**
+     * The unit of the annotation.
+     *
      * @return unit of the value the element must be higher or equal to
      */
     DataSizeUnit unit() default DataSizeUnit.BYTES;

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/MinDuration.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/MinDuration.java
@@ -18,7 +18,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * The annotated element must be a {@link io.dropwizard.util.Duration}
  * whose value must be higher or equal to the specified minimum.
- * <p/>
+ * <br/>
  * <code>null</code> elements are considered valid
  */
 @Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
@@ -26,23 +26,44 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Documented
 @Constraint(validatedBy = MinDurationValidator.class)
 public @interface MinDuration {
+    /**
+     * The validation message for this constraint.
+     *
+     * @return the message
+     */
     String message() default "must be greater than ${inclusive == true ? 'or equal to ' : ''}{value} {unit}";
 
+    /**
+     * The groups the constraint belongs to.
+     *
+     * @return an array of classes representing the groups
+     */
     Class<?>[] groups() default { };
 
+    /**
+     * The payloads of this constraint.
+     *
+     * @return the array of payload classes
+     */
     @SuppressWarnings("UnusedDeclaration") Class<? extends Payload>[] payload() default { };
 
     /**
+     * The annotation's value.
+     *
      * @return value the element must be higher or equal to
      */
     long value();
 
     /**
+     * The unit of the annotation.
+     *
      * @return unit of the value the element must be higher or equal to
      */
     TimeUnit unit() default TimeUnit.SECONDS;
 
     /**
+     * If the boundary value is inclusive or not.
+     *
      * @return {@code true} if the validation is to allow values equal to {@link #value()}.
      * False if the validation is to be exclusive.
      * Defaults to {@code true}.

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/MinSize.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/MinSize.java
@@ -19,7 +19,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * The annotated element must be a {@link io.dropwizard.util.Size}
  * whose value must be higher or equal to the specified minimum.
- * <p/>
+ * <br/>
  * <code>null</code> elements are considered valid
  *
  * @deprecated Use {@link MinDataSize} for correct SI and IEC prefixes.
@@ -30,18 +30,37 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Documented
 @Constraint(validatedBy = MinSizeValidator.class)
 public @interface MinSize {
+    /**
+     * The validation message for this constraint.
+     *
+     * @return the message
+     */
     String message() default "must be greater than or equal to {value} {unit}";
 
+    /**
+     * The groups the constraint belongs to.
+     *
+     * @return an array of classes representing the groups
+     */
     Class<?>[] groups() default { };
 
+    /**
+     * The payloads of this constraint.
+     *
+     * @return the array of payload classes
+     */
     @SuppressWarnings("UnusedDeclaration") Class<? extends Payload>[] payload() default { };
 
     /**
+     * The annotation's value.
+     *
      * @return value the element must be higher or equal to
      */
     long value();
 
     /**
+     * The unit of the annotation.
+     *
      * @return unit of the value the element must be higher or equal to
      */
     SizeUnit unit() default SizeUnit.BYTES;

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/OneOf.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/OneOf.java
@@ -22,24 +22,45 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Documented
 @Constraint(validatedBy = OneOfValidator.class)
 public @interface OneOf {
+    /**
+     * The validation message for this constraint.
+     *
+     * @return the message
+     */
     String message() default "must be one of {value}";
 
+    /**
+     * The groups the constraint belongs to.
+     *
+     * @return an array of classes representing the groups
+     */
     Class<?>[] groups() default {};
 
+    /**
+     * The payloads of this constraint.
+     *
+     * @return the array of payload classes
+     */
     @SuppressWarnings("UnusedDeclaration") Class<? extends Payload>[] payload() default {};
 
     /**
      * The set of valid values.
+     *
+     * @return an array containing the valid string values
      */
     String[] value();
 
     /**
      * Whether or not to ignore case.
+     *
+     * @return if the case should be ignored
      */
     boolean ignoreCase() default false;
 
     /**
      * Whether or not to ignore leading and trailing whitespace.
+     *
+     * @return if leading and trailing whitespaces should be ignored
      */
     boolean ignoreWhitespace() default false;
 }

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/OneOfValidator.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/OneOfValidator.java
@@ -3,6 +3,9 @@ package io.dropwizard.validation;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
+/**
+ * Check that the string representation of an object is in a given set of valid values.
+ */
 public class OneOfValidator implements ConstraintValidator<OneOf, Object> {
     private String[] values = new String[]{};
     private boolean caseInsensitive;

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/PortRange.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/PortRange.java
@@ -22,13 +22,38 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Constraint(validatedBy = PortRangeValidator.class)
 @Documented
 public @interface PortRange {
+    /**
+     * The minimum value of the port range the validated {@code int} must be in.
+     *
+     * @return the minimum value
+     */
     int min() default 1;
 
+    /**
+     * The maximum value of the port range the validated {@code int} must be in.
+     *
+     * @return the maximum value
+     */
     int max() default 65535;
 
+    /**
+     * The validation message for this constraint.
+     *
+     * @return the message
+     */
     String message() default "{org.hibernate.validator.constraints.Range.message}";
 
+    /**
+     * The groups the constraint belongs to.
+     *
+     * @return an array of classes representing the groups
+     */
     Class<?>[] groups() default {};
 
+    /**
+     * The payloads of this constraint.
+     *
+     * @return the array of payload classes
+     */
     Class<? extends Payload>[] payload() default {};
 }

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/SizeRange.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/SizeRange.java
@@ -32,20 +32,50 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @MaxSize(value = Long.MAX_VALUE, unit = SizeUnit.TERABYTES)
 @ReportAsSingleViolation
 public @interface SizeRange {
+    /**
+     * The minimum value of the range the validated {@link io.dropwizard.util.Size} must be in.
+     *
+     * @return the minimum value
+     */
     @OverridesAttribute(constraint = MinSize.class, name = "value")
     long min() default 0;
 
+    /**
+     * The maximum value of the range the validated {@link io.dropwizard.util.Size} must be in.
+     *
+     * @return the maximum value
+     */
     @OverridesAttribute(constraint = MaxSize.class, name = "value")
     long max() default Long.MAX_VALUE;
 
+    /**
+     * The unit of the validated range.
+     *
+     * @return the {@link SizeUnit}
+     */
     @OverridesAttribute(constraint = MinSize.class, name = "unit")
     @OverridesAttribute(constraint = MaxSize.class, name = "unit")
     SizeUnit unit() default SizeUnit.BYTES;
 
+    /**
+     * The validation message for this constraint.
+     *
+     * @return the message
+     */
     String message() default "must be between {min} {unit} and {max} {unit}";
 
+    /**
+     * The groups the constraint belongs to.
+     *
+     * @return an array of classes representing the groups
+     */
     Class<?>[] groups() default { };
 
+    /**
+     * The payloads of this constraint.
+     *
+     * @return the array of payload classes
+     */
     @SuppressWarnings("UnusedDeclaration") Class<? extends Payload>[] payload() default { };
 
     /**
@@ -54,7 +84,12 @@ public @interface SizeRange {
     @Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
     @Retention(RUNTIME)
     @Documented
-    public @interface List {
+    @interface List {
+        /**
+         * The annotation's value.
+         *
+         * @return the array of {@link SizeRange} annotations this container annotation holds
+         */
         SizeRange[] value();
     }
 }

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/ValidationMethod.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/ValidationMethod.java
@@ -20,9 +20,24 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Constraint(validatedBy = MethodValidator.class)
 @Documented
 public @interface ValidationMethod {
+    /**
+     * The validation message for this constraint.
+     *
+     * @return the message
+     */
     String message() default "is not valid";
 
+    /**
+     * The groups the constraint belongs to.
+     *
+     * @return an array of classes representing the groups
+     */
     Class<?>[] groups() default {};
 
+    /**
+     * The payloads of this constraint.
+     *
+     * @return the array of payload classes
+     */
     @SuppressWarnings("UnusedDeclaration") Class<? extends Payload>[] payload() default { };
 }

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/SelfValidating.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/SelfValidating.java
@@ -19,9 +19,24 @@ import java.lang.annotation.Target;
 @Constraint(validatedBy = SelfValidatingValidator.class)
 public @interface SelfValidating {
 
+    /**
+     * The validation message for this constraint.
+     *
+     * @return the message
+     */
     String message() default "";
 
+    /**
+     * The groups the constraint belongs to.
+     *
+     * @return an array of classes representing the groups
+     */
     Class<?>[] groups() default {};
 
+    /**
+     * The payloads of this constraint.
+     *
+     * @return the array of payload classes
+     */
     Class<? extends Payload>[] payload() default {};
 }

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/SelfValidatingValidator.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/SelfValidatingValidator.java
@@ -26,6 +26,9 @@ import java.util.stream.Collectors;
 public class SelfValidatingValidator implements ConstraintValidator<SelfValidating, Object> {
     private final Logger log;
 
+    /**
+     * Constructs a new {@link SelfValidatingValidator} instance with a new logger of this class.
+     */
     public SelfValidatingValidator() {
         this(LoggerFactory.getLogger(SelfValidatingValidator.class));
     }

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/ValidationCaller.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/ValidationCaller.java
@@ -10,17 +10,35 @@ import javax.annotation.Nullable;
  */
 public abstract class ValidationCaller<T> {
 
+    /**
+     * The object to call validation methods on.
+     */
     @Nullable
     protected T validationObject;
 
+    /**
+     * Sets the validation object variable.
+     *
+     * @param obj the new validation object
+     */
     public void setValidationObject(T obj) {
         this.validationObject = obj;
     }
 
+    /**
+     * Gets the validation object.
+     *
+     * @return the validation object
+     */
     @Nullable
     public T getValidationObject() {
         return validationObject;
     }
 
+    /**
+     * This method is intended to call a validation methods on the validation object.
+     *
+     * @param vc the {@link ViolationCollector} to collect violations
+     */
     public abstract void call(ViolationCollector vc);
 }

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/ViolationCollector.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/selfvalidating/ViolationCollector.java
@@ -16,13 +16,18 @@ public class ViolationCollector {
     private final ConstraintValidatorContext constraintValidatorContext;
     private boolean violationOccurred = false;
 
+    /**
+     * Constructs a new {@link ViolationCollector} with the given {@link ConstraintValidatorContext}.
+     *
+     * @param constraintValidatorContext the wrapped {@link ConstraintValidatorContext}
+     */
     public ViolationCollector(ConstraintValidatorContext constraintValidatorContext) {
         this.constraintValidatorContext = constraintValidatorContext;
     }
 
     /**
      * Adds a new violation to this collector. This also sets {@code violationOccurred} to {@code true}.
-     * <p>
+     * <br/>
      * Prefer the method with explicit message parameters if you want to interpolate the message.
      *
      * @param message the message of the violation
@@ -48,7 +53,7 @@ public class ViolationCollector {
 
     /**
      * Adds a new violation to this collector. This also sets {@code violationOccurred} to {@code true}.
-     * <p>
+     * <br/>
      * Prefer the method with explicit message parameters if you want to interpolate the message.
      *
      * @param propertyName the name of the property
@@ -138,6 +143,12 @@ public class ViolationCollector {
                 .addConstraintViolation();
     }
 
+    /**
+     * Returns a {@link HibernateConstraintValidatorContext} updated with the given message parameters.
+     *
+     * @param messageParameters the message parameters to set to the context
+     * @return the {@link HibernateConstraintValidatorContext}
+     */
     private HibernateConstraintValidatorContext getContextWithMessageParameters(Map<String, Object> messageParameters) {
         final HibernateConstraintValidatorContext context =
                 constraintValidatorContext.unwrap(HibernateConstraintValidatorContext.class);
@@ -160,6 +171,8 @@ public class ViolationCollector {
     }
 
     /**
+     * Returns, if a violation has previously occurred.
+     *
      * @return if any violation was collected
      */
     public boolean hasViolationOccurred() {

--- a/dropwizard-validation/src/main/java/io/dropwizard/validation/valuehandling/GuavaOptionalValueExtractor.java
+++ b/dropwizard-validation/src/main/java/io/dropwizard/validation/valuehandling/GuavaOptionalValueExtractor.java
@@ -14,6 +14,9 @@ import javax.validation.valueextraction.ValueExtractor;
  * @since 2.0
  */
 public class GuavaOptionalValueExtractor implements ValueExtractor<Optional<@ExtractedValue ?>> {
+    /**
+     * A singleton {@link ValueExtractorDescriptor} for the {@link GuavaOptionalValueExtractor}.
+     */
     public static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor(new GuavaOptionalValueExtractor());
 
     private GuavaOptionalValueExtractor() {


### PR DESCRIPTION
This PR is meant as a starting point to fix JavaDoc errors during the run of the compiler and during javadoc generation via the `maven-javadoc-plugin`.

@dropwizard/committers I think up-to-date JavaDoc is always a good thing, although this might take some time to accomplish. I've now corrected the errors in the `dropwizard-util` module. Do you think it's worth doing so for all other modules?

I've experienced, that the invocation of the `javadoc:jar` target on a JDK 17 causes errors, even with our `<doclint>none</doclint>` settings. The errors vanish when passing `-Ddoclint=none` on the command line. Maybe I'm missing something here, but we should be able to build the project on a JDK 17.