### PR TITLE
Clean test db

### DIFF
--- a/dropwizard-migrations/pom.xml
+++ b/dropwizard-migrations/pom.xml
@@ -139,6 +139,29 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-clean-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>clean-test-db</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                        <configuration>
+                            <filesets>
+                                <fileset>
+                                    <directory>${project.basedir}/src/test/resources</directory>
+                                    <includes>
+                                        <include>test-db.mv.db</include>
+                                    </includes>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Appveyor doesn't clean and re-initialize the repo in a build. Re-running the H2 Script tool against the existing database fails with an error. This PR cleans the H2 database in the default build lifecycle to force re-generation in the test cycle.

(cherry picked from commit 20b5f1eae03cdc8c2975d3b5ceaf6f39c176d070)

Refs #7389 