### PR TITLE
Replace deprecated use of asList() in assert-j

### DIFF
--- a/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
@@ -672,9 +672,11 @@ class HttpClientBuilderTest {
                 builder.using(httpProcessor)
                         .createClient(apacheBuilder, connectionManager, "test");
         assertThat(client).isNotNull();
-        assertThat(apacheBuilder).extracting("requestInterceptors").asList()
+        assertThat(apacheBuilder).extracting("requestInterceptors")
+                .asInstanceOf(InstanceOfAssertFactories.LIST)
                 .satisfies(requestInterceptors -> assertThat(requestInterceptors).hasSize(1));
-        assertThat(apacheBuilder).extracting("responseInterceptors").asList()
+        assertThat(apacheBuilder).extracting("responseInterceptors")
+                .asInstanceOf(InstanceOfAssertFactories.LIST)
                 .satisfies(responseInterceptors -> assertThat(responseInterceptors).hasSize(1));
     }
 

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
@@ -7,6 +7,7 @@ import io.dropwizard.jersey.jackson.JacksonMessageBodyProviderTest.Example;
 import io.dropwizard.jersey.jackson.JacksonMessageBodyProviderTest.ListExample;
 import io.dropwizard.jersey.jackson.JacksonMessageBodyProviderTest.PartialExample;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -548,7 +549,8 @@ class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
         assertThat(response.readEntity(new GenericType<List<ListExample>>() {
         }))
             .singleElement()
-            .extracting("examples").asList()
+            .extracting("examples")
+            .asInstanceOf(InstanceOfAssertFactories.LIST)
             .singleElement()
             .extracting("id")
             .isEqualTo(1);

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/common/DefaultLoggingFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/common/DefaultLoggingFactoryTest.java
@@ -17,6 +17,7 @@ import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.validation.BaseValidator;
 import org.apache.commons.text.StringSubstitutor;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.data.MapEntry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -96,7 +97,8 @@ class DefaultLoggingFactoryTest {
                     .satisfies(f -> assertThat(f.getArchivedLogFilenamePattern()).isEqualTo("${new_app}-%d.log.gz"))
                     .satisfies(f -> assertThat(f.getArchivedFileCount()).isEqualTo(5))
                     .satisfies(f -> assertThat(f.getBufferSize().toKibibytes()).isEqualTo(256))
-                    .extracting(FileAppenderFactory::getFilterFactories).asList()
+                    .extracting(FileAppenderFactory::getFilterFactories)
+                    .asInstanceOf(InstanceOfAssertFactories.LIST)
                     .hasSize(2)
                     .satisfies(factories -> assertThat(factories).element(0).isExactlyInstanceOf(TestFilterFactory.class))
                     .satisfies(factories -> assertThat(factories).element(1).isExactlyInstanceOf(SecondTestFilterFactory.class)));

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/RequestLogFactoryTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/RequestLogFactoryTest.java
@@ -9,6 +9,7 @@ import io.dropwizard.logging.common.ConsoleAppenderFactory;
 import io.dropwizard.logging.common.FileAppenderFactory;
 import io.dropwizard.logging.common.SyslogAppenderFactory;
 import io.dropwizard.validation.BaseValidator;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +34,7 @@ class RequestLogFactoryTest {
     void fileAppenderFactoryIsSet() {
         assertThat(logbackAccessRequestLogFactory)
             .extracting(LogbackAccessRequestLogFactory::getAppenders)
-            .asList()
+            .asInstanceOf(InstanceOfAssertFactories.LIST)
             .singleElement()
             .isInstanceOf(FileAppenderFactory.class);
     }


### PR DESCRIPTION
This was deprecated in assertj 3.25.0 in favour of asInstanceOf()