### PR TITLE
Convert to jakarta.inject 2.0.1

### DIFF
--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -40,7 +40,7 @@
         <jackson.version>2.18.2</jackson.version>
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
         <jakarta.el.version>5.0.1</jakarta.el.version>
-        <jakarta.inject-api.version>2.0.1.MR</jakarta.inject-api.version>
+        <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
         <jakarta.servlet-api.version>6.0.0</jakarta.servlet-api.version>
         <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>


### PR DESCRIPTION
###### Problem:

The `jakarta.inject-api-2.0.1.MR` was created to maintain runtime compatibility with java 8[1] for ee8. Since 5.x is on ee10 and has a runtime minimum of 17. The multi release jar is no longer needed. This would also be in line with the version of inject declared in the ee10 BOM[2].

[1] https://github.com/jakartaee/inject/issues/18
[2] https://github.com/jakartaee/jakartaee-api/blob/10.0.0/pom.xml#L73


jakarta.inject-api-2.0.1.jar
```
    ├── META-INF
    │   ├── LICENSE.txt
    │   ├── MANIFEST.MF
    │   ├── NOTICE.md
    │   └── maven
    │       └── jakarta.inject
    │           └── jakarta.inject-api
    │               ├── pom.properties
    │               └── pom.xml
    ├── jakarta
    │   └── inject
    │       ├── Inject.class
    │       ├── Named.class
    │       ├── Provider.class
    │       ├── Qualifier.class
    │       ├── Scope.class
    │       └── Singleton.class
    └── module-info.class
```

jakarta.inject-api-2.0.1.MR.jar
```
├── META-INF
│   ├── LICENSE.txt
│   ├── MANIFEST.MF
│   ├── NOTICE.md
│   ├── maven
│   │   └── jakarta.inject
│   │       └── jakarta.inject-api
│   │           ├── pom.properties
│   │           └── pom.xml
│   └── versions
│       └── 9
│           └── module-info.class
└── jakarta
    └── inject
        ├── Inject.class
        ├── Named.class
        ├── Provider.class
        ├── Qualifier.class
        ├── Scope.class
        └── Singleton.class
```

###### Solution:
Declare version to be consistent with jetty ee10 bom

