### PR TITLE
Logback request log: combine headers

### DIFF
--- a/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/DropwizardJettyServerAdapter.java
+++ b/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/DropwizardJettyServerAdapter.java
@@ -34,6 +34,12 @@ class DropwizardJettyServerAdapter implements ServerAdapter {
 
     @Override
     public Map<String, String> buildResponseHeaderMap() {
-        return response.getHttpFields().stream().collect(Collectors.toMap(HttpField::getName, HttpField::getValue));
+        return response.getHttpFields()
+            .stream()
+            .collect(
+                Collectors.groupingBy(HttpField::getName,
+                    Collectors.mapping(HttpField::getValue,
+                        Collectors.joining(",")))
+            );
     }
 }

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/LogbackAccessRequestLogTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/LogbackAccessRequestLogTest.java
@@ -2,6 +2,7 @@ package io.dropwizard.request.logging;
 
 import ch.qos.logback.access.spi.IAccessEvent;
 import ch.qos.logback.core.Appender;
+import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.HttpChannelState;
@@ -51,6 +52,11 @@ class LogbackAccessRequestLogTest {
 
         when(response.getHttpChannel()).thenReturn(channel);
 
+        HttpFields.Mutable responseFields = HttpFields.build();
+        responseFields.add("Testheader", "Testvalue1");
+        responseFields.add("Testheader", "Testvalue2");
+        when(response.getHttpFields()).thenReturn(responseFields);
+
         requestLog.addAppender(appender);
 
         requestLog.start();
@@ -72,6 +78,13 @@ class LogbackAccessRequestLogTest {
 
         assertThat(event.getStatusCode()).isEqualTo(200);
         assertThat(event.getContentLength()).isEqualTo(8290L);
+    }
+
+    @Test
+    void combinesHeaders() {
+        final IAccessEvent event = logAndCapture();
+
+        assertThat(event.getResponseHeaderMap()).containsEntry("Testheader", "Testvalue1,Testvalue2");
     }
 
     private IAccessEvent logAndCapture() {


### PR DESCRIPTION
Combines the headers with equal names instead of throwing an exception in the default map collector. Combining headers into a comma-separated list is allowed in [RFC 7230](https://www.rfc-editor.org/rfc/rfc7230#section-3.2.2).