### PR TITLE
Fix object identity of ScheduledHealthCheck

### DIFF
--- a/dropwizard-health/src/main/java/io/dropwizard/health/ScheduledHealthCheck.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/ScheduledHealthCheck.java
@@ -100,7 +100,9 @@ class ScheduledHealthCheck implements Runnable {
         if (!(o instanceof ScheduledHealthCheck)) return false;
         final ScheduledHealthCheck that = (ScheduledHealthCheck) o;
         return critical == that.critical &&
+            previouslyRecovered == that.previouslyRecovered &&
             Objects.equals(name, that.name) &&
+            type == that.type &&
             Objects.equals(healthCheck, that.healthCheck) &&
             Objects.equals(schedule, that.schedule) &&
             Objects.equals(state, that.state) &&
@@ -110,22 +112,22 @@ class ScheduledHealthCheck implements Runnable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, critical, healthCheck, schedule, state, healthyCheckCounter, unhealthyCheckCounter);
+        return Objects.hash(name, type, critical, healthCheck, schedule, state, healthyCheckCounter, unhealthyCheckCounter, previouslyRecovered);
     }
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("ScheduledHealthCheck{");
-        sb.append("name='").append(name).append('\'');
-        sb.append(", critical=").append(critical);
-        sb.append(", healthCheck=").append(healthCheck);
-        sb.append(", schedule=").append(schedule);
-        sb.append(", state=").append(state);
-        sb.append(", healthyCheckCounter=").append(getCounterString(healthyCheckCounter));
-        sb.append(", unhealthyCheckCounter=").append(getCounterString(unhealthyCheckCounter));
-        sb.append(", previouslyRecovered=").append(previouslyRecovered);
-        sb.append('}');
-        return sb.toString();
+        return "ScheduledHealthCheck{" +
+            "name='" + name + '\'' +
+            ", type=" + type +
+            ", critical=" + critical +
+            ", healthCheck=" + healthCheck +
+            ", schedule=" + schedule +
+            ", state=" + state +
+            ", healthyCheckCounter=" + healthyCheckCounter +
+            ", unhealthyCheckCounter=" + unhealthyCheckCounter +
+            ", previouslyRecovered=" + previouslyRecovered +
+            '}';
     }
 
     private String getCounterString(Counter counter) {

--- a/dropwizard-health/src/main/java/io/dropwizard/health/check/http/HttpHealthResponse.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/check/http/HttpHealthResponse.java
@@ -43,10 +43,9 @@ public class HttpHealthResponse {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("HttpHealthResponse{");
-        sb.append("status=").append(status);
-        sb.append(", body='").append(body).append('\'');
-        sb.append('}');
-        return sb.toString();
+        return "HttpHealthResponse{" +
+            "status=" + status +
+            ", body='" + body + '\'' +
+            '}';
     }
 }


### PR DESCRIPTION
The previouslyRecovered and type fields were not included in `equals`, `hashCode` or `toString` of ScheduledHealthCheck

Take the opportunity to align the `toString` methods with other Dropwizard code, using string concatenation instead of `StringBuilder`.

Refs #9471

(cherry picked from commit 3652fb5f353f1d877e22a6e6600188b73c6bece8)