### PR TITLE
Suppress warnings for static loggers

### DIFF
--- a/dropwizard-assets/src/main/java/io/dropwizard/assets/AssetsBundle.java
+++ b/dropwizard-assets/src/main/java/io/dropwizard/assets/AssetsBundle.java
@@ -13,6 +13,7 @@ import java.nio.charset.StandardCharsets;
  * A bundle for serving static asset files from the classpath.
  */
 public class AssetsBundle implements ConfiguredBundle<Configuration> {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(AssetsBundle.class);
 
     private static final String DEFAULT_ASSETS_NAME = "assets";

--- a/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactory.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardSSLConnectionSocketFactory.java
@@ -24,6 +24,7 @@ import java.util.List;
 import static java.util.Objects.requireNonNull;
 
 public class DropwizardSSLConnectionSocketFactory {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger log = LoggerFactory.getLogger(DropwizardSSLConnectionSocketFactory.class);
 
     private final TlsConfiguration configuration;

--- a/dropwizard-core/src/main/java/io/dropwizard/cli/CheckCommand.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/CheckCommand.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
  * @param <T> the {@link Configuration} subclass which is loaded from the configuration file
  */
 public class CheckCommand<T extends Configuration> extends ConfiguredCommand<T> {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(CheckCommand.class);
 
     private final Class<T> configurationClass;

--- a/dropwizard-core/src/main/java/io/dropwizard/cli/ServerCommand.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/ServerCommand.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
  * @param <T> the {@link Configuration} subclass which is loaded from the configuration file
  */
 public class ServerCommand<T extends Configuration> extends EnvironmentCommand<T> {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(ServerCommand.class);
 
     private final Class<T> configurationClass;

--- a/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
@@ -224,6 +224,7 @@ import java.util.stream.Collectors;
  * @see SimpleServerFactory
  */
 public abstract class AbstractServerFactory implements ServerFactory {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(ServerFactory.class);
 
     @Valid

--- a/dropwizard-core/src/main/java/io/dropwizard/server/DefaultServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/DefaultServerFactory.java
@@ -68,6 +68,7 @@ import java.util.Map;
  */
 @JsonTypeName("default")
 public class DefaultServerFactory extends AbstractServerFactory {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultServerFactory.class);
 
     @Valid

--- a/dropwizard-core/src/main/java/io/dropwizard/server/SimpleServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/SimpleServerFactory.java
@@ -56,6 +56,7 @@ import java.util.Map;
 @JsonTypeName("simple")
 public class SimpleServerFactory extends AbstractServerFactory {
 
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(SimpleServerFactory.class);
 
     @Valid

--- a/dropwizard-core/src/main/java/io/dropwizard/setup/AdminEnvironment.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/AdminEnvironment.java
@@ -18,6 +18,7 @@ import static java.util.Objects.requireNonNull;
  * The administrative environment of a Dropwizard application.
  */
 public class AdminEnvironment extends ServletEnvironment {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(AdminEnvironment.class);
 
     private final HealthCheckRegistry healthChecks;

--- a/dropwizard-core/src/main/java/io/dropwizard/sslreload/SslReloadBundle.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/sslreload/SslReloadBundle.java
@@ -18,6 +18,7 @@ import java.util.Set;
  * refresh ssl configuration on request
  */
 public class SslReloadBundle implements ConfiguredBundle<Configuration> {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(SslReloadBundle.class);
 
     private final SslReloadTask reloadTask = new SslReloadTask();

--- a/dropwizard-e2e/src/main/java/com/example/badlog/BadLogApp.java
+++ b/dropwizard-e2e/src/main/java/com/example/badlog/BadLogApp.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class BadLogApp extends Application<Configuration> {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(BadLogApp.class);
 
     @Override

--- a/dropwizard-e2e/src/test/java/com/example/badlog/BadLogTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/badlog/BadLogTest.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 class BadLogTest {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(BadLogTest.class);
     private static final PrintStream oldOut = System.out;
     private static final PrintStream oldErr = System.err;

--- a/dropwizard-health/src/main/java/io/dropwizard/health/DefaultHealthFactory.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/DefaultHealthFactory.java
@@ -32,6 +32,7 @@ import static java.util.concurrent.Executors.defaultThreadFactory;
 
 @JsonTypeName("default")
 public class DefaultHealthFactory implements HealthFactory {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultHealthFactory.class);
 
     private static final String DEFAULT_BASE_NAME = "health-check";

--- a/dropwizard-health/src/main/java/io/dropwizard/health/DelayedShutdownHandler.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/DelayedShutdownHandler.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
  * determine the instance should no longer receive requests.
  */
 public class DelayedShutdownHandler extends AbstractLifeCycle {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(DelayedShutdownHandler.class);
 
     private final ShutdownNotifier shutdownNotifier;

--- a/dropwizard-health/src/main/java/io/dropwizard/health/HealthCheckConfigValidator.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/HealthCheckConfigValidator.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 class HealthCheckConfigValidator implements Managed {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(HealthCheckConfigValidator.class);
 
     private final List<HealthCheckConfiguration> configs;

--- a/dropwizard-health/src/main/java/io/dropwizard/health/HealthCheckManager.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/HealthCheckManager.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 
 class HealthCheckManager implements HealthCheckRegistryListener, HealthStatusChecker, ShutdownNotifier,
     HealthStateListener, HealthStateAggregator {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(HealthCheckManager.class);
 
     private final AtomicBoolean isAppAlive = new AtomicBoolean(true);

--- a/dropwizard-health/src/main/java/io/dropwizard/health/HealthCheckScheduler.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/HealthCheckScheduler.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 class HealthCheckScheduler {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(HealthCheckScheduler.class);
 
     private final ScheduledExecutorService executorService;

--- a/dropwizard-health/src/main/java/io/dropwizard/health/HealthEnvironment.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/HealthEnvironment.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.Objects;
 
 public class HealthEnvironment {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(HealthEnvironment.class);
 
     @Nonnull

--- a/dropwizard-health/src/main/java/io/dropwizard/health/ScheduledHealthCheck.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/ScheduledHealthCheck.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Objects;
 
 class ScheduledHealthCheck implements Runnable {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(ScheduledHealthCheck.class);
 
     private final String name;

--- a/dropwizard-health/src/main/java/io/dropwizard/health/State.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/State.java
@@ -8,6 +8,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 class State {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(State.class);
 
     private final String name;

--- a/dropwizard-health/src/main/java/io/dropwizard/health/check/http/HttpHealthCheck.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/check/http/HttpHealthCheck.java
@@ -15,6 +15,7 @@ import java.util.Objects;
 public class HttpHealthCheck extends HealthCheck {
     // visible for testing
     static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(2);
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpHealthCheck.class);
     @Nonnull
     private final String url;

--- a/dropwizard-health/src/main/java/io/dropwizard/health/check/tcp/TcpHealthCheck.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/check/tcp/TcpHealthCheck.java
@@ -12,6 +12,7 @@ import java.time.Duration;
 import java.util.Objects;
 
 public class TcpHealthCheck extends HealthCheck {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(TcpHealthCheck.class);
 
     private static final Duration DEFAULT_CONNECTION_TIMEOUT = Duration.ofSeconds(2);

--- a/dropwizard-health/src/main/java/io/dropwizard/health/response/JsonHealthResponseProvider.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/response/JsonHealthResponseProvider.java
@@ -25,6 +25,7 @@ public class JsonHealthResponseProvider implements HealthResponseProvider {
     public static final String CHECK_TYPE_QUERY_PARAM = "type";
     public static final String NAME_QUERY_PARAM = "name";
     public static final String ALL_VALUE = "all";
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(JsonHealthResponseProvider.class);
     private static final String MEDIA_TYPE = MediaType.APPLICATION_JSON;
 

--- a/dropwizard-health/src/main/java/io/dropwizard/health/response/ServletHealthResponder.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/response/ServletHealthResponder.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import static java.util.Objects.requireNonNull;
 
 public class ServletHealthResponder extends HttpServlet {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(ServletHealthResponder.class);
 
     private final HealthResponseProvider healthResponseProvider;

--- a/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckManagerTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckManagerTest.java
@@ -410,6 +410,7 @@ class HealthCheckManagerTest {
     }
 
     private static class CountingHealthCheck extends HealthCheck {
+        @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
         private static final Logger log = LoggerFactory.getLogger(CountingHealthCheck.class);
         private final Counter counter = new Counter();
 

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryFactory.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryFactory.java
@@ -22,6 +22,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 
 public class SessionFactoryFactory {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(SessionFactoryFactory.class);
     private static final String DEFAULT_NAME = "hibernate";
 

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/PersistenceExceptionMapper.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/PersistenceExceptionMapper.java
@@ -18,6 +18,7 @@ import static java.util.Objects.requireNonNull;
 @Provider
 public class PersistenceExceptionMapper implements ExtendedExceptionMapper<PersistenceException> {
 
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(DataException.class);
 
     @Context

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/DiscoverableSubtypeResolver.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/DiscoverableSubtypeResolver.java
@@ -21,6 +21,7 @@ import java.util.List;
  */
 public class DiscoverableSubtypeResolver extends StdSubtypeResolver {
     private static final long serialVersionUID = 1L;
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(DiscoverableSubtypeResolver.class);
 
     private final List<Class<?>> discoveredSubtypes;

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -44,6 +44,7 @@ import java.util.stream.Collectors;
 import static java.util.Objects.requireNonNull;
 
 public class DropwizardResourceConfig extends ResourceConfig {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(DropwizardResourceConfig.class);
     private static final String NEWLINE = String.format("%n");
     private static final TypeResolver TYPE_RESOLVER = new TypeResolver();

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/EarlyEofExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/EarlyEofExceptionMapper.java
@@ -18,6 +18,7 @@ import javax.ws.rs.ext.Provider;
 @Provider
 public class EarlyEofExceptionMapper implements ExceptionMapper<EofException> {
 
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(EarlyEofExceptionMapper.class);
 
     @Override

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/EofExceptionWriterInterceptor.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/EofExceptionWriterInterceptor.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 @Provider
 @Priority(Integer.MAX_VALUE)
 public class EofExceptionWriterInterceptor implements WriterInterceptor {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(EofExceptionWriterInterceptor.class);
 
     private final Counter exceptionCounter;

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/AllowedMethodsFilter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/AllowedMethodsFilter.java
@@ -24,6 +24,7 @@ public class AllowedMethodsFilter implements Filter {
             "GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH"
     );
 
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOG = LoggerFactory.getLogger(AllowedMethodsFilter.class);
 
     private Set<String> allowedMethods = Collections.emptySet();

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/AbstractParam.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/AbstractParam.java
@@ -16,6 +16,7 @@ import javax.ws.rs.core.Response.Status;
  * @param <T> the type of value wrapped by the parameter
  */
 public abstract class AbstractParam<T> {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractParam.class);
     private final String parameterName;
     private final T value;

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/DropwizardConfiguredValidator.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/DropwizardConfiguredValidator.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import static java.util.Objects.requireNonNull;
 
 public class DropwizardConfiguredValidator implements ConfiguredValidator {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(DropwizardConfiguredValidator.class);
 
     private final Validator validator;

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/FuzzyEnumParamConverter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/FuzzyEnumParamConverter.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
  */
 @Provider
 public class FuzzyEnumParamConverter<T> implements ParamConverter<T> {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(FuzzyEnumParamConverter.class);
 
     private final Class<T> rawType;

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/JerseyViolationExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/JerseyViolationExceptionMapper.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 
 @Provider
 public class JerseyViolationExceptionMapper implements ExceptionMapper<JerseyViolationException> {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(JerseyViolationExceptionMapper.class);
 
     @Override

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpsConnectorFactory.java
@@ -225,6 +225,7 @@ import java.util.stream.Collectors;
  */
 @JsonTypeName("https")
 public class HttpsConnectorFactory extends HttpConnectorFactory {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpsConnectorFactory.class);
     private static final AtomicBoolean LOGGED = new AtomicBoolean(false);
 

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/setup/ServletEnvironment.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/setup/ServletEnvironment.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import static java.util.Objects.requireNonNull;
 
 public class ServletEnvironment {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(ServletEnvironment.class);
 
     private final MutableServletContextHandler handler;

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/ExecutorServiceManager.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/ExecutorServiceManager.java
@@ -8,6 +8,7 @@ import java.util.concurrent.ExecutorService;
 
 public class ExecutorServiceManager implements Managed {
 
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOG = LoggerFactory.getLogger(ExecutorServiceManager.class);
     private final ExecutorService executor;
     private final Duration shutdownPeriod;

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilder.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilder.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class ExecutorServiceBuilder {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static Logger log = LoggerFactory.getLogger(ExecutorServiceBuilder.class);
 
     private static final AtomicLong COUNT = new AtomicLong(0);

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/LifecycleEnvironment.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/LifecycleEnvironment.java
@@ -17,6 +17,7 @@ import java.util.concurrent.ThreadFactory;
 import static java.util.Objects.requireNonNull;
 
 public class LifecycleEnvironment {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(LifecycleEnvironment.class);
 
     private final List<LifeCycle> managedObjects;

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/AbstractAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/AbstractAppenderFactory.java
@@ -103,6 +103,7 @@ import java.util.concurrent.TimeUnit;
  * </table>
  */
 public abstract class AbstractAppenderFactory<E extends DeferredProcessingAware> implements AppenderFactory<E> {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractAppenderFactory.class);
 
     @NotNull

--- a/dropwizard-metrics/src/main/java/io/dropwizard/metrics/MetricsFactory.java
+++ b/dropwizard-metrics/src/main/java/io/dropwizard/metrics/MetricsFactory.java
@@ -44,6 +44,7 @@ import java.util.List;
  * </table>
  */
 public class MetricsFactory {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(MetricsFactory.class);
 
     @Valid

--- a/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbCalculateChecksumCommand.java
+++ b/dropwizard-migrations/src/main/java/io/dropwizard/migrations/DbCalculateChecksumCommand.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import java.util.function.Consumer;
 
 public class DbCalculateChecksumCommand<T extends Configuration> extends AbstractLiquibaseCommand<T> {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger("liquibase");
 
     private Consumer<CheckSum> checkSumConsumer = checkSum -> LOGGER.info("checksum = {}", checkSum);

--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/TaskServlet.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/tasks/TaskServlet.java
@@ -41,6 +41,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class TaskServlet extends HttpServlet {
     private static final long serialVersionUID = 7404713218661358124L;
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(TaskServlet.class);
     private static final String DEFAULT_CONTENT_TYPE = "text/plain;charset=UTF-8";
     private final ConcurrentMap<String, Task> tasks;

--- a/dropwizard-views/src/main/java/io/dropwizard/views/ViewRenderExceptionMapper.java
+++ b/dropwizard-views/src/main/java/io/dropwizard/views/ViewRenderExceptionMapper.java
@@ -20,6 +20,7 @@ import static io.dropwizard.util.Throwables.findThrowableInChain;
 @Provider
 public class ViewRenderExceptionMapper implements ExtendedExceptionMapper<WebApplicationException> {
 
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(ViewRenderExceptionMapper.class);
 
     /**


### PR DESCRIPTION
Don't display a warning, if a `Logger` is declared `static`.

Raised as a followup for #5725. @joschi Did you mean doing this instead of disabling the check?