### PR TITLE
Suppress warnings about Slf4j initialisation

### DIFF
--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthFilter.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/AuthFilter.java
@@ -19,7 +19,7 @@ import static java.util.Objects.requireNonNull;
 
 @Priority(Priorities.AUTHENTICATION)
 public abstract class AuthFilter<C, P extends Principal> implements ContainerRequestFilter {
-
+    @SuppressWarnings("Slf4jLoggerShouldBePrivate")
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 
     protected String prefix =  "Basic";

--- a/dropwizard-core/src/main/java/io/dropwizard/core/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/core/server/AbstractServerFactory.java
@@ -246,6 +246,7 @@ import static com.codahale.metrics.annotation.ResponseMeteredLevel.COARSE;
  * @see DefaultServerFactory
  * @see SimpleServerFactory
  */
+@SuppressWarnings("Slf4jIllegalPassedClass")
 public abstract class AbstractServerFactory implements ServerFactory {
     private static final Logger LOGGER = LoggerFactory.getLogger(ServerFactory.class);
 

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/PersistenceExceptionMapper.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/PersistenceExceptionMapper.java
@@ -17,7 +17,7 @@ import static java.util.Objects.requireNonNull;
 
 @Provider
 public class PersistenceExceptionMapper implements ExtendedExceptionMapper<PersistenceException> {
-
+    @SuppressWarnings("Slf4jIllegalPassedClass")
     private static final Logger LOGGER = LoggerFactory.getLogger(DataException.class);
 
     @Context

--- a/dropwizard-jackson/src/main/java/io/dropwizard/jackson/DiscoverableSubtypeResolver.java
+++ b/dropwizard-jackson/src/main/java/io/dropwizard/jackson/DiscoverableSubtypeResolver.java
@@ -21,6 +21,7 @@ import java.util.List;
  */
 public class DiscoverableSubtypeResolver extends StdSubtypeResolver {
     private static final long serialVersionUID = 1L;
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(DiscoverableSubtypeResolver.class);
 
     /**

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/LoggingExceptionMapper.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/errors/LoggingExceptionMapper.java
@@ -15,6 +15,7 @@ import static java.util.Objects.requireNonNull;
 
 @Provider
 public abstract class LoggingExceptionMapper<E extends Throwable> implements ExceptionMapper<E> {
+    @SuppressWarnings("Slf4jLoggerShouldBePrivate")
     protected final Logger logger;
 
     /**

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/RequestIdFilter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/RequestIdFilter.java
@@ -28,6 +28,7 @@ public class RequestIdFilter implements ContainerResponseFilter {
 
     private static final String REQUEST_ID = "X-Request-Id";
 
+    @SuppressWarnings("Slf4jLoggerShouldBeFinal") // Non-final to enable injecting a mock in tests
     private Logger logger = LoggerFactory.getLogger(RequestIdFilter.class);
 
     void setLogger(Logger logger) {

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/ExecutorServiceManager.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/ExecutorServiceManager.java
@@ -7,7 +7,7 @@ import org.slf4j.LoggerFactory;
 import java.util.concurrent.ExecutorService;
 
 public class ExecutorServiceManager implements Managed {
-
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOG = LoggerFactory.getLogger(ExecutorServiceManager.class);
     private final ExecutorService executor;
     private final Duration shutdownPeriod;

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilder.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilder.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class ExecutorServiceBuilder {
+    @SuppressWarnings({"Slf4jLoggerShouldBeFinal", "Slf4jLoggerShouldBeNonStatic"}) // Non-final to enable injecting a mock in tests
     private static Logger log = LoggerFactory.getLogger(ExecutorServiceBuilder.class);
 
     private static final AtomicLong COUNT = new AtomicLong(0);

--- a/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/LifecycleEnvironment.java
+++ b/dropwizard-lifecycle/src/main/java/io/dropwizard/lifecycle/setup/LifecycleEnvironment.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ThreadFactory;
 import static java.util.Objects.requireNonNull;
 
 public class LifecycleEnvironment {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(LifecycleEnvironment.class);
 
     private final List<LifeCycle> managedObjects;

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/setup/ExecutorServiceBuilderTest.java
@@ -26,11 +26,11 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 class ExecutorServiceBuilderTest {
-
     private static final String WARNING = "Parameter 'maximumPoolSize' is conflicting with unbounded work queues";
 
     private final MetricRegistry metricRegistry = new MetricRegistry();
     private ExecutorServiceBuilder executorServiceBuilder;
+    @SuppressWarnings("Slf4jLoggerShouldBeFinal")
     private Logger log;
 
     @BeforeEach

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/common/AbstractAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/common/AbstractAppenderFactory.java
@@ -104,6 +104,7 @@ import java.util.concurrent.TimeUnit;
  * </table>
  */
 public abstract class AbstractAppenderFactory<E extends DeferredProcessingAware> implements AppenderFactory<E> {
+    @SuppressWarnings("Slf4jLoggerShouldBeNonStatic")
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractAppenderFactory.class);
 
     @NotNull

--- a/dropwizard-servlets/src/main/java/io/dropwizard/servlets/SlowRequestFilter.java
+++ b/dropwizard-servlets/src/main/java/io/dropwizard/servlets/SlowRequestFilter.java
@@ -26,6 +26,7 @@ public class SlowRequestFilter implements Filter {
     private final long threshold;
 
     private Supplier<Long> currentTimeProvider = System::nanoTime;
+    @SuppressWarnings("Slf4jLoggerShouldBeFinal") // Non-final to enable injecting a mock in tests
     private Logger logger = LoggerFactory.getLogger(SlowRequestFilter.class);
 
     /**

--- a/dropwizard-validation/src/test/java/io/dropwizard/validation/SelfValidationTest.java
+++ b/dropwizard-validation/src/test/java/io/dropwizard/validation/SelfValidationTest.java
@@ -55,6 +55,7 @@ class SelfValidationTest {
     private static final ListAppender listAppender = new ListAppender();
     private final Logger logger = (Logger)org.slf4j.LoggerFactory.getLogger(SelfValidationTest.class);
 
+    @SuppressWarnings("Slf4jIllegalPassedClass")
     @BeforeAll
     static void setUp() {
         Logger selfValidatingValidatorLogger = (Logger)LoggerFactory.getLogger(SelfValidatingValidator.class);
@@ -365,6 +366,7 @@ class SelfValidationTest {
         assertThat(listAppender.getAllLoggingEvents()).isEmpty();
     }
 
+    @SuppressWarnings("Slf4jIllegalPassedClass")
     @Test
     void messageParametersExample() {
         Logger hibernateLogger = (Logger)LoggerFactory.getLogger(AbstractMessageInterpolator.class);


### PR DESCRIPTION
These cases all look intentional and the warnings are just adding noise to the build output.

Refs #10289