### PR TITLE
Expose MethodInterceptor and the invoke method

### DIFF
--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactory.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactory.java
@@ -108,7 +108,7 @@ public class UnitOfWorkAwareProxyFactory {
         return new UnitOfWorkAspect(sessionFactories);
     }
 
-    class MethodInterceptor {
+    public class MethodInterceptor {
 
         private final Map<String, SessionFactory> sessionFactories;
 
@@ -117,7 +117,7 @@ public class UnitOfWorkAwareProxyFactory {
         }
 
         @RuntimeType
-        Object invoke(@Origin Method overridden, @SuperCall Callable<Object> proxy) throws Throwable {
+        public Object invoke(@Origin Method overridden, @SuperCall Callable<Object> proxy) throws Throwable {
             final UnitOfWork[] unitsOfWork = overridden.getAnnotationsByType(UnitOfWork.class);
             if (unitsOfWork.length == 0) {
                 return proxy.call();


### PR DESCRIPTION
The `MethodInterceptor` cannot be found outside of the declaring package. Additionally, the `invoke` method has to be exposed, else ByteBuddy won't find a method to delegate to.

Closes #5873 