### PR TITLE
Unix Socket Connector: Attempt to delete the preexisting socket file

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -485,11 +485,14 @@ Extends the attributes that are available to the :ref:`HTTP connector <man-confi
         - type: unix-socket
           ...
           path: /path/to/file
+          deleteSocketFileOnStartup: false
 
 ================================ ================================ ======================================================================================
 Name                             Default                          Description
 ================================ ================================ ======================================================================================
 path                             /tmp/dropwizard.sock             The path to the unix domain socket file.
+deleteSocketFileOnStartup        false                            Whether to delete socket file on path (if it exists) on startup
+                                                                  instead of failing to start.
 ================================ ================================ ======================================================================================
 
 .. _man-configuration-http2:

--- a/dropwizard-unix-socket/pom.xml
+++ b/dropwizard-unix-socket/pom.xml
@@ -65,6 +65,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/dropwizard-unix-socket/src/main/java/io/dropwizard/unixsocket/UnixSocketConnectorFactory.java
+++ b/dropwizard-unix-socket/src/main/java/io/dropwizard/unixsocket/UnixSocketConnectorFactory.java
@@ -46,6 +46,7 @@ public class UnixSocketConnectorFactory extends HttpConnectorFactory {
     private static final Logger LOGGER = LoggerFactory.getLogger(UnixSocketConnectorFactory.class);
 
     private String path = "/tmp/dropwizard.sock";
+    private boolean deleteSocketFileOnStartup;
 
     @JsonProperty
     public String getPath() {
@@ -55,6 +56,16 @@ public class UnixSocketConnectorFactory extends HttpConnectorFactory {
     @JsonProperty
     public void setPath(String path) {
         this.path = path;
+    }
+
+    @JsonProperty
+    public boolean isDeleteSocketFileOnStartup() {
+        return deleteSocketFileOnStartup;
+    }
+
+    @JsonProperty
+    public void setDeleteSocketFileOnStartup(boolean deleteSocketFileOnStartup) {
+        this.deleteSocketFileOnStartup = deleteSocketFileOnStartup;
     }
 
     @Override
@@ -85,11 +96,13 @@ public class UnixSocketConnectorFactory extends HttpConnectorFactory {
         connector.setIdleTimeout(getIdleTimeout().toMilliseconds());
         connector.setName(name);
 
-        // in case there is a leftover domain socket due to ungraceful stop, try to delete it first.
-        try {
-            Files.deleteIfExists(unixDomainPath);
-        } catch (IOException e) {
-            LOGGER.warn("Failed to delete existing unix domain socket file at {}.", path);
+        if (deleteSocketFileOnStartup) {
+            // in case there is a leftover domain socket due to ungraceful stop, try to delete it first.
+            try {
+                Files.deleteIfExists(unixDomainPath);
+            } catch (IOException e) {
+                LOGGER.warn("Failed to delete existing unix domain socket file at {}.", path);
+            }
         }
         return connector;
     }

--- a/dropwizard-unix-socket/src/test/resources/yaml/usock-server.yml
+++ b/dropwizard-unix-socket/src/test/resources/yaml/usock-server.yml
@@ -3,6 +3,7 @@ server:
     type: simple
     connector:
         type: unix-socket
+        deleteSocketFileOnStartup: false
         useDateHeader: false
     applicationContextPath: /app
     adminContextPath: /admin


### PR DESCRIPTION
###### Problem:
We have noticed that if the dropwizard application dies (or `kill -9`ed) abruptly, it leaves the socket file behind. And when the application starts again, it fails with
```
ERROR[ServerCommand] Unable to start server, shutting down
java.lang.RuntimeException: java.io.IOException: Could not bind UnixDomainServerConnector to <path_to_socket>
```

###### Solution:
UnixSocketConnectorFactory tries to delete the socket file on startup.
