### PR TITLE
Change assertion to assumption to fix errors on different file systems

### DIFF
--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/assets/ResourceURLTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/assets/ResourceURLTest.java
@@ -11,6 +11,7 @@ import java.util.jar.JarEntry;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class ResourceURLTest {
@@ -119,7 +120,7 @@ class ResourceURLTest {
     void appendTrailingSlashAddsASlash() {
         final URL url = getClass().getResource("/META-INF");
 
-        assertThat(url.toExternalForm())
+        assumeThat(url.toExternalForm())
                 .doesNotMatch(".*/$");
         assertThat(ResourceURL.appendTrailingSlash(url).toExternalForm())
                 .endsWith("/");


### PR DESCRIPTION
Code scanning fails for a while due to an assertion error for no trailing slash when resolving the `META-INF` directory. The description of `Class#getResource(String)` doesn't state anything on trailing slashes, so the assertion should be changed to an assumption.