### PR TITLE
Update dependency com.fasterxml.jackson:jackson-bom to v2.14.0 (release/2.1.x)

### DIFF
--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -36,7 +36,7 @@
         <hk2.version>2.6.1</hk2.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.15</httpcore.version>
-        <jackson.version>2.13.4.20221013</jackson.version>
+        <jackson.version>2.14.0</jackson.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
         <jakarta.el.version>3.0.4</jakarta.el.version>
         <jakarta.inject-api.version>1.0.5</jakarta.inject-api.version>


### PR DESCRIPTION
Jackson 2.13 -> 2.14.0 to avoid CVE-2022-40153

The currently used jackson-bom [references](https://github.com/FasterXML/jackson-bom/blob/jackson-bom-2.13.4.20221013/pom.xml#L63) jackson-dataformat-xml 2.13.4 which [depends](https://github.com/FasterXML/jackson-dataformat-xml/blob/jackson-dataformat-xml-2.13.4/pom.xml#L90) on `woodstox-core:6.3.1`.

woodstox-core >= 6.0.0, < 6.4.0 is affected by a high severity vulnerability alert,  CVE-2022-40153.

jackson-dataformat 2.14.0, [via](https://github.com/FasterXML/jackson-bom/blob/jackson-bom-2.14.0/pom.xml#L63) jackson-bom 2.14.0, has updated the [dependency](https://github.com/FasterXML/jackson-dataformat-xml/blob/jackson-dataformat-xml-2.14.0/pom.xml#L90) to 6.4.0 which does not have the vulnerability.

###### Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->

###### Solution:
<!-- Describe the modifications you've done. -->

###### Result:
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->
