### PR TITLE
Replace call to deprecated logback PatternLayout#getDefaultConverterMap

### DIFF
--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/common/DropwizardLayout.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/common/DropwizardLayout.java
@@ -3,7 +3,6 @@ package io.dropwizard.logging.common;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.PatternLayout;
 
-import java.util.Map;
 import java.util.TimeZone;
 
 /**
@@ -18,15 +17,14 @@ public class DropwizardLayout extends PatternLayout {
     public DropwizardLayout(LoggerContext context, TimeZone timeZone) {
         super();
         setOutputPatternAsHeader(false);
-        Map<String, String> defaultConverterMap = getDefaultConverterMap();
-        defaultConverterMap.put("dwEx", PrefixedThrowableProxyConverter.class.getName());
-        defaultConverterMap.put("dwException", PrefixedThrowableProxyConverter.class.getName());
-        defaultConverterMap.put("dwThrowable", PrefixedThrowableProxyConverter.class.getName());
-        defaultConverterMap.put("dwREx", PrefixedRootCauseFirstThrowableProxyConverter.class.getName());
-        defaultConverterMap.put("dwRootException", PrefixedRootCauseFirstThrowableProxyConverter.class.getName());
-        defaultConverterMap.put("dwXEx", PrefixedExtendedThrowableProxyConverter.class.getName());
-        defaultConverterMap.put("dwXException", PrefixedExtendedThrowableProxyConverter.class.getName());
-        defaultConverterMap.put("dwXThrowable", PrefixedExtendedThrowableProxyConverter.class.getName());
+        getDefaultConverterSupplierMap().put("dwEx", PrefixedThrowableProxyConverter::new);
+        getDefaultConverterSupplierMap().put("dwException", PrefixedThrowableProxyConverter::new);
+        getDefaultConverterSupplierMap().put("dwThrowable", PrefixedThrowableProxyConverter::new);
+        getDefaultConverterSupplierMap().put("dwREx", PrefixedRootCauseFirstThrowableProxyConverter::new);
+        getDefaultConverterSupplierMap().put("dwRootException", PrefixedRootCauseFirstThrowableProxyConverter::new);
+        getDefaultConverterSupplierMap().put("dwXEx", PrefixedExtendedThrowableProxyConverter::new);
+        getDefaultConverterSupplierMap().put("dwXException", PrefixedExtendedThrowableProxyConverter::new);
+        getDefaultConverterSupplierMap().put("dwXThrowable", PrefixedExtendedThrowableProxyConverter::new);
         setPattern("%-5p [%d{ISO8601," + timeZone.getID() + "}] %c: %m%n%dwREx");
         setContext(context);
     }

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/common/DropwizardLayoutTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/common/DropwizardLayoutTest.java
@@ -9,30 +9,31 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 class DropwizardLayoutTest {
-    private final LoggerContext context = mock(LoggerContext.class);
-    private final TimeZone timeZone = TimeZone.getTimeZone("UTC");
-    private final DropwizardLayout layout = new DropwizardLayout(context, timeZone);
+    private final LoggerContext context = mock();
+    private final DropwizardLayout layout = new DropwizardLayout(context, TimeZone.getTimeZone("UTC"));
 
     @Test
-    void prefixesThrowables() throws Exception {
-        assertThat(layout.getDefaultConverterMap())
-                .containsEntry("dwEx", PrefixedThrowableProxyConverter.class.getName());
+    void prefixesThrowables() {
+        assertThat(layout.getDefaultConverterSupplierMap())
+                .hasEntrySatisfying("dwEx", supplier ->
+                    assertThat(supplier.get()).isInstanceOf(PrefixedThrowableProxyConverter.class));
     }
 
     @Test
-    void prefixesExtendedThrowables() throws Exception {
-        assertThat(layout.getDefaultConverterMap())
-                .containsEntry("dwXEx", PrefixedExtendedThrowableProxyConverter.class.getName());
+    void prefixesExtendedThrowables() {
+        assertThat(layout.getDefaultConverterSupplierMap())
+                .hasEntrySatisfying("dwXEx", supplier ->
+                    assertThat(supplier.get()).isInstanceOf(PrefixedExtendedThrowableProxyConverter.class));
     }
 
     @Test
-    void hasAContext() throws Exception {
+    void hasAContext() {
         assertThat(layout.getContext())
                 .isEqualTo(context);
     }
 
     @Test
-    void hasAPatternWithATimeZoneAndExtendedThrowables() throws Exception {
+    void hasAPatternWithATimeZoneAndExtendedThrowables() {
         assertThat(layout.getPattern())
                 .isEqualTo("%-5p [%d{ISO8601,UTC}] %c: %m%n%dwREx");
     }


### PR DESCRIPTION
This was deprecated in logback 1.5.13 and replaced by the more typesafe getDefaultConverterSupplierMap

Refs #10446