### PR TITLE
Upgrade to hibernate-core 6.1.3

### DIFF
--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -31,7 +31,7 @@
         <error_prone.version>2.15.0</error_prone.version>
         <freemarker.version>2.3.31</freemarker.version>
         <guava.version>31.1-jre</guava.version>
-        <hibernate-core.version>5.6.11.Final</hibernate-core.version>
+        <hibernate-core.version>6.1.3.Final</hibernate-core.version>
         <hibernate-validator.version>7.0.5.Final</hibernate-validator.version>
         <hk2.version>3.0.3</hk2.version>
         <httpclient.version>5.1.3</httpclient.version>
@@ -59,7 +59,6 @@
         <nullaway.version>0.10.1</nullaway.version>
         <slf4j.version>2.0.0</slf4j.version>
         <tomcat-jdbc.version>10.0.23</tomcat-jdbc.version>
-        <usertype.core.version>7.0.0.CR1</usertype.core.version>
 
         <!-- Test dependencies -->
         <assertj.version>3.23.1</assertj.version>
@@ -211,27 +210,8 @@
                 <version>${h2.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.jadira.usertype</groupId>
-                <artifactId>usertype.core</artifactId>
-                <version>${usertype.core.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.joda</groupId>
-                        <artifactId>joda-money</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.geronimo.specs</groupId>
-                        <artifactId>geronimo-jta_1.1_spec</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate</groupId>
-                <artifactId>hibernate-core-jakarta</artifactId>
+                <groupId>org.hibernate.orm</groupId>
+                <artifactId>hibernate-core</artifactId>
                 <version>${hibernate-core.version}</version>
                 <exclusions>
                     <exclusion>

--- a/dropwizard-hibernate/pom.xml
+++ b/dropwizard-hibernate/pom.xml
@@ -112,18 +112,9 @@
             <artifactId>javassist</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jadira.usertype</groupId>
-            <artifactId>usertype.core</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-core-jakarta</artifactId>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-core</artifactId>
             <exclusions>
-                <exclusion>
-                    <groupId>com.sun.activation</groupId>
-                    <artifactId>jakarta.activation</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>jakarta.xml.bind</groupId>
                     <artifactId>jakarta.xml.bind-api</artifactId>

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryFactory.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryFactory.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 public class SessionFactoryFactory {
     private static final Logger LOGGER = LoggerFactory.getLogger(SessionFactoryFactory.class);
@@ -62,7 +63,8 @@ public class SessionFactoryFactory {
                                                        Map<String, String> properties) {
         final DatasourceConnectionProviderImpl connectionProvider = new DatasourceConnectionProviderImpl();
         connectionProvider.setDataSource(dataSource);
-        connectionProvider.configure(properties);
+        Map<String, Object> newProperties = properties.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        connectionProvider.configure(newProperties);
         return connectionProvider;
     }
 
@@ -83,8 +85,6 @@ public class SessionFactoryFactory {
         configuration.setProperty(AvailableSettings.USE_REFLECTION_OPTIMIZER, "true");
         configuration.setProperty(AvailableSettings.ORDER_UPDATES, "true");
         configuration.setProperty(AvailableSettings.ORDER_INSERTS, "true");
-        configuration.setProperty(AvailableSettings.USE_NEW_ID_GENERATOR_MAPPINGS, "true");
-        configuration.setProperty("jadira.usertype.autoRegisterUserTypes", "true");
         for (Map.Entry<String, String> property : properties.entrySet()) {
             configuration.setProperty(property.getKey(), property.getValue());
         }

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/dual/DualSessionFactory.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/dual/DualSessionFactory.java
@@ -6,19 +6,16 @@ import jakarta.persistence.PersistenceUnitUtil;
 import jakarta.persistence.Query;
 import jakarta.persistence.SynchronizationType;
 import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.metamodel.Metamodel;
 import org.hibernate.Cache;
 import org.hibernate.HibernateException;
-import org.hibernate.Metamodel;
 import org.hibernate.Session;
 import org.hibernate.SessionBuilder;
 import org.hibernate.SessionFactory;
 import org.hibernate.StatelessSession;
 import org.hibernate.StatelessSessionBuilder;
-import org.hibernate.TypeHelper;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.engine.spi.FilterDefinition;
-import org.hibernate.metadata.ClassMetadata;
-import org.hibernate.metadata.CollectionMetadata;
 import org.hibernate.stat.Statistics;
 
 import javax.naming.NamingException;
@@ -27,6 +24,8 @@ import java.sql.Connection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 /** Represents a wrapper/decorator class for a Hibernate session factory that can manage
  *  both a primary session factory and a read-only session factory.
@@ -35,7 +34,7 @@ import java.util.Set;
  *
  */
 
-@SuppressWarnings({"deprecation", "rawtypes"})
+@SuppressWarnings({"rawtypes"})
 public class DualSessionFactory implements SessionFactory {
 
     private static final long serialVersionUID = 1L;
@@ -80,6 +79,11 @@ public class DualSessionFactory implements SessionFactory {
     public CriteriaBuilder getCriteriaBuilder() { return current().getCriteriaBuilder(); }
 
     @Override
+    public Metamodel getMetamodel() {
+        return current().getMetamodel();
+    }
+
+    @Override
     public boolean isOpen() { return current().isOpen(); }
 
     @Override
@@ -99,9 +103,6 @@ public class DualSessionFactory implements SessionFactory {
 
     @Override
     public <T> List<EntityGraph<? super T>> findEntityGraphsByType(Class<T> entityClass) { return current().findEntityGraphsByType(entityClass); }
-
-    @Override
-    public Metamodel getMetamodel() { return current().getMetamodel(); }
 
     @Override
     public Reference getReference() throws NamingException { return current().getReference(); }
@@ -128,6 +129,26 @@ public class DualSessionFactory implements SessionFactory {
     public StatelessSession openStatelessSession(Connection connection) { return current().openStatelessSession(connection); }
 
     @Override
+    public void inSession(Consumer<Session> action) {
+        current().inSession(action);
+    }
+
+    @Override
+    public void inTransaction(Consumer<Session> action) {
+        current().inTransaction(action);
+    }
+
+    @Override
+    public <R> R fromSession(Function<Session, R> action) {
+        return current().fromSession(action);
+    }
+
+    @Override
+    public <R> R fromTransaction(Function<Session, R> action) {
+        return current().fromTransaction(action);
+    }
+
+    @Override
     public Statistics getStatistics() { return current().getStatistics(); }
 
     @Override
@@ -147,22 +168,4 @@ public class DualSessionFactory implements SessionFactory {
 
     @Override
     public boolean containsFetchProfileDefinition(String name) { return current().containsFetchProfileDefinition(name); }
-
-    @Override
-    public TypeHelper getTypeHelper() { return current().getTypeHelper(); }
-
-    @Override
-    public ClassMetadata getClassMetadata(Class entityClass) { return current().getClassMetadata(entityClass); }
-
-    @Override
-    public ClassMetadata getClassMetadata(String entityName) { return current().getClassMetadata(entityName); }
-
-    @Override
-    public CollectionMetadata getCollectionMetadata(String roleName) { return current().getCollectionMetadata(roleName); }
-
-    @Override
-    public Map<String, ClassMetadata> getAllClassMetadata() { return current().getAllClassMetadata(); }
-
-    @Override
-    public Map getAllCollectionMetadata() { return current().getAllCollectionMetadata(); }
 }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/AbstractDAOTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/AbstractDAOTest.java
@@ -1,8 +1,5 @@
 package io.dropwizard.hibernate;
 
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaQuery;
-import org.hibernate.Criteria;
 import org.hibernate.HibernateException;
 import org.hibernate.NonUniqueResultException;
 import org.hibernate.Session;
@@ -10,10 +7,11 @@ import org.hibernate.SessionFactory;
 import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.proxy.LazyInitializer;
 import org.hibernate.query.Query;
+import org.hibernate.query.criteria.HibernateCriteriaBuilder;
+import org.hibernate.query.criteria.JpaCriteriaQuery;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -39,11 +37,6 @@ class AbstractDAOTest {
         }
 
         @Override
-        public Criteria criteria() {
-            return super.criteria();
-        }
-
-        @Override
         public Query<?> namedQuery(String queryName) throws HibernateException {
             return super.namedQuery(queryName);
         }
@@ -59,18 +52,8 @@ class AbstractDAOTest {
         }
 
         @Override
-        public String uniqueResult(Criteria criteria) throws HibernateException {
-            return super.uniqueResult(criteria);
-        }
-
-        @Override
         public String uniqueResult(Query<String> query) throws HibernateException {
             return super.uniqueResult(query);
-        }
-
-        @Override
-        public List<String> list(Criteria criteria) throws HibernateException {
-            return super.list(criteria);
         }
 
         @Override
@@ -79,7 +62,7 @@ class AbstractDAOTest {
         }
 
         @Override
-        public String get(Serializable id) {
+        public String get(Object id) {
             return super.get(id);
         }
 
@@ -95,10 +78,9 @@ class AbstractDAOTest {
     }
 
     private final SessionFactory factory = mock(SessionFactory.class);
-    private final CriteriaBuilder criteriaBuilder = mock(CriteriaBuilder.class);
-    private final Criteria criteria = mock(Criteria.class);
+    private final HibernateCriteriaBuilder criteriaBuilder = mock(HibernateCriteriaBuilder.class);
     @SuppressWarnings("unchecked")
-    private final CriteriaQuery<String> criteriaQuery = mock(CriteriaQuery.class);
+    private final JpaCriteriaQuery<String> criteriaQuery = mock(JpaCriteriaQuery.class);
     @SuppressWarnings("unchecked")
     private final Query<String> query = mock(Query.class);
     private final Session session = mock(Session.class);
@@ -108,7 +90,6 @@ class AbstractDAOTest {
     void setup() throws Exception {
         when(criteriaBuilder.createQuery(same(String.class))).thenReturn(criteriaQuery);
         when(factory.getCurrentSession()).thenReturn(session);
-        when(session.createCriteria(String.class)).thenReturn(criteria);
         when(session.getCriteriaBuilder()).thenReturn(criteriaBuilder);
         when(session.getNamedQuery(anyString())).thenReturn(query);
         when(session.createQuery(anyString(), same(String.class))).thenReturn(query);
@@ -152,28 +133,12 @@ class AbstractDAOTest {
     }
 
     @Test
-    void createsNewCriteria() throws Exception {
-        assertThat(dao.criteria())
-                .isEqualTo(criteria);
-
-        verify(session).createCriteria(String.class);
-    }
-
-    @Test
     void createsNewCriteriaQueries() throws Exception {
         assertThat(dao.criteriaQuery())
                 .isEqualTo(criteriaQuery);
 
         verify(session).getCriteriaBuilder();
         verify(criteriaBuilder).createQuery(String.class);
-    }
-
-    @Test
-    void returnsUniqueResultsFromCriteriaQueries() throws Exception {
-        when(criteria.uniqueResult()).thenReturn("woo");
-
-        assertThat(dao.uniqueResult(criteria))
-                .isEqualTo("woo");
     }
 
     @Test
@@ -200,14 +165,6 @@ class AbstractDAOTest {
 
         assertThat(dao.uniqueResult(query))
                 .isEqualTo("woo");
-    }
-
-    @Test
-    void returnsUniqueListsFromCriteriaQueries() throws Exception {
-        when(criteria.list()).thenReturn(Collections.singletonList("woo"));
-
-        assertThat(dao.list(criteria))
-                .containsOnly("woo");
     }
 
     @Test

--- a/dropwizard-testing/pom.xml
+++ b/dropwizard-testing/pom.xml
@@ -245,14 +245,10 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-core-jakarta</artifactId>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-core</artifactId>
             <scope>provided</scope>
             <exclusions>
-                <exclusion>
-                    <groupId>com.sun.activation</groupId>
-                    <artifactId>jakarta.activation</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>jakarta.xml.bind</groupId>
                     <artifactId>jakarta.xml.bind-api</artifactId>

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/common/DAOTest.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/common/DAOTest.java
@@ -116,8 +116,6 @@ public class DAOTest {
             config.setProperty(AvailableSettings.USE_REFLECTION_OPTIMIZER, "true");
             config.setProperty(AvailableSettings.ORDER_UPDATES, "true");
             config.setProperty(AvailableSettings.ORDER_INSERTS, "true");
-            config.setProperty(AvailableSettings.USE_NEW_ID_GENERATOR_MAPPINGS, "true");
-            config.setProperty("jadira.usertype.autoRegisterUserTypes", "true");
 
             entityClasses.forEach(config::addAnnotatedClass);
             properties.forEach(config::setProperty);


### PR DESCRIPTION
Refs #5168 

After looking at the Hibernate 6.0.x and 6.1.x migration guides and the Jackson hibernate module, I think we can upgrade Hibernate to 6.1.x while using the Jackson module for the 5.x series using the `jakarta` namespace.

This introduces the following changes:
 - drop support for `jadira.usertype`. The latest version (7.0.0.CR1) is from 2018 and the library hasn't provided Hibernate 6 support yet
 - drop Hibernate `Criteria`: The methods to provide `Criteria` instances were deprecated and are removed in Hibernate 6
 - removal of `Serializable` as id restriction: Hibernate 6 supports any `Object` as id, so the restriction for an id object to implement `Serializable` got removed. Therefore the method signatures have to be changed to support all `Object`s
 - `uniqueElement`: The `uniqueElement` method was moved to `AbstractSelectionQuery` and the access modifier was changed to `protected`. Therefore add a small utility method which mirrors the behaviour
 - removal of `AvailableSettings.USE_NEW_ID_GENERATOR_MAPPINGS`: The `AvailableSettings.USE_NEW_ID_GENERATOR_MAPPINGS` property was removed. As the default value was `true` before, simply remove setting the property