### PR TITLE
Provides "Required" configuration file parameter

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/cli/ConfiguredCommand.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/ConfiguredCommand.java
@@ -78,6 +78,19 @@ public abstract class ConfiguredCommand<T extends Configuration> extends Command
                         .help("application configuration file");
     }
 
+
+    /**
+     * Adds the required configuration file argument for the configured command.
+     * @param subparser The subparser to register the argument on
+     * @return the register argument
+     */
+    protected Argument addRequiredFileArgument(Subparser subparser) {
+        return subparser.addArgument("file")
+                        .nargs(1)
+                        .help("application configuration file");
+    }
+
+
     @Override
     @SuppressWarnings("unchecked")
     public void run(Bootstrap<?> wildcardBootstrap, Namespace namespace) throws Exception {

--- a/dropwizard-core/src/main/java/io/dropwizard/cli/ConfiguredCommand.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/cli/ConfiguredCommand.java
@@ -86,7 +86,6 @@ public abstract class ConfiguredCommand<T extends Configuration> extends Command
      */
     protected Argument addRequiredFileArgument(Subparser subparser) {
         return subparser.addArgument("file")
-                        .nargs(1)
                         .help("application configuration file");
     }
 


### PR DESCRIPTION
###### Problem:

One of my applications needs an `EnvironmentCommand` that has an additional (custom) positional parameter that requires at least one argument.
I.e. I am specifying the argument using the "+" format: `.nargs("+")`

In the error case where I fail to include any arguments (for my additional parameter):
`java com.company.MyApplication myCommand config.yml`

I want the application to print the standard help text saying that I am missing the required argument.

However argparse4j gets confused, because it allocates the one argument it does have `config.yml` to my custom argument and then assumes that the application doesn't need a config file.

This leads to spurious error/exception output, as various parts of the application fail to initialize without their configuration.

Critically the standard usage message is never printed, because other exceptions prevent that usage logic from getting executed.

###### Solution:

I realize that not all applications require a configuration file - otherwise I would have simply changed the standard method to call `.nargs(1)`.

Instead I added an additional method that sets up the config file as a required parameter.
So in the configure method of the command instead of calling:  `super.configure(subparser);`
I now call:  `addRequiredFileArgument(subparser);`


###### Result:

At the end of the day I just want a way of saying that one (or in my case all) of the Environment/Configured commands require the config file to operate correctly.

I can just extend the `EnvironmentCommand` in my own code base to override the standard method.
But I would like some standard way of providing this functionality in the core of DropWizard so that future updates don't break my code base.

I understand I could make sure all parts of my application work correctly without a config, but that is a lot of work when the most common case is that someone simply forgets an argument on the command line, then gets pages of irrelevant exception output.

Finally, I realize that this extra method is still a kludge - the primary reason for this PR is just to explain the problem - so someone more familiar with the core code base can come up with a better solution.