### PR TITLE
Fix Javadoc for AppenderFactory

### DIFF
--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/common/AppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/common/AppenderFactory.java
@@ -16,7 +16,7 @@ import io.dropwizard.logging.common.layout.LayoutFactory;
  * <ol>
  * <li>Create a class which implements {@link AppenderFactory}.</li>
  * <li>Annotate it with {@code @JsonTypeName} and give it a unique type name.</li>
- * <li>add a {@code META-INF/services/io.dropwizard.logging.AppenderFactory} file with your
+ * <li>add a {@code META-INF/services/io.dropwizard.logging.common.AppenderFactory} file with your
  * implementation's full class name to the class path.</li>
  * </ol>
  *


### PR DESCRIPTION
###### Problem:
AppenderFactory service name has not been updated in the javadocs when package was refactored

###### Solution:
Update the service name to io.dropwizard.logging.common.AppenderFactory

###### Result:
Fix the javadocs

Closes #7797
