### PR TITLE
Revert "Update scacap/action-surefire-report digest to 01b2782"

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -46,7 +46,7 @@ jobs:
         path: '**/*-reports'
     - name: Publish Test Results
       if: always()
-      uses: scacap/action-surefire-report@01b27826d208fcb14a8c92a40cb01865c160b825 # v1
+      uses: scacap/action-surefire-report@a2d14baac06028516812d93c36cb9c99aa50198e # v1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         check_name: Test Report (${{ matrix.os }} - Java ${{ matrix.java_version }})


### PR DESCRIPTION
Reverts dropwizard/dropwizard#6788

```
Run scacap/action-surefire-report@01b27826d208fcb14a8c92a40cb01865c160b825
  with:
    github_token: ***
    check_name: Test Report (windows-latest - Java 17)
    report_paths: **/*-reports/TEST-*.xml
    create_check: true
    fail_on_test_failures: false
    fail_if_no_tests: true
    skip_publishing: false
    file_name_in_stack_trace: false
  env:
    JAVA_OPTS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
    JAVA_HOME: C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\17.0.6-10\x6[4](https://github.com/dropwizard/dropwizard/actions/runs/4382796006/jobs/7672260302#step:7:4)
    JAVA_HOME_17_X[6](https://github.com/dropwizard/dropwizard/actions/runs/4382796006/jobs/7672260302#step:7:6)4: C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\1[7](https://github.com/dropwizard/dropwizard/actions/runs/4382796006/jobs/7672260302#step:7:7).0.6-[10](https://github.com/dropwizard/dropwizard/actions/runs/4382796006/jobs/7672260302#step:7:10)\x64
Error: Container action is only supported on Linux
```