### PR TITLE
Expose Jackson.configure method

### DIFF
--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java
@@ -62,12 +62,12 @@ public class Jackson {
     }
 
     /**
-     * Configures an {@link ObjectMapper} with a set of common modules and properties.
+     * Configures an {@link ObjectMapper} with the default set of common modules and properties.
      *
      * @param mapper the {@link ObjectMapper} to configure
      * @return the configured {@link ObjectMapper}
      */
-    private static ObjectMapper configure(ObjectMapper mapper) {
+    public static ObjectMapper configure(ObjectMapper mapper) {
         final List<Module> modules = ObjectMapper.findModules();
 
         mapper.registerModule(new GuavaModule());


### PR DESCRIPTION
###### Problem:
Up until now, I were using the [`ObjectMapper.enable(MapperFeature)`](https://fasterxml.github.io/jackson-databind/javadoc/2.13/com/fasterxml/jackson/databind/ObjectMapper.html#enable-com.fasterxml.jackson.databind.MapperFeature...-) call to enable the [`PROPAGATE_TRANSIENT_MARKER` feature](https://fasterxml.github.io/jackson-databind/javadoc/2.13/com/fasterxml/jackson/databind/MapperFeature.html#PROPAGATE_TRANSIENT_MARKER), so transient properties in non-Jackson-aware code get skipped in the resulting JSON.

I'd set this property in the `initialize` method like so:
```java
@Override
public void initialize(Bootstrap<T> bootstrap) {
	bootstrap.getObjectMapper().enable(MapperFeature.PROPAGATE_TRANSIENT_MARKER);
}
```

Since version 2.13 however, this method has been marked as deprecated, which means it might get removed in a future version, making this approach a non-ideal one.

The deprecation node says to use a [JsonMapper.Builder](https://fasterxml.github.io/jackson-databind/javadoc/2.13/com/fasterxml/jackson/databind/json/JsonMapper.Builder.html), set the relevant flags, then build the `ObjectMapper`.

However, the problem is that [Dropwizard does not expose the `configure` method in its Jackson class](https://github.com/dropwizard/dropwizard/blob/release/4.0.x/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java#L70), which makes it impossible to create an `ObjectMapper` with this flag set, and install easily all Dropwizard-provided modules without having to copy and paste said code.

###### Solution:
This PR makes said method public, so one can configure arbitrary `ObjectMapper`s with Dropwizard's default set of mappers and settings.

```java
public void initialize(Bootstrap<T> bootstrap) {
	JsonMapper mapper = JsonMapper.builder()
			.enable(MapperFeature.PROPAGATE_TRANSIENT_MARKER)
			.build();
	Jackson.configure(mapper);
	bootstrap.setObjectMapper(mapper);
}
```