### PR TITLE
Update package name to correct path in 3.0 docs

### DIFF
--- a/docs/source/manual/upgrade-notes/upgrade-notes-3_0_x.rst
+++ b/docs/source/manual/upgrade-notes/upgrade-notes-3_0_x.rst
@@ -59,7 +59,7 @@ Affected packages:
 ======================  =========================  ================================
 Maven module            Old package                New package
 ======================  =========================  ================================
-``dropwizard-core``     ``io.dropwizard``          ``io.drowizard.core``
+``dropwizard-core``     ``io.dropwizard``          ``io.dropwizard.core``
 ``dropwizard-logging``  ``io.dropwizard.logging``  ``io.dropwizard.logging.common``
 ``dropwizard-metrics``  ``io.dropwizard.metrics``  ``io.dropwizard.metrics.common``
 ``dropwizard-views``    ``io.dropwizard.views``    ``io.dropwizard.views.common``


### PR DESCRIPTION
Updates the package name to the correct path in the 3.0 upgrade documentation.

```
io.drowizard.core -> io.dropwizard.core
```

###### Problem:
I noticed a small package typo while updating a legacy 2.0 app and reviewing the 3.0 documentation.

###### Solution:
Updated the package to the correct name.

###### Result:
Documentation for the 3.0 upgrade will be updated the reflect the correct dropwizard-core package name.