### PR TITLE
Make ProtocolUpgradeEnabled configurable

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -1481,6 +1481,7 @@ See HttpClientConfiguration_  for more options.
       keepAlive: 0ms
       retries: 0
       userAgent: <application name> (<client name>)
+      protocolUpgradeEnabled: true
 
 
 =============================  ======================================  =============================================================================
@@ -1502,6 +1503,8 @@ retries                        0                                       The numbe
 userAgent                      ``applicationName`` (``clientName``)    The User-Agent to send with requests.
 validateAfterInactivityPeriod  0 milliseconds                          The maximum time before a persistent connection is checked to remain active.
                                                                        If set to 0, no inactivity check will be performed.
+protocolUpgradeEnabled         true                                    If set to false, ``connection: Upgrade`` and ``upgrade: TLS/1.2`` are not sent
+                                                                       anymore by the HTTP client. Might be required for Istio/Envoy.
 =============================  ======================================  =============================================================================
 
 

--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
@@ -366,6 +366,7 @@ public class HttpClientBuilder {
                 ? NO_RETRIES
                 : (httpRequestRetryStrategy == null ? new DefaultHttpRequestRetryStrategy(configuration.getRetries(),
                 TimeValue.ofSeconds(1L)) : httpRequestRetryStrategy);
+        final boolean protocolUpgradeEnabled = configuration.isProtocolUpgradeEnabled();
 
         final RequestConfig requestConfig
                 = RequestConfig.custom().setCookieSpec(cookiePolicy)
@@ -373,6 +374,7 @@ public class HttpClientBuilder {
                 .setConnectTimeout(connectionTimeout, TimeUnit.MILLISECONDS)
                 .setConnectionKeepAlive(TimeValue.of(-1, TimeUnit.MILLISECONDS))
                 .setConnectionRequestTimeout(connectionRequestTimeout, TimeUnit.MILLISECONDS)
+                .setProtocolUpgradeEnabled(protocolUpgradeEnabled)
                 .build();
         final SocketConfig socketConfig = SocketConfig.custom()
                 .setTcpNoDelay(true)

--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientConfiguration.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientConfiguration.java
@@ -65,6 +65,8 @@ public class HttpClientConfiguration {
     @Nullable
     private TlsConfiguration tlsConfiguration;
 
+    private boolean protocolUpgradeEnabled = true;
+
     @JsonProperty
     public void setKeepAlive(Duration keepAlive) {
         this.keepAlive = keepAlive;
@@ -190,5 +192,15 @@ public class HttpClientConfiguration {
     @JsonProperty("tls")
     public void setTlsConfiguration(TlsConfiguration tlsConfiguration) {
         this.tlsConfiguration = tlsConfiguration;
+    }
+
+    @JsonProperty
+    public boolean isProtocolUpgradeEnabled() {
+        return protocolUpgradeEnabled;
+    }
+
+    @JsonProperty
+    public void setProtocolUpgradeEnabled(boolean protocolUpgradeEnabled) {
+        this.protocolUpgradeEnabled = protocolUpgradeEnabled;
     }
 }


### PR DESCRIPTION
###### Problem:

Closes #9597
The httpclient5.4 sends request headers `"connection: Upgrade` and `upgrade: TLS/1.2` by default.
When istio/envoy sees these headers the request is aborted with `response: "upgrade_failed"`
The httpclient5 can be configured to not do this, but there is no practical way to access that setting from dropwizard plumbing today.

This PR attempts to remedy that issue.

###### Solution:

Make  `protocolUpgradeEnabled` configurable on the HttpClientConfiguration.

###### Result:

When `protocolUpgradeEnabled` is set to `false`, it will allow the httpclient5 client to successfully interoperate with istio/envoy.