### PR TITLE
Add configurable response code meters

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -36,6 +36,8 @@ maxThreads                          1024                                        
 minThreads                          8                                                The minimum number of threads to keep alive in the thread pool. Note that each Jetty connector consumes threads from the pool. See :ref:`HTTP connector <man-configuration-http>` how the thread counts are calculated.
 maxQueuedRequests                   1024                                             The maximum number of requests to queue before blocking
                                                                                      the acceptors.
+responseMeteredLevel                COARSE                                           The response metered level to decide what response code meters are included
+metricPrefix                        (none)                                           The metricPrefix to use in the metric name for jetty metrics
 idleThreadTimeout                   1 minute                                         The amount of time a worker thread can be idle before
                                                                                      being stopped.
 nofileSoftLimit                     (none)                                           The number of open file descriptors before a soft error is issued.

--- a/dropwizard-core/pom.xml
+++ b/dropwizard-core/pom.xml
@@ -77,6 +77,10 @@
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-annotation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-jvm</artifactId>
         </dependency>
         <dependency>

--- a/dropwizard-core/src/test/java/io/dropwizard/core/server/AbstractServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/core/server/AbstractServerFactoryTest.java
@@ -1,5 +1,6 @@
 package io.dropwizard.core.server;
 
+import com.codahale.metrics.annotation.ResponseMeteredLevel;
 import io.dropwizard.core.Application;
 import io.dropwizard.core.Configuration;
 import io.dropwizard.core.setup.Environment;
@@ -67,6 +68,16 @@ class AbstractServerFactoryTest {
         serverFactory.build(environment);
 
         assertThat(jerseyEnvironment.getUrlPattern()).isEqualTo(DEFAULT_PATTERN);
+    }
+
+    @Test
+    void usesDefaultResponseMeteredLevelWhenNotSet() {
+        assertThat(serverFactory.getResponseMeteredLevel()).isEqualTo(ResponseMeteredLevel.COARSE);
+    }
+
+    @Test
+    void usesDefaultMetricPrefixWhenNotSet() {
+        assertThat(serverFactory.getMetricPrefix()).isNull();
     }
 
     /**

--- a/dropwizard-core/src/test/java/io/dropwizard/core/server/DefaultServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/core/server/DefaultServerFactoryTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import static com.codahale.metrics.annotation.ResponseMeteredLevel.ALL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -86,6 +87,18 @@ class DefaultServerFactoryTest {
     void hasAMinimumNumberOfThreads() {
         assertThat(http.getMinThreads())
                 .isEqualTo(89);
+    }
+
+    @Test
+    void hasResponseMeteredLevel() {
+        assertThat(http.getResponseMeteredLevel())
+            .isEqualTo(ALL);
+    }
+
+    @Test
+    void hasMetricPrefix() {
+        assertThat(http.getMetricPrefix())
+            .isEqualTo("jetty");
     }
 
     @Test

--- a/dropwizard-core/src/test/resources/yaml/server.yml
+++ b/dropwizard-core/src/test/resources/yaml/server.yml
@@ -5,6 +5,8 @@ requestLog:
       currentLogFilename: ./logs/requests.log
       archivedLogFilenamePattern: ./logs/requests-%d.log.gz
       archivedFileCount: 5
+responseMeteredLevel: ALL
+metricPrefix: jetty
 gzip:
   enabled: false
 serverPush:


### PR DESCRIPTION
###### Problem:
Currently we only have top level 1xx/2xx/3xx/4xx/5xx meters at the jetty level. We have many use cases where we care about specific response codes like 401/503 and resort to manually instrumenting responses from every resource. This PR allows users to configure what response code meters to include.

###### Solution:
With the new release of metrics (since 4.2.16), we can specify what response code meters to include. Exposed the same via ```AbstractServerFactory```. Additionally allowed specifying the ```metricPrefix``` to include for jetty metrics

###### Result:
To maintain backward compatibility the default behavior remains the same with this change. Users will have to explicitly specify the DETAILED/ALL responseMeteredLevel if they want more response code meters.

Refs https://github.com/dropwizard/dropwizard/pull/6692