### PR TITLE
Logback request log: combine headers

### DIFF
--- a/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/DropwizardJettyServerAdapter.java
+++ b/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/DropwizardJettyServerAdapter.java
@@ -1,0 +1,45 @@
+package io.dropwizard.request.logging;
+
+import ch.qos.logback.access.spi.ServerAdapter;
+import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+class DropwizardJettyServerAdapter implements ServerAdapter {
+    private final Request request;
+    private final Response response;
+
+    public DropwizardJettyServerAdapter(Request request, Response response) {
+        this.request = request;
+        this.response = response;
+    }
+
+    @Override
+    public long getRequestTimestamp() {
+        return request.getTimeStamp();
+    }
+
+    @Override
+    public long getContentLength() {
+        return response.getHttpChannel().getBytesWritten();
+    }
+
+    @Override
+    public int getStatusCode() {
+        return response.getCommittedMetaData().getStatus();
+    }
+
+    @Override
+    public Map<String, String> buildResponseHeaderMap() {
+        return response.getHttpFields()
+            .stream()
+            .collect(
+                Collectors.groupingBy(HttpField::getName,
+                    Collectors.mapping(HttpField::getValue,
+                        Collectors.joining(",")))
+            );
+    }
+}

--- a/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/LogbackAccessRequestLog.java
+++ b/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/LogbackAccessRequestLog.java
@@ -1,6 +1,15 @@
 package io.dropwizard.request.logging;
 
 import ch.qos.logback.access.jetty.RequestLogImpl;
+import ch.qos.logback.access.spi.AccessEvent;
+import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.spi.FilterReply;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+
+import java.util.EventListener;
+import java.util.Iterator;
 
 /**
  * The Dropwizard request log uses logback-access, but we override it to remove the requirement for logback-access.xml
@@ -10,5 +19,40 @@ public class LogbackAccessRequestLog extends RequestLogImpl {
     @Override
     public void configure() {
         setName("LogbackAccessRequestLog");
+    }
+
+    @Override
+    public void log(Request jettyRequest, Response jettyResponse) {
+        DropwizardJettyServerAdapter adapter = new DropwizardJettyServerAdapter(jettyRequest, jettyResponse);
+        IAccessEvent accessEvent = new AccessEvent(this, jettyRequest, jettyResponse, adapter);
+        if (getFilterChainDecision(accessEvent) == FilterReply.DENY) {
+            return;
+        }
+        appendLoopOnAppenders(accessEvent);
+    }
+
+    private void appendLoopOnAppenders(IAccessEvent iAccessEvent) {
+        Iterator<Appender<IAccessEvent>> appenderIterator = this.iteratorForAppenders();
+        while (appenderIterator.hasNext()) {
+            appenderIterator.next().doAppend(iAccessEvent);
+        }
+    }
+
+    @Override
+    public boolean addEventListener(EventListener eventListener) {
+        if (eventListener instanceof Listener) {
+            addLifeCycleListener((Listener) eventListener);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean removeEventListener(EventListener eventListener) {
+        if (eventListener instanceof Listener) {
+            removeLifeCycleListener((Listener) eventListener);
+            return true;
+        }
+        return false;
     }
 }

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/LogbackAccessRequestLogTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/LogbackAccessRequestLogTest.java
@@ -2,6 +2,7 @@ package io.dropwizard.request.logging;
 
 import ch.qos.logback.access.spi.IAccessEvent;
 import ch.qos.logback.core.Appender;
+import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.HttpChannelState;
@@ -51,6 +52,11 @@ class LogbackAccessRequestLogTest {
 
         when(response.getHttpChannel()).thenReturn(channel);
 
+        HttpFields.Mutable responseFields = HttpFields.build();
+        responseFields.add("Testheader", "Testvalue1");
+        responseFields.add("Testheader", "Testvalue2");
+        when(response.getHttpFields()).thenReturn(responseFields);
+
         requestLog.addAppender(appender);
 
         requestLog.start();
@@ -72,6 +78,13 @@ class LogbackAccessRequestLogTest {
 
         assertThat(event.getStatusCode()).isEqualTo(200);
         assertThat(event.getContentLength()).isEqualTo(8290L);
+    }
+
+    @Test
+    void combinesHeaders() {
+        final IAccessEvent event = logAndCapture();
+
+        assertThat(event.getResponseHeaderMap()).containsEntry("Testheader", "Testvalue1,Testvalue2");
     }
 
     private IAccessEvent logAndCapture() {


### PR DESCRIPTION
Refs #7965

This PR ports the `DropwizardJettyServerAdapter` to the `release/4.0.x` branch. This allows logging all response headers instead of only the last header value.