### PR TITLE
Address errorprone warnings in dropwizard-logging

### DIFF
--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/AbstractAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/AbstractAppenderFactory.java
@@ -155,6 +155,8 @@ public abstract class AbstractAppenderFactory<E extends DeferredProcessingAware>
     }
 
     /**
+     * Returns the duration required between logged messages. Messages logged more frequently than this will be dropped.
+     * A {@code null} value means there is no rate limit.
      * @since 2.0
      */
     @JsonProperty
@@ -164,6 +166,8 @@ public abstract class AbstractAppenderFactory<E extends DeferredProcessingAware>
     }
 
     /**
+     * Sets the time period required between logged messages. Messages logged more frequently than this will be dropped.
+     * A {@code null} value disables the rate limit.
      * @since 2.0
      */
     @JsonProperty

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/DefaultLoggingFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/DefaultLoggingFactory.java
@@ -122,8 +122,8 @@ public class DefaultLoggingFactory implements LoggingFactory {
     public void configure(MetricRegistry metricRegistry, String name) {
         LoggingUtil.hijackJDKLogging();
 
-        CHANGE_LOGGER_CONTEXT_LOCK.lock();
         final Logger root;
+        CHANGE_LOGGER_CONTEXT_LOCK.lock();
         try {
             root = configureLoggers(name);
         } finally {

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/FileAppenderFactory.java
@@ -208,6 +208,8 @@ public class FileAppenderFactory<E extends DeferredProcessingAware> extends Abst
     }
 
     /**
+     * Returns the total size threshold at which archived log files will be
+     * removed. A zero value means there is limit.
      * @since 2.0
      */
     @JsonProperty
@@ -217,6 +219,8 @@ public class FileAppenderFactory<E extends DeferredProcessingAware> extends Abst
     }
 
     /**
+     * Sets the total size threshold at which archived log files will be
+     * removed. A zero value means there is limit.
      * @since 2.0
      */
     @JsonProperty
@@ -244,6 +248,8 @@ public class FileAppenderFactory<E extends DeferredProcessingAware> extends Abst
     }
 
     /**
+     * Returns a boolean indicating whether the {@code totalSizeCap} property
+     * will be used.
      * @since 2.0
      */
     @JsonIgnore


### PR DESCRIPTION
###### Problem:
errorprone warns about javadoc and locking in `dropwizard-logging`

###### Solution:
Add javadoc summaries for public methods which have javadoc comments already.

Remove javadoc from `FileAppenderFactory#isTotalSizeCapValid()` - it's  a validation method so the `@since` tag is pretty superfluous.

Take the `CHANGE_LOGGER_CONTEXT_LOCK` immediately before the `try` in `DefaultLoggingFactory`.

###### Result:
errorprone warnings in `dropwizard-logging` are reduced to just one, relating to the static logger (there are separate PRs dealing with that).