### PR TITLE
Update logback to version 1.3.0

### DIFF
--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -53,11 +53,11 @@
         <liquibase-core.version>4.15.0</liquibase-core.version>
         <liquibase-slf4j.version>4.1.0</liquibase-slf4j.version>
         <logback-throttling-appender.version>1.1.9</logback-throttling-appender.version>
-        <logback.version>1.2.11</logback.version>
+        <logback.version>1.3.0</logback.version>
         <metrics4.version>4.2.11</metrics4.version>
         <mustache-compiler.version>0.9.10</mustache-compiler.version>
         <nullaway.version>0.9.9</nullaway.version>
-        <slf4j.version>1.7.36</slf4j.version>
+        <slf4j.version>2.0.0</slf4j.version>
         <tomcat-jdbc.version>10.0.23</tomcat-jdbc.version>
         <usertype.core.version>7.0.0.CR1</usertype.core.version>
 

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/common/DefaultLoggingFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/common/DefaultLoggingFactory.java
@@ -3,7 +3,6 @@ package io.dropwizard.logging.common;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.jmx.JMXConfigurator;
 import ch.qos.logback.classic.jul.LevelChangePropagator;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
@@ -28,16 +27,9 @@ import io.dropwizard.logging.common.layout.DropwizardLayoutFactory;
 import io.dropwizard.logging.common.layout.LayoutFactory;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import javax.management.InstanceAlreadyExistsException;
-import javax.management.MBeanRegistrationException;
-import javax.management.MBeanServer;
-import javax.management.MalformedObjectNameException;
-import javax.management.NotCompliantMBeanException;
-import javax.management.ObjectName;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.io.PrintStream;
-import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -51,7 +43,6 @@ import static java.util.Objects.requireNonNull;
 
 @JsonTypeName("default")
 public class DefaultLoggingFactory implements LoggingFactory {
-    private static final ReentrantLock MBEAN_REGISTRATION_LOCK = new ReentrantLock();
     private static final ReentrantLock CHANGE_LOGGER_CONTEXT_LOCK = new ReentrantLock();
 
     @NotNull
@@ -143,23 +134,6 @@ public class DefaultLoggingFactory implements LoggingFactory {
             StatusPrinter.printIfErrorsOccured(loggerContext);
         } finally {
             StatusPrinter.setPrintStream(System.out);
-        }
-
-        final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
-        MBEAN_REGISTRATION_LOCK.lock();
-        try {
-            final ObjectName objectName = new ObjectName("io.dropwizard:type=Logging");
-            if (!server.isRegistered(objectName)) {
-                server.registerMBean(new JMXConfigurator(loggerContext,
-                                server,
-                                objectName),
-                        objectName);
-            }
-        } catch (MalformedObjectNameException | InstanceAlreadyExistsException |
-                NotCompliantMBeanException | MBeanRegistrationException e) {
-            throw new RuntimeException(e);
-        } finally {
-            MBEAN_REGISTRATION_LOCK.unlock();
         }
 
         configureInstrumentation(root, metricRegistry);

--- a/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/LogbackAccessRequestLog.java
+++ b/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/LogbackAccessRequestLog.java
@@ -25,7 +25,7 @@ public class LogbackAccessRequestLog extends RequestLogImpl implements LifeCycle
     @Override
     public void log(Request jettyRequest, Response jettyResponse) {
         DropwizardJettyServerAdapter adapter = new DropwizardJettyServerAdapter(jettyRequest, jettyResponse);
-        IAccessEvent accessEvent = new AccessEvent(jettyRequest, jettyResponse, adapter);
+        IAccessEvent accessEvent = new AccessEvent(this, jettyRequest, jettyResponse, adapter);
         if (getFilterChainDecision(accessEvent) == FilterReply.DENY) {
             return;
         }

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/layout/SafeRequestParameterConverterTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/layout/SafeRequestParameterConverterTest.java
@@ -2,6 +2,7 @@ package io.dropwizard.request.logging.layout;
 
 import ch.qos.logback.access.spi.AccessEvent;
 import ch.qos.logback.access.spi.ServerAdapter;
+import ch.qos.logback.core.Context;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,7 +22,7 @@ class SafeRequestParameterConverterTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        accessEvent = new AccessEvent(httpServletRequest, Mockito.mock(HttpServletResponse.class),
+        accessEvent = new AccessEvent(Mockito.mock(Context.class), httpServletRequest, Mockito.mock(HttpServletResponse.class),
             Mockito.mock(ServerAdapter.class));
 
         safeRequestParameterConverter.setOptionList(Collections.singletonList("name"));


### PR DESCRIPTION
Updates Logback to version 1.3.0 and therefore SLF4J to version 2.0.0.

Additionally drops support for JMX because Logback 1.3.0 dropped support for it.