### PR TITLE
fix: fix flaky test io.dropwizard.health.HealthCheckConfigValidatorTest#startValidationsShouldFailIfAHealthCheckConfiguredButNotRegistered

### DIFF
--- a/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckConfigValidatorTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckConfigValidatorTest.java
@@ -147,8 +147,10 @@ class HealthCheckConfigValidatorTest {
                 .contains("  * check-3");
             assertThat(logEvent.getFormattedMessage())
                 .contains("  * check-3");
-            assertThat(e.getMessage())
-                .contains("[check-3, check-2]");
+            assertThat(e.getMessage()).satisfiesAnyOf(
+                message -> assertThat(message).contains("[check-3, check-2]"),
+                message -> assertThat(message).contains("[check-2, check-3]")
+            );
         }
     }
 }


### PR DESCRIPTION
###### Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->
The HealthCheckConfigValidator#startValidationsShouldFailIfAHealthCheckConfiguredButNotRegistered test is flaky due to the use of the non-deterministic Set<> instance used in the class HealthCheckConfigValidator.
HealthCheckConfigValidator is intended to throw an exception with an error message containing specific words. Due to the use of a Set to generate the error message, this error message is not deterministic because the ordering, in which the elements are returned from the Set, is not deterministic. This results in a flaky test. 
The flaky test was found by using the [NonDex](https://mvnrepository.com/artifact/edu.illinois/nondex-maven-plugin) tool.

###### Solution:
Instead of checking if the error message contains an array with a specific ordering of the expected strings, check if the error message contains either the one or the other ordering (random ordering as intended by the use of Sets). 

###### Result:
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->
The test is deterministic and not flaky. This improves the quality of the test and reduces the time to search for the bug during future development.

###### Reproduce:
```shell
mvn -pl dropwizard-health edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=io.dropwizard.health.HealthCheckConfigValidatorTest#startValidationsShouldFailIfAHealthCheckConfiguredButNotRegistered -DnondexSeed=933178
``` 