### PR TITLE
Unix domain socket connector

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -492,8 +492,6 @@ Name                             Default                          Description
 path                             /tmp/dropwizard.sock             The path to the unix domain socket file.
 ================================ ================================ ======================================================================================
 
-.. _sslyze: https://github.com/nabla-c0d3/sslyze
-
 .. _man-configuration-http2:
 
 HTTP/2 over TLS

--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -472,7 +472,7 @@ disableSniHostCheck              false                            Whether to dis
 
 .. _man-configuration-unix-socket:
 
-HTTPS
+Unix Domain Socket
 -----
 
 Extends the attributes that are available to the :ref:`HTTP connector <man-configuration-http>` but does not require port.

--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -470,6 +470,30 @@ disableSniHostCheck              false                            Whether to dis
 
 .. _sslyze: https://github.com/nabla-c0d3/sslyze
 
+.. _man-configuration-unix-socket:
+
+HTTPS
+-----
+
+Extends the attributes that are available to the :ref:`HTTP connector <man-configuration-http>` but does not require port.
+
+.. code-block:: yaml
+
+    # Extending from the default server configuration
+    server:
+      applicationConnectors:
+        - type: unix-socket
+          ...
+          path: /path/to/file
+
+================================ ================================ ======================================================================================
+Name                             Default                          Description
+================================ ================================ ======================================================================================
+path                             /tmp/dropwizard.sock             The path to the unix domain socket file.
+================================ ================================ ======================================================================================
+
+.. _sslyze: https://github.com/nabla-c0d3/sslyze
+
 .. _man-configuration-http2:
 
 HTTP/2 over TLS

--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -473,7 +473,7 @@ disableSniHostCheck              false                            Whether to dis
 .. _man-configuration-unix-socket:
 
 Unix Domain Socket
------
+------------------
 
 Extends the attributes that are available to the :ref:`HTTP connector <man-configuration-http>` but does not require port.
 

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -160,7 +160,7 @@
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-unix-socket</artifactId>
-                <version>4.0.3-SNAPSHOT</version>
+                <version>5.0.0-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/dropwizard-bom/pom.xml
+++ b/dropwizard-bom/pom.xml
@@ -157,6 +157,11 @@
                 <artifactId>dropwizard-health</artifactId>
                 <version>5.0.0-SNAPSHOT</version>
             </dependency>
+            <dependency>
+                <groupId>io.dropwizard</groupId>
+                <artifactId>dropwizard-unix-socket</artifactId>
+                <version>4.0.3-SNAPSHOT</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
@@ -703,7 +703,7 @@ public class HttpConnectorFactory implements ConnectorFactory {
         return name(HttpConnectionFactory.class,  bindHost, Integer.toString(port), "connections");
     }
 
-    protected Connector buildConnector(Server server,
+    protected ServerConnector buildConnector(Server server,
                                              Scheduler scheduler,
                                              ByteBufferPool bufferPool,
                                              String name,

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
@@ -703,7 +703,7 @@ public class HttpConnectorFactory implements ConnectorFactory {
         return name(HttpConnectionFactory.class,  bindHost, Integer.toString(port), "connections");
     }
 
-    protected ServerConnector buildConnector(Server server,
+    protected Connector buildConnector(Server server,
                                              Scheduler scheduler,
                                              ByteBufferPool bufferPool,
                                              String name,

--- a/dropwizard-unix-socket/pom.xml
+++ b/dropwizard-unix-socket/pom.xml
@@ -21,17 +21,45 @@
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>
-            <artifactId>dropwizard-core</artifactId>
+            <artifactId>dropwizard-util</artifactId>
         </dependency>
-
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-jetty</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-unixdomain-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.toolchain</groupId>
+                    <artifactId>jetty-jakarta-servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker-qual</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
         </dependency>
 
         <dependency>
@@ -52,6 +80,21 @@
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-jersey</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/dropwizard-unix-socket/pom.xml
+++ b/dropwizard-unix-socket/pom.xml
@@ -15,7 +15,7 @@
     <name>Dropwizard Unix Socket Support</name>
 
     <properties>
-        <module.name>io.dropwizard.dropwizard-unix-socket</module.name>
+        <module.name>io.dropwizard.dropwizard.unixsocket</module.name>
         <maven.compiler.release>16</maven.compiler.release>
     </properties>
 

--- a/dropwizard-unix-socket/pom.xml
+++ b/dropwizard-unix-socket/pom.xml
@@ -16,7 +16,6 @@
 
     <properties>
         <module.name>io.dropwizard.dropwizard.unixsocket</module.name>
-        <maven.compiler.release>16</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/dropwizard-unix-socket/pom.xml
+++ b/dropwizard-unix-socket/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.dropwizard</groupId>
         <artifactId>dropwizard-parent</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../dropwizard-parent</relativePath>
     </parent>
 

--- a/dropwizard-unix-socket/pom.xml
+++ b/dropwizard-unix-socket/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.dropwizard</groupId>
+        <artifactId>dropwizard-parent</artifactId>
+        <version>4.0.3-SNAPSHOT</version>
+        <relativePath>../dropwizard-parent</relativePath>
+    </parent>
+
+    <artifactId>dropwizard-unix-socket</artifactId>
+    <name>Dropwizard Unix Socket Support</name>
+
+    <properties>
+        <module.name>io.dropwizard.dropwizard-unix-socket</module.name>
+        <maven.compiler.release>16</maven.compiler.release>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-jetty</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-unixdomain-server</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/dropwizard-unix-socket/pom.xml
+++ b/dropwizard-unix-socket/pom.xml
@@ -15,7 +15,7 @@
     <name>Dropwizard Unix Socket Support</name>
 
     <properties>
-        <module.name>io.dropwizard.dropwizard.unixsocket</module.name>
+        <module.name>io.dropwizard.unixsocket</module.name>
     </properties>
 
     <dependencies>

--- a/dropwizard-unix-socket/pom.xml
+++ b/dropwizard-unix-socket/pom.xml
@@ -54,6 +54,10 @@
             <artifactId>metrics-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-jetty11</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.checkerframework</groupId>
             <artifactId>checker-qual</artifactId>
         </dependency>

--- a/dropwizard-unix-socket/pom.xml
+++ b/dropwizard-unix-socket/pom.xml
@@ -97,5 +97,10 @@
             <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-client</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/dropwizard-unix-socket/src/main/java/io/dropwizard/unixsocket/UnixSocketConnectorFactory.java
+++ b/dropwizard-unix-socket/src/main/java/io/dropwizard/unixsocket/UnixSocketConnectorFactory.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.dropwizard.jetty.HttpConnectorFactory;
 import io.dropwizard.metrics.jetty11.InstrumentedConnectionFactory;
-import jakarta.validation.constraints.NotEmpty;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;

--- a/dropwizard-unix-socket/src/main/java/io/dropwizard/unixsocket/UnixSocketConnectorFactory.java
+++ b/dropwizard-unix-socket/src/main/java/io/dropwizard/unixsocket/UnixSocketConnectorFactory.java
@@ -1,0 +1,87 @@
+package io.dropwizard.unixsocket;
+
+import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.dropwizard.jetty.HttpConnectorFactory;
+import io.dropwizard.metrics.jetty11.InstrumentedConnectionFactory;
+import jakarta.validation.constraints.NotEmpty;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.unixdomain.server.UnixDomainServerConnector;
+import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
+import org.eclipse.jetty.util.thread.ThreadPool;
+
+import java.nio.file.Paths;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+/**
+ * Builds Unix Domain Socket connectors.
+ * <p/>
+ * <b>Configuration Parameters:</b>
+ * <table>
+ *     <tr>
+ *         <td>Name</td>
+ *         <td>Default</td>
+ *         <td>Description</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code path}</td>
+ *         <td>/tmp/dropwizard.sock</td>
+ *         <td>
+ *             The path to the unix domain socket file.
+ *         </td>
+ *     </tr>
+ * </table>
+ * <p/>
+ */
+@JsonTypeName("unix-socket")
+public class UnixSocketConnectorFactory extends HttpConnectorFactory {
+
+    private String path = "/tmp/dropwizard.sock";
+
+    @JsonProperty
+    public String getPath() {
+        return path;
+    }
+
+    @JsonProperty
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    @Override
+    public Connector build(Server server,
+                           MetricRegistry metrics,
+                           String name,
+                           @Nullable ThreadPool threadPool) {
+        var scheduler = new ScheduledExecutorScheduler();
+        var bufferPool = buildBufferPool();
+        var httpConfig = buildHttpConfiguration();
+        var httpConnectionFactory = buildHttpConnectionFactory(httpConfig);
+        var instrumentedConnectionFactory = new InstrumentedConnectionFactory(httpConnectionFactory,
+            metrics.timer(httpConnections()));
+
+        final UnixDomainServerConnector connector = new UnixDomainServerConnector(server,
+            threadPool,
+            scheduler,
+            bufferPool,
+            getAcceptorThreads().orElse(-1),
+            getSelectorThreads().orElse(-1),
+            instrumentedConnectionFactory);
+        if (getAcceptQueueSize() != null) {
+            connector.setAcceptQueueSize(getAcceptQueueSize());
+        }
+        connector.setUnixDomainPath(Paths.get(path));
+        connector.setIdleTimeout(getIdleTimeout().toMilliseconds());
+        connector.setName(name);
+        return connector;
+    }
+
+    @Override
+    protected String httpConnections() {
+        return name(UnixSocketConnectorFactory.class, path, "connections");
+    }
+}

--- a/dropwizard-unix-socket/src/main/java/io/dropwizard/unixsocket/UnixSocketConnectorFactory.java
+++ b/dropwizard-unix-socket/src/main/java/io/dropwizard/unixsocket/UnixSocketConnectorFactory.java
@@ -1,16 +1,15 @@
 package io.dropwizard.unixsocket;
 
-import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.dropwizard.jetty.HttpConnectorFactory;
-import io.dropwizard.metrics.jetty11.InstrumentedConnectionFactory;
-import jakarta.validation.constraints.NotEmpty;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.eclipse.jetty.io.ByteBufferPool;
+import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.unixdomain.server.UnixDomainServerConnector;
-import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
+import org.eclipse.jetty.util.thread.Scheduler;
 import org.eclipse.jetty.util.thread.ThreadPool;
 
 import java.nio.file.Paths;
@@ -53,24 +52,15 @@ public class UnixSocketConnectorFactory extends HttpConnectorFactory {
     }
 
     @Override
-    public Connector build(Server server,
-                           MetricRegistry metrics,
-                           String name,
-                           @Nullable ThreadPool threadPool) {
-        var scheduler = new ScheduledExecutorScheduler();
-        var bufferPool = buildBufferPool();
-        var httpConfig = buildHttpConfiguration();
-        var httpConnectionFactory = buildHttpConnectionFactory(httpConfig);
-        var instrumentedConnectionFactory = new InstrumentedConnectionFactory(httpConnectionFactory,
-            metrics.timer(httpConnections()));
-
+    protected Connector buildConnector(Server server, Scheduler scheduler, ByteBufferPool bufferPool, String name, @Nullable ThreadPool threadPool, ConnectionFactory... factories) {
         final UnixDomainServerConnector connector = new UnixDomainServerConnector(server,
             threadPool,
             scheduler,
             bufferPool,
             getAcceptorThreads().orElse(-1),
             getSelectorThreads().orElse(-1),
-            instrumentedConnectionFactory);
+            factories);
+
         if (getAcceptQueueSize() != null) {
             connector.setAcceptQueueSize(getAcceptQueueSize());
         }

--- a/dropwizard-unix-socket/src/main/resources/META-INF/services/io.dropwizard.jetty.ConnectorFactory
+++ b/dropwizard-unix-socket/src/main/resources/META-INF/services/io.dropwizard.jetty.ConnectorFactory
@@ -1,0 +1,1 @@
+io.dropwizard.unixsocket.UnixSocketConnectorFactory

--- a/dropwizard-unix-socket/src/test/java/io/dropwizard/unixsocket/UnixSocketConnectorFactoryTest.java
+++ b/dropwizard-unix-socket/src/test/java/io/dropwizard/unixsocket/UnixSocketConnectorFactoryTest.java
@@ -12,6 +12,8 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.BufferedReader;
@@ -31,6 +33,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
+@DisabledOnOs(OS.WINDOWS) // Windows has Unix Socket support but not on all versions.
 @ExtendWith(DropwizardExtensionsSupport.class)
 class UnixSocketConnectorFactoryTest {
     private static final String httpRequest = "GET /app/hello HTTP/1.1\r\n" +

--- a/dropwizard-unix-socket/src/test/java/io/dropwizard/unixsocket/UnixSocketConnectorFactoryTest.java
+++ b/dropwizard-unix-socket/src/test/java/io/dropwizard/unixsocket/UnixSocketConnectorFactoryTest.java
@@ -15,7 +15,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
 import java.net.StandardProtocolFamily;
 import java.net.UnixDomainSocketAddress;
 import java.nio.channels.Channels;

--- a/dropwizard-unix-socket/src/test/java/io/dropwizard/unixsocket/UnixSocketConnectorFactoryTest.java
+++ b/dropwizard-unix-socket/src/test/java/io/dropwizard/unixsocket/UnixSocketConnectorFactoryTest.java
@@ -1,6 +1,5 @@
 package io.dropwizard.unixsocket;
 
-import com.codahale.metrics.health.HealthCheck;
 import io.dropwizard.core.Application;
 import io.dropwizard.core.Configuration;
 import io.dropwizard.core.setup.Environment;
@@ -111,12 +110,6 @@ class UnixSocketConnectorFactoryTest {
         @Override
         public void run(Configuration configuration, Environment environment) {
             environment.jersey().register(new FakeResource());
-            environment.healthChecks().register("hello-check", new HealthCheck() {
-                @Override
-                protected Result check() {
-                    return Result.healthy();
-                }
-            });
         }
 
         @Path("/hello")

--- a/dropwizard-unix-socket/src/test/java/io/dropwizard/unixsocket/UnixSocketConnectorFactoryTest.java
+++ b/dropwizard-unix-socket/src/test/java/io/dropwizard/unixsocket/UnixSocketConnectorFactoryTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-public class UnixSocketConnectorFactoryTest {
+class UnixSocketConnectorFactoryTest {
     private static final String httpRequest = "GET /app/hello HTTP/1.1\r\n" +
         "Host: dropwizard-unixsock\r\n" +
         "\r\n";
@@ -45,7 +45,7 @@ public class UnixSocketConnectorFactoryTest {
     }
 
     @Test
-    public void testClient() throws Exception {
+    void testClient() throws Exception {
         try (SocketChannel channel = SocketChannel.open(StandardProtocolFamily.UNIX)) {
             channel.connect(socketAddress);
             OutputStream os = Channels.newOutputStream(channel);
@@ -64,7 +64,7 @@ public class UnixSocketConnectorFactoryTest {
     }
 
     @Test
-    public void testManyCalls() throws Exception {
+    void testManyCalls() throws Exception {
         try (SocketChannel channel = SocketChannel.open(StandardProtocolFamily.UNIX)) {
             channel.connect(socketAddress);
             OutputStream os = Channels.newOutputStream(channel);

--- a/dropwizard-unix-socket/src/test/java/io/dropwizard/unixsocket/UnixSocketConnectorFactoryTest.java
+++ b/dropwizard-unix-socket/src/test/java/io/dropwizard/unixsocket/UnixSocketConnectorFactoryTest.java
@@ -1,0 +1,125 @@
+package io.dropwizard.unixsocket;
+
+import com.codahale.metrics.health.HealthCheck;
+import io.dropwizard.core.Application;
+import io.dropwizard.core.Configuration;
+import io.dropwizard.core.setup.Environment;
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.*;
+import java.net.StandardProtocolFamily;
+import java.net.UnixDomainSocketAddress;
+import java.nio.channels.Channels;
+import java.nio.channels.SocketChannel;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+public class UnixSocketConnectorFactoryTest {
+    private static final String httpRequest = "GET /app/hello HTTP/1.1\r\n" +
+        "Host: dropwizard-unixsock\r\n" +
+        "\r\n";
+
+    public DropwizardAppExtension<Configuration> ext = new DropwizardAppExtension<>(HelloWorldApplication.class,
+        ResourceHelpers.resourceFilePath("yaml/usock-server.yml"));
+
+    private UnixDomainSocketAddress socketAddress;
+
+    @BeforeEach
+    public void setUp() {
+        final File socket = new File("/tmp/dropwizard.sock");
+        socket.deleteOnExit();
+
+        socketAddress = UnixDomainSocketAddress.of(socket.getPath());
+    }
+
+    @Test
+    public void testClient() throws Exception {
+        try (SocketChannel channel = SocketChannel.open(StandardProtocolFamily.UNIX)) {
+            channel.connect(socketAddress);
+            OutputStream os = Channels.newOutputStream(channel);
+            try (OutputStreamWriter osw = new OutputStreamWriter(os, UTF_8)) {
+                try (PrintWriter writer = new PrintWriter(osw)) {
+                    InputStream is = Channels.newInputStream(channel);
+                    try (BufferedReader reader = new BufferedReader(new InputStreamReader(is, UTF_8))) {
+                        writer.print(httpRequest);
+                        writer.flush();
+
+                        verifyHelloWorldReceived(reader);
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testManyCalls() throws Exception {
+        try (SocketChannel channel = SocketChannel.open(StandardProtocolFamily.UNIX)) {
+            channel.connect(socketAddress);
+            OutputStream os = Channels.newOutputStream(channel);
+            try (OutputStreamWriter osw = new OutputStreamWriter(os, UTF_8)) {
+                try (PrintWriter writer = new PrintWriter(osw)) {
+                    InputStream is = Channels.newInputStream(channel);
+                    try (BufferedReader reader = new BufferedReader(new InputStreamReader(is, UTF_8))) {
+                        for (int i = 0; i < 1000; i++) {
+                            writer.print(httpRequest);
+                            writer.flush();
+
+                            verifyHelloWorldReceived(reader);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static void verifyHelloWorldReceived(BufferedReader reader) throws IOException {
+        for (int i = 0; i < 5; i++) {
+            String line = reader.readLine();
+            if (line.isEmpty()) {
+                // here comes body. Need to be specific otherwise it hangs for a long time.
+                char[] buffer = new char[18];
+                int read = reader.read(buffer, 0, 18);
+                assertThat(read).isEqualTo(18);
+                assertThat(new String(buffer)).isEqualTo("{\"hello\": \"World\"}");
+                return;
+            }
+        }
+        fail("Have not received hello world.");
+    }
+
+    public static class HelloWorldApplication extends Application<Configuration> {
+
+        @Override
+        public void run(Configuration configuration, Environment environment) {
+            environment.jersey().register(new FakeResource());
+            environment.healthChecks().register("hello-check", new HealthCheck() {
+                @Override
+                protected Result check() {
+                    return Result.healthy();
+                }
+            });
+        }
+
+        @Path("/hello")
+        @Produces(MediaType.APPLICATION_JSON)
+        public static class FakeResource {
+
+            @GET
+            public String get() {
+                return "{\"hello\": \"World\"}";
+            }
+        }
+    }
+}

--- a/dropwizard-unix-socket/src/test/resources/yaml/usock-server.yml
+++ b/dropwizard-unix-socket/src/test/resources/yaml/usock-server.yml
@@ -1,0 +1,8 @@
+---
+server:
+    type: simple
+    connector:
+        type: unix-socket
+        useDateHeader: false
+    applicationContextPath: /app
+    adminContextPath: /admin

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <module>dropwizard-request-logging</module>
         <module>dropwizard-json-logging</module>
         <module>dropwizard-health</module>
+        <module>dropwizard-unix-socket</module>
 
         <module>dropwizard-example</module>
         <module>docs/source/examples</module>


### PR DESCRIPTION
###### Problem:
Since Java 16, Unix Domain Sockets are supported natively. And since Jetty 10, there is a ready made connector for it and it is not considered experimental anymore.
The typical use case is a reverse proxy connecting to unix socket instead of TCP which has various advantages (which I can't really provide a source right now :)).

###### Solution:
Created a new connector type "unix-socket".
I've reimplemented #1893 but it needed some adjustments considering how much dropwizard changed since then.
The test was also a little tricky (and not very pretty) considering there is no unix socket support in Apache HTTP client. Or at least I couldn't find any but please correct me otherwise.

###### Result:
It's pretty simple to listen on unix sockets now. That was something we wanted in our product for a long time.
Also this works on Windows since Windows now also supports unix domain sockets.
