### PR TITLE
Add JReleaser to simplify release announcements

### DIFF
--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -8,6 +8,11 @@ on:
       developmentVersion:
         description: 'Version of the next development cycle (must end in "-SNAPSHOT")'
         required: true
+      jreleaser:
+        description: If this release should automatically be published and announced
+        required: false
+        type: boolean
+        default: true
 jobs:
   trigger-release:
     runs-on: 'ubuntu-latest'
@@ -40,9 +45,33 @@ jobs:
         git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
         git config --global author.name "${GITHUB_ACTOR}"
     - name: Prepare release
+      id: prepare
       run: ./mvnw -V -B -ntp -Prelease -DreleaseVersion=${{ inputs.releaseVersion }} -DdevelopmentVersion=${{ inputs.developmentVersion }} release:prepare
     - name: Rollback on failure
       if: failure()
       run: |
         ./mvnw -B release:rollback -Prelease
         echo "You may need to manually delete the GitHub tag, if it was created."
+    - name: JReleaser
+      if: ${{ steps.prepare.conclusion == 'success' && inputs.jreleaser == 'true' }}
+      id: jreleaser
+      uses: jreleaser/release-action@v2
+      with:
+        arguments: full-release
+      env:
+        JRELEASER_PROJECT_VERSION: ${{ inputs.releaseVersion }}
+        JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        JRELEASER_GITHUB_USERNAME: ${{ GITHUB_ACTOR }}
+        JRELEASER_TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
+        JRELEASER_TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
+        JRELEASER_TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+        JRELEASER_TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+        JRELEASER_MASTODON_ACCESS_TOKEN: ${{ secrets.MASTODON_ACCESS_TOKEN }}
+    - name: JReleaser release output
+      if: ${{ always() && steps.jreleaser.conclusion != 'skipped' }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: jreleaser-release
+        path: |
+          out/jreleaser/trace.log
+          out/jreleaser/output.properties

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ atlassian-ide-plugin.xml
 logs
 
 .DS_Store
+
+out/jreleaser/

--- a/.jreleaser/announcement.tpl
+++ b/.jreleaser/announcement.tpl
@@ -1,0 +1,4 @@
+#Dropwizard {{projectVersion}} has just been released. #Java
+
+All changes of this release are listed in the release notes:
+https://github.com/dropwizard/dropwizard/releases/tag/v{{projectVersion}}

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -1,0 +1,42 @@
+---
+project:
+  name: dropwizard
+  description: |
+      A damn simple library for building production-ready RESTful web services.
+  links:
+    homepage: https://www.dropwizard.io
+  license: Apache-2.0
+  copyright: 2010-2013 Coda Hale and Yammer, Inc., 2014-2020 Dropwizard Team
+  authors:
+    - arteam
+    - carlo-rtr
+    - evnm
+    - joschi
+    - jplock
+    - natalie-zamani
+    - ryankennedy
+    - skamille
+    - zUniQueX
+  java:
+    groupId: io.dropwizard
+    version: 8
+
+release:
+  github:
+    overwrite: true
+    discussionCategoryName: Announcements
+    owner: dropwizard
+    commitAuthor:
+      name: 'Dropwizard Release Action'
+      email: '48418865+dropwizard-committers@users.noreply.github.com'
+    releaseNotes:
+      enabled: true
+
+announce:
+  twitter:
+    active: RELEASE
+    statusTemplate: .jreleaser/announcement.tpl
+  mastodon:
+    active: RELEASE
+    statusTemplate: .jreleaser/announcement.tpl
+    host: https://jvm.social


### PR DESCRIPTION
* Add jreleaser to simplify release announcements: https://jreleaser.org/
* Fix yamllint issues
* Add Mastodon announcer
* Rename Twitter template to generic announcement

Co-authored-by: Jochen Schalanda <jochen@schalanda.name>

Refs #7692
(cherry picked from commit 28d0505d4a9795e2938b7c6981dfa59836e862c5)