### PR TITLE
Fix NullPointerException in DropwizardApacheConnector

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardApacheConnector.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardApacheConnector.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Optional;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.List;
 
 /**
  * Dropwizard Apache Connector.
@@ -219,10 +220,19 @@ public class DropwizardApacheConnector implements Connector {
         private JerseyRequestHttpEntity(ClientRequest clientRequest) {
             super(
                 clientRequest.getMediaType().toString(),
-                clientRequest.getRequestHeader(HttpHeaders.CONTENT_ENCODING).stream().findFirst().orElse(null),
+                getEncoding(clientRequest),
                 true
             );
             this.clientRequest = clientRequest;
+        }
+
+        @Nullable
+        private static String getEncoding(ClientRequest clientRequest) {
+            List<String> contentEncoding = clientRequest.getRequestHeader(HttpHeaders.CONTENT_ENCODING);
+            if (contentEncoding == null) {
+                return null;
+            }
+            return contentEncoding.stream().findFirst().orElse(null);
         }
 
         /**

--- a/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardApacheConnector.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardApacheConnector.java
@@ -226,15 +226,6 @@ public class DropwizardApacheConnector implements Connector {
             this.clientRequest = clientRequest;
         }
 
-        @Nullable
-        private static String getEncoding(ClientRequest clientRequest) {
-            List<String> contentEncoding = clientRequest.getRequestHeader(HttpHeaders.CONTENT_ENCODING);
-            if (contentEncoding == null) {
-                return null;
-            }
-            return contentEncoding.stream().findFirst().orElse(null);
-        }
-
         /**
          * {@inheritDoc}
          */
@@ -305,7 +296,7 @@ public class DropwizardApacheConnector implements Connector {
         private BufferedJerseyRequestHttpEntity(ClientRequest clientRequest) {
             super(
                 clientRequest.getMediaType().toString(),
-                clientRequest.getRequestHeader(HttpHeaders.CONTENT_ENCODING).stream().findFirst().orElse(null),
+                getEncoding(clientRequest),
                 false
             );
             final ByteArrayOutputStream stream = new ByteArrayOutputStream(BUFFER_INITIAL_SIZE);
@@ -370,6 +361,15 @@ public class DropwizardApacheConnector implements Connector {
         @Override
         public void close() throws IOException {
         }
+    }
+
+    @Nullable
+    private static String getEncoding(ClientRequest clientRequest) {
+        List<String> contentEncoding = clientRequest.getRequestHeader(HttpHeaders.CONTENT_ENCODING);
+        if (contentEncoding == null) {
+            return null;
+        }
+        return contentEncoding.stream().findFirst().orElse(null);
     }
 }
 


### PR DESCRIPTION
###### Problem:
If `JerseyClientConfiguration.setGzipEnabledForRequests(false)` then there is no `CONTENT_ENCODING` header
on the `org.glassfish.jersey.client.ClientRequest`.

`org.glassfish.jersey.client.ClientRequest` returns null from `getRequestHeader` if there is no header, which causes
this code to fail.

###### Solution:
Check for null and handle it correctly

Fixes #7319