### PR TITLE
Simplify GraphiteReporterFactoryTest

### DIFF
--- a/dropwizard-metrics-graphite/src/test/java/io/dropwizard/metrics/graphite/GraphiteReporterFactoryTest.java
+++ b/dropwizard-metrics-graphite/src/test/java/io/dropwizard/metrics/graphite/GraphiteReporterFactoryTest.java
@@ -9,16 +9,14 @@ import io.dropwizard.jackson.DiscoverableSubtypeResolver;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.validation.BaseValidator;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 class GraphiteReporterFactoryTest {
-
-    private final GraphiteReporter.Builder builderSpy = mock(GraphiteReporter.Builder.class);
-
+    private final GraphiteReporter.Builder builderSpy = mock();
     private final GraphiteReporterFactory graphiteReporterFactory = new GraphiteReporterFactory() {
         @Override
         protected GraphiteReporter.Builder builder(MetricRegistry registry) {
@@ -35,7 +33,7 @@ class GraphiteReporterFactoryTest {
     @Test
     void createDefaultFactory() throws Exception {
         final GraphiteReporterFactory factory = new YamlConfigurationFactory<>(GraphiteReporterFactory.class,
-             BaseValidator.newValidator(), Jackson.newObjectMapper(), "dw")
+            BaseValidator.newValidator(), Jackson.newObjectMapper(), "dw")
             .build();
         assertThat(factory.getFrequency()).isNotPresent();
     }
@@ -44,14 +42,10 @@ class GraphiteReporterFactoryTest {
     void testNoAddressResolutionForGraphite() {
         graphiteReporterFactory.build(new MetricRegistry());
 
-        final ArgumentCaptor<Graphite> argument = ArgumentCaptor.forClass(Graphite.class);
-        verify(builderSpy).build(argument.capture());
-
-        final Graphite graphite = argument.getValue();
-        assertThat(graphite)
-            .satisfies(g -> assertThat(g).extracting("hostname").isEqualTo("localhost"))
-            .satisfies(g -> assertThat(g).extracting("port").isEqualTo(2003))
-            .satisfies(g -> assertThat(g).extracting("address").isNull());
+        verify(builderSpy).build(ArgumentMatchers.assertArg(graphite -> assertThat(graphite)
+            .isInstanceOf(Graphite.class)
+            .extracting("hostname", "port", "address")
+            .contains("localhost", 2003, null)));
     }
 
     @Test
@@ -59,13 +53,9 @@ class GraphiteReporterFactoryTest {
         graphiteReporterFactory.setTransport("udp");
         graphiteReporterFactory.build(new MetricRegistry());
 
-        final ArgumentCaptor<GraphiteUDP> argument = ArgumentCaptor.forClass(GraphiteUDP.class);
-        verify(builderSpy).build(argument.capture());
-
-        final GraphiteUDP graphite = argument.getValue();
-        assertThat(graphite)
-            .satisfies(g -> assertThat(g).extracting("hostname").isEqualTo("localhost"))
-            .satisfies(g -> assertThat(g).extracting("port").isEqualTo(2003))
-            .satisfies(g -> assertThat(g).extracting("address").isNull());
+        verify(builderSpy).build(ArgumentMatchers.<GraphiteUDP>assertArg(graphite -> assertThat(graphite)
+            .isInstanceOf(GraphiteUDP.class)
+            .extracting("hostname", "port", "address")
+            .contains("localhost", 2003, null)));
     }
 }


### PR DESCRIPTION
We can replace use of ArgumentCaptor with assertArg here, as well as extracting all the fields of interest in one go with Assert-J.

Refs #10386