### PR TITLE
Make it impossible to instantiate JettyAuthenticationUtil

### DIFF
--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/JettyAuthenticationUtil.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/JettyAuthenticationUtil.java
@@ -20,6 +20,8 @@ import java.util.Set;
 class JettyAuthenticationUtil {
     private static final Type HTTP_SERVLET_REQUEST_REF_TYPE = (new GenericType<Ref<HttpServletRequest>>() {}).getType();
 
+    private JettyAuthenticationUtil() {}
+
     static void setJettyAuthenticationIfPossible(SecurityContext securityContext, @Nullable InjectionManager injectionManager) {
         if (injectionManager == null) {
             return;


### PR DESCRIPTION
This is a helper class of static methods - add a private constructor to prevent instantiation.

(appeasing a Sonarqube grumble).

Technically a breaking change - should I raise this against 5.x instead?