### PR TITLE
Adjust tests to different optional behaviour of Jersey 2.38

### DIFF
--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalCookieParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalCookieParamResourceTest.java
@@ -34,9 +34,10 @@ class OptionalCookieParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    void shouldReturnMessageWhenMessageIsBlank() {
+    void shouldReturnDefaultMessageWhenMessageIsBlank() {
+        String defaultMessage = "Default Message";
         String response = target("/optional/message").request().cookie("message", "").get(String.class);
-        assertThat(response).isEmpty();
+        assertThat(response).isEqualTo(defaultMessage);
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalFormParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalFormParamResourceTest.java
@@ -37,11 +37,12 @@ class OptionalFormParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    void shouldReturnMessageWhenMessageBlank() {
+    void shouldReturnDefaultMessageWhenMessageBlank() {
+        String defaultMessage = "Default Message";
         final Form form = new Form("message", "");
         final Response response = target("/optional/message").request().post(Entity.form(form));
 
-        assertThat(response.readEntity(String.class)).isEmpty();
+        assertThat(response.readEntity(String.class)).isEqualTo(defaultMessage);
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalHeaderParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalHeaderParamResourceTest.java
@@ -34,9 +34,10 @@ class OptionalHeaderParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    void shouldReturnMessageWhenMessageIsBlank() {
+    void shouldReturnDefaultMessageWhenMessageIsBlank() {
+        String defaultMessage = "Default Message";
         String response = target("/optional/message").request().header("message", "").get(String.class);
-        assertThat(response).isEmpty();
+        assertThat(response).isEqualTo(defaultMessage);
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalQueryParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/optional/OptionalQueryParamResourceTest.java
@@ -41,9 +41,10 @@ class OptionalQueryParamResourceTest extends AbstractJerseyTest {
     }
 
     @Test
-    void shouldReturnMessageWhenMessageIsBlank() {
+    void shouldReturnDefaultMessageWhenMessageIsBlank() {
+        String defaultMessage = "Default Message";
         String response = target("/optional/message").queryParam("message", "").request().get(String.class);
-        assertThat(response).isEmpty();
+        assertThat(response).isEqualTo(defaultMessage);
     }
 
     @Test

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
@@ -1147,13 +1147,14 @@ class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     }
 
     @Test
-    void optionalInt_fails_with_empty_string() {
+    void optionalInt_succeeds_with_empty_string() {
         final Response response = target("/valid/optionalInt")
                 .queryParam("num", "")
                 .request()
                 .get();
 
-        assertThat(response.getStatus()).isEqualTo(404);
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.readEntity(Integer.class)).isEqualTo(42);
     }
 
     @Test
@@ -1207,7 +1208,8 @@ class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
                 .request()
                 .get();
 
-        assertThat(response.getStatus()).isEqualTo(404);
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.readEntity(Integer.class)).isEqualTo(42);
     }
 
     @Test


### PR DESCRIPTION
Follow-up for #6380

The `Optional` handling was changed in https://github.com/eclipse-ee4j/jersey/pull/5194. An `Optional` will be empty, if an empty string is provided for a parameter. This partially restores behavior previous to Jersey 2.35: [here](https://github.com/dropwizard/dropwizard/commit/38277c4339ed2731a58f49df5dbb6bc228882eb3#diff-4d6c6806a2239cf8f9414414c0cb9602f9cb87eb55460aa762ce92d94f85417aL1205-L1206) the new status is 200 again, but the default value isn't processed. The `Optional` is empty.

(cherry picked from commit 6af3f10513d527d1d704a71a82743569b7c0b434)