### PR TITLE
Fix token permissions for PRs from forks

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,6 +22,11 @@ jobs:
         uses: frenck/action-yamllint@9f9442422961e9f3436836f1082d327f482f402b # v1.4.1
   build:
     runs-on: ${{ matrix.os }}
+    permissions:
+      checks: write
+      contents: read
+      issues: read
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
See https://github.com/ScaCap/action-surefire-report/issues/31

Pull requests from forked repositories currently have token permission issues and the Java CI checks fail. This prevents auto-merging. Pull requests from the dropwizard-repo itself have the following permissions:

```
Actions: write
Checks: write
Contents: write
Deployments: write
Discussions: write
Issues: write
Metadata: read
Packages: write
Pages: write
PullRequests: write
RepositoryProjects: write
SecurityEvents: write
Statuses: write
```
while pull requests from forked repos have the following permissions:
```
Actions: read
Checks: read
Contents: read
Deployments: read
Discussions: read
Issues: read
Metadata: read
Packages: read
Pages: read
PullRequests: read
RepositoryProjects: read
SecurityEvents: read
Statuses: read
```