### PR TITLE
Managed virtual executor service

### DIFF
--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/LifecycleEnvironment.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/LifecycleEnvironment.java
@@ -68,6 +68,10 @@ public class LifecycleEnvironment {
     }
 
     public ExecutorService virtualExecutorService(String nameFormat) {
+        return virtualExecutorService(nameFormat, Duration.seconds(5));
+    }
+
+    public ExecutorService virtualExecutorService(String nameFormat, Duration shutdownTime) {
         try {
             Object virtualThreadBuilder = Thread.class.getDeclaredMethod("ofVirtual").invoke(null);
             Object virtualThreadFactory = Class.forName("java.lang.Thread$Builder")
@@ -77,7 +81,7 @@ public class LifecycleEnvironment {
             ExecutorService virtualThreadExecutor = (ExecutorService) Executors.class
                 .getDeclaredMethod("newThreadPerTaskExecutor", ThreadFactory.class)
                 .invoke(null, factory);
-            manage(new ExecutorServiceManager(virtualThreadExecutor, Duration.seconds(5), nameFormat));
+            manage(new ExecutorServiceManager(virtualThreadExecutor, shutdownTime, nameFormat));
             return virtualThreadExecutor;
         } catch (InvocationTargetException invocationTargetException) {
             throw new IllegalStateException("Error while creating virtual executor service", invocationTargetException.getCause());


### PR DESCRIPTION
###### Problem:
Java 21 has virtual/lightweight thread support now which is a really powerful tool for performance. We use thread pools quite a lot in our application and were looking forward to replace them with virtual threads instead. But also want them to be managed by dropwizard so we get nice metrics and all.
https://github.com/dropwizard/dropwizard/issues/8004

###### Solution:
Used reflection in order to support older java.
I didn't create/reuse any builders as all the fields in the ExecutorServiceBuilders are obsolete for virtual threads. We let JVM handle it all instead.
I am not sure if this really covers all the aspects of "being managed by dropwizard". Would be good if someone more familiar with the code makes sure that it does.
