### PR TITLE
Fix the broken link to Apache HttpClient 5.X migration guide

### DIFF
--- a/docs/source/manual/upgrade-notes/upgrade-notes-3_0_x.rst
+++ b/docs/source/manual/upgrade-notes/upgrade-notes-3_0_x.rst
@@ -41,7 +41,7 @@ The most functions from Dropwizard are provided as before, but some changes have
  - the ``ServiceUnavailableRetryStrategy`` is removed
  - the ``HttpRequestRetryHandler`` is replaced by the ``HttpRequestRetryStrategy``
 
-For more information refer to the `Apache HttpClient 5.0 migration guide <https://hc.apache.org/httpcomponents-client-5.1.x/migration-guide/migration-to-classic.html>`_.
+For more information refer to the `Apache HttpClient 5.X migration guide <https://hc.apache.org/httpcomponents-client-5.2.x/migration-guide/migration-to-classic.html>`_.
 
 Dropwizard Package Structure and JPMS
 =====================================


### PR DESCRIPTION
Refs #7613
(cherry picked from commit cc457cca8f7bf622e67ba26d1c7b7dd060685860)