### PR TITLE
Request log remote user

### DIFF
--- a/dropwizard-auth/pom.xml
+++ b/dropwizard-auth/pom.xml
@@ -92,6 +92,24 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.toolchain</groupId>
+                    <artifactId>jetty-jakarta-servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.jersey.test-framework</groupId>
             <artifactId>jersey-test-framework-core</artifactId>
             <scope>test</scope>

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthFilter.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthFilter.java
@@ -1,12 +1,14 @@
 package io.dropwizard.auth;
 
 import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.core.SecurityContext;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.glassfish.jersey.internal.inject.InjectionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,6 +27,10 @@ public abstract class AuthFilter<C, P extends Principal> implements ContainerReq
     protected Authenticator<C, P> authenticator = credentials -> Optional.empty();
     protected Authorizer<P> authorizer = new PermitAllAuthorizer<>();
     protected UnauthorizedHandler unauthorizedHandler = new DefaultUnauthorizedHandler();
+
+    @Nullable
+    @Inject
+    private InjectionManager injectionManager;
 
     /**
      * Abstract builder for auth filters.
@@ -144,7 +150,7 @@ public abstract class AuthFilter<C, P extends Principal> implements ContainerReq
             final SecurityContext securityContext = requestContext.getSecurityContext();
             final boolean secure = securityContext != null && securityContext.isSecure();
 
-            requestContext.setSecurityContext(new SecurityContext() {
+            SecurityContext dropwizardAuthenticatedSecurityContext = new SecurityContext() {
                 @Override
                 public Principal getUserPrincipal() {
                     return prince;
@@ -164,7 +170,9 @@ public abstract class AuthFilter<C, P extends Principal> implements ContainerReq
                 public String getAuthenticationScheme() {
                     return scheme;
                 }
-            });
+            };
+            requestContext.setSecurityContext(dropwizardAuthenticatedSecurityContext);
+            JettyAuthenticationUtil.setJettyAuthenticationIfPossible(dropwizardAuthenticatedSecurityContext, injectionManager);
             return true;
         } catch (AuthenticationException e) {
             logger.warn("Error authenticating credentials", e);

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/JettyAuthenticationUtil.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/JettyAuthenticationUtil.java
@@ -1,0 +1,82 @@
+package io.dropwizard.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.SecurityContext;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.eclipse.jetty.security.AbstractUserAuthentication;
+import org.eclipse.jetty.server.Authentication;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.UserIdentity;
+import org.glassfish.jersey.internal.inject.InjectionManager;
+import org.glassfish.jersey.internal.util.collection.Ref;
+
+import javax.security.auth.Subject;
+import java.lang.reflect.Type;
+import java.security.Principal;
+import java.util.Optional;
+import java.util.Set;
+
+class JettyAuthenticationUtil {
+    private static final Type HTTP_SERVLET_REQUEST_REF_TYPE = (new GenericType<Ref<HttpServletRequest>>() {}).getType();
+
+    static void setJettyAuthenticationIfPossible(SecurityContext securityContext, @Nullable InjectionManager injectionManager) {
+        if (injectionManager == null) {
+            return;
+        }
+        final Ref<HttpServletRequest> requestRef = injectionManager.getInstance(HTTP_SERVLET_REQUEST_REF_TYPE);
+        if (requestRef == null) {
+            return;
+        }
+        HttpServletRequest request = requestRef.get();
+        if (!(request instanceof Request)) {
+            return;
+        }
+        Request jettyRequest = (Request) request;
+
+        Authentication authentication = new DropwizardJettyAuthentication(securityContext);
+        jettyRequest.setAuthentication(authentication);
+    }
+
+    private static class DropwizardJettyAuthentication extends AbstractUserAuthentication {
+        public DropwizardJettyAuthentication(SecurityContext securityContext) {
+            super(securityContext.getAuthenticationScheme(), new DropwizardJettyUserIdentity(securityContext));
+        }
+    }
+
+    private static class DropwizardJettyUserIdentity implements UserIdentity {
+        private final Subject subject;
+        private final SecurityContext securityContext;
+
+        public DropwizardJettyUserIdentity(SecurityContext securityContext) {
+            this.securityContext = securityContext;
+            this.subject = new Subject(true, Set.of(securityContext.getUserPrincipal()), Set.of(), Set.of());
+        }
+
+        @Override
+        public Subject getSubject() {
+            return subject;
+        }
+
+        @Override
+        public Principal getUserPrincipal() {
+            return securityContext.getUserPrincipal();
+        }
+
+        @Override
+        public boolean isUserInRole(String role, Scope scope) {
+            // Servlet spec forbids the role name "*", so return false in that case
+            if ("*".equals(role)) {
+                return false;
+            }
+
+            // get the scope-mapped role, if present
+            // else use the original role
+            String resolvedRole = Optional.ofNullable(scope)
+                .map(Scope::getRoleRefMap)
+                .map(roleMap -> roleMap.get(role))
+                .orElse(role);
+            return securityContext.isUserInRole(resolvedRole);
+        }
+    }
+}

--- a/dropwizard-e2e/pom.xml
+++ b/dropwizard-e2e/pom.xml
@@ -177,6 +177,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-auth</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/dropwizard-e2e/src/test/java/com/example/request_log/RequestLogPatternIntegrationTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/request_log/RequestLogPatternIntegrationTest.java
@@ -1,10 +1,12 @@
 package com.example.request_log;
 
+import jakarta.ws.rs.core.HttpHeaders;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import java.nio.file.Files;
+import java.util.Base64;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -31,5 +33,18 @@ class RequestLogPatternIntegrationTest extends AbstractRequestLogPatternIntegrat
 
         List<String> logs = Files.readAllLines(requestLogFile, UTF_8);
         assertThat(logs).hasSize(100).allMatch(s -> REQUEST_LOG_PATTERN.matcher(s).matches());
+    }
+
+    @Test
+    void testRemoteUserIsSetCorrectly() {
+        final String username = "admin";
+        final String password = "";
+        final String basicAuth = String.format("%s:%s", username, password);
+        final String basicAuthHeader = "Basic " + Base64.getEncoder().encodeToString(basicAuth.getBytes(UTF_8));
+
+        String url = String.format("http://localhost:%d/greet/authenticated", dropwizardAppRule.getLocalPort());
+        String remoteUser = client.target(url).request().header(HttpHeaders.AUTHORIZATION, basicAuthHeader).get(String.class);
+
+        assertThat(remoteUser).isEqualTo(username);
     }
 }


### PR DESCRIPTION
Closes #7506

Currently, a request log implementation cannot get the information of a requesting user from the `dropwizard-auth` module, because the information doesn't leave the servlet level. This PR modifies the Jetty `Authentication` with the new Dropwizard authentication information and exposes the authenticated user through the `HttpServletRequest#getRemoteUser()` method.