### PR TITLE
extra info for enableOCSP and enableCRLDP

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -478,8 +478,8 @@ needClientAuth                   (none)                           Whether or not
 wantClientAuth                   (none)                           Whether or not client authentication is requested.
 certAlias                        (none)                           The alias of the certificate to use.
 crlPath                          (none)                           The path to the file which contains the Certificate Revocation List.
-enableCRLDP                      false                            Whether or not CRL Distribution Points (CRLDP) support is enabled.
-enableOCSP                       false                            Whether or not On-Line Certificate Status Protocol (OCSP) support is enabled.
+enableCRLDP                      false                            Whether or not CRL Distribution Points (CRLDP) support is enabled. (requires validateCerts or validatePeers)
+enableOCSP                       false                            Whether or not On-Line Certificate Status Protocol (OCSP) support is enabled. (requires validateCerts or validatePeers)
 maxCertPathLength                (unlimited)                      The maximum certification path length.
 ocspResponderUrl                 (none)                           The location of the OCSP responder.
 jceProvider                      (none)                           The name of the JCE provider to use for cryptographic support. See `Oracle documentation <https://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html>`_ for more information.


### PR DESCRIPTION
###### Problem:
I've spent a little too much time trying to understand why setting **enableOCSP** to true does nothing. Only after searching the source code, did I discover that I also need **validatePeers**, and without it **enableOCSP** will be just ignored. 

###### Solution:
Adding short info that for **enableCRLDP** or **enableOCSP** to work any of the **validate*** options needs to be set to true.

###### Result:
It will save the time of someone similar to me in the future.