### PR TITLE
Update link to Jetty architecture documentation

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -19,7 +19,7 @@ Tweaking some of the options will require good understanding of how Jetty is wor
       type: default
       maxThreads: 1024
 
-.. _Jetty architecture chapter: http://www.eclipse.org/jetty/documentation/current/architecture.html#basic-architecture
+.. _Jetty architecture chapter: https://www.eclipse.org/jetty/documentation/current/#architecture
 
 
 .. _man-configuration-all:


### PR DESCRIPTION
###### Problem:
The link to the Jetty architecture documentation no longer works

###### Solution:
Change the link to the new address

###### Result:
Following the link on https://www.dropwizard.io/en/latest/manual/configuration.html now leads to the Jetty architecture documentation.