### PR TITLE
Replace some ArgumentCaptor use with assertArg

### DIFF
--- a/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/JerseyClientBuilderTest.java
@@ -45,7 +45,6 @@ import org.glassfish.jersey.client.spi.ConnectorProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
@@ -69,6 +68,8 @@ import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.assertArg;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -79,14 +80,14 @@ class JerseyClientBuilderTest {
     private final MetricRegistry metricRegistry = new MetricRegistry();
     private final JerseyClientBuilder builder = new JerseyClientBuilder(metricRegistry);
     private final LifecycleEnvironment lifecycleEnvironment = spy(new LifecycleEnvironment(metricRegistry));
-    private final Environment environment = mock(Environment.class);
+    private final Environment environment = mock();
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
-    private final ObjectMapper objectMapper = mock(ObjectMapper.class);
+    private final ObjectMapper objectMapper = mock();
     private final Validator validator = Validators.newValidator();
-    private final HttpClientBuilder apacheHttpClientBuilder = mock(HttpClientBuilder.class);
+    private final HttpClientBuilder apacheHttpClientBuilder = mock();
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         when(environment.lifecycle()).thenReturn(lifecycleEnvironment);
         when(environment.getObjectMapper()).thenReturn(objectMapper);
         when(environment.getValidator()).thenReturn(validator);
@@ -237,28 +238,27 @@ class JerseyClientBuilderTest {
     }
 
     @Test
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings("unchecked")
     void usesAnExecutorServiceFromTheEnvironment() {
         final JerseyClientConfiguration configuration = new JerseyClientConfiguration();
         configuration.setMinThreads(7);
         configuration.setMaxThreads(532);
         configuration.setWorkQueueSize(16);
 
-        final ExecutorServiceBuilder executorServiceBuilderMock = mock(ExecutorServiceBuilder.class);
+        final ExecutorServiceBuilder executorServiceBuilderMock = mock();
         when(lifecycleEnvironment.executorService("jersey-client-test-%d")).thenReturn(executorServiceBuilderMock);
 
         when(executorServiceBuilderMock.minThreads(7)).thenReturn(executorServiceBuilderMock);
         when(executorServiceBuilderMock.maxThreads(532)).thenReturn(executorServiceBuilderMock);
 
-        final ArgumentCaptor<ArrayBlockingQueue> arrayBlockingQueueCaptor =
-                ArgumentCaptor.forClass(ArrayBlockingQueue.class);
-        when(executorServiceBuilderMock.workQueue(arrayBlockingQueueCaptor.capture()))
+        when(executorServiceBuilderMock.workQueue(any(ArrayBlockingQueue.class)))
                 .thenReturn(executorServiceBuilderMock);
-        when(executorServiceBuilderMock.build()).thenReturn(mock(ExecutorService.class));
+        when(executorServiceBuilderMock.build()).thenReturn(mock());
 
         builder.using(configuration).using(environment).build("test");
 
-        assertThat(arrayBlockingQueueCaptor.getValue().remainingCapacity()).isEqualTo(16);
+        verify(executorServiceBuilderMock).workQueue(assertArg(queue ->
+            assertThat(queue.remainingCapacity()).isEqualTo(16)));
     }
 
     @Test

--- a/dropwizard-example/src/test/java/com/example/helloworld/resources/PeopleResourceTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/resources/PeopleResourceTest.java
@@ -12,13 +12,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 
 import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.assertArg;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
@@ -33,7 +33,6 @@ class PeopleResourceTest {
     public static final ResourceExtension RESOURCES = ResourceExtension.builder()
             .addResource(new PeopleResource(PERSON_DAO))
             .build();
-    private final ArgumentCaptor<Person> personCaptor = ArgumentCaptor.forClass(Person.class);
     private Person person;
 
     @BeforeEach
@@ -57,8 +56,8 @@ class PeopleResourceTest {
                 .post(Entity.entity(person, MediaType.APPLICATION_JSON_TYPE));
 
         assertThat(response.getStatusInfo()).isEqualTo(Response.Status.OK);
-        verify(PERSON_DAO).create(personCaptor.capture());
-        assertThat(personCaptor.getValue()).isEqualTo(person);
+        verify(PERSON_DAO).create(assertArg(personArg ->
+            assertThat(personArg).isEqualTo(person)));
     }
 
     @Test

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/dual/HibernateBundleTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/dual/HibernateBundleTest.java
@@ -1,7 +1,6 @@
 package io.dropwizard.hibernate.dual;
 
 import com.codahale.metrics.health.HealthCheckRegistry;
-import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.hibernate5.jakarta.Hibernate5JakartaModule;
 import io.dropwizard.core.Configuration;
@@ -17,7 +16,6 @@ import io.dropwizard.jersey.setup.JerseyEnvironment;
 import org.hibernate.SessionFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 
 import java.util.Collections;
 import java.util.List;
@@ -27,6 +25,7 @@ import static io.dropwizard.hibernate.HibernateBundle.DEFAULT_NAME;
 import static io.dropwizard.hibernate.dual.HibernateBundle.PRIMARY;
 import static io.dropwizard.hibernate.dual.HibernateBundle.READER;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.assertArg;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.eq;
@@ -65,20 +64,20 @@ public class HibernateBundleTest {
         when(jerseyEnvironment.getResourceConfig()).thenReturn(new DropwizardResourceConfig());
 
         when(factory.build(eq(bundle),
-                           any(Environment.class),
-                           any(DataSourceFactory.class),
-                           anyList(),
-                           eq(PREFIX + PRIMARY))).thenReturn(sessionFactory);
+            any(Environment.class),
+            any(DataSourceFactory.class),
+            anyList(),
+            eq(PREFIX + PRIMARY))).thenReturn(sessionFactory);
 
         when(factory.build(eq(bundle),
-                           any(Environment.class),
-                           any(DataSourceFactory.class),
-                           anyList(),
-                           eq(PREFIX + READER))).thenReturn(readFactory);
+            any(Environment.class),
+            any(DataSourceFactory.class),
+            anyList(),
+            eq(PREFIX + READER))).thenReturn(readFactory);
     }
 
     @Test
-    public void addsHibernateSupportToJackson() throws Exception {
+    public void addsHibernateSupportToJackson() {
         final ObjectMapper objectMapperFactory = mock(ObjectMapper.class);
 
         final Bootstrap<?> bootstrap = mock(Bootstrap.class);
@@ -86,10 +85,8 @@ public class HibernateBundleTest {
 
         bundle.initialize(bootstrap);
 
-        final ArgumentCaptor<Module> captor = ArgumentCaptor.forClass(Module.class);
-        verify(objectMapperFactory).registerModule(captor.capture());
-
-        assertThat(captor.getValue()).isInstanceOf(Hibernate5JakartaModule.class);
+        verify(objectMapperFactory).registerModule(assertArg(module ->
+            assertThat(module).isInstanceOf(Hibernate5JakartaModule.class)));
     }
 
     @Test
@@ -103,9 +100,7 @@ public class HibernateBundleTest {
     public void registersATransactionalListener() throws Exception {
         bundle.run(configuration, environment);
 
-        final ArgumentCaptor<UnitOfWorkApplicationListener> captor =
-                ArgumentCaptor.forClass(UnitOfWorkApplicationListener.class);
-        verify(jerseyEnvironment).register(captor.capture());
+        verify(jerseyEnvironment).register(any(UnitOfWorkApplicationListener.class));
     }
 
     @Test
@@ -114,15 +109,15 @@ public class HibernateBundleTest {
 
         bundle.run(configuration, environment);
 
-        final ArgumentCaptor<SessionFactoryHealthCheck> captor =
-                ArgumentCaptor.forClass(SessionFactoryHealthCheck.class);
-        verify(healthChecks).register(eq(PREFIX + PRIMARY), captor.capture());
-        assertThat(captor.getValue().getSessionFactory()).isInstanceOf(SessionFactory.class);
-        assertThat(captor.getValue().getValidationQuery()).isEqualTo(Optional.of("SELECT something"));
+        verify(healthChecks).register(eq(PREFIX + PRIMARY), assertArg(healthCheck ->
+            assertThat(healthCheck).isInstanceOfSatisfying(SessionFactoryHealthCheck.class, sfhc -> assertThat(sfhc)
+                .satisfies(check -> assertThat(check.getSessionFactory()).isInstanceOf(SessionFactory.class))
+                .satisfies(check -> assertThat(check.getValidationQuery()).isEqualTo(Optional.of("SELECT something"))))));
 
-        verify(healthChecks).register(eq(PREFIX + READER), captor.capture());
-        assertThat(captor.getValue().getSessionFactory()).isInstanceOf(SessionFactory.class);
-        assertThat(captor.getValue().getValidationQuery()).isEqualTo(Optional.of("/* Health Check */ SELECT 1"));
+        verify(healthChecks).register(eq(PREFIX + READER), assertArg(healthCheck ->
+            assertThat(healthCheck).isInstanceOfSatisfying(SessionFactoryHealthCheck.class, sfhc -> assertThat(sfhc)
+                .satisfies(check -> assertThat(check.getSessionFactory()).isInstanceOf(SessionFactory.class))
+                .satisfies(check -> assertThat(check.getValidationQuery()).isEqualTo(Optional.of("/* Health Check */ SELECT 1"))))));
     }
 
     @Test
@@ -146,21 +141,19 @@ public class HibernateBundleTest {
             }
         };
         when(factory.build(eq(customBundle),
-                any(Environment.class),
-                any(DataSourceFactory.class),
-                anyList(),
-                eq(name + PRIMARY))).thenReturn(sessionFactory);
+            any(Environment.class),
+            any(DataSourceFactory.class),
+            anyList(),
+            eq(name + PRIMARY))).thenReturn(sessionFactory);
         when(factory.build(eq(customBundle),
-                any(Environment.class),
-                any(DataSourceFactory.class),
-                anyList(),
-                eq(name + READER))).thenReturn(readFactory);
+            any(Environment.class),
+            any(DataSourceFactory.class),
+            anyList(),
+            eq(name + READER))).thenReturn(readFactory);
 
         customBundle.run(configuration, environment);
 
-        final ArgumentCaptor<SessionFactoryHealthCheck> captor =
-                ArgumentCaptor.forClass(SessionFactoryHealthCheck.class);
-        verify(healthChecks).register(eq(name + READER), captor.capture());
+        verify(healthChecks).register(eq(name + READER), any(SessionFactoryHealthCheck.class));
     }
 
     @Test


### PR DESCRIPTION
Newer releases of Mockito added support for embedding test assertions in verify statements, which means we don't always need to use `ArgumentCaptor`.

Refs #10291