### PR TITLE
Use Mockito BOM in dropwizard-dependencies

### DIFF
--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -457,13 +457,10 @@
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
+                <artifactId>mockito-bom</artifactId>
                 <version>${mockito.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-junit-jupiter</artifactId>
-                <version>${mockito.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>


### PR DESCRIPTION
###### Problem:
Keeping Mockito versions in sync with dropwizard can be a little tedious.

###### Solution:
Mockito publishes a bom, use that bom in the dropwizard-dependencies bom so importers of the dropwizard-dependencies bom can enjoy some small ergonomic benefit by no longer needing to re-declare versions for various mockito jars.

###### Result:
My dropwizard apps can now depend on several more jars without having to manage them:
- mockito-errorprone
- mockito-inline
- mockito-proxy
- mockito-subclass
