### PR TITLE
only create the requestLog once to speed up the test

### DIFF
--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/old/LogbackClassicRequestLogFactoryTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/old/LogbackClassicRequestLogFactoryTest.java
@@ -17,7 +17,7 @@ import org.eclipse.jetty.server.CustomRequestLog;
 import org.eclipse.jetty.server.HttpChannelState;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -38,14 +38,14 @@ class LogbackClassicRequestLogFactoryTest {
         BootstrapLogging.bootstrap();
     }
 
-    private RequestLogFactory<?> requestLog;
+    private static RequestLogFactory<?> requestLog;
 
-    @BeforeEach
-    void setUp() throws Exception {
+    @BeforeAll
+    static void setUp() throws Exception {
         final ObjectMapper objectMapper = Jackson.newObjectMapper();
         objectMapper.getSubtypeResolver().registerSubtypes(ConsoleAppenderFactory.class, FileAppenderFactory.class,
             SyslogAppenderFactory.class);
-        this.requestLog = new YamlConfigurationFactory<>(RequestLogFactory.class,
+        requestLog = new YamlConfigurationFactory<>(RequestLogFactory.class,
             BaseValidator.newValidator(), objectMapper, "dw")
             .build(new ResourceConfigurationSourceProvider(), "yaml/logbackClassicRequestLog.yml");
     }


### PR DESCRIPTION
###### Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->
In the test class `LogbackClassicRequestLogFactoryTest`, there are three tests but all of them are not modifying `requestLog` or other related classes and they are just accessing `requestLog`. Repeatly creating the `requestLog` object from the `yaml` file will increase the test runtime.

###### Solution:
<!-- Describe the modifications you've done. -->
The solution is to just create the `requestLog` once before running all tests in the test class `LogbackClassicRequestLogFactoryTest`.

###### Result:
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->
There will be no repeated cost when creating the `requestLog` by justing creating it once. The test runtime can also be improved.

