### PR TITLE
chore: remove Checker framework

### DIFF
--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -22,7 +22,6 @@
         <argparse4j.version>0.9.0</argparse4j.version>
         <byte-buddy.version>1.17.7</byte-buddy.version>
         <caffeine.version>3.2.2</caffeine.version>
-        <checker-qual.version>3.50.0</checker-qual.version>
         <classmate.version>1.7.0</classmate.version>
         <commons-codec.version>1.19.0</commons-codec.version>
         <commons-collections4.version>4.5.0</commons-collections4.version>
@@ -128,11 +127,6 @@
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_annotations</artifactId>
                 <version>${error_prone.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.checkerframework</groupId>
-                <artifactId>checker-qual</artifactId>
-                <version>${checker-qual.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jspecify</groupId>


### PR DESCRIPTION
The Checker framework has been replaced by JSpecify in #9782.