### PR TITLE
Add GracefulHandler for a graceful shutdown

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/core/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/core/server/AbstractServerFactory.java
@@ -40,6 +40,7 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ErrorHandler;
+import org.eclipse.jetty.server.handler.GracefulHandler;
 import org.eclipse.jetty.setuid.RLimit;
 import org.eclipse.jetty.setuid.SetUIDListener;
 import org.eclipse.jetty.util.BlockingArrayQueue;
@@ -738,6 +739,12 @@ public abstract class AbstractServerFactory implements ServerFactory {
             }
             server.setRequestLog(log);
         }
+    }
+
+    protected Handler addGracefulHandler(Handler handler) {
+        final GracefulHandler gracefulHandler = new GracefulHandler();
+        gracefulHandler.setHandler(handler);
+        return gracefulHandler;
     }
 
     protected Handler buildGzipHandler(Handler handler) {

--- a/dropwizard-core/src/main/java/io/dropwizard/core/server/DefaultServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/core/server/DefaultServerFactory.java
@@ -192,7 +192,7 @@ public class DefaultServerFactory extends AbstractServerFactory {
                                                                   applicationHandler,
                                                                   adminHandler);
         final Handler gzipHandler = buildGzipHandler(routingHandler);
-        server.setHandler(gzipHandler);
+        server.setHandler(addGracefulHandler(gzipHandler));
         addRequestLog(server, environment.getName(), environment.getApplicationContext());
         return server;
     }

--- a/dropwizard-core/src/main/java/io/dropwizard/core/server/SimpleServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/core/server/SimpleServerFactory.java
@@ -132,7 +132,7 @@ public class SimpleServerFactory extends AbstractServerFactory {
                 adminContextPath, adminHandler);
         final ContextRoutingHandler routingHandler = new ContextRoutingHandler(handlers);
         final Handler gzipHandler = buildGzipHandler(routingHandler);
-        server.setHandler(gzipHandler);
+        server.setHandler(addGracefulHandler(gzipHandler));
         addRequestLog(server, environment.getName(), environment.getApplicationContext());
 
         return server;


### PR DESCRIPTION
Jetty uses the `StatisticsHandler` for a graceful shutdown of requests up to Jetty 11. Jetty 12 changes this behavior and introduces the `GracefulHandler` for a graceful shutdown.

This PR updates the method signature of `Handler addStatsHandler(Handler)` to `Handler addGracefulHandler(Handler)` because the old `StatisticsHandler` was only used to perform a graceful shutdown. Metrics get collected with the `dropwizard-metrics` module through `InstrumentedHandler`s.

If a Jetty `StatisticsHandler` shall be used anyway, a user can override the method and wrap the handlers to return both handler objects from the new method.