### PR TITLE
Don't run scacap/action-surefire-report in forks

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Build
       run: ./mvnw --no-transfer-progress -V -B -fae -s .github/settings.xml -e "-DtrimStackTrace=false" "-Dsurefire.rerunFailingTestsCount=1" install
     - name: Upload Test Reports
-      if: always()
+      if: github.event.pull_request.head.repo.full_name == 'dropwizard/dropwizard'
       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
       with:
         name: test-reports-${{ matrix.os }}-java${{ matrix.java_version }}


### PR DESCRIPTION
The `scacap/action-surefire-report` action needs write permissions to work properly. Actions triggered from forked repositories cannot acquire those permissions and the action will fail.

Restrict execution of this action to be run in the main Dropwizard repo only.

(cherry picked from commit ecf06826ec239c4e52984089d1ca4756ad14a8ab)

Refs #7617