### PR TITLE
Improve virtual thread handling

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/core/cli/ServerCommand.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/core/cli/ServerCommand.java
@@ -50,6 +50,13 @@ public class ServerCommand<T extends Configuration> extends EnvironmentCommand<T
             server.addEventListener(new LifeCycleListener());
             cleanupAsynchronously();
             server.start();
+            new Thread(() -> {
+                try {
+                    server.join();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }, "dw-awaiter").start();
         } catch (Exception e) {
             LOGGER.error("Unable to start server, shutting down", e);
             try {

--- a/dropwizard-core/src/main/java/io/dropwizard/core/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/core/server/AbstractServerFactory.java
@@ -57,6 +57,7 @@ import java.util.EnumSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.stream.Collectors;
@@ -668,8 +669,23 @@ public abstract class AbstractServerFactory implements ServerFactory {
         final InstrumentedQueuedThreadPool threadPool =
                 new InstrumentedQueuedThreadPool(metricRegistry, maxThreads, minThreads,
                     (int) idleThreadTimeout.toMilliseconds(), queue, threadFactory);
+        if (enableVirtualThreads) {
+            threadPool.setVirtualThreadsExecutor(getVirtualThreadsExecutorService());
+        }
         threadPool.setName("dw");
         return threadPool;
+    }
+
+    protected ExecutorService getVirtualThreadsExecutorService() {
+        try {
+            return (ExecutorService) Executors.class
+                .getDeclaredMethod("newVirtualThreadPerTaskExecutor")
+                .invoke(null);
+        } catch (InvocationTargetException invocationTargetException) {
+            throw new IllegalStateException("Error while obtaining a virtual thread executor", invocationTargetException.getCause());
+        } catch (Exception exception) {
+            throw new IllegalStateException("Error while obtaining a virtual thread executor", exception);
+        }
     }
 
     protected ThreadFactory getThreadFactory(boolean virtualThreadsRequested) {

--- a/dropwizard-core/src/main/java/io/dropwizard/core/server/DefaultServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/core/server/DefaultServerFactory.java
@@ -240,6 +240,9 @@ public class DefaultServerFactory extends AbstractServerFactory {
             60000, // overload default
             null, // overload default
             threadFactory);
+        if (enableAdminVirtualThreads) {
+            threadPool.setVirtualThreadsExecutor(getVirtualThreadsExecutorService());
+        }
         threadPool.setName("dw-admin");
         server.addBean(threadPool);
 


### PR DESCRIPTION
Fixes #8137

If the Jetty thread pool(s) only contain virtual threads, there is no application platform thread that will keep the JVM alive and hence a shutdown will be initiated right after the server startup. This PR starts a new platform thread that calls `Server.join()` to properly keep the application alive:

```
"dw-awaiter" id=97 state=WAITING
    - waiting on <0x2197f7df> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
    - locked <0x2197f7df> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
    at java.base@21.0.1/jdk.internal.misc.Unsafe.park(Native Method)
    at java.base@21.0.1/java.util.concurrent.locks.LockSupport.park(LockSupport.java:371)
    at java.base@21.0.1/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:519)
    at java.base@21.0.1/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3780)
    at java.base@21.0.1/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3725)
    at java.base@21.0.1/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1707)
    at app//org.eclipse.jetty.util.thread.AutoLock$WithCondition.await(AutoLock.java:126)
    at app//org.eclipse.jetty.util.thread.QueuedThreadPool.join(QueuedThreadPool.java:822)
    at app//org.eclipse.jetty.server.Server.join(Server.java:662)
    at app//io.dropwizard.core.cli.ServerCommand.lambda$run$0(ServerCommand.java:55)
    at app//io.dropwizard.core.cli.ServerCommand$$Lambda/0x00007ff17c3ad300.run(Unknown Source)
    at java.base@21.0.1/java.lang.Thread.runWith(Thread.java:1596)
    at java.base@21.0.1/java.lang.Thread.run(Thread.java:1583)
```

Additionally, the virtual threads executor is set for Jetty's `QueuedThreadPool`s for tasks not dispatched to the thread pool (see [`AdaptiveExecutionStrategy`](https://github.com/jetty/jetty.project/blob/jetty-11.0.x/jetty-util/src/main/java/org/eclipse/jetty/util/thread/strategy/AdaptiveExecutionStrategy.java#L474-L477)).