### PR TITLE
Flush appenders before stopping

### DIFF
--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/TlsSocketAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/TlsSocketAppenderFactoryTest.java
@@ -72,6 +72,7 @@ class TlsSocketAppenderFactoryTest {
             Logger logger = LoggerFactory.getLogger("com.example.app");
             List<String> loggedMessages = generateLogs(logger);
 
+            loggingFactory.stop();
             loggingFactory.reset();
 
             assertThat(receivedMessages.get(1, TimeUnit.MINUTES))


### PR DESCRIPTION
Attempt to fix an unstable test in the class `TlsSocketAppenderFactoryTest`.

### Problem:
`loggingFactory.reset()` must be called in order to receive the logged messages because it closes the `OutputStream` of the `Socket` in the appender. The relevant call is `detachAndStopAllAppenders()` which eventually closes the appender but maybe discards messages to be written asynchronously.

If the appender is closed before all asynchronously messages are written, the test fails. This leads to a race condition between writing the log messages and closing the appender.

### Solution:
`loggingFactory.stop()` will attempt to flush outstanding log messages, so the messages should all be written when the appender eventually gets stopped.