### PR TITLE
Add configurable response code meters

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -36,6 +36,8 @@ maxThreads                          1024                                        
 minThreads                          8                                                The minimum number of threads to keep alive in the thread pool. Note that each Jetty connector consumes threads from the pool. See :ref:`HTTP connector <man-configuration-http>` how the thread counts are calculated.
 maxQueuedRequests                   1024                                             The maximum number of requests to queue before blocking
                                                                                      the acceptors.
+responseMeteredLevel                COARSE                                           The response metered level to decide what response code meters are included
+metricPrefix                        (none)                                           The metricPrefix to use in the metric name for jetty metrics
 idleThreadTimeout                   1 minute                                         The amount of time a worker thread can be idle before
                                                                                      being stopped.
 nofileSoftLimit                     (none)                                           The number of open file descriptors before a soft error is issued.

--- a/dropwizard-core/pom.xml
+++ b/dropwizard-core/pom.xml
@@ -63,6 +63,10 @@
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-annotation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-jetty9</artifactId>
             <exclusions>
                 <exclusion>

--- a/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
@@ -1,6 +1,7 @@
 package io.dropwizard.server;
 
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.annotation.ResponseMeteredLevel;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.codahale.metrics.jetty9.InstrumentedHandler;
 import com.codahale.metrics.jetty9.InstrumentedQueuedThreadPool;
@@ -56,6 +57,8 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.stream.Collectors;
 
+import static com.codahale.metrics.annotation.ResponseMeteredLevel.COARSE;
+
 /**
  * A base class for {@link ServerFactory} implementations.
  * <p/>
@@ -80,6 +83,16 @@ import java.util.stream.Collectors;
  *         <td>{@code serverPush}</td>
  *         <td></td>
  *         <td>The {@link ServerPushFilterFactory} configuration.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code responseMeteredLevel}</td>
+ *         <td>COARSE</td>
+ *         <td>The response metered level to decide what response code meters are included.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code metricPrefix}</td>
+ *         <td></td>
+ *         <td>The metricPrefix to use in the metric name for jetty metrics.</td>
  *     </tr>
  *     <tr>
  *         <td>{@code maxThreads}</td>
@@ -238,6 +251,13 @@ public abstract class AbstractServerFactory implements ServerFactory {
     @NotNull
     private ServerPushFilterFactory serverPush = new ServerPushFilterFactory();
 
+    @Valid
+    @NotNull
+    private ResponseMeteredLevel responseMeteredLevel = COARSE;
+
+    @Nullable
+    private String metricPrefix;
+
     @Min(4)
     private int maxThreads = 1024;
 
@@ -330,6 +350,17 @@ public abstract class AbstractServerFactory implements ServerFactory {
     @JsonProperty("serverPush")
     public void setServerPush(ServerPushFilterFactory serverPush) {
         this.serverPush = serverPush;
+    }
+
+    @JsonProperty("responseMeteredLevel")
+    public ResponseMeteredLevel getResponseMeteredLevel() {
+        return responseMeteredLevel;
+    }
+
+    @JsonProperty("metricPrefix")
+    @Nullable
+    public String getMetricPrefix() {
+        return metricPrefix;
     }
 
     @JsonProperty
@@ -601,7 +632,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
             }
             handler.addServlet(new ServletHolder("jersey", jerseyContainer), jersey.getUrlPattern());
         }
-        final InstrumentedHandler instrumented = new InstrumentedHandler(metricRegistry);
+        final InstrumentedHandler instrumented = new InstrumentedHandler(metricRegistry, metricPrefix, responseMeteredLevel);
         instrumented.setServer(server);
         instrumented.setHandler(handler);
         return instrumented;

--- a/dropwizard-core/src/test/java/io/dropwizard/server/AbstractServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/AbstractServerFactoryTest.java
@@ -1,5 +1,6 @@
 package io.dropwizard.server;
 
+import com.codahale.metrics.annotation.ResponseMeteredLevel;
 import io.dropwizard.Configuration;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.setup.JerseyContainerHolder;
@@ -66,6 +67,16 @@ class AbstractServerFactoryTest {
         serverFactory.build(environment);
 
         assertThat(jerseyEnvironment.getUrlPattern()).isEqualTo(DEFAULT_PATTERN);
+    }
+
+    @Test
+    void usesDefaultResponseMeteredLevelWhenNotSet() {
+        assertThat(serverFactory.getResponseMeteredLevel()).isEqualTo(ResponseMeteredLevel.COARSE);
+    }
+
+    @Test
+    void usesDefaultMetricPrefixWhenNotSet() {
+        assertThat(serverFactory.getMetricPrefix()).isNull();
     }
 
     /**

--- a/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/server/DefaultServerFactoryTest.java
@@ -39,6 +39,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import static com.codahale.metrics.annotation.ResponseMeteredLevel.ALL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -85,6 +86,18 @@ class DefaultServerFactoryTest {
     void hasAMinimumNumberOfThreads() {
         assertThat(http.getMinThreads())
                 .isEqualTo(89);
+    }
+
+    @Test
+    void hasResponseMeteredLevel() {
+        assertThat(http.getResponseMeteredLevel())
+            .isEqualTo(ALL);
+    }
+
+    @Test
+    void hasMetricPrefix() {
+        assertThat(http.getMetricPrefix())
+            .isEqualTo("jetty");
     }
 
     @Test

--- a/dropwizard-core/src/test/resources/yaml/server.yml
+++ b/dropwizard-core/src/test/resources/yaml/server.yml
@@ -5,6 +5,8 @@ requestLog:
       currentLogFilename: ./logs/requests.log
       archivedLogFilenamePattern: ./logs/requests-%d.log.gz
       archivedFileCount: 5
+responseMeteredLevel: ALL
+metricPrefix: jetty
 gzip:
   enabled: false
 serverPush:


### PR DESCRIPTION
###### Problem:
Currently we only have top level 1xx/2xx/3xx/4xx/5xx meters at the jetty level. We have many use cases where we care about specific response codes like 401/503 and resort to manually instrumenting responses from every resource. This PR allows users to configure what response code meters to include.

###### Solution:
With the new release of metrics (since 4.2.16), we can specify what response code meters to include. Exposed the same via ```AbstractServerFactory```. Additionally allowed specifying the ```metricPrefix``` to include for jetty metrics

###### Result:
To maintain backward compatibility the default behavior remains the same with this change. Users will have to explicitly specify the DETAILED/ALL responseMeteredLevel if they want more response code meters.
