### PR TITLE
Use github context to retrieve actor

### DIFF
--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -64,7 +64,7 @@ jobs:
         env:
           JRELEASER_PROJECT_VERSION: ${{ inputs.releaseVersion }}
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JRELEASER_GITHUB_USERNAME: ${{ GITHUB_ACTOR }}
+          JRELEASER_GITHUB_USERNAME: ${{ github.actor }}
           JRELEASER_TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
           JRELEASER_TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
           JRELEASER_TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}


### PR DESCRIPTION
The `${GITHUB_ACTOR}` variable cannot be used when setting the context for JReleaser.