### PR TITLE
Use JsonNode for serialisation tests, not the object under test

### DIFF
--- a/docs/source/manual/testing.rst
+++ b/docs/source/manual/testing.rst
@@ -89,6 +89,7 @@ Next, write a test for serializing a ``Person`` instance to JSON:
 
 .. code-block:: java
 
+    import com.fasterxml.jackson.databind.JsonNode;
     import com.fasterxml.jackson.databind.ObjectMapper;
     import org.junit.jupiter.api.Test;
 
@@ -104,7 +105,7 @@ Next, write a test for serializing a ``Person`` instance to JSON:
             final Person person = new Person("Luther Blissett", "lb@example.com");
 
             final String expected = MAPPER.writeValueAsString(
-                    MAPPER.readValue(getClass().getResource("/fixtures/person.json"), Person.class));
+                    MAPPER.readValue(getClass().getResource("/fixtures/person.json"), JsonNode.class));
 
             assertThat(MAPPER.writeValueAsString(person)).isEqualTo(expected);
         }


### PR DESCRIPTION
This stops us from relying on serialisation being effective in order to test that serialisation -- if a class has issues with its serialisation then the old example would apply the problematic serialisation to the expected value as well as to the actual value.

Instead, we use JsonNode as a mechanism to make sure we retain the exact structure of the input, while still ensuring we don't fail on formatting differences.

Refs https://github.com/dropwizard/dropwizard/pull/9827