### PR TITLE
Fixed Possible Json Ordering Permutations Problem in Tests

### DIFF
--- a/dropwizard-health/src/test/java/io/dropwizard/health/response/JsonHealthResponseProviderTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/response/JsonHealthResponseProviderTest.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
@@ -61,7 +62,7 @@ class JsonHealthResponseProviderTest {
         // then
         assertThat(response.isHealthy()).isTrue();
         assertThat(response.getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
-        assertThat(response.getMessage()).isEqualToIgnoringWhitespace(fixture("/json/single-healthy-response.json"));
+        assertEquals(mapper.readTree(response.getMessage()), mapper.readTree(fixture("/json/single-healthy-response.json")));
     }
 
     @Test
@@ -87,7 +88,7 @@ class JsonHealthResponseProviderTest {
         // then
         assertThat(response.isHealthy()).isTrue();
         assertThat(response.getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
-        assertThat(response.getMessage()).isEqualToIgnoringWhitespace(fixture("/json/multiple-healthy-responses.json"));
+        assertEquals(mapper.readTree(response.getMessage()), mapper.readTree(fixture("/json/multiple-healthy-responses.json")));
     }
 
     @Test

--- a/dropwizard-health/src/test/java/io/dropwizard/health/response/JsonHealthResponseProviderTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/response/JsonHealthResponseProviderTest.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
@@ -62,7 +61,7 @@ class JsonHealthResponseProviderTest {
         // then
         assertThat(response.isHealthy()).isTrue();
         assertThat(response.getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
-        assertEquals(mapper.readTree(response.getMessage()), mapper.readTree(fixture("/json/single-healthy-response.json")));
+        assertThat(mapper.readTree(response.getMessage())).isEqualTo(mapper.readTree(fixture("/json/single-healthy-response.json")));
     }
 
     @Test
@@ -88,7 +87,7 @@ class JsonHealthResponseProviderTest {
         // then
         assertThat(response.isHealthy()).isTrue();
         assertThat(response.getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
-        assertEquals(mapper.readTree(response.getMessage()), mapper.readTree(fixture("/json/multiple-healthy-responses.json")));
+        assertThat(mapper.readTree(response.getMessage())).isEqualTo(mapper.readTree(fixture("/json/multiple-healthy-responses.json")));
     }
 
     @Test


### PR DESCRIPTION
# Summary

Following the problem of flakiness that occurred in the test file
`dropwizard-health io.dropwizard.health.response.JsonHealthResponseProviderTest`
with below three tests
```
shouldHandleMultipleHealthStateViewsCorrectly
shouldHandleSingleHealthStateViewCorrectly
```
The test flakiness is due to comparisons between Json Strings and outputs from
`response.getMessage()` which is an Object in JSON format that compare with a JSON file locates in the `resources `file.

However, JsonObject does not guarantee entry orders, its object is an unordered set of name/value pairs, and internal permutations may occur in the output as JSON String.

## Brief changelog

Since JSON library `com.fasterxml.jackson.databind.ObjectMapper` is used in the current project, I use `mapper.readTree(JSON String)` when comparing them, thus the equals() method ignores the order and treats them as equal.This will make the test more stable.

## Verifying this change

This test avoids nested or different orders of JSON strings that cause flaky errors.
Since I didn't touch any Source code, it should be no impact on the project.
And it passed the local test with.`mvn clean install -P contrib-check`
