### PR TITLE
Skip Http2WithConscryptTest on ARM MacOS

### DIFF
--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2WithConscryptTest.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2WithConscryptTest.java
@@ -7,13 +7,13 @@ import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import org.conscrypt.OpenSSLProvider;
 import org.eclipse.jetty.http.HttpVersion;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.security.Security;
 
 import static io.dropwizard.testing.ConfigOverride.config;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 class Http2WithConscryptTest extends Http2TestCommon {
@@ -35,19 +35,21 @@ class Http2WithConscryptTest extends Http2TestCommon {
     );
 
     @Test
+    @DisabledIf(
+        value = "isConscryptAvailable",
+        disabledReason ="Conscrypt native library not available on ARM MacOS - see https://github.com/google/conscrypt/issues/1034"
+    )
     void testHttp1WithCustomCipher() throws Exception {
-        assumeConscryptAvailable();
         assertResponse(http1Client.GET("https://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_1_1);
     }
 
     @Test
+    @DisabledIf(
+        value = "isConscryptAvailable",
+        disabledReason ="Conscrypt native library not available on ARM MacOS - see https://github.com/google/conscrypt/issues/1034"
+    )
     void testHttp2WithCustomCipher() throws Exception {
-        assumeConscryptAvailable();
         assertResponse(http2Client.GET("https://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_2);
-    }
-
-    private static void assumeConscryptAvailable() {
-        assumeTrue(isConscryptAvailable(), "Conscrypt native library not available on ARM MacOS - see https://github.com/google/conscrypt/issues/1034");
     }
 
     private static boolean isConscryptAvailable() {

--- a/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2WithConscryptTest.java
+++ b/dropwizard-http2/src/test/java/io/dropwizard/http2/Http2WithConscryptTest.java
@@ -13,12 +13,15 @@ import java.security.Security;
 
 import static io.dropwizard.testing.ConfigOverride.config;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 class Http2WithConscryptTest extends Http2TestCommon {
 
     static {
-        Security.addProvider(new OpenSSLProvider());
+        if (isConscryptAvailable()) {
+            Security.addProvider(new OpenSSLProvider());
+        }
     }
 
     private static final String PREFIX = "tls_conscrypt";
@@ -33,12 +36,27 @@ class Http2WithConscryptTest extends Http2TestCommon {
 
     @Test
     void testHttp1WithCustomCipher() throws Exception {
+        assumeConscryptAvailable();
         assertResponse(http1Client.GET("https://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_1_1);
     }
 
     @Test
     void testHttp2WithCustomCipher() throws Exception {
+        assumeConscryptAvailable();
         assertResponse(http2Client.GET("https://localhost:" + appRule.getLocalPort() + "/api/test"), HttpVersion.HTTP_2);
+    }
+
+    private static void assumeConscryptAvailable() {
+        assumeTrue(isConscryptAvailable(), "Conscrypt native library not available on ARM MacOS - see https://github.com/google/conscrypt/issues/1034");
+    }
+
+    private static boolean isConscryptAvailable() {
+        try {
+            new OpenSSLProvider();
+            return true;
+        } catch (UnsatisfiedLinkError | NoClassDefFoundError | ExceptionInInitializerError e) {
+            return false;
+        }
     }
 
 }


### PR DESCRIPTION
###### Problem:

When run on an ARM MacOS machine, I'm always getting:
```
[ERROR]   Http2WithConscryptTest.testHttp1WithCustomCipher » UnsatisfiedLink no conscrypt_openjdk_jni-osx-aarch_64 in java.library.path: /Users/richardnorth/Library/Java/Extensions:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:.
[ERROR]   Http2WithConscryptTest.testHttp2WithCustomCipher » NoClassDefFound Could not initialize class io.dropwizard.http2.Http2WithConscryptTest
```

I believe this is due to https://github.com/google/conscrypt/issues/1034 - lack of an ARM native build for MacOS for the Conscrypt library.

###### Solution:
Skip the affected tests when running on ARM MacOS (`aarch64`), so that build does not fail.

It's never a particularly satisfying thing to have to skip tests, but I think it's probably the simplest/clearest way to unblock contributions from developers on ARM Macs. Please do say if there's a better approach that you'd prefer, though.


