### PR TITLE
Use non-deprecated httpclient methods for managing client timeouts

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientBuilder.java
@@ -20,6 +20,7 @@ import org.apache.hc.client5.http.auth.Credentials;
 import org.apache.hc.client5.http.auth.CredentialsStore;
 import org.apache.hc.client5.http.auth.NTCredentials;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.cookie.StandardCookieSpec;
 import org.apache.hc.client5.http.impl.DefaultConnectionKeepAliveStrategy;
@@ -44,6 +45,7 @@ import org.apache.hc.core5.http.io.SocketConfig;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.http.protocol.HttpProcessor;
 import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import javax.net.ssl.HostnameVerifier;
@@ -356,7 +358,6 @@ public class HttpClientBuilder {
             final String name) {
         final String cookiePolicy = configuration.isCookiesEnabled() ? StandardCookieSpec.RELAXED : StandardCookieSpec.IGNORE;
         final int timeout = (int) configuration.getTimeout().toMilliseconds();
-        final int connectionTimeout = (int) configuration.getConnectionTimeout().toMilliseconds();
         final int connectionRequestTimeout = (int) configuration.getConnectionRequestTimeout().toMilliseconds();
         final long keepAlive = configuration.getKeepAlive().toMilliseconds();
         final ConnectionReuseStrategy reuseStrategy = keepAlive == 0
@@ -371,7 +372,6 @@ public class HttpClientBuilder {
         final RequestConfig requestConfig
                 = RequestConfig.custom().setCookieSpec(cookiePolicy)
                 .setResponseTimeout(timeout, TimeUnit.MILLISECONDS)
-                .setConnectTimeout(connectionTimeout, TimeUnit.MILLISECONDS)
                 .setConnectionKeepAlive(TimeValue.of(-1, TimeUnit.MILLISECONDS))
                 .setConnectionRequestTimeout(connectionRequestTimeout, TimeUnit.MILLISECONDS)
                 .setProtocolUpgradeEnabled(protocolUpgradeEnabled)
@@ -516,7 +516,11 @@ public class HttpClientBuilder {
             InstrumentedHttpClientConnectionManager connectionManager) {
         connectionManager.setDefaultMaxPerRoute(configuration.getMaxConnectionsPerRoute());
         connectionManager.setMaxTotal(configuration.getMaxConnections());
-        connectionManager.setValidateAfterInactivity(TimeValue.ofMilliseconds((int) configuration.getValidateAfterInactivityPeriod().toMilliseconds()));
+        final ConnectionConfig connectionConfig = ConnectionConfig.custom()
+            .setConnectTimeout(Timeout.of(configuration.getConnectionTimeout().toJavaDuration()))
+            .setValidateAfterInactivity(TimeValue.of(configuration.getValidateAfterInactivityPeriod().toJavaDuration()))
+            .build();
+        connectionManager.setConnectionConfigResolver(route -> connectionConfig);
         return connectionManager;
     }
 

--- a/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
@@ -21,6 +21,7 @@ import org.apache.hc.client5.http.auth.CredentialsProvider;
 import org.apache.hc.client5.http.auth.CredentialsStore;
 import org.apache.hc.client5.http.auth.NTCredentials;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.cookie.StandardCookieSpec;
 import org.apache.hc.client5.http.impl.DefaultConnectionKeepAliveStrategy;
@@ -33,6 +34,7 @@ import org.apache.hc.client5.http.routing.HttpRoutePlanner;
 import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
 import org.apache.hc.client5.http.socket.PlainConnectionSocketFactory;
 import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.core5.function.Resolver;
 import org.apache.hc.core5.http.ConnectionReuseStrategy;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpException;
@@ -356,13 +358,12 @@ class HttpClientBuilderTest {
 
     @Test
     void setsTheConnectTimeout() {
-        configuration.setConnectionTimeout(Duration.milliseconds(500));
-        assertThat(builder.using(configuration).createClient(apacheBuilder, connectionManager, "test")).isNotNull();
+        configuration.setConnectionTimeout(Duration.milliseconds(123));
 
-        assertThat(apacheBuilder)
-                .extracting("defaultRequestConfig")
-                .isInstanceOfSatisfying(RequestConfig.class, requestConfig ->
-                        assertThat(requestConfig.getConnectTimeout()).isEqualTo(Timeout.ofMilliseconds(500L)));
+        assertThat(builder.using(configuration).build("test"))
+            .extracting("connManager.connectionConfigResolver").isInstanceOfSatisfying(Resolver.class, resolver ->
+                assertThat(resolver.resolve(new HttpRoute(HttpHost.create(URI.create("https://example.org:443")))))
+                    .isInstanceOfSatisfying(ConnectionConfig.class, config -> assertThat(config.getConnectTimeout()).isEqualTo(Timeout.ofMilliseconds(123L))));
     }
 
     @Test
@@ -559,12 +560,11 @@ class HttpClientBuilderTest {
     void setValidateAfterInactivityPeriodFromConfiguration() {
         int validateAfterInactivityPeriod = 50000;
         configuration.setValidateAfterInactivityPeriod(Duration.milliseconds(validateAfterInactivityPeriod));
-        final ConfiguredCloseableHttpClient client = builder.using(configuration)
-                .createClient(apacheBuilder, builder.configureConnectionManager(connectionManager), "test");
 
-        assertThat(client).isNotNull();
-        assertThat(apacheBuilder).extracting("connManager").isSameAs(connectionManager);
-        verify(connectionManager).setValidateAfterInactivity(TimeValue.ofMilliseconds(validateAfterInactivityPeriod));
+        assertThat(builder.using(configuration).build("test"))
+            .extracting("connManager.connectionConfigResolver").isInstanceOfSatisfying(Resolver.class, resolver ->
+                assertThat(resolver.resolve(new HttpRoute(HttpHost.create(URI.create("https://example.org:443")))))
+                    .isInstanceOfSatisfying(ConnectionConfig.class, config -> assertThat(config.getValidateAfterInactivity()).isEqualTo(TimeValue.ofMilliseconds(validateAfterInactivityPeriod))));
     }
 
     @Test


### PR DESCRIPTION
Revalidation timeouts and connection timeouts have moved to a ConnectionConfig class which allows them to be adjusted per-route.

Refs #10453