### PR TITLE
Deprecate `ServerPushFilterFactory`

### DIFF
--- a/dropwizard-jetty/src/main/java/io/dropwizard/jetty/ServerPushFilterFactory.java
+++ b/dropwizard-jetty/src/main/java/io/dropwizard/jetty/ServerPushFilterFactory.java
@@ -66,7 +66,10 @@ import java.util.stream.Collectors;
  *         </td>
  *     </tr>
  * </table>
+ *
+ * @deprecated Jetty 12.0.3 removes the {@link PushCacheFilter} without replacement
  */
+@Deprecated
 public class ServerPushFilterFactory {
 
     private boolean enabled = false;


### PR DESCRIPTION
Jetty 12.0.3 removes the `PushCacheFilter` without replacement. Therefore the `ServerPushFilterFactory` has to be deprecated too.