### PR TITLE
Added Valid annotation to DiscoverableLayoutFactory in  AbstractAppenderFactory (release/2.1.x)

### DIFF
--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
@@ -5,8 +5,11 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.spi.DeferredProcessingAware;
 import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.configuration.ConfigurationValidationException;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
@@ -27,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
 
+import javax.validation.constraints.Min;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.Arrays;
@@ -34,6 +38,7 @@ import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.entry;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
@@ -227,5 +232,20 @@ class LayoutIntegrationTests {
             System.setErr(old);
         }
 
+    }
+
+    @Test
+    void invalidJsonLogLayoutField() {
+        assertThatExceptionOfType(ConfigurationValidationException.class)
+            .isThrownBy(() -> getAppenderFactory("yaml/custom-json-log-invalid.yml"))
+            .withMessageContaining("messageSize must be greater than or equal to 1");
+    }
+
+    @JsonTypeName("custom-json")
+    public static class CustomJsonLayoutBaseFactory extends EventJsonLayoutBaseFactory {
+
+        @JsonProperty
+        @Min(1)
+        private int messageSize = 8000;
     }
 }

--- a/dropwizard-json-logging/src/test/resources/META-INF/services/io.dropwizard.logging.layout.DiscoverableLayoutFactory
+++ b/dropwizard-json-logging/src/test/resources/META-INF/services/io.dropwizard.logging.layout.DiscoverableLayoutFactory
@@ -1,0 +1,1 @@
+io.dropwizard.logging.json.LayoutIntegrationTests$CustomJsonLayoutBaseFactory

--- a/dropwizard-json-logging/src/test/resources/yaml/custom-json-log-invalid.yml
+++ b/dropwizard-json-logging/src/test/resources/yaml/custom-json-log-invalid.yml
@@ -1,0 +1,4 @@
+type: console
+layout:
+    type: custom-json
+    messageSize: 0

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/AbstractAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/AbstractAppenderFactory.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -112,6 +113,7 @@ public abstract class AbstractAppenderFactory<E extends DeferredProcessingAware>
     protected String logFormat;
 
     @Nullable
+    @Valid
     protected DiscoverableLayoutFactory<E> layout;
 
     @NotNull


### PR DESCRIPTION
###### Problem:
The layout field in `AbstractAppenderFactory` does not have `@Valid` annotation that is required to validate the fields. This change is necessary because when extending and creating custom logging layouts, the annotations based validations for the newly added fields does not work.

###### Solution:
Added `@Valid` for `DiscoverableLayoutFactory` layout in `AbstractAppenderFactory`.

###### Result:
See solution.
