### PR TITLE
Use platform threads instead of virtual threads for thread pools

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/core/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/core/server/AbstractServerFactory.java
@@ -665,10 +665,9 @@ public abstract class AbstractServerFactory implements ServerFactory {
 
     protected ThreadPool createThreadPool(MetricRegistry metricRegistry) {
         final BlockingQueue<Runnable> queue = new BlockingArrayQueue<>(minThreads, maxThreads, maxQueuedRequests);
-        final ThreadFactory threadFactory = getThreadFactory(enableVirtualThreads);
         final InstrumentedQueuedThreadPool threadPool =
                 new InstrumentedQueuedThreadPool(metricRegistry, maxThreads, minThreads,
-                    (int) idleThreadTimeout.toMilliseconds(), queue, threadFactory);
+                    (int) idleThreadTimeout.toMilliseconds(), queue);
         if (enableVirtualThreads) {
             threadPool.setVirtualThreadsExecutor(getVirtualThreadsExecutorService());
         }
@@ -685,26 +684,6 @@ public abstract class AbstractServerFactory implements ServerFactory {
             throw new IllegalStateException("Error while obtaining a virtual thread executor", invocationTargetException.getCause());
         } catch (Exception exception) {
             throw new IllegalStateException("Error while obtaining a virtual thread executor", exception);
-        }
-    }
-
-    protected ThreadFactory getThreadFactory(boolean virtualThreadsRequested) {
-        if (!virtualThreadsRequested) {
-            return Executors.defaultThreadFactory();
-        }
-
-        if (!VirtualThreads.areSupported()) {
-            throw new UnsupportedOperationException("Virtual threads are requested but not supported on the current runtime");
-        }
-
-        try {
-            Class<?> threadBuilderClass = Class.forName("java.lang.Thread$Builder");
-            Object virtualThreadBuilder = threadBuilderClass.cast(Thread.class.getDeclaredMethod("ofVirtual").invoke(null));
-            return (ThreadFactory) threadBuilderClass.getDeclaredMethod("factory").invoke(virtualThreadBuilder);
-        } catch (InvocationTargetException invocationTargetException) {
-            throw new IllegalStateException("Error while enabling virtual threads", invocationTargetException.getCause());
-        } catch (Exception exception) {
-            throw new IllegalStateException("Error while enabling virtual threads", exception);
         }
     }
 

--- a/dropwizard-core/src/main/java/io/dropwizard/core/server/DefaultServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/core/server/DefaultServerFactory.java
@@ -229,17 +229,14 @@ public class DefaultServerFactory extends AbstractServerFactory {
     }
 
     private List<Connector> buildAdminConnectors(MetricRegistry metricRegistry, Server server) {
-        final ThreadFactory threadFactory = getThreadFactory(enableAdminVirtualThreads);
         // threadpool is shared between all the connectors, so it should be managed by the server instead of the
         // individual connectors
         @SuppressWarnings("NullAway")
         final QueuedThreadPool threadPool = new InstrumentedQueuedThreadPool(
             metricRegistry,
             adminMaxThreads,
-            adminMinThreads,
-            60000, // overload default
-            null, // overload default
-            threadFactory);
+            adminMinThreads
+        );
         if (enableAdminVirtualThreads) {
             threadPool.setVirtualThreadsExecutor(getVirtualThreadsExecutorService());
         }


### PR DESCRIPTION
Refs #9308 

Virtual threads shall not be pooled, so use platform threads for the Jetty thread pools.