### PR TITLE
Restrict execution of the scacap/action-surefire-report

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -66,7 +66,7 @@ jobs:
           name: test-reports-${{ matrix.os }}-java${{ matrix.java_version }}
           path: '**/*-reports'
       - name: Publish Test Results
-        if: always()
+        if: github.event.pull_request.head.repo.full_name == 'dropwizard/dropwizard'
         uses: scacap/action-surefire-report@6efd3d10b5c1996a0724dd4c4915a073f685fefa # v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The `scacap/action-surefire-report` action needs write permissions to work properly. Actions triggered from forked repositories cannot acquire those permissions and the action will fail.

Restrict execution of this action to be run in the main dropwizard repo only.