### PR TITLE
Switch back to subclass mock maker in `dropwizard-servlets`

### DIFF
--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -415,6 +415,11 @@
                 <version>${mockito.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-subclass</artifactId>
+                <version>${mockito.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${assertj.version}</version>

--- a/dropwizard-servlets/pom.xml
+++ b/dropwizard-servlets/pom.xml
@@ -75,6 +75,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-subclass</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-http</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
###### Problem:
The update to Mockito 5.x brought the new inlining mockmaker as default, which currently breaks our tests in the `dropwizard-servlets` module.

###### Solution:
Use the older subclassing mockmaker, which was the default in Mockito up to 5.x.
