### PR TITLE
Ensure lexicographical order in messages from HealthCheckConfigValidator

### DIFF
--- a/dropwizard-health/src/main/java/io/dropwizard/health/HealthCheckConfigValidator.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/HealthCheckConfigValidator.java
@@ -32,9 +32,10 @@ class HealthCheckConfigValidator implements Managed {
             .collect(Collectors.toSet());
 
         // find health checks that are registered but do not have a configured schedule
-        final Set<String> notConfiguredHealthCheckNames = registeredHealthCheckNames.stream()
+        final List<String> notConfiguredHealthCheckNames = registeredHealthCheckNames.stream()
             .filter(healthCheckName -> !configuredHealthCheckNames.contains(healthCheckName))
-            .collect(Collectors.toSet());
+            .sorted()
+            .collect(Collectors.toList());
 
         if (!notConfiguredHealthCheckNames.isEmpty()) {
             final String healthCheckList = notConfiguredHealthCheckNames.stream()
@@ -45,9 +46,10 @@ class HealthCheckConfigValidator implements Managed {
         }
 
         // find health checks that are configured with a schedule but are not actually registered
-        final Set<String> notRegisteredHealthCheckNames = configuredHealthCheckNames.stream()
+        final List<String> notRegisteredHealthCheckNames = configuredHealthCheckNames.stream()
             .filter(healthCheckName -> !registeredHealthCheckNames.contains(healthCheckName))
-            .collect(Collectors.toSet());
+            .sorted()
+            .collect(Collectors.toList());
 
         if (!notRegisteredHealthCheckNames.isEmpty()) {
             final String healthCheckList = notRegisteredHealthCheckNames.stream()

--- a/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckConfigValidatorTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckConfigValidatorTest.java
@@ -148,7 +148,8 @@ class HealthCheckConfigValidatorTest {
             assertThat(logEvent.getFormattedMessage())
                 .contains("  * check-3");
             assertThat(e.getMessage())
-                .contains("[check-3, check-2]");
+                .contains("check-2")
+                .contains("check-3");
         }
     }
 }

--- a/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckConfigValidatorTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckConfigValidatorTest.java
@@ -148,8 +148,7 @@ class HealthCheckConfigValidatorTest {
             assertThat(logEvent.getFormattedMessage())
                 .contains("  * check-3");
             assertThat(e.getMessage())
-                .contains("check-2")
-                .contains("check-3");
+                .contains("[check-3, check-2]");
         }
     }
 }

--- a/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckConfigValidatorTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckConfigValidatorTest.java
@@ -142,13 +142,10 @@ class HealthCheckConfigValidatorTest {
             assertThat(logEvent.getLevel())
                 .isEqualTo(Level.ERROR);
             assertThat(logEvent.getFormattedMessage())
-                .doesNotContain("  * check-1");
-            assertThat(logEvent.getFormattedMessage())
-                .contains("  * check-3");
-            assertThat(logEvent.getFormattedMessage())
-                .contains("  * check-3");
+                .doesNotContain("  * check-1")
+                .contains("  * check-2\n  * check-3");
             assertThat(e.getMessage())
-                .contains("[check-3, check-2]");
+                .contains("[check-2, check-3]");
         }
     }
 }


### PR DESCRIPTION
###### Problem:
1. This PR is to fix a flaky test `io.dropwizard.health.HealthCheckConfigValidatorTest.startValidationsShouldFailIfAHealthCheckConfiguredButNotRegistered` in module `dropwizard-health`. We found this when using the latest version of dropwizard.
2. Steps to reproduce the test failure:
- Run the following commands:
```
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -pl dropwizard-health -Dtest=io.dropwizard.health.HealthCheckConfigValidatorTest#startValidationsShouldFailIfAHealthCheckConfiguredButNotRegistered
```
- Then you will get the following test failures:
```
[ERROR]   HealthCheckConfigValidatorTest.startValidationsShouldFailIfAHealthCheckConfiguredButNotRegistered:151 
Expecting actual:
  "The following configured health checks were not registered: [check-2, check-3]"
to contain:
  "[check-3, check-2]" 
```
###### Solution:
The flakiness is caused by lines 150-151: `assertThat(e.getMessage()).contains("[check-3, check-2]");`, the assertion asserts the orders of these two elements must be `check-3,check-2`, but actually the order is non-deterministic, which can lead the test fail. To fix the flakiness, the assertion can be changed to ` assertThat(e.getMessage()).contains("check-2").contains("check-3");`, which does not assume an order.
