### PR TITLE
Feat/add cache support for stale while revalidate

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/caching/CacheControl.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/caching/CacheControl.java
@@ -162,13 +162,35 @@ public @interface CacheControl {
      *         fresh
      */
     int maxAge() default -1;
-
     /**
      * The time unit of {@link #maxAge()}.
      *
      * @return the time unit of {@link #maxAge()}
      */
     TimeUnit maxAgeUnit() default TimeUnit.SECONDS;
+
+    /**
+     * Controls the {@code stale-while-revalidate} setting of the {@code Cache-Control} header. The unit of this
+     * amount is determined by {@link #staleWhileRevalidateUnit()}}.
+     *
+     * <p>From the HTTPbis spec:</p>
+     * <blockquote>
+     *     The stale-while-revalidate HTTP response Cache-Control extension allows servers to instruct caches to serve stale responses while validating them,
+     *     to avoid latency in some situations.
+     * </blockquote>
+     *
+     * @see #staleWhileRevalidateUnit()
+     * @return the number of {@link #staleWhileRevalidateUnit()}}s for which the response should be served while revalidating
+     *
+     */
+    int staleWhileRevalidate() default -1;
+
+    /**
+     * The time unit of {@link #staleWhileRevalidate()}.
+     *
+     * @return the time unit of {@link #staleWhileRevalidate()}
+     */
+    TimeUnit staleWhileRevalidateUnit() default TimeUnit.SECONDS;
 
     /**
      * Controls the {@code s-max-age} setting of the {@code Cache-Control} header. The unit of this

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/caching/CacheControlledResponseFeatureTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/caching/CacheControlledResponseFeatureTest.java
@@ -90,4 +90,12 @@ class CacheControlledResponseFeatureTest extends AbstractJerseyTest {
         assertThat(response.getHeaders().get(HttpHeaders.CACHE_CONTROL))
                 .containsOnly("no-transform, s-maxage=46800");
     }
+
+    @Test
+    void staleWhileRevalidateResponsesHaveCacheControlHeaders() throws Exception {
+        final Response response = target("/caching/stale-while-revalidate").request().get();
+
+        assertThat(response.getHeaders().get(HttpHeaders.CACHE_CONTROL))
+                .containsOnly("no-transform, stale-while-revalidate=46800");
+    }
 }

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/caching/CachingResource.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/caching/CachingResource.java
@@ -72,4 +72,11 @@ public class CachingResource {
     public String showSharedMaxAge() {
         return "shared-max-age";
     }
+
+    @GET
+    @Path("/stale-while-revalidate")
+    @CacheControl(staleWhileRevalidate = 13, staleWhileRevalidateUnit = TimeUnit.HOURS)
+    public String showStaleWhileRevalidate() {
+        return "stale-while-revalidate";
+    }
 }


### PR DESCRIPTION
###### Problem:
No support for stale while revalidate header in cache control #8492 

###### Solution:
Add it as part of the `CacheControl` annotation

Closes #8492

