### PR TITLE
Exclude `jetty-servlet-api`

### DIFF
--- a/dropwizard-e2e/pom.xml
+++ b/dropwizard-e2e/pom.xml
@@ -118,8 +118,8 @@
             <artifactId>jetty-server</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>javax.servlet</groupId>
-                    <artifactId>javax.servlet-api</artifactId>
+                    <groupId>org.eclipse.jetty.toolchain</groupId>
+                    <artifactId>jetty-servlet-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/dropwizard-health/pom.xml
+++ b/dropwizard-health/pom.xml
@@ -84,8 +84,8 @@
             <artifactId>jetty-server</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>javax.servlet</groupId>
-                    <artifactId>javax.servlet-api</artifactId>
+                    <groupId>org.eclipse.jetty.toolchain</groupId>
+                    <artifactId>jetty-servlet-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/dropwizard-json-logging/pom.xml
+++ b/dropwizard-json-logging/pom.xml
@@ -77,8 +77,8 @@
             <artifactId>jetty-server</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>javax.servlet</groupId>
-                    <artifactId>javax.servlet-api</artifactId>
+                    <groupId>org.eclipse.jetty.toolchain</groupId>
+                    <artifactId>jetty-servlet-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/dropwizard-lifecycle/pom.xml
+++ b/dropwizard-lifecycle/pom.xml
@@ -22,8 +22,8 @@
             <artifactId>jetty-server</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>javax.servlet</groupId>
-                    <artifactId>javax.servlet-api</artifactId>
+                    <groupId>org.eclipse.jetty.toolchain</groupId>
+                    <artifactId>jetty-servlet-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/dropwizard-parent/pom.xml
+++ b/dropwizard-parent/pom.xml
@@ -197,6 +197,8 @@
                                         <exclude>javax.activation:javax.activation-api</exclude>
                                         <!-- Replaced with jakarta.servlet:jakarta.servlet-api -->
                                         <exclude>javax.servlet:javax.servlet-api</exclude>
+                                        <!-- Replaced with jakarta.servlet:jakarta.servlet-api -->
+                                        <exclude>org.eclipse.jetty.toolchain:jetty-servlet-api</exclude>
                                         <!-- Replaced with jakarta.validation:jakarta.validation-api -->
                                         <exclude>javax.validation:validation-api</exclude>
                                         <!-- Replaced with jakarta.xml.bind:jakarta.xml.bind-api -->

--- a/dropwizard-testing/pom.xml
+++ b/dropwizard-testing/pom.xml
@@ -157,8 +157,8 @@
             <artifactId>jetty-server</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>javax.servlet</groupId>
-                    <artifactId>javax.servlet-api</artifactId>
+                    <groupId>org.eclipse.jetty.toolchain</groupId>
+                    <artifactId>jetty-servlet-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
Jetty switched from `javax.servlet-api` to a repackaged artifact `jetty-servlet-api`, which is replaced in Dropwizard by `jakarta.servlet-api`. Therefore change the exclusions to the new artifacts.