### PR TITLE
Introducing Dropwizard Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Dropwizard
 [![Maintainability](https://api.codeclimate.com/v1/badges/11a16ea08c8b5499e2b9/maintainability)](https://codeclimate.com/github/dropwizard/dropwizard/maintainability)
 [![Reproducible Builds](https://img.shields.io/badge/Reproducible_Builds-ok-green?labelColor=blue)](https://github.com/jvm-repo-rebuild/reproducible-central#io.dropwizard:dropwizard-core)
 [![Contribute with Gitpod](https://img.shields.io/badge/Contribute%20with-Gitpod-908a85?logo=gitpod)](https://gitpod.io/#https://github.com/dropwizard/dropwizard)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Dropwizard%20Guru-006BFF)](https://gurubase.io/g/dropwizard)
 
 *Dropwizard is a sneaky way of making fast Java web applications.*
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Dropwizard Guru](https://gurubase.io/g/dropwizard) to Gurubase. Dropwizard Guru uses the data from this repo and data from the [docs](http://www.dropwizard.io) to answer questions by leveraging the LLM.

In this PR, I showcased the "Dropwizard Guru", which highlights that Dropwizard now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Dropwizard Guru in Gurubase, just let me know that's totally fine.
