### PR TITLE
Only include org.eclipse.m2e:lifecycle-mapping plugin under Eclipse IDE

### DIFF
--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -524,12 +524,30 @@
                     <artifactId>pgpverify-maven-plugin</artifactId>
                     <version>${pgpverify-maven-plugin.version}</version>
                 </plugin>
-                <plugin>
-                    <groupId>org.eclipse.m2e</groupId>
-                    <artifactId>lifecycle-mapping</artifactId>
-                    <version>${lifecycle-mapping.version}</version>
-                </plugin>
             </plugins>
         </pluginManagement>
     </build>
+
+    <profiles>
+        <profile>
+            <id>compile-eclipse</id>
+            <activation>
+                <jdk>1.8</jdk>
+                <property>
+                    <name>m2e.version</name>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.eclipse.m2e</groupId>
+                            <artifactId>lifecycle-mapping</artifactId>
+                            <version>${lifecycle-mapping.version}</version>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Renovate fails to look up `org.eclipse.m2e:lifecycle-mapping` because it is not a "real" Maven plugin. It is only available when running in Eclipse IDE.

> Renovate failed to look up the following dependencies: Failed to look up maven dependency `org.eclipse.m2e:lifecycle-mapping`.

By putting it into a profile (see also https://github.com/dropwizard/dropwizard/blob/v2.0.34/dropwizard-parent/pom.xml#L153-L195), Renovate should be able to parse the POM.