### PR TITLE
Introduce new Dropwizard specific conversion words

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -679,7 +679,7 @@ Console
           discardingThreshold: 0
           timeZone: UTC
           target: stdout
-          logFormat: "%-5p [%d{ISO8601,UTC}] %c: %m%n%rEx"
+          logFormat: "%-5p [%d{ISO8601,UTC}] %c: %m%n%dwREx"
           filterFactories:
             - type: URI
 
@@ -700,7 +700,7 @@ timeZone               UTC                                      The time zone to
                                                                 To use the system/default time zone, set it to ``system``.
 target                 stdout                                   The name of the standard stream to which events will be written.
                                                                 Can be ``stdout`` or ``stderr``.
-logFormat              %-5p [%d{ISO8601,UTC}] %c: %m%n%rEx      The Logback pattern with which events will be formatted. See
+logFormat              %-5p [%d{ISO8601,UTC}] %c: %m%n%dwREx    The Logback pattern with which events will be formatted. See
                                                                 the Logback_ documentation for details.
                                                                 The default log pattern is ```%h %l %u [%t{dd/MMM/yyyy:HH:mm:ss Z,UTC}] "%r" %s %b "%i{Referer}" "%i{User-Agent}" %D```.
                                                                 Use the placeholder ``%dwTimeZone`` to include the value of
@@ -733,7 +733,7 @@ File
           archivedLogFilenamePattern: /var/log/myapplication-%d.log
           archivedFileCount: 5
           timeZone: UTC
-          logFormat: "%-5p [%d{ISO8601,UTC}] %c: %m%n%rEx"
+          logFormat: "%-5p [%d{ISO8601,UTC}] %c: %m%n%dwREx"
           bufferSize: 8KiB
           immediateFlush: true
           filterFactories:
@@ -770,7 +770,7 @@ maxFileSize                  (unlimited)                                The maxi
 totalSizeCap                 (unlimited)                                Controls the total size of all files.
                                                                         Oldest archives are deleted asynchronously when the total size cap is exceeded.
 timeZone                     UTC                                        The time zone to which event timestamps will be converted.
-logFormat                    %-5p [%d{ISO8601,UTC}] %c: %m%n%rEx        The Logback pattern with which events will be formatted. See
+logFormat                    %-5p [%d{ISO8601,UTC}] %c: %m%n%dwREx      The Logback pattern with which events will be formatted. See
                                                                         the Logback_ documentation for details.
                                                                         The default log pattern is ```%h %l %u [%t{dd/MMM/yyyy:HH:mm:ss Z,UTC}] "%r" %s %b "%i{Referer}" "%i{User-Agent}" %D```.
                                                                         Use the placeholder ``%dwTimeZone`` to include the value of
@@ -802,7 +802,7 @@ Syslog
           facility: local0
           threshold: ALL
           stackTracePrefix: \t
-          logFormat: "%-5p [%d{ISO8601,UTC}] %c: %m%n%rEx"
+          logFormat: "%-5p [%d{ISO8601,UTC}] %c: %m%n%dwREx"
           filterFactories:
             - type: URI
 
@@ -818,7 +818,7 @@ facility                     local0                                 The syslog f
                                                                     ``local1``, ``local2``, ``local3``, ``local4``, ``local5``,
                                                                     ``local6``, or ``local7``.
 threshold                    ALL                                    The lowest level of events to write to the file.
-logFormat                    %-5p [%d{ISO8601,UTC}] %c: %m%n%rEx    The Logback pattern with which events will be formatted. See
+logFormat                    %-5p [%d{ISO8601,UTC}] %c: %m%n%dwREx  The Logback pattern with which events will be formatted. See
                                                                     the Logback_ documentation for details.
                                                                     The default log pattern is ```%h %l %u [%t{dd/MMM/yyyy:HH:mm:ss Z,UTC}] "%r" %s %b "%i{Referer}" "%i{User-Agent}" %D```.
 stackTracePrefix             \t                                     The prefix to use when writing stack trace lines (these are sent

--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -846,6 +846,12 @@ A few items of note:
   Instead, `\t` is used (this is the default value of the `SyslogAppender` that comes with Logback). This can be
   configured with the `stackTracePrefix` option when defining your appender.
 
+To apply the prefixing with the `!` symbol Dropwizard introduces several new `Logback conversion words <https://logback.qos.ch/manual/layouts.html#conversionWord>`_.
+These are ``dwEx``, ``dwException``, ``dwThrowable``, ``dwXEx``, ``dwXException``, ``dwXThrowable``, ``dwREx`` and ``dwRootException``.
+These conversion words work like the ones from Logback, except that the first tab of a stack trace is replaced by a `!`.
+
+The default Dropwizard logging layout uses the Dropwizard specific conversion words.
+
 Configuration
 -------------
 

--- a/docs/source/manual/upgrade-notes/upgrade-notes-3_0_x.rst
+++ b/docs/source/manual/upgrade-notes/upgrade-notes-3_0_x.rst
@@ -86,3 +86,20 @@ because the current version of the Jadira Usertype Core library doesn't support 
 
 If you want to continue using this library, you have to set the property ``jadira.usertype.autoRegisterUserTypes`` to ``true`` in your application's database configuration
 and add a dependency on the current version of the Usertype Core library.
+
+Logback layout conversion words
+===============================
+Logback allows to use specific `conversion words <https://logback.qos.ch/manual/layouts.html#conversionWord>`_ in its ``PatternLayout`` to insert information obtained by an instance of a specific ``Converter``.
+
+Previously, Dropwizard has overridden the abbreviated conversion words for exceptions (``ex``, ``xEx`` and ``rEx``) to apply stack trace prefixing with a `!` rather than a tab.
+
+In Dropwizard 3.x these overrides are removed and all exception conversion words work as documented in the Logback manual.
+To apply the stack trace prefixing, new conversion words are introduced with a prefix ``dw``. Therefore the following new conversion words can be used:
+
+ - ``dwEx``, ``dwException`` and ``dwThrowable`` instead of ``ex``, ``exception`` and ``throwable``
+ - ``dwXEx``, ``dwXException`` and ``dwXThrowable`` instead of ``xEx``, ``xException`` and ``xThrowable``
+ - ``dwREx`` and ``dwRootException`` instead of ``rEx`` and ``rootException``
+
+Those newly introduced conversion words work like the Logback ones, except that the first tab is replaced by a `!`.
+
+To simplify the upgrade to Dropwizard 3.x for most users, the default Dropwizard logging layout is modified to use the new Dropwizard specific conversion words.

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/common/DropwizardLayout.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/common/DropwizardLayout.java
@@ -3,6 +3,7 @@ package io.dropwizard.logging.common;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.PatternLayout;
 
+import java.util.Map;
 import java.util.TimeZone;
 
 /**
@@ -17,10 +18,16 @@ public class DropwizardLayout extends PatternLayout {
     public DropwizardLayout(LoggerContext context, TimeZone timeZone) {
         super();
         setOutputPatternAsHeader(false);
-        getDefaultConverterMap().put("ex", PrefixedThrowableProxyConverter.class.getName());
-        getDefaultConverterMap().put("xEx", PrefixedExtendedThrowableProxyConverter.class.getName());
-        getDefaultConverterMap().put("rEx", PrefixedRootCauseFirstThrowableProxyConverter.class.getName());
-        setPattern("%-5p [%d{ISO8601," + timeZone.getID() + "}] %c: %m%n%rEx");
+        Map<String, String> defaultConverterMap = getDefaultConverterMap();
+        defaultConverterMap.put("dwEx", PrefixedThrowableProxyConverter.class.getName());
+        defaultConverterMap.put("dwException", PrefixedThrowableProxyConverter.class.getName());
+        defaultConverterMap.put("dwThrowable", PrefixedThrowableProxyConverter.class.getName());
+        defaultConverterMap.put("dwREx", PrefixedRootCauseFirstThrowableProxyConverter.class.getName());
+        defaultConverterMap.put("dwRootException", PrefixedRootCauseFirstThrowableProxyConverter.class.getName());
+        defaultConverterMap.put("dwXEx", PrefixedExtendedThrowableProxyConverter.class.getName());
+        defaultConverterMap.put("dwXException", PrefixedExtendedThrowableProxyConverter.class.getName());
+        defaultConverterMap.put("dwXThrowable", PrefixedExtendedThrowableProxyConverter.class.getName());
+        setPattern("%-5p [%d{ISO8601," + timeZone.getID() + "}] %c: %m%n%dwREx");
         setContext(context);
     }
 }

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/common/DropwizardLayoutTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/common/DropwizardLayoutTest.java
@@ -16,13 +16,13 @@ class DropwizardLayoutTest {
     @Test
     void prefixesThrowables() throws Exception {
         assertThat(layout.getDefaultConverterMap())
-                .containsEntry("ex", PrefixedThrowableProxyConverter.class.getName());
+                .containsEntry("dwEx", PrefixedThrowableProxyConverter.class.getName());
     }
 
     @Test
     void prefixesExtendedThrowables() throws Exception {
         assertThat(layout.getDefaultConverterMap())
-                .containsEntry("xEx", PrefixedExtendedThrowableProxyConverter.class.getName());
+                .containsEntry("dwXEx", PrefixedExtendedThrowableProxyConverter.class.getName());
     }
 
     @Test
@@ -34,6 +34,6 @@ class DropwizardLayoutTest {
     @Test
     void hasAPatternWithATimeZoneAndExtendedThrowables() throws Exception {
         assertThat(layout.getPattern())
-                .isEqualTo("%-5p [%d{ISO8601,UTC}] %c: %m%n%rEx");
+                .isEqualTo("%-5p [%d{ISO8601,UTC}] %c: %m%n%dwREx");
     }
 }


### PR DESCRIPTION
Follow-up for #4211.

This PR introduces the new conversion words `dwEx`, `dwException`, `dwThrowable`, `dwXEx`, `dwXException`, `dwXThrowable`, `dwREx` and `dwRootException`. Therefore all exception specific Logback conversion words work as documented in the Logback manual. This improves our configuration docs, which previously deferred to the Logback documentation without a note on the conversion word overrides.

Additionally, a section in the core docs is added to explain the stack trace prefixing.