### PR TITLE
Use JUnit's ReflectionSupport rather than its internal ReflectionUtils

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardExtensionsSupport.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardExtensionsSupport.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.commons.support.ReflectionSupport;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -145,7 +145,9 @@ public class DropwizardExtensionsSupport implements BeforeAllCallback, BeforeEac
         return null;
     }
 
-    private DropwizardExtension getDropwizardExtension(Field member, @Nullable Object o) throws IllegalAccessException {
-        return (DropwizardExtension) ReflectionUtils.makeAccessible(member).get(o);
+    private DropwizardExtension getDropwizardExtension(Field member, @Nullable Object o) {
+        return ReflectionSupport.tryToReadFieldValue(member, o)
+            .andThenTry(DropwizardExtension.class::cast)
+            .getOrThrow(e -> new IllegalStateException("Failed to read " + DropwizardExtension.class.getSimpleName() + " field: " + member, e));
     }
 }


### PR DESCRIPTION
###### Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->

`DropwizardExtensionsSupport` is using JUnit-internal API that was removed in JUnit 5.11.0.

Related issue: junit-team/junit5#3925

###### Solution:
<!-- Describe the modifications you've done. -->

This change replace the call to internal API with a call to a public, supported one that was introduced in JUnit 5.4.

###### Result:
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->

Future versions of Dropwizard won't break when JUnit changes its internal API.