### PR TITLE
Remove reference to travis.yml in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,3 @@ trim_trailing_whitespace = true
 
 [*.properties]
 charset = latin1
-
-[travis.yml]
-indent_size = 2
-indent_style = space


### PR DESCRIPTION
Travis support was removed in 2020 in 80589ad65a225e45cb5f1108021aa5d55fb02846