### PR TITLE
Remove redundant outputPatternAsHeader logging setting from tests

### DIFF
--- a/dropwizard-auth/src/test/resources/logback-test.xml
+++ b/dropwizard-auth/src/test/resources/logback-test.xml
@@ -1,7 +1,6 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <outputPatternAsHeader>false</outputPatternAsHeader>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>

--- a/dropwizard-client/src/test/resources/logback-test.xml
+++ b/dropwizard-client/src/test/resources/logback-test.xml
@@ -1,7 +1,6 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <outputPatternAsHeader>false</outputPatternAsHeader>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>

--- a/dropwizard-configuration/src/test/resources/logback-test.xml
+++ b/dropwizard-configuration/src/test/resources/logback-test.xml
@@ -1,7 +1,6 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <outputPatternAsHeader>false</outputPatternAsHeader>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>

--- a/dropwizard-core/src/test/resources/logback-test.xml
+++ b/dropwizard-core/src/test/resources/logback-test.xml
@@ -1,7 +1,6 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <outputPatternAsHeader>false</outputPatternAsHeader>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>

--- a/dropwizard-db/src/test/resources/logback-test.xml
+++ b/dropwizard-db/src/test/resources/logback-test.xml
@@ -1,7 +1,6 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <outputPatternAsHeader>false</outputPatternAsHeader>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>

--- a/dropwizard-hibernate/src/test/resources/logback-test.xml
+++ b/dropwizard-hibernate/src/test/resources/logback-test.xml
@@ -1,7 +1,6 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <outputPatternAsHeader>false</outputPatternAsHeader>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>

--- a/dropwizard-jersey/src/test/resources/logback-test.xml
+++ b/dropwizard-jersey/src/test/resources/logback-test.xml
@@ -1,7 +1,6 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <outputPatternAsHeader>false</outputPatternAsHeader>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>

--- a/dropwizard-jetty/src/test/resources/logback-test.xml
+++ b/dropwizard-jetty/src/test/resources/logback-test.xml
@@ -1,7 +1,6 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <outputPatternAsHeader>false</outputPatternAsHeader>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>

--- a/dropwizard-lifecycle/src/test/resources/logback-test.xml
+++ b/dropwizard-lifecycle/src/test/resources/logback-test.xml
@@ -1,7 +1,6 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <outputPatternAsHeader>false</outputPatternAsHeader>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>

--- a/dropwizard-logging/src/test/resources/logback-test.xml
+++ b/dropwizard-logging/src/test/resources/logback-test.xml
@@ -1,7 +1,6 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <outputPatternAsHeader>false</outputPatternAsHeader>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>

--- a/dropwizard-migrations/src/test/resources/logback-test.xml
+++ b/dropwizard-migrations/src/test/resources/logback-test.xml
@@ -1,7 +1,6 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <outputPatternAsHeader>false</outputPatternAsHeader>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>

--- a/dropwizard-servlets/src/test/resources/logback-test.xml
+++ b/dropwizard-servlets/src/test/resources/logback-test.xml
@@ -1,7 +1,6 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <outputPatternAsHeader>false</outputPatternAsHeader>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>

--- a/dropwizard-testing/src/test/resources/logback-test.xml
+++ b/dropwizard-testing/src/test/resources/logback-test.xml
@@ -1,7 +1,6 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <outputPatternAsHeader>false</outputPatternAsHeader>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>

--- a/dropwizard-views-freemarker/src/test/resources/logback-test.xml
+++ b/dropwizard-views-freemarker/src/test/resources/logback-test.xml
@@ -1,7 +1,6 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <outputPatternAsHeader>false</outputPatternAsHeader>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>

--- a/dropwizard-views-mustache/src/test/resources/logback-test.xml
+++ b/dropwizard-views-mustache/src/test/resources/logback-test.xml
@@ -1,7 +1,6 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <outputPatternAsHeader>false</outputPatternAsHeader>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>

--- a/dropwizard-views/src/test/resources/logback-test.xml
+++ b/dropwizard-views/src/test/resources/logback-test.xml
@@ -1,7 +1,6 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <outputPatternAsHeader>false</outputPatternAsHeader>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>


### PR DESCRIPTION
This defaults to false - we don't need to set it to false explicitly.

See https://logback.qos.ch/manual/encoders.html#outputPatternAsHeader

If you'd rather merge into 2.1.x rather than 2.0.x, close this and look at https://github.com/dropwizard/dropwizard/pull/5770 instead.