### PR TITLE
Exchange HTTP client implementation

### DIFF
--- a/dropwizard-testing/pom.xml
+++ b/dropwizard-testing/pom.xml
@@ -178,7 +178,11 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.connectors</groupId>
-            <artifactId>jersey-grizzly-connector</artifactId>
+            <artifactId>jersey-apache5-connector</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardAppExtension.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardAppExtension.java
@@ -11,15 +11,16 @@ import io.dropwizard.jersey.jackson.JacksonFeature;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.DropwizardTestSupport;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.glassfish.jersey.apache5.connector.Apache5ConnectorProvider;
+import org.glassfish.jersey.apache5.connector.Apache5HttpClientBuilderConfigurator;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.JerseyClientBuilder;
 import org.glassfish.jersey.client.RequestEntityProcessing;
-import org.glassfish.jersey.grizzly.connector.GrizzlyConnectorProvider;
 
 import javax.ws.rs.client.Client;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
@@ -256,8 +257,11 @@ public class DropwizardAppExtension<C extends Configuration> implements Dropwiza
 
     protected JerseyClientBuilder clientBuilder() {
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.connectorProvider(new GrizzlyConnectorProvider())
+        Apache5HttpClientBuilderConfigurator contentCompressionConfigurator =
+            HttpClientBuilder::disableContentCompression;
+        clientConfig.connectorProvider(new Apache5ConnectorProvider())
             .register(new JacksonFeature(getObjectMapper()))
+            .register(contentCompressionConfigurator)
             .property(ClientProperties.CONNECT_TIMEOUT, DEFAULT_CONNECT_TIMEOUT_MS)
             .property(ClientProperties.READ_TIMEOUT, DEFAULT_READ_TIMEOUT_MS)
             .property(ClientProperties.REQUEST_ENTITY_PROCESSING, RequestEntityProcessing.BUFFERED);


### PR DESCRIPTION
In `release/2.1.x` the Grizzly connector was introduced, since we needed a different connector for Java 17 and it passed the existing tests.

For `release/3.0.x` we can exchange the client with an other implementation. As @joschi suggested, we should keep our dependencies as simple as possible. Because we already use the Apache HttpClient in `dropwizard-client`, we can use the Jersey connector for that library.

To pass all existing tests, the Apache HttpClient is modified to defer content compression to Jersey. Else the `Content-Encoding` header [would be unset](https://github.com/apache/httpcomponents-client/blob/master/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ContentCompressionExec.java#L168). This breaks a test in the framework.

Since the `HttpUrlConnection` didn't do content decompression before, this change shouldn't break any implementation.