### PR TITLE
Remove the Jadira Usertype Core library

### DIFF
--- a/docs/source/manual/upgrade-notes/upgrade-notes-3_0_x.rst
+++ b/docs/source/manual/upgrade-notes/upgrade-notes-3_0_x.rst
@@ -77,3 +77,12 @@ Removal of classes from `dropwizard-util`
 Many classes from the ``dropwizard-util`` module are now obsolete, since the Java standard library provides replacements for them.
 
 For example the ``Sets`` class provided helper methods for creating ``Set`` instances. Starting from Java 9, this can be done by using ``Set.of(...)``.
+
+Jadira Usertype Core library
+============================
+Dropwizard previously registered the types from the Jadira Usertype Core library automatically.
+In order to align the versions 3.0.x and 4.0.x we will drop support for this library in Dropwizard 3
+because the current version of the Jadira Usertype Core library doesn't support Hibernate 6.x, which will be used in Dropwizard 4.0.x.
+
+If you want to continue using this library, you have to set the property ``jadira.usertype.autoRegisterUserTypes`` to ``true`` in your application's database configuration
+and add a dependency on the current version of the Usertype Core library.

--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -59,7 +59,6 @@
         <nullaway.version>0.10.2</nullaway.version>
         <slf4j.version>2.0.1</slf4j.version>
         <tomcat-jdbc.version>10.0.23</tomcat-jdbc.version>
-        <usertype.core.version>7.0.0.CR1</usertype.core.version>
 
         <!-- Test dependencies -->
         <assertj.version>3.23.1</assertj.version>
@@ -209,25 +208,6 @@
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
                 <version>${h2.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jadira.usertype</groupId>
-                <artifactId>usertype.core</artifactId>
-                <version>${usertype.core.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.joda</groupId>
-                        <artifactId>joda-money</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.geronimo.specs</groupId>
-                        <artifactId>geronimo-jta_1.1_spec</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>

--- a/dropwizard-hibernate/pom.xml
+++ b/dropwizard-hibernate/pom.xml
@@ -122,11 +122,6 @@
             <artifactId>byte-buddy</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jadira.usertype</groupId>
-            <artifactId>usertype.core</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
             <exclusions>

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryFactory.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/SessionFactoryFactory.java
@@ -84,7 +84,6 @@ public class SessionFactoryFactory {
         configuration.setProperty(AvailableSettings.ORDER_UPDATES, "true");
         configuration.setProperty(AvailableSettings.ORDER_INSERTS, "true");
         configuration.setProperty(AvailableSettings.USE_NEW_ID_GENERATOR_MAPPINGS, "true");
-        configuration.setProperty("jadira.usertype.autoRegisterUserTypes", "true");
         for (Map.Entry<String, String> property : properties.entrySet()) {
             configuration.setProperty(property.getKey(), property.getValue());
         }

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/common/DAOTest.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/common/DAOTest.java
@@ -117,7 +117,6 @@ public class DAOTest {
             config.setProperty(AvailableSettings.ORDER_UPDATES, "true");
             config.setProperty(AvailableSettings.ORDER_INSERTS, "true");
             config.setProperty(AvailableSettings.USE_NEW_ID_GENERATOR_MAPPINGS, "true");
-            config.setProperty("jadira.usertype.autoRegisterUserTypes", "true");
 
             entityClasses.forEach(config::addAnnotatedClass);
             properties.forEach(config::setProperty);


### PR DESCRIPTION
In order to align the versions 3.0.x and 4.0.x this PR drops support for Jadira Usertype Core in 3.0.x.