### PR TITLE
docs: fix incorrect format string in archivedLogFilenamePattern

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -647,7 +647,7 @@ Logging
           appenders:
             - type: file
               currentLogFilename: /var/log/myapplication-sql.log
-              archivedLogFilenamePattern: /var/log/myapplication-sql-%d.log.gz
+              archivedLogFilenamePattern: /var/log/myapplication-sql-%i.log.gz
               archivedFileCount: 5
       appenders:
         - type: console


### PR DESCRIPTION
Closes #10153