### PR TITLE
Use Session#persist instead of the deprecated Session#saveOrUpdate in tests

### DIFF
--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DAOTestExtensionTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/DAOTestExtensionTest.java
@@ -68,7 +68,7 @@ class DAOTestExtensionTest {
 
     private TestEntity persist(TestEntity testEntity) {
         final Session currentSession = daoTestExtension.getSessionFactory().getCurrentSession();
-        currentSession.saveOrUpdate(testEntity);
+        currentSession.persist(testEntity);
 
         return testEntity;
     }


### PR DESCRIPTION
###### Problem:
The `dropwizard-testing` tests were using a deprecated Hibernate API

###### Solution:
Switch to a non-deprecated one. I think I chose the correct call?