### PR TITLE
feat(deps): update Logback to v1.5.16 and use logback-access v2.0.5

### DIFF
--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -55,7 +55,8 @@
         <liquibase-core.version>4.30.0</liquibase-core.version>
         <liquibase-slf4j.version>5.1.0</liquibase-slf4j.version>
         <logback-throttling-appender.version>1.4.2</logback-throttling-appender.version>
-        <logback.version>1.4.14</logback.version>
+        <logback.version>1.5.16</logback.version>
+        <logback.access.version>2.0.5</logback.access.version>
         <metrics4.version>4.2.29</metrics4.version>
         <mustache-compiler.version>0.9.14</mustache-compiler.version>
         <nullaway.version>0.12.2</nullaway.version>
@@ -368,11 +369,6 @@
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-access</artifactId>
-                <version>${logback.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-core</artifactId>
                 <version>${logback.version}</version>
             </dependency>
@@ -386,6 +382,16 @@
                         <artifactId>slf4j-api</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback.access</groupId>
+                <artifactId>logback-access-common</artifactId>
+                <version>${logback.access.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback.access</groupId>
+                <artifactId>logback-access-jetty12</artifactId>
+                <version>${logback.access.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard.logback</groupId>

--- a/dropwizard-json-logging/pom.xml
+++ b/dropwizard-json-logging/pom.xml
@@ -25,11 +25,6 @@
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-logging</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-access</artifactId>
-        </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
@@ -37,6 +32,10 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback.access</groupId>
+            <artifactId>logback-access-common</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/AccessJsonLayoutBaseFactory.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/AccessJsonLayoutBaseFactory.java
@@ -1,6 +1,6 @@
 package io.dropwizard.logging.json;
 
-import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.access.common.spi.IAccessEvent;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.core.LayoutBase;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/AbstractJsonLayout.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/AbstractJsonLayout.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 /**
  * Provides the common functionality for building JSON representations
- * of {@link ch.qos.logback.access.spi.IAccessEvent} and {@link ch.qos.logback.classic.spi.ILoggingEvent}
+ * of {@link ch.qos.logback.access.common.spi.IAccessEvent} and {@link ch.qos.logback.classic.spi.ILoggingEvent}
  * events.
  *
  * @param <E> represents the type of the event

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/AccessJsonLayout.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/AccessJsonLayout.java
@@ -1,6 +1,6 @@
 package io.dropwizard.logging.json.layout;
 
-import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.access.common.spi.IAccessEvent;
 import io.dropwizard.logging.json.AccessAttribute;
 import org.checkerframework.checker.nullness.qual.Nullable;
 

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
@@ -241,7 +241,6 @@ class LayoutIntegrationTests {
             }
 
             JsonNode jsonNode = objectMapper.readTree(redirectedStream.toString());
-            System.out.println(jsonNode);
             assertThat(jsonNode.fieldNames().next()).isEqualTo("timestamp");
             assertThat(jsonNode.get("timestamp").isNumber()).isTrue();
             assertThat(jsonNode.get("requestTime").isNumber()).isTrue();

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
@@ -1,6 +1,6 @@
 package io.dropwizard.logging.json;
 
-import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.access.common.spi.IAccessEvent;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.spi.DeferredProcessingAware;
@@ -24,6 +24,7 @@ import org.eclipse.jetty.ee10.servlet.ServletContextRequest;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.server.ConnectionMetaData;
+import org.eclipse.jetty.server.CookieCache;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.RequestLog;
@@ -46,6 +47,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.entry;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -192,11 +194,14 @@ class LayoutIntegrationTests {
             RequestLog requestLog = requestLogHandler.build("json-access-log-test");
 
             Request request = mock(Request.class);
+            CookieCache cookieCache = mock(CookieCache.class);
             Response response = mock(Response.class);
             ConnectionMetaData connectionMetaData = mock(ConnectionMetaData.class);
             HttpURI httpURI = mock(HttpURI.class);
 
             when(response.getHeaders()).thenReturn(HttpFields.build());
+            when(request.getAttribute(Request.COOKIE_ATTRIBUTE)).thenReturn(cookieCache);
+
             when(request.getConnectionMetaData()).thenReturn(connectionMetaData);
 
             when(httpURI.getPath()).thenReturn("/test/users");
@@ -236,6 +241,7 @@ class LayoutIntegrationTests {
             }
 
             JsonNode jsonNode = objectMapper.readTree(redirectedStream.toString());
+            System.out.println(jsonNode);
             assertThat(jsonNode.fieldNames().next()).isEqualTo("timestamp");
             assertThat(jsonNode.get("timestamp").isNumber()).isTrue();
             assertThat(jsonNode.get("requestTime").isNumber()).isTrue();

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/AccessJsonLayoutTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/AccessJsonLayoutTest.java
@@ -1,6 +1,6 @@
 package io.dropwizard.logging.json.layout;
 
-import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.access.common.spi.IAccessEvent;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/common/DefaultLoggingFactoryPrintErrorMessagesTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/common/DefaultLoggingFactoryPrintErrorMessagesTest.java
@@ -2,7 +2,8 @@ package io.dropwizard.logging.common;
 
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.util.StatusPrinter;
+import ch.qos.logback.core.util.StatusPrinter2;
+
 import com.codahale.metrics.MetricRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -96,10 +97,11 @@ class DefaultLoggingFactoryPrintErrorMessagesTest {
 
     @Test
     void testLogbackStatusPrinterPrintStreamIsRestoredToSystemOut() throws Exception {
-        Field field = StatusPrinter.class.getDeclaredField("ps");
+        StatusPrinter2 statusPrinter2 = new StatusPrinter2();
+        Field field = statusPrinter2.getClass().getDeclaredField("ps");
         field.setAccessible(true);
 
-        assertThat(field.get(null))
+        assertThat(field.get(statusPrinter2))
             .isInstanceOfSatisfying(PrintStream.class, printStream -> assertThat(printStream).isSameAs(System.out));
     }
 }

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/common/TestPatternLayoutFactory.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/common/TestPatternLayoutFactory.java
@@ -2,7 +2,9 @@ package io.dropwizard.logging.common;
 
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Context;
 import ch.qos.logback.core.LayoutBase;
+import ch.qos.logback.core.pattern.DynamicConverter;
 import ch.qos.logback.core.pattern.PatternLayoutBase;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.dropwizard.logging.common.layout.DiscoverableLayoutFactory;
@@ -10,19 +12,30 @@ import io.dropwizard.logging.common.layout.DiscoverableLayoutFactory;
 import java.util.Collections;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.function.Supplier;
 
 @JsonTypeName("test-pattern")
 public class TestPatternLayoutFactory implements DiscoverableLayoutFactory<ILoggingEvent> {
 
     @Override
     public LayoutBase<ILoggingEvent> build(LoggerContext context, TimeZone timeZone) {
-        return new TestPatternLayout();
+        return new TestPatternLayout(context);
     }
 
     public static class TestPatternLayout extends PatternLayoutBase<ILoggingEvent> {
+        private TestPatternLayout(Context context) {
+            super();
+            setContext(context);
+        }
+
         @Override
         public String doLayout(ILoggingEvent event) {
             return "TEST PATTERN!\n";
+        }
+
+        @Override
+        protected Map<String,Supplier<DynamicConverter>> getDefaultConverterSupplierMap() {
+            return Collections.emptyMap();
         }
 
         @Override

--- a/dropwizard-request-logging/pom.xml
+++ b/dropwizard-request-logging/pom.xml
@@ -27,15 +27,19 @@
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-access</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback.access</groupId>
+            <artifactId>logback-access-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback.access</groupId>
+            <artifactId>logback-access-jetty12</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/DropwizardJettyServerAdapter.java
+++ b/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/DropwizardJettyServerAdapter.java
@@ -1,6 +1,6 @@
 package io.dropwizard.request.logging;
 
-import ch.qos.logback.access.spi.ServerAdapter;
+import ch.qos.logback.access.common.spi.ServerAdapter;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;

--- a/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/LogbackAccessRequestLog.java
+++ b/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/LogbackAccessRequestLog.java
@@ -1,8 +1,8 @@
 package io.dropwizard.request.logging;
 
 import ch.qos.logback.access.jetty.RequestLogImpl;
-import ch.qos.logback.access.spi.AccessEvent;
-import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.access.common.spi.AccessEvent;
+import ch.qos.logback.access.common.spi.IAccessEvent;
 import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.spi.FilterReply;
 import jakarta.servlet.http.HttpServletRequest;

--- a/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/LogbackAccessRequestLogFactory.java
+++ b/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/LogbackAccessRequestLogFactory.java
@@ -1,6 +1,6 @@
 package io.dropwizard.request.logging;
 
-import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.access.common.spi.IAccessEvent;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/async/AsyncAccessEventAppenderFactory.java
+++ b/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/async/AsyncAccessEventAppenderFactory.java
@@ -1,6 +1,6 @@
 package io.dropwizard.request.logging.async;
 
-import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.access.common.spi.IAccessEvent;
 import ch.qos.logback.core.AsyncAppenderBase;
 import io.dropwizard.logging.common.async.AsyncAppenderFactory;
 

--- a/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/filter/UriFilterFactory.java
+++ b/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/filter/UriFilterFactory.java
@@ -1,6 +1,6 @@
 package io.dropwizard.request.logging.filter;
 
-import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.access.common.spi.IAccessEvent;
 import ch.qos.logback.core.filter.Filter;
 import ch.qos.logback.core.spi.FilterReply;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/layout/LogbackAccessRequestLayout.java
+++ b/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/layout/LogbackAccessRequestLayout.java
@@ -1,6 +1,6 @@
 package io.dropwizard.request.logging.layout;
 
-import ch.qos.logback.access.PatternLayout;
+import ch.qos.logback.access.common.PatternLayout;
 import ch.qos.logback.core.Context;
 
 import java.util.TimeZone;
@@ -17,8 +17,8 @@ public class LogbackAccessRequestLayout extends PatternLayout {
 
     static  {
         // Replace the buggy default converter which don't work async appenders
-        defaultConverterMap.put("requestParameter", SafeRequestParameterConverter.class.getName());
-        defaultConverterMap.put("reqParameter", SafeRequestParameterConverter.class.getName());
+        ch.qos.logback.classic.PatternLayout.DEFAULT_CONVERTER_MAP.put("requestParameter", SafeRequestParameterConverter.class.getName());
+        ch.qos.logback.classic.PatternLayout.DEFAULT_CONVERTER_MAP.put("reqParameter", SafeRequestParameterConverter.class.getName());
     }
 
     public LogbackAccessRequestLayout(Context context, TimeZone timeZone) {

--- a/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/layout/LogbackAccessRequestLayoutFactory.java
+++ b/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/layout/LogbackAccessRequestLayoutFactory.java
@@ -1,6 +1,6 @@
 package io.dropwizard.request.logging.layout;
 
-import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.access.common.spi.IAccessEvent;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.core.pattern.PatternLayoutBase;
 import io.dropwizard.logging.common.layout.LayoutFactory;

--- a/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/layout/SafeRequestParameterConverter.java
+++ b/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/layout/SafeRequestParameterConverter.java
@@ -1,14 +1,14 @@
 package io.dropwizard.request.logging.layout;
 
-import ch.qos.logback.access.pattern.AccessConverter;
-import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.access.common.pattern.AccessConverter;
+import ch.qos.logback.access.common.spi.IAccessEvent;
 import ch.qos.logback.core.util.OptionHelper;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Arrays;
 
 /**
- * A safe version of {@link ch.qos.logback.access.pattern.RequestParameterConverter} which works
+ * A safe version of {@link ch.qos.logback.access.common.pattern.RequestParameterConverter} which works
  * with async appenders. It loads request parameters from a cached map rather than trying to load
  * request data from the original request which may be closed.
  */

--- a/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/old/LogbackClassicRequestLogFactory.java
+++ b/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/old/LogbackClassicRequestLogFactory.java
@@ -5,6 +5,7 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Context;
 import ch.qos.logback.core.CoreConstants;
+import ch.qos.logback.core.pattern.DynamicConverter;
 import ch.qos.logback.core.pattern.PatternLayoutBase;
 import ch.qos.logback.core.spi.AppenderAttachableImpl;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -28,6 +29,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.function.Supplier;
 
 /**
  * A factory for creating {@link RequestLog} instances using logback-classic.
@@ -65,6 +67,11 @@ public class LogbackClassicRequestLogFactory implements RequestLogFactory<Reques
         @Override
         public String doLayout(ILoggingEvent event) {
             return event.getFormattedMessage() + CoreConstants.LINE_SEPARATOR;
+        }
+
+        @Override
+        protected Map<String,Supplier<DynamicConverter>> getDefaultConverterSupplierMap() {
+            return Collections.emptyMap();
         }
 
         @Override

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/LogbackAccessRequestLogTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/LogbackAccessRequestLogTest.java
@@ -1,6 +1,6 @@
 package io.dropwizard.request.logging;
 
-import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.access.common.spi.IAccessEvent;
 import ch.qos.logback.core.Appender;
 import org.eclipse.jetty.ee10.servlet.ServletChannel;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/filter/UriFilterFactoryTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/filter/UriFilterFactoryTest.java
@@ -1,6 +1,6 @@
 package io.dropwizard.request.logging.filter;
 
-import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.access.common.spi.IAccessEvent;
 import ch.qos.logback.core.filter.Filter;
 import ch.qos.logback.core.spi.FilterReply;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/layout/SafeRequestParameterConverterTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/layout/SafeRequestParameterConverterTest.java
@@ -1,7 +1,7 @@
 package io.dropwizard.request.logging.layout;
 
-import ch.qos.logback.access.spi.AccessEvent;
-import ch.qos.logback.access.spi.ServerAdapter;
+import ch.qos.logback.access.common.spi.AccessEvent;
+import ch.qos.logback.access.common.spi.ServerAdapter;
 import ch.qos.logback.core.Context;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/LogbackExcludedTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/LogbackExcludedTest.java
@@ -68,7 +68,7 @@ class LogbackExcludedTest {
             cmType.getConstructor(omType, Class.class).newInstance(omType.newInstance(), confType);
 
             // make sure nothing is emitted to stderr; previously the absence of Logback in the classpath would cause
-            // "class io.dropwizard.configuration.ConfigurationMetadata$1: Type ch.qos.logback.access.spi.IAccessEvent
+            // "class io.dropwizard.configuration.ConfigurationMetadata$1: Type ch.qos.logback.access.common.spi.IAccessEvent
             // not present" to be emitted to stderr
             String err = byteStream.toString();
             assertThat(err).isEmpty();


### PR DESCRIPTION
###### Problem:
The `release/5.0.x` branch is using a [single version number](https://github.com/dropwizard/dropwizard/blob/release/5.0.x/dropwizard-dependencies/pom.xml#L58) for both logback and logback-access:

```xml
<logback.version>1.4.14</logback.version>
```

This was fine for version `1.4.14`, however, moving the above version number to the latest version of logback (`1.5.16`), means that [a relocation](https://github.com/qos-ch/logback/blob/v_1.5.16/logback-access/pom.xml) is performed, and the following dependency used:

```
<distributionManagement>
    <relocation>
      <groupId>ch.qos.logback.access</groupId>      
      <artifactId>common</artifactId>
      <version>2.0.1</version>      
    </relocation>
</distributionManagement>
```

This does not work, as seen in this automated PR which is failing some checks: [fix(deps): update logback monorepo to v1.5.16 (release/5.0.x) (minor)](https://github.com/dropwizard/dropwizard/pull/9747).

This is due to the way that logback [split out logback-access into it's own repo](https://github.com/qos-ch/logback-access) as of March 2024, which contains separate modules for common code, jetty and tomcat:

![image](https://github.com/user-attachments/assets/9ecbce90-7bec-439a-89e8-c9f7223dfe8f)

###### Solution:
Specify separate version numbers for logback and the new logback-access modules, so we can include the relevant logback-access modules for the `release/5.0.x` branch:


```xml
<dependency>
  <groupId>ch.qos.logback.access</groupId>
  <artifactId>logback-access-common</artifactId>
  <version>${logback.access.version}</version>
</dependency>
  <dependency>
  <groupId>ch.qos.logback.access</groupId>
  <artifactId>logback-access-jetty12</artifactId>
  <version>${logback.access.version}</version>
</dependency>
```

Closes #9747