### PR TITLE
Use Jetty 12 VirtualThreadPool

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/core/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/core/server/AbstractServerFactory.java
@@ -35,6 +35,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.Validator;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import org.eclipse.jetty.util.thread.VirtualThreadPool;
 import org.jspecify.annotations.Nullable;
 import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.server.Handler;
@@ -652,22 +653,10 @@ public abstract class AbstractServerFactory implements ServerFactory {
                 new InstrumentedQueuedThreadPool(metricRegistry, maxThreads, minThreads,
                     (int) idleThreadTimeout.toMilliseconds(), queue);
         if (enableVirtualThreads) {
-            threadPool.setVirtualThreadsExecutor(getVirtualThreadsExecutorService());
+            threadPool.setVirtualThreadsExecutor(new VirtualThreadPool(maxThreads));
         }
         threadPool.setName("dw");
         return threadPool;
-    }
-
-    protected ExecutorService getVirtualThreadsExecutorService() {
-        try {
-            return (ExecutorService) Executors.class
-                .getDeclaredMethod("newVirtualThreadPerTaskExecutor")
-                .invoke(null);
-        } catch (InvocationTargetException invocationTargetException) {
-            throw new IllegalStateException("Error while obtaining a virtual thread executor", invocationTargetException.getCause());
-        } catch (Exception exception) {
-            throw new IllegalStateException("Error while obtaining a virtual thread executor", exception);
-        }
     }
 
     protected Server buildServer(LifecycleEnvironment lifecycle,

--- a/dropwizard-core/src/main/java/io/dropwizard/core/server/DefaultServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/core/server/DefaultServerFactory.java
@@ -18,6 +18,7 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.util.thread.ThreadPool;
+import org.eclipse.jetty.util.thread.VirtualThreadPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -239,7 +240,7 @@ public class DefaultServerFactory extends AbstractServerFactory {
             adminMinThreads
         );
         if (enableAdminVirtualThreads) {
-            threadPool.setVirtualThreadsExecutor(getVirtualThreadsExecutorService());
+            threadPool.setVirtualThreadsExecutor(new VirtualThreadPool(adminMaxThreads));
         }
         threadPool.setName("dw-admin");
         server.addBean(threadPool);


### PR DESCRIPTION
###### Problem:
The current implementation of enableVirtualThreads is unbounded and doesn't respect the maxThreads option in the server configuration which could potentially cause resource/memory exhaustion.

###### Solution:
They've added [VirtualThreadPool](https://github.com/jetty/jetty.project/blob/jetty-12.0.x/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/VirtualThreadPool.java) in Jetty 12 and it seems like it's the [preferred way](https://jetty.org/docs/jetty/12/programming-guide/arch/threads.html#thread-pool-virtual-threads-queued)

Since we still are in the release candidate phase with 5.x, this shouldn't be a big change. Thoughts?
