### PR TITLE
Use JUnit's ReflectionSupport rather than its internal ReflectionUtils

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardExtensionsSupport.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardExtensionsSupport.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.commons.support.ReflectionSupport;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -145,7 +145,9 @@ public class DropwizardExtensionsSupport implements BeforeAllCallback, BeforeEac
         return null;
     }
 
-    private DropwizardExtension getDropwizardExtension(Field member, @Nullable Object o) throws IllegalAccessException {
-        return (DropwizardExtension) ReflectionUtils.makeAccessible(member).get(o);
+    private DropwizardExtension getDropwizardExtension(Field member, @Nullable Object o) {
+        return ReflectionSupport.tryToReadFieldValue(member, o)
+            .andThenTry(DropwizardExtension.class::cast)
+            .getOrThrow(e -> new IllegalStateException("Failed to read " + DropwizardExtension.class.getSimpleName() + " field: " + member, e));
     }
 }


### PR DESCRIPTION
`DropwizardExtensionsSupport` is using JUnit-internal API that was removed in JUnit 5.11.0.

Refs junit-team/junit5#3925
Refs #9157
(cherry picked from commit c5b8df7edc352274f27cd1a61f9dde726e33c678)