### PR TITLE
Minimise test logging configuration

### DIFF
--- a/dropwizard-auth/src/test/resources/logback-test.xml
+++ b/dropwizard-auth/src/test/resources/logback-test.xml
@@ -1,10 +1,3 @@
 <configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-    <root level="off">
-        <appender-ref ref="STDOUT"/>
-    </root>
+    <root level="off"/>
 </configuration>

--- a/dropwizard-client/src/test/resources/logback-test.xml
+++ b/dropwizard-client/src/test/resources/logback-test.xml
@@ -1,10 +1,3 @@
 <configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-    <root level="off">
-        <appender-ref ref="STDOUT"/>
-    </root>
+    <root level="off"/>
 </configuration>

--- a/dropwizard-configuration/src/test/resources/logback-test.xml
+++ b/dropwizard-configuration/src/test/resources/logback-test.xml
@@ -1,10 +1,3 @@
 <configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-    <root level="off">
-        <appender-ref ref="STDOUT"/>
-    </root>
+    <root level="off"/>
 </configuration>

--- a/dropwizard-core/src/test/resources/logback-test.xml
+++ b/dropwizard-core/src/test/resources/logback-test.xml
@@ -1,10 +1,3 @@
 <configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-    <root level="off">
-        <appender-ref ref="STDOUT"/>
-    </root>
+    <root level="off"/>
 </configuration>

--- a/dropwizard-db/src/test/resources/logback-test.xml
+++ b/dropwizard-db/src/test/resources/logback-test.xml
@@ -1,10 +1,3 @@
 <configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-    <root level="off">
-        <appender-ref ref="STDOUT"/>
-    </root>
+    <root level="off"/>
 </configuration>

--- a/dropwizard-hibernate/src/test/resources/logback-test.xml
+++ b/dropwizard-hibernate/src/test/resources/logback-test.xml
@@ -1,10 +1,3 @@
 <configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-    <root level="off">
-        <appender-ref ref="STDOUT"/>
-    </root>
+    <root level="off"/>
 </configuration>

--- a/dropwizard-jersey/src/test/resources/logback-test.xml
+++ b/dropwizard-jersey/src/test/resources/logback-test.xml
@@ -1,10 +1,3 @@
 <configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-    <root level="off">
-        <appender-ref ref="STDOUT"/>
-    </root>
+    <root level="off"/>
 </configuration>

--- a/dropwizard-jetty/src/test/resources/logback-test.xml
+++ b/dropwizard-jetty/src/test/resources/logback-test.xml
@@ -1,13 +1,3 @@
 <configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-
-    <logger level="info" name="io.dropwizard.jetty.HttpsConnectorFactory"/>
-
-    <root level="off">
-        <appender-ref ref="STDOUT"/>
-    </root>
+    <root level="off"/>
 </configuration>

--- a/dropwizard-lifecycle/src/test/resources/logback-test.xml
+++ b/dropwizard-lifecycle/src/test/resources/logback-test.xml
@@ -1,10 +1,3 @@
 <configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-    <root level="off">
-        <appender-ref ref="STDOUT"/>
-    </root>
+    <root level="off"/>
 </configuration>

--- a/dropwizard-logging/src/test/resources/logback-test.xml
+++ b/dropwizard-logging/src/test/resources/logback-test.xml
@@ -1,10 +1,3 @@
 <configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-    <root level="off">
-        <appender-ref ref="STDOUT"/>
-    </root>
+    <root level="off"/>
 </configuration>

--- a/dropwizard-migrations/src/test/resources/logback-test.xml
+++ b/dropwizard-migrations/src/test/resources/logback-test.xml
@@ -1,10 +1,3 @@
 <configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-    <root level="off">
-        <appender-ref ref="STDOUT"/>
-    </root>
+    <root level="off"/>
 </configuration>

--- a/dropwizard-servlets/src/test/resources/logback-test.xml
+++ b/dropwizard-servlets/src/test/resources/logback-test.xml
@@ -1,10 +1,3 @@
 <configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-    <root level="off">
-        <appender-ref ref="STDOUT"/>
-    </root>
+    <root level="off"/>
 </configuration>

--- a/dropwizard-testing/src/test/resources/logback-test.xml
+++ b/dropwizard-testing/src/test/resources/logback-test.xml
@@ -1,10 +1,3 @@
 <configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-    <root level="info">
-        <appender-ref ref="STDOUT"/>
-    </root>
+    <root level="off"/>
 </configuration>

--- a/dropwizard-validation/src/test/resources/logback-test.xml
+++ b/dropwizard-validation/src/test/resources/logback-test.xml
@@ -1,10 +1,3 @@
 <configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-    <root level="off">
-        <appender-ref ref="STDOUT"/>
-    </root>
+    <root level="off" />
 </configuration>

--- a/dropwizard-views-freemarker/src/test/resources/logback-test.xml
+++ b/dropwizard-views-freemarker/src/test/resources/logback-test.xml
@@ -1,10 +1,3 @@
 <configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-    <root level="off">
-        <appender-ref ref="STDOUT"/>
-    </root>
+    <root level="off"/>
 </configuration>

--- a/dropwizard-views-mustache/src/test/resources/logback-test.xml
+++ b/dropwizard-views-mustache/src/test/resources/logback-test.xml
@@ -1,10 +1,3 @@
 <configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-    <root level="off">
-        <appender-ref ref="STDOUT"/>
-    </root>
+    <root level="off"/>
 </configuration>

--- a/dropwizard-views/src/test/resources/logback-test.xml
+++ b/dropwizard-views/src/test/resources/logback-test.xml
@@ -1,10 +1,3 @@
 <configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-    <root level="off">
-        <appender-ref ref="STDOUT"/>
-    </root>
+    <root level="off"/>
 </configuration>


### PR DESCRIPTION
If we're turning logging off, we don't really need to configure an appender.

Is this what you were thinking, @zUniQueX?