### PR TITLE
Immediately release http client resources

### DIFF
--- a/dropwizard-testing/pom.xml
+++ b/dropwizard-testing/pom.xml
@@ -170,6 +170,10 @@
             <artifactId>httpclient5</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
             <exclusions>


### PR DESCRIPTION
Fixes #9246

When retrieving responses from Jersey clients in the `dropwizard-testing` module to `Response` objects instead of reading them directly, a user has to ensure the `Response` gets closed correctly to release resources of the underlying http client.

In earlier versions of dropwizard this wasn't a problem since there an other http client connector was used.

This PR adds a response interceptor reading the whole entity into a byte array to allow releasing http client resources immediately.