### PR TITLE
Remove duplicate dropwizard-metrics dependency in dropwizard-core

### DIFF
--- a/dropwizard-core/pom.xml
+++ b/dropwizard-core/pom.xml
@@ -67,10 +67,6 @@
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-annotation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-jetty11</artifactId>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
io.dropwizard.metrics/metrics-annotation was declared twice.

Spotted by IntelliJ IDEA