### PR TITLE
Expose uri compliance

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -318,6 +318,7 @@ HTTP
           useForwardedHeaders: false
           useProxyProtocol: false
           httpCompliance: RFC7230
+          uriCompliance: DEFAULT
 
 
 ======================== ==================  ======================================================================================
@@ -373,6 +374,16 @@ httpCompliance           RFC7230             This sets the http compliance level
 
                                              * RFC7230: Disallow header folding.
                                              * RFC2616: Allow header folding.
+uriCompliance            DEFAULT             This sets the uri compliance level used by Jetty when parsing http, this can be useful when
+                                             attempting to avoid breaking changes with Jetty 10 and onward;
+                                             Possible values are set forth in the ``org.eclipse.jetty.http.UriCompliance``
+                                             enum and include:
+
+                                             * DEFAULT: The default compliance mode that extends RFC3986 compliance with
+                                               additional violations to avoid most ambiguous URIs.
+                                             * LEGACY: Compliance mode that models Jetty-9.4 behavior.
+                                             * RFC3986: Compliance mode that exactly follows RFC3986, including allowing
+                                               all additional ambiguous URI Violations.
 requestCookieCompliance  RFC6265             This sets the cookie compliance level used by Jetty when parsing request ``Cookie``
                                              headers, this can be useful when needing to support Version=1 cookies defined in
                                              RFC2109 (and continued in RFC2965) which allows for special/reserved characters

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/HttpConnectorFactory.java
@@ -3,15 +3,8 @@ package io.dropwizard.jetty;
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.core.JacksonException;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import io.dropwizard.metrics.jetty11.InstrumentedConnectionFactory;
 import io.dropwizard.util.DataSize;
 import io.dropwizard.util.DataSizeUnit;
@@ -40,7 +33,6 @@ import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
 import org.eclipse.jetty.util.thread.Scheduler;
 import org.eclipse.jetty.util.thread.ThreadPool;
 
-import java.io.IOException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -621,77 +613,27 @@ public class HttpConnectorFactory implements ConnectorFactory {
         this.responseCookieCompliance = responseCookieCompliance;
     }
 
-    private static class HttpComplianceSerializer extends StdSerializer<HttpCompliance> {
+    private static class HttpComplianceSerializer extends StringMethodSerializer<HttpCompliance> {
         public HttpComplianceSerializer() {
-            this(null);
-        }
-
-        protected HttpComplianceSerializer(@Nullable Class<HttpCompliance> t) {
-            super(t);
-        }
-
-        @Override
-        public void serialize(HttpCompliance httpCompliance, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
-            if (httpCompliance == null) {
-                jsonGenerator.writeNull();
-            } else {
-                jsonGenerator.writeString(httpCompliance.getName());
-            }
+            super(HttpCompliance.class, HttpCompliance::getName);
         }
     }
 
-    private static class HttpComplianceDeserializer extends StdDeserializer<HttpCompliance> {
+    private static class HttpComplianceDeserializer extends StringMethodDeserializer<HttpCompliance> {
         public HttpComplianceDeserializer() {
-            this(null);
-        }
-
-        protected HttpComplianceDeserializer(@Nullable Class<?> vc) {
-            super(vc);
-        }
-
-        @Override
-        public @Nullable HttpCompliance deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
-            if (jsonParser.getText() != null && !jsonParser.getText().isEmpty()) {
-                return HttpCompliance.valueOf(jsonParser.getText());
-            }
-            return null;
+            super(HttpCompliance.class, HttpCompliance::valueOf);
         }
     }
 
-    private static class CookieComplianceSerializer extends StdSerializer<CookieCompliance> {
+    private static class CookieComplianceSerializer extends StringMethodSerializer<CookieCompliance> {
         public CookieComplianceSerializer() {
-            this(null);
-        }
-
-        protected CookieComplianceSerializer(@Nullable Class<CookieCompliance> t) {
-            super(t);
-        }
-
-        @Override
-        public void serialize(CookieCompliance cookieCompliance, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
-            if (cookieCompliance == null) {
-                jsonGenerator.writeNull();
-            } else {
-                jsonGenerator.writeString(cookieCompliance.getName());
-            }
+            super(CookieCompliance.class, CookieCompliance::getName);
         }
     }
 
-    private static class CookieComplianceDeserializer extends StdDeserializer<CookieCompliance> {
+    private static class CookieComplianceDeserializer extends StringMethodDeserializer<CookieCompliance> {
         public CookieComplianceDeserializer() {
-            this(null);
-        }
-
-        protected CookieComplianceDeserializer(@Nullable Class<?> vc) {
-            super(vc);
-        }
-
-        @Override
-        public @Nullable CookieCompliance deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JacksonException {
-            if (jsonParser.getText() != null && !jsonParser.getText().isEmpty()) {
-                return CookieCompliance.valueOf(jsonParser.getText());
-            }
-            return null;
+            super(CookieCompliance.class, CookieCompliance::valueOf);
         }
     }
 

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/StringMethodDeserializer.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/StringMethodDeserializer.java
@@ -1,0 +1,28 @@
+package io.dropwizard.jetty;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+class StringMethodDeserializer<T> extends StdDeserializer<T> {
+
+    private final Function<String, T> deserializerFunction;
+
+    protected StringMethodDeserializer(Class<T> clazz, Function<String, T> deserializerFunction) {
+        super(clazz);
+        this.deserializerFunction = deserializerFunction;
+    }
+
+    @Override
+    public @Nullable T deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+        String text = jsonParser.getText();
+        if (text != null && !text.isEmpty()) {
+            return deserializerFunction.apply(text);
+        }
+        return null;
+    }
+}

--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/StringMethodSerializer.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/StringMethodSerializer.java
@@ -1,0 +1,27 @@
+package io.dropwizard.jetty;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+class StringMethodSerializer<T> extends StdSerializer<T> {
+
+    private final Function<T, String> serializerFunction;
+
+    protected StringMethodSerializer(Class<T> clazz, Function<T, String> serializerFunction) {
+        super(clazz);
+        this.serializerFunction = serializerFunction;
+    }
+
+    @Override
+    public void serialize(T t, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        if (t == null) {
+            jsonGenerator.writeNull();
+        } else {
+            jsonGenerator.writeString(serializerFunction.apply(t));
+        }
+    }
+}

--- a/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
+++ b/dropwizard-jetty/src/test/java/io/dropwizard/jetty/HttpConnectorFactoryTest.java
@@ -17,6 +17,7 @@ import jakarta.validation.Validator;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.eclipse.jetty.http.CookieCompliance;
 import org.eclipse.jetty.http.HttpCompliance;
+import org.eclipse.jetty.http.UriCompliance;
 import org.eclipse.jetty.server.ForwardedRequestCustomizer;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
@@ -80,6 +81,7 @@ class HttpConnectorFactoryTest {
         assertThat(http.isUseDateHeader()).isTrue();
         assertThat(http.isUseForwardedHeaders()).isFalse();
         assertThat(http.getHttpCompliance()).isEqualTo(HttpCompliance.RFC7230);
+        assertThat(http.getUriCompliance()).isEqualTo(UriCompliance.DEFAULT);
         assertThat(http.getRequestCookieCompliance()).isEqualTo(CookieCompliance.RFC6265);
         assertThat(http.getResponseCookieCompliance()).isEqualTo(CookieCompliance.RFC6265);
     }
@@ -114,6 +116,7 @@ class HttpConnectorFactoryTest {
         HttpConfiguration httpConfiguration = http.buildHttpConfiguration();
         assertThat(httpConfiguration.getCustomizers()).hasAtLeastOneElementOfType(ForwardedRequestCustomizer.class);
         assertThat(http.getHttpCompliance()).isEqualTo(HttpCompliance.RFC2616);
+        assertThat(http.getUriCompliance()).isEqualTo(UriCompliance.UNSAFE);
         assertThat(http.getRequestCookieCompliance()).isEqualTo(CookieCompliance.RFC2965);
         assertThat(http.getResponseCookieCompliance()).isEqualTo(CookieCompliance.RFC6265);
     }

--- a/dropwizard-jetty/src/test/resources/yaml/http-connector.yml
+++ b/dropwizard-jetty/src/test/resources/yaml/http-connector.yml
@@ -22,5 +22,6 @@ useServerHeader: true
 useDateHeader: false
 useForwardedHeaders: true
 httpCompliance: RFC2616
+uriCompliance: UNSAFE
 requestCookieCompliance: RFC2965
 responseCookieCompliance: RFC6265


### PR DESCRIPTION
Follow-up for #7042.

Refactors the `HttpCompliance(De)Serializer` and `CookieCompliance(De)Serializer` classes to have common base classes for string representations of objects through member functions.

Exposes a property to set the Jetty uri compliance.