### PR TITLE
Set `LoggerContext` in `LoggingEvent`

### DIFF
--- a/dropwizard-e2e/src/test/java/com/example/request_log/ClassicRequestLogIntegrationTest.java
+++ b/dropwizard-e2e/src/test/java/com/example/request_log/ClassicRequestLogIntegrationTest.java
@@ -1,0 +1,44 @@
+package com.example.request_log;
+
+import io.dropwizard.testing.ConfigOverride;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisabledOnOs(OS.WINDOWS) // FIXME: Make tests run on Windows
+class ClassicRequestLogIntegrationTest extends AbstractRequestLogPatternIntegrationTest {
+
+    private static final Pattern REQUEST_LOG_PATTERN = Pattern.compile(
+            "127\\.0\\.0\\.1 - - \\[.+\\] \"GET /greet HTTP/1\\.1\" 200 15 \"-\" \"TestApplication \\(test-request-logs\\)\" \\d+"
+    );
+
+    @Override
+    protected List<ConfigOverride> configOverrides() {
+        final List<ConfigOverride> configOverrides = new ArrayList<>(super.configOverrides());
+        configOverrides.add(ConfigOverride.config("server.requestLog.type", "classic"));
+        return configOverrides;
+    }
+
+    @Test
+    void testDefaultPattern() throws Exception {
+        String url = String.format("http://localhost:%d/greet?name=Charley", dropwizardAppRule.getLocalPort());
+        for (int i = 0; i < 100; i++) {
+            client.target(url).request().get();
+        }
+
+        dropwizardAppRule.getConfiguration().getLoggingFactory().stop();
+        dropwizardAppRule.getConfiguration().getLoggingFactory().reset();
+        Thread.sleep(100L);
+
+        List<String> logs = Files.readAllLines(requestLogFile, UTF_8);
+        assertThat(logs).hasSize(100).allMatch(s -> REQUEST_LOG_PATTERN.matcher(s).matches());
+    }
+}

--- a/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/old/DropwizardSlf4jRequestLogWriter.java
+++ b/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/old/DropwizardSlf4jRequestLogWriter.java
@@ -1,11 +1,13 @@
 package io.dropwizard.request.logging.old;
 
 import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.spi.AppenderAttachableImpl;
 import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
@@ -16,9 +18,11 @@ import java.io.IOException;
  */
 public class DropwizardSlf4jRequestLogWriter extends AbstractLifeCycle implements RequestLog.Writer {
     private AppenderAttachableImpl<ILoggingEvent> appenders;
+    private final LoggerContext loggerContext;
 
     DropwizardSlf4jRequestLogWriter(AppenderAttachableImpl<ILoggingEvent> appenders) {
         this.appenders = appenders;
+        this.loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
     }
 
     @Override
@@ -28,6 +32,7 @@ public class DropwizardSlf4jRequestLogWriter extends AbstractLifeCycle implement
         event.setLoggerName("http.request");
         event.setMessage(entry);
         event.setTimeStamp(System.currentTimeMillis());
+        event.setLoggerContext(loggerContext);
 
         appenders.appendLoopOnAppenders(event);
     }


### PR DESCRIPTION
Logback 1.4.8 refactored the handling of MDC and now requires a `LoggerContext` to be set in a `LoggingEvent`. Else a NPE is thrown.

https://logback.qos.ch/news.html#1.3.8

Fixes #7830