### PR TITLE
Revert "fix(deps): update dependency jakarta.inject:jakarta.inject-api to v2.0.1.mr (release/5.0.x)"

### DIFF
--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -40,7 +40,7 @@
         <jackson.version>2.18.3</jackson.version>
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
         <jakarta.el.version>5.0.1</jakarta.el.version>
-        <jakarta.inject-api.version>2.0.1.MR</jakarta.inject-api.version>
+        <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
         <jakarta.servlet-api.version>6.0.0</jakarta.servlet-api.version>
         <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>


### PR DESCRIPTION
Reverts #9886 which reverted #9854

When renovate attempts re-re-revert after merge the ignore option should be used.