### PR TITLE
Cache proxy classes

### DIFF
--- a/dropwizard-hibernate/pom.xml
+++ b/dropwizard-hibernate/pom.xml
@@ -68,6 +68,14 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker-qual</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
         </dependency>

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactory.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactory.java
@@ -1,5 +1,8 @@
 package io.dropwizard.hibernate;
 
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.implementation.MethodDelegation;
@@ -7,6 +10,8 @@ import net.bytebuddy.implementation.bind.annotation.Origin;
 import net.bytebuddy.implementation.bind.annotation.RuntimeType;
 import net.bytebuddy.implementation.bind.annotation.SuperCall;
 import net.bytebuddy.matcher.ElementMatchers;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.SessionFactory;
 
 import java.lang.reflect.InvocationTargetException;
@@ -29,19 +34,38 @@ import java.util.stream.Collectors;
 public class UnitOfWorkAwareProxyFactory {
 
     private final Map<String, SessionFactory> sessionFactories;
+    private final LoadingCache<Class<?>, Class<?>> proxyCache;
 
     public UnitOfWorkAwareProxyFactory(String name, SessionFactory sessionFactory) {
+        this(Caffeine.newBuilder(), name, sessionFactory);
+    }
+
+    public UnitOfWorkAwareProxyFactory(Caffeine<Object, Object> proxyCacheBuilder, String name, SessionFactory sessionFactory) {
         sessionFactories = Collections.singletonMap(name, sessionFactory);
+        proxyCache = buildCache(proxyCacheBuilder);
     }
 
     public UnitOfWorkAwareProxyFactory(HibernateBundle<?>... bundles) {
+        this(Caffeine.newBuilder(), bundles);
+    }
+
+    public UnitOfWorkAwareProxyFactory(Caffeine<Object, Object> proxyCacheBuilder, HibernateBundle<?>... bundles) {
         final Map<String, SessionFactory> sessionFactoriesBuilder = new HashMap<>();
         for (HibernateBundle<?> bundle : bundles) {
             sessionFactoriesBuilder.put(bundle.name(), bundle.getSessionFactory());
         }
         sessionFactories = Collections.unmodifiableMap(sessionFactoriesBuilder);
+        proxyCache = buildCache(proxyCacheBuilder);
     }
 
+    private LoadingCache<Class<?>, Class<?>> buildCache(Caffeine<Object, Object> proxyCacheBuilder) {
+        return proxyCacheBuilder.build(new CacheLoader<Class<?>, Class<?>>() {
+            @Override
+            public @Nullable Class<?> load(@NonNull Class<?> key) {
+                return createProxyClass(key);
+            }
+        });
+    }
 
     /**
      * Creates a new <b>@UnitOfWork</b> aware proxy of a class with the default constructor.
@@ -76,12 +100,9 @@ public class UnitOfWorkAwareProxyFactory {
      * @param <T>                   the type of the class
      * @return a new proxy
      */
+    @SuppressWarnings("unchecked")
     public <T> T create(Class<T> clazz, Class<?>[] constructorParamTypes, Object[] constructorArguments) {
-        final Class<? extends T> proxied = new ByteBuddy().subclass(clazz).method(ElementMatchers.any())
-            .intercept(MethodDelegation.to(new MethodInterceptor(sessionFactories)))
-            .make()
-            .load(clazz.getClassLoader(), ClassLoadingStrategy.Default.INJECTION)
-            .getLoaded();
+        final Class<? extends T> proxied = (Class<? extends T>) proxyCache.get(clazz);
 
         try {
             return (constructorParamTypes.length == 0 ?
@@ -91,6 +112,14 @@ public class UnitOfWorkAwareProxyFactory {
                 InvocationTargetException e) {
             throw new IllegalStateException("Unable to create a proxy for the class '" + clazz + "'", e);
         }
+    }
+
+    protected <T> Class<? extends T> createProxyClass(Class<T> classToProxy) {
+        return new ByteBuddy().subclass(classToProxy).method(ElementMatchers.any())
+            .intercept(MethodDelegation.to(new MethodInterceptor(sessionFactories)))
+            .make()
+            .load(classToProxy.getClassLoader(), ClassLoadingStrategy.Default.INJECTION)
+            .getLoaded();
     }
 
     /**


### PR DESCRIPTION
Closes #6263 

This PR introduces caching for proxy classes. Javassist automatically did this while ByteBuddy doesn't use a cache internally.

This change will provide small benefit in comparison to the maintenance IMHO. See what you think about it.