### PR TITLE
4.0.x Timestamp field comes first in generated JSON log output

### DIFF
--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/MapBuilder.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/MapBuilder.java
@@ -2,7 +2,7 @@ package io.dropwizard.logging.json.layout;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -32,7 +32,8 @@ public class MapBuilder {
         this.timestampFormatter = timestampFormatter;
         this.customFieldNames = requireNonNull(customFieldNames);
         this.additionalFields = requireNonNull(additionalFields);
-        this.map = new HashMap<>(expectedSize);
+        this.map = new LinkedHashMap<>(expectedSize);
+        this.map.put(getFieldName("timestamp"), null); // Insert a null timestamp at first and fix it at build time
     }
 
     /**
@@ -132,6 +133,7 @@ public class MapBuilder {
 
     public Map<String, Object> build() {
         map.putAll(additionalFields);
+        map.remove(getFieldName("timestamp"), null); // drop the "timestamp" field if never assigned a real value
         return map;
     }
 

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
@@ -153,6 +153,7 @@ class LayoutIntegrationTests {
             await().atMost(1, TimeUnit.SECONDS).until(() -> !redirectedStream.toString().isEmpty());
 
             JsonNode jsonNode = objectMapper.readTree(redirectedStream.toString());
+            assertThat(jsonNode.fieldNames().next()).isEqualTo("timestamp");
             assertThat(jsonNode.get("timestamp").isTextual()).isTrue();
             assertThat(jsonNode.get("level").asText()).isEqualTo("INFO");
             assertThat(jsonNode.get("logger").asText()).isEqualTo("com.example.app");
@@ -212,6 +213,7 @@ class LayoutIntegrationTests {
             await().atMost(1, TimeUnit.SECONDS).until(() -> !redirectedStream.toString().isEmpty());
 
             JsonNode jsonNode = objectMapper.readTree(redirectedStream.toString());
+            assertThat(jsonNode.fieldNames().next()).isEqualTo("timestamp");
             assertThat(jsonNode.get("timestamp").isNumber()).isTrue();
             assertThat(jsonNode.get("requestTime").isNumber()).isTrue();
             assertThat(jsonNode.get("remoteAddress").asText()).isEqualTo("10.0.0.1");

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/MapBuilderTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/MapBuilderTest.java
@@ -118,4 +118,28 @@ class MapBuilderTest {
     void testAddMapSupplierNotInvoked() {
         assertThat(mapBuilder.addMap("status", false, () -> {throw new RuntimeException();}).build()).isEmpty();
     }
+
+    @Test
+    void testTimestampIsAlwaysFirst() {
+        mapBuilder.add("status", true, "200");
+        mapBuilder.addTimestamp("timestamp", true, 1514906361000L);
+        mapBuilder.addNumber("code", true, 123);
+        mapBuilder.addTimestamp("timestamp2", true, 1514906361000L);
+
+        assertThat(mapBuilder.build().keySet())
+            .containsExactly("timestamp", "status", "code", "timestamp2");
+    }
+    @Test
+    void testTimestampIsAlwaysFirstWhenRenamed() {
+        final MapBuilder mapBuilder = new MapBuilder(timestampFormatter,
+            Collections.singletonMap("timestamp", "renamed-timestamp"), Collections.emptyMap(), size);
+
+        mapBuilder.add("status", true, "200");
+        mapBuilder.addNumber("code", true, 123);
+        mapBuilder.addTimestamp("timestamp2", true, 1514906361000L);
+        mapBuilder.addTimestamp("timestamp", true, 1514906361000L);
+
+        assertThat(mapBuilder.build().keySet())
+            .containsExactly("renamed-timestamp", "status", "code", "timestamp2");
+    }
 }


### PR DESCRIPTION
Duplicate of #6642 except targeting release/4.0.x

###### Problem:
json-logging outputs JSON objects with undefined field order, but some log processing services (ex. Splunk) require the timestamp field to be within the first N characters of an object.

###### Solution:
The MapBuilder class now maintains insertion order (via LinkedHashMap) except that the "timestamp" field is always written first.

###### Result:
The output JSON from json-logging always has the timestamp field appear first within the object