### PR TITLE
Enable support for project loom for Jetty's thread pool

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -67,6 +67,7 @@ registerDefaultExceptionMappers     true                                        
 enableThreadNameFilter              true                                             Whether or not to apply the ``ThreadNameFilter`` that adjusts thread names to include the request method and request URI.
 dumpAfterStart                      false                                            Whether or not to dump `Jetty Diagnostics`_ after start.
 dumpBeforeStop                      false                                            Whether or not to dump `Jetty Diagnostics`_ before stop.
+enableVirtualThreads                false                                            Whether to enable virtual threads for Jetty's thread pool.
 =================================== ===============================================  =============================================================================
 
 .. _Jetty Diagnostics: https://www.eclipse.org/jetty/documentation/9.4.x/jetty-dump-tool.html

--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -243,6 +243,7 @@ Extends the attributes that are available to :ref:`all servers <man-configuratio
     server:
       adminMinThreads: 1
       adminMaxThreads: 64
+      enableAdminVirtualThreads: false
       adminContextPath: /
       applicationContextPath: /
       applicationConnectors:
@@ -263,19 +264,20 @@ Extends the attributes that are available to :ref:`all servers <man-configuratio
           validateCerts: false
 
 
-========================  =======================   =====================================================================
-Name                      Default                   Description
-========================  =======================   =====================================================================
-applicationConnectors     An `HTTP connector`_      A set of :ref:`connectors <man-configuration-connectors>` which will
-                          listening on port 8080.   handle application requests.
-adminConnectors           An `HTTP connector`_      An `HTTP connector`_ listening on port 8081.
-                          listening on port 8081.   A set of :ref:`connectors <man-configuration-connectors>` which will
-                                                    handle admin requests.
-adminMinThreads           1                         The minimum number of threads to use for admin requests.
-adminMaxThreads           64                        The maximum number of threads to use for admin requests.
-adminContextPath          /                         The context path of the admin servlets, including metrics and tasks.
-applicationContextPath    /                         The context path of the application servlets, including Jersey.
-========================  =======================   =====================================================================
+=========================  =======================   =====================================================================
+Name                       Default                   Description
+=========================  =======================   =====================================================================
+applicationConnectors      An `HTTP connector`_      A set of :ref:`connectors <man-configuration-connectors>` which will
+                           listening on port 8080.   handle application requests.
+adminConnectors            An `HTTP connector`_      An `HTTP connector`_ listening on port 8081.
+                           listening on port 8081.   A set of :ref:`connectors <man-configuration-connectors>` which will
+                                                     handle admin requests.
+adminMinThreads            1                         The minimum number of threads to use for admin requests.
+adminMaxThreads            64                        The maximum number of threads to use for admin requests.
+enableAdminVirtualThreads  false                     Whether to use virtual threads for the admin connectors.
+adminContextPath           /                         The context path of the admin servlets, including metrics and tasks.
+applicationContextPath     /                         The context path of the application servlets, including Jersey.
+=========================  =======================   =====================================================================
 
 .. _`HTTP connector`:  https://github.com/dropwizard/dropwizard/blob/master/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
 

--- a/dropwizard-core/src/main/java/io/dropwizard/core/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/core/server/AbstractServerFactory.java
@@ -664,7 +664,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
 
     protected ThreadPool createThreadPool(MetricRegistry metricRegistry) {
         final BlockingQueue<Runnable> queue = new BlockingArrayQueue<>(minThreads, maxThreads, maxQueuedRequests);
-        final ThreadFactory threadFactory = getThreadFactory();
+        final ThreadFactory threadFactory = getThreadFactory(enableVirtualThreads);
         final InstrumentedQueuedThreadPool threadPool =
                 new InstrumentedQueuedThreadPool(metricRegistry, maxThreads, minThreads,
                     (int) idleThreadTimeout.toMilliseconds(), queue, threadFactory);
@@ -672,8 +672,8 @@ public abstract class AbstractServerFactory implements ServerFactory {
         return threadPool;
     }
 
-    protected ThreadFactory getThreadFactory() {
-        if (!enableVirtualThreads) {
+    protected ThreadFactory getThreadFactory(boolean virtualThreadsRequested) {
+        if (!virtualThreadsRequested) {
             return Executors.defaultThreadFactory();
         }
 

--- a/dropwizard-core/src/main/java/io/dropwizard/core/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/core/server/AbstractServerFactory.java
@@ -678,7 +678,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
         }
 
         if (!VirtualThreads.areSupported()) {
-            throw new UnsupportedOperationException("Virtual threads are requested but no supported on the current runtime");
+            throw new UnsupportedOperationException("Virtual threads are requested but not supported on the current runtime");
         }
 
         try {

--- a/dropwizard-core/src/test/java/io/dropwizard/core/VirtualThreadsTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/core/VirtualThreadsTest.java
@@ -6,13 +6,19 @@ import io.dropwizard.core.server.DefaultServerFactory;
 import io.dropwizard.core.setup.Environment;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.validation.Validators;
+import org.eclipse.jetty.server.AbstractConnector;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.VirtualThreads;
+import org.eclipse.jetty.util.thread.ThreadPool;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -21,24 +27,83 @@ class VirtualThreadsTest {
     private static class VirtualThreadsConfiguration extends Configuration {
     }
 
-    private final AtomicBoolean isVirtualThread = new AtomicBoolean(false);
-    private final Runnable virtualThreadRunnable = () -> isVirtualThread.set(VirtualThreads.isVirtualThread());
+    @Test
+    void virtualThreadsEnabledWhenRequested() throws Exception {
+        boolean isVirtualThread = probeVirtualThread(
+            defaultServerFactory -> defaultServerFactory.setEnableVirtualThreads(true),
+            this::selectServerThreadPool
+        );
+
+        assertThat(isVirtualThread).isTrue();
+    }
 
     @Test
-    void virtualThreadsSupported() throws Exception {
+    void virtualThreadsDisabledWhenNotRequested() throws Exception {
+        boolean isVirtualThread = probeVirtualThread(
+            defaultServerFactory -> defaultServerFactory.setEnableVirtualThreads(false),
+            this::selectServerThreadPool
+        );
+
+        assertThat(isVirtualThread).isFalse();
+    }
+
+    @Test
+    void virtualAdminThreadsEnabledWhenRequested() throws Exception {
+        boolean isVirtualThread = probeVirtualThread(
+            defaultServerFactory -> defaultServerFactory.setEnableAdminVirtualThreads(true),
+            this::selectAdminThreadPool
+        );
+
+        assertThat(isVirtualThread).isTrue();
+    }
+
+    @Test
+    void virtualAdminThreadsDisabledWhenNotRequested() throws Exception {
+        boolean isVirtualThread = probeVirtualThread(
+            defaultServerFactory -> defaultServerFactory.setEnableAdminVirtualThreads(false),
+            this::selectAdminThreadPool
+        );
+
+        assertThat(isVirtualThread).isFalse();
+    }
+
+    private boolean probeVirtualThread(Consumer<DefaultServerFactory> defaultServerFactoryConsumer,
+                                       Function<Server, ThreadPool> threadPoolSelector) throws Exception {
+        final AtomicBoolean isVirtualThread = new AtomicBoolean(false);
+
         Environment environment = new Environment("VirtualThreadsTest", Jackson.newMinimalObjectMapper(),
             Validators.newValidatorFactory(), new MetricRegistry(), this.getClass().getClassLoader(),
             new HealthCheckRegistry(), new VirtualThreadsConfiguration());
         DefaultServerFactory defaultServerFactory = new DefaultServerFactory();
-        defaultServerFactory.setEnableVirtualThreads(true);
+        defaultServerFactoryConsumer.accept(defaultServerFactory);
         Server server = defaultServerFactory.build(environment);
         server.start();
         try {
-            server.getThreadPool().execute(virtualThreadRunnable);
+            ThreadPool threadPool = threadPoolSelector.apply(server);
+            threadPool.execute(
+                () -> isVirtualThread.set(VirtualThreads.isVirtualThread())
+            );
         } finally {
             server.stop();
         }
 
-        assertThat(isVirtualThread).isTrue();
+        return isVirtualThread.get();
+    }
+
+    private ThreadPool selectServerThreadPool(Server server) {
+        return server.getThreadPool();
+    }
+
+    private ThreadPool selectAdminThreadPool(Server server) {
+        final int adminPort = 8081;
+        return Arrays.stream(server.getConnectors())
+            .filter(ServerConnector.class::isInstance)
+            .map(ServerConnector.class::cast)
+            .filter(serverConnector -> serverConnector.getLocalPort() == adminPort)
+            .map(AbstractConnector::getExecutor)
+            .filter(ThreadPool.class::isInstance)
+            .map(ThreadPool.class::cast)
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("Couldn't find thread pool of admin connector"));
     }
 }

--- a/dropwizard-core/src/test/java/io/dropwizard/core/VirtualThreadsTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/core/VirtualThreadsTest.java
@@ -1,0 +1,44 @@
+package io.dropwizard.core;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import io.dropwizard.core.server.DefaultServerFactory;
+import io.dropwizard.core.setup.Environment;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jersey.validation.Validators;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.VirtualThreads;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnabledForJreRange(min = JRE.JAVA_21)
+class VirtualThreadsTest {
+    private static class VirtualThreadsConfiguration extends Configuration {
+    }
+
+    private final AtomicBoolean isVirtualThread = new AtomicBoolean(false);
+    private final Runnable virtualThreadRunnable = () -> isVirtualThread.set(VirtualThreads.isVirtualThread());
+
+    @Test
+    void virtualThreadsSupported() throws Exception {
+        Environment environment = new Environment("VirtualThreadsTest", Jackson.newMinimalObjectMapper(),
+            Validators.newValidatorFactory(), new MetricRegistry(), this.getClass().getClassLoader(),
+            new HealthCheckRegistry(), new VirtualThreadsConfiguration());
+        DefaultServerFactory defaultServerFactory = new DefaultServerFactory();
+        defaultServerFactory.setEnableVirtualThreads(true);
+        Server server = defaultServerFactory.build(environment);
+        server.start();
+        try {
+            server.getThreadPool().execute(virtualThreadRunnable);
+        } finally {
+            server.stop();
+        }
+
+        assertThat(isVirtualThread).isTrue();
+    }
+}


### PR DESCRIPTION
This PR provides a new configuration option to enable virtual threads for Jetty's thread pool.

If the current runtime doesn't support virtual threads, platform threads are used instead.