### PR TITLE
Update pgpverify-maven-plugin configuration.

### DIFF
--- a/.mvn/pgpverify/custom-keys-map.list
+++ b/.mvn/pgpverify/custom-keys-map.list
@@ -2,7 +2,7 @@
 # This fills in the gaps for https://github.com/s4u/pgp-keys-map
 
 # io.smallrye:jandex:jar:3.2.0 PGP key has been revoked and public key is not available
-io.smallrye:jandex:3.2.0    = !0x94976E17E18DD3201447286954963C3E875A56AE
+io.smallrye:jandex:jar:3.2.0    = !0x94976E17E18DD3201447286954963C3E875A56AE
 
 # pgp-keys-map has 'org.hibernate.* = noSig', but 'org.hibernate.validator' has a key that matches the one
 # for 'org.hibernate.orm'

--- a/.mvn/pgpverify/custom-keys-map.list
+++ b/.mvn/pgpverify/custom-keys-map.list
@@ -1,0 +1,10 @@
+# Defines a custom keys map file for use by pgpverify-maven-plugin
+# This fills in the gaps for https://github.com/s4u/pgp-keys-map
+
+# io.smallrye:jandex:jar:3.2.0 PGP key has been revoked and public key is not available
+io.smallrye:jandex:3.2.0    = !0x94976E17E18DD3201447286954963C3E875A56AE
+
+# pgp-keys-map has 'org.hibernate.* = noSig', but 'org.hibernate.validator' has a key that matches the one
+# for 'org.hibernate.orm'
+# https://hibernate.org/community/keys/
+org.hibernate.orm           = 0x1452F35849B50750F6A3BBB4B54011358B352F85

--- a/dropwizard-parent/pom.xml
+++ b/dropwizard-parent/pom.xml
@@ -23,9 +23,6 @@
         <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
         <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
 
-        <pgpverify.skip>true</pgpverify.skip>
-        <pgpverify.verifyPomFiles>false</pgpverify.verifyPomFiles>
-
         <surefire.argLine>-Duser.language=en -Duser.region=US -Duser.timezone=UTC</surefire.argLine>
         <agents.argLine>-javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy.version}/byte-buddy-agent-${byte-buddy.version}.jar</agents.argLine>
         <argLine>${surefire.argLine} --illegal-access=deny --add-opens java.base/java.net=ALL-UNNAMED ${agents.argLine}</argLine>
@@ -221,8 +218,21 @@
                 <groupId>org.simplify4u.plugins</groupId>
                 <artifactId>pgpverify-maven-plugin</artifactId>
                 <configuration>
+                    <skip>false</skip>
                     <quiet>true</quiet>
                     <pgpKeyServer>hkps://keyserver.ubuntu.com, hkps://keys.openpgp.org</pgpKeyServer>
+                    <pgpKeyServerLoadBalance>true</pgpKeyServerLoadBalance>
+                    <verifyPomFiles>false</verifyPomFiles>
+                    <keysMapLocations>
+                        <keysMapLocation>
+                            <!-- file provided by the org.simplify4u:pgp-keys-map dependency -->
+                            <location>/pgp-keys-map.list</location>
+                        </keysMapLocation>
+                        <keysMapLocation>
+                            <!-- file containing Dropwizard project overrides for keys mapping -->
+                            <location>${project.baseUri}/../.mvn/pgpverify/custom-keys-map.list</location>
+                        </keysMapLocation>
+                    </keysMapLocations>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Improves the configuration of the pgpverify-maven-plugin to allow it to be re-enabled.

Defines plugin configuration to use both the file from the
`org.simplify4u:pgp-keys-map` dependency and a custom keys-map file to allow for
customizations when the `pgp-keys-map` project (https://github.com/s4u/pgp-keys-map/blob/master/resources/pgp-keys-map.list) is missing something.

Related: #10112
