### PR TITLE
Remove `@Nullable` from `CacheLoader` return type.

### DIFF
--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactory.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/UnitOfWorkAwareProxyFactory.java
@@ -61,7 +61,7 @@ public class UnitOfWorkAwareProxyFactory {
     private LoadingCache<Class<?>, Class<?>> buildCache(Caffeine<Object, Object> proxyCacheBuilder) {
         return proxyCacheBuilder.build(new CacheLoader<Class<?>, Class<?>>() {
             @Override
-            public @Nullable Class<?> load(@NonNull Class<?> key) {
+            public Class<?> load(@NonNull Class<?> key) {
                 return createProxyClass(key);
             }
         });


### PR DESCRIPTION
Our `CacheLoader` never returns `null`. When we upgrade to Caffeine
3.2.0 (https://github.com/dropwizard/dropwizard/pull/9792), we'll have
to either:

- Declare that we're implementing a `CacheLoader<..., @Nullable
  Class<?>>`, in which case we can keep `@Nullable` in the return type.
- Continue to declare that we're implementing a `CacheLoader<...,
  Class<?>>`, in which case we'll need to remove `@Nullable` from the
  return type.

See https://github.com/ben-manes/caffeine/issues/1826.
