### PR TITLE
Update qodana Github action to 2023.3.1

### DIFF
--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: 'Qodana Scan'
-        uses: JetBrains/qodana-action@v2023.2
+        uses: JetBrains/qodana-action@v2023.3.1
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
       # yamllint disable-line rule:line-length


### PR DESCRIPTION
Github is warning about the Qodana action using NodeJS 16.

This version still uses Node 16, but a bump to Node 20 was committed 2 weeks ago so consider this to be preparation for that.