### PR TITLE
CONTRIBUTING.md: remove Google Group instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,10 +50,11 @@ it sits in the queue for a long time, or cannot be accepted at all.**
 
 Developer List
 ===
-If you have questions, feel free to open an issue or [a Github
-Discussion][discussion] on the project.
+If you have questions, feel free to open an issue or a [discussion](https://github.com/dropwizard/dropwizard/discussions) on GitHub.
 
-[discussion]: https://github.com/dropwizard/dropwizard/discussions
+Feel free to post questions about internals, ideas for new features or refactorings,
+different strategies, requests for comment/review etc. This is the forum for everyone
+who wants to actively contribute to the project itself.
 
 Committers
 ===

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,14 +50,10 @@ it sits in the queue for a long time, or cannot be accepted at all.**
 
 Developer List
 ===
-The Google Group [dropwizard-dev](https://groups.google.com/forum/#!forum/dropwizard-dev)
-is the place to discuss everything to do with the development of the framework itself,
-including docs, process and community management.
+If you have questions, feel free to open an issue or [a Github
+Discussion][discussion] on the project.
 
-
-Feel free to post questions about internals, ideas for new features or refactorings,
-different strategies, requests for comment/review etc. This is the forum for everyone
-who wants to actively contribute to the project itself.
+[discussion]: https://github.com/dropwizard/dropwizard/discussions
 
 Committers
 ===


### PR DESCRIPTION
It looks like the Google Group previously linked in the README has had one post in the last year, which received no replies. By contrast, Github Discussions is a much more active forum for discussion.

###### Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->

###### Solution:
<!-- Describe the modifications you've done. -->

###### Result:
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->
