### PR TITLE
Removed jakarta.el-api exclusion

### DIFF
--- a/dropwizard-core/pom.xml
+++ b/dropwizard-core/pom.xml
@@ -186,10 +186,6 @@
             <artifactId>jersey-bean-validation</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>jakarta.el</groupId>
-                    <artifactId>jakarta.el-api</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>org.glassfish.hk2.external</groupId>
                     <artifactId>jakarta.inject</artifactId>
                 </exclusion>

--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -151,6 +151,11 @@
                 <version>${jakarta.el.version}</version>
             </dependency>
             <dependency>
+                <groupId>jakarta.el</groupId>
+                <artifactId>jakarta.el-api</artifactId>
+                <version>${jakarta.el.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>jakarta.activation</groupId>
                 <artifactId>jakarta.activation-api</artifactId>
                 <version>${activation-api.version}</version>


### PR DESCRIPTION
##### Problem:
The `jakarta.el-api` exclusion made sense when it was first introduced by @josephlbarnett back in 2019 (see #2750).  But with the move from `jakarta.el` to [Eclipse Expressly](https://github.com/eclipse-ee4j/expressly) in DropWizard 5 it doesn't make sense any more.  Expressly does not include the `jakarta.el-api` classes the way that `jakarta.el-3.0.0` did.  Indeed, as @aharin correctly points out [here](https://github.com/dropwizard/dropwizard/pull/2750#issuecomment-1653695853), they were not included in `jakarta.el-4.0.0` either, so this change would also be correct in DropWizard 4.

Because of the way Maven dependency resolution works this exclusion can come into play in some situations and result in the `jakarta.el-api` not being included in the output package.  It is a critical dependency so it must be included.  This can of course be worked around by adding it as a runtime-scope dependency, but with this change in place that workaround will not be necessary.

##### Solution:
- Removed the exclusion
- Added it to the list of dependencies