### PR TITLE
Fix mustache docs link in views.rst

### DIFF
--- a/docs/source/manual/views.rst
+++ b/docs/source/manual/views.rst
@@ -9,7 +9,7 @@ Dropwizard Views
 .. rubric:: The ``dropwizard-views-mustache`` & ``dropwizard-views-freemarker`` modules provide you with simple, fast HTML views using either FreeMarker_ or Mustache_.
 
 .. _FreeMarker: https://freemarker.apache.org/
-.. _Mustache: http://mustache.github.com/mustache.5.html
+.. _Mustache: http://mustache.github.io/mustache.5.html
 
 To enable views for your :ref:`Application <man-core-application>`, add the ``ViewBundle`` in the ``initialize`` method of your Application class:
 


### PR DESCRIPTION
Fix mustache link in dropwizard-views

###### Problem:
Exiting link points to: https://mustache.github.com/mustache.5.html

###### Solution:
Link should point to: https://mustache.github.io/mustache.5.html

###### Result:
Working link.
