### PR TITLE
Improve startup performance for many loggers

### DIFF
--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/DefaultLoggingFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/DefaultLoggingFactory.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.logback.AsyncAppenderBaseProxy;
 import io.dropwizard.logging.async.AsyncAppenderFactory;
@@ -266,6 +267,8 @@ public class DefaultLoggingFactory implements LoggingFactory {
         final AsyncAppenderFactory<ILoggingEvent> asyncAppenderFactory = new AsyncLoggingEventAppenderFactory();
         final LayoutFactory<ILoggingEvent> layoutFactory = new DropwizardLayoutFactory();
 
+        final ObjectMapper objectMapper = Jackson.newObjectMapper();
+
         for (Map.Entry<String, JsonNode> entry : loggers.entrySet()) {
             final Logger logger = loggerContext.getLogger(entry.getKey());
             final JsonNode jsonNode = entry.getValue();
@@ -276,7 +279,7 @@ public class DefaultLoggingFactory implements LoggingFactory {
                 // A level and an appender
                 final LoggerConfiguration configuration;
                 try {
-                    configuration = Jackson.newObjectMapper().treeToValue(jsonNode, LoggerConfiguration.class);
+                    configuration = objectMapper.treeToValue(jsonNode, LoggerConfiguration.class);
                 } catch (JsonProcessingException e) {
                     throw new IllegalArgumentException("Wrong format of logger '" + entry.getKey() + "'", e);
                 }


### PR DESCRIPTION
The `DefaultLoggingFactory#configureLoggers(String)` method creates a new `ObjectMapper` for each deserialization of a `LoggerConfiguration`. The `Jackson.newObjectMapper()` method trasitively calls `ObjectMapper.findModules()`, which [is described as an expensive call](https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/latest/com/fasterxml/jackson/databind/ObjectMapper.html#findModules--).

For applications which configure many loggers with custom appenders this may result in a performance issue.

Therefore create one `ObjectMapper` and share it between all deserializations.