### PR TITLE
Address some errorprone warnings in the tests

### DIFF
--- a/dropwizard-auth/src/test/java/io/dropwizard/auth/CachingAuthenticatorTest.java
+++ b/dropwizard-auth/src/test/java/io/dropwizard/auth/CachingAuthenticatorTest.java
@@ -25,7 +25,7 @@ class CachingAuthenticatorTest {
             .maximumSize(1L)
             .executor(Runnable::run);
 
-    @Mock(lenient = true)
+    @Mock(strictness = Mock.Strictness.LENIENT)
     private Authenticator<String, Principal> underlying;
     private CachingAuthenticator<String, Principal> cached;
 

--- a/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/HttpClientBuilderTest.java
@@ -711,7 +711,7 @@ class HttpClientBuilderTest {
     void configureCredentialReturnsUserNamePasswordCredentialsForBasicConfig() {
         assertThat(builder.configureCredentials(new AuthConfiguration("username", "password")))
                 .isInstanceOfSatisfying(UsernamePasswordCredentials.class, upCredentials -> assertThat(upCredentials)
-                        .satisfies(c -> assertThat(c.getPassword()).isEqualTo("password".toCharArray()))
+                        .satisfies(c -> assertThat(c.getUserPassword()).isEqualTo("password".toCharArray()))
                         .satisfies(c -> assertThat(c.getUserPrincipal().getName()).isEqualTo("username")));
     }
 }

--- a/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationValidationExceptionTest.java
+++ b/dropwizard-configuration/src/test/java/io/dropwizard/configuration/ConfigurationValidationExceptionTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnabledIf("isDefaultLocaleEnglish")
 class ConfigurationValidationExceptionTest {
     private static class Example {
+        @SuppressWarnings("MultipleNullnessAnnotations")
         @NotNull
         @Nullable // Weird combination, but Hibernate Validator is not good with the compile nullable checks
         String woo;

--- a/dropwizard-core/src/test/java/io/dropwizard/core/server/DefaultServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/core/server/DefaultServerFactoryTest.java
@@ -70,6 +70,7 @@ class DefaultServerFactoryTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     void loadsServerPushConfig() {
         final ServerPushFilterFactory serverPush = http.getServerPush();
         assertThat(serverPush.isEnabled()).isTrue();

--- a/dropwizard-core/src/test/java/io/dropwizard/core/setup/ExceptionMapperBinderTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/core/setup/ExceptionMapperBinderTest.java
@@ -64,6 +64,7 @@ class ExceptionMapperBinderTest {
     @Produces("application/json")
     private static class TestValidationResource {
         @GET
+        @SuppressWarnings("unused")
         public String get(@NotEmpty @QueryParam("foo") String foo) {
             return foo;
         }

--- a/dropwizard-db/src/test/java/io/dropwizard/db/TimeBoundHealthCheckTest.java
+++ b/dropwizard-db/src/test/java/io/dropwizard/db/TimeBoundHealthCheckTest.java
@@ -8,7 +8,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.mockito.Mockito.mock;
@@ -17,17 +16,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class TimeBoundHealthCheckTest {
-
     @Test
-    @SuppressWarnings("unchecked")
     void testCheck() throws InterruptedException, ExecutionException, TimeoutException {
-        final ExecutorService executorService = mock(ExecutorService.class);
-        final Duration duration = mock(Duration.class);
-        when(duration.getQuantity()).thenReturn(5L);
-        when(duration.getUnit()).thenReturn(TimeUnit.SECONDS);
+        final ExecutorService executorService = mock();
+        final Duration duration = Duration.seconds(5);
 
-        final Callable<HealthCheck.Result> callable = mock(Callable.class);
-        final Future<HealthCheck.Result> future = mock(Future.class);
+        final Callable<HealthCheck.Result> callable = mock();
+        final Future<HealthCheck.Result> future = mock();
         when(executorService.submit(callable)).thenReturn(future);
 
         new TimeBoundHealthCheck(executorService, duration).check(callable);

--- a/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckConfigValidatorTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/HealthCheckConfigValidatorTest.java
@@ -2,17 +2,12 @@ package io.dropwizard.health;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.classic.spi.LoggingEvent;
-import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.read.ListAppender;
 import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
@@ -23,29 +18,30 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
-@ExtendWith(MockitoExtension.class)
 class HealthCheckConfigValidatorTest {
-
-    @Mock
-    private Appender<ILoggingEvent> mockLogAppender;
+    private final ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
 
     @BeforeEach
-    void setUp() throws Exception {
+    @SuppressWarnings("Slf4jIllegalPassedClass")
+    void setUp() {
         ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) LoggerFactory
             .getLogger(HealthCheckConfigValidator.class);
-        logger.addAppender(mockLogAppender);
+        listAppender.start();
+        logger.addAppender(listAppender);
     }
 
     @AfterEach
-    void tearDown() throws Exception {
+    @SuppressWarnings("Slf4jIllegalPassedClass")
+    void tearDown() {
         ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) LoggerFactory
             .getLogger(HealthCheckConfigValidator.class);
-        logger.detachAppender(mockLogAppender);
+        logger.detachAppender(listAppender);
         MDC.clear();
     }
 
@@ -60,7 +56,7 @@ class HealthCheckConfigValidatorTest {
         validator.start();
 
         // then
-        verifyNoInteractions(mockLogAppender);
+        assertThat(listAppender.list).isEmpty();
     }
 
     @Test
@@ -82,13 +78,12 @@ class HealthCheckConfigValidatorTest {
         validator.start();
 
         // then
-        verifyNoInteractions(mockLogAppender);
+        assertThat(listAppender.list).isEmpty();
     }
 
     @Test
     void startValidationsShouldSucceedButLogWhenNotAllHealthChecksAreConfigured() throws Exception {
         // given
-        ArgumentCaptor<LoggingEvent> captor = ArgumentCaptor.forClass(LoggingEvent.class);
         HealthCheckConfiguration check1 = new HealthCheckConfiguration();
         check1.setName("check-1");
         List<HealthCheckConfiguration> configs = singletonList(check1);
@@ -102,21 +97,18 @@ class HealthCheckConfigValidatorTest {
         validator.start();
 
         // then
-        verify(mockLogAppender).doAppend(captor.capture());
-        LoggingEvent logEvent = captor.getValue();
-        assertThat(logEvent.getLevel()).isEqualTo(Level.INFO);
-        assertThat(logEvent.getFormattedMessage())
-            .doesNotContain("  * check-1");
-        assertThat(logEvent.getFormattedMessage())
-            .contains("  * check-2");
-        assertThat(logEvent.getFormattedMessage())
-            .contains("  * check-3");
+        assertThat(listAppender.list)
+            .singleElement()
+            .satisfies(logEvent -> assertThat(logEvent.getLevel()).isEqualTo(Level.INFO))
+            .satisfies(logEvent -> assertThat(logEvent.getFormattedMessage())
+                .doesNotContain("  * check-1")
+                .contains("  * check-2")
+                .contains("  * check-3"));
     }
 
     @Test
     void startValidationsShouldFailIfAHealthCheckConfiguredButNotRegistered() throws Exception {
         // given
-        ArgumentCaptor<LoggingEvent> captor = ArgumentCaptor.forClass(LoggingEvent.class);
         List<HealthCheckConfiguration> configs = new ArrayList<>();
         HealthCheckConfiguration check1 = new HealthCheckConfiguration();
         check1.setName("check-1");
@@ -130,22 +122,16 @@ class HealthCheckConfigValidatorTest {
         HealthCheckRegistry registry = new HealthCheckRegistry();
         registry.register("check-1", mock(HealthCheck.class));
 
-        // when
-        try {
-            HealthCheckConfigValidator validator = new HealthCheckConfigValidator(unmodifiableList(configs), registry);
-            validator.start();
-            fail("configured health checks that aren't registered should fail");
-        } catch (IllegalStateException e) {
-            // then
-            verify(mockLogAppender).doAppend(captor.capture());
-            LoggingEvent logEvent = captor.getValue();
-            assertThat(logEvent.getLevel())
-                .isEqualTo(Level.ERROR);
-            assertThat(logEvent.getFormattedMessage())
+        HealthCheckConfigValidator validator = new HealthCheckConfigValidator(unmodifiableList(configs), registry);
+        assertThatIllegalStateException()
+            .isThrownBy(validator::start)
+            .withMessageContaining("[check-2, check-3]");
+
+        assertThat(listAppender.list)
+            .singleElement()
+            .satisfies(logEvent -> assertThat(logEvent.getLevel()).isEqualTo(Level.ERROR))
+            .satisfies(logEvent -> assertThat(logEvent.getFormattedMessage())
                 .doesNotContain("  * check-1")
-                .contains("  * check-2\n  * check-3");
-            assertThat(e.getMessage())
-                .contains("[check-2, check-3]");
-        }
+                .contains("  * check-2\n  * check-3"));
     }
 }

--- a/dropwizard-health/src/test/java/io/dropwizard/health/ScheduledHealthCheckTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/ScheduledHealthCheckTest.java
@@ -4,14 +4,11 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheck;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(MockitoExtension.class)
 class ScheduledHealthCheckTest {
     private static final HealthStateListener LISTENER = new HealthStateListener() {
         @Override
@@ -27,23 +24,20 @@ class ScheduledHealthCheckTest {
         }
     };
     private final MetricRegistry metrics = new MetricRegistry();
-    @Mock
-    private HealthCheck healthCheck;
-    @Mock
-    private Schedule schedule;
+    private final HealthCheck healthCheck = mock();
 
     @Test
     void healthyCheckShouldResultInSuccess() {
-        when(schedule.getSuccessAttempts()).thenReturn(1);
-        when(schedule.getFailureAttempts()).thenReturn(1);
+        int successAttempts = 1;
+        int failureAttempts = 1;
 
         final String name = "test";
 
         final Counter healthyCounter = metrics.counter("test.healthy");
         final Counter unhealthyCounter = metrics.counter("test.unhealthy");
-        final State state = new State(name, schedule.getFailureAttempts(), schedule.getSuccessAttempts(), false, LISTENER);
+        final State state = new State(name, failureAttempts, successAttempts, false, LISTENER);
         final ScheduledHealthCheck scheduledHealthCheck = new ScheduledHealthCheck(name, HealthCheckType.READY, true,
-            healthCheck, schedule, state, healthyCounter, unhealthyCounter);
+            healthCheck, mock(), state, healthyCounter, unhealthyCounter);
 
         when(healthCheck.execute()).thenReturn(HealthCheck.Result.healthy());
 
@@ -60,15 +54,15 @@ class ScheduledHealthCheckTest {
 
     @Test
     void unhealthyCheckShouldResultInFail() {
-        when(schedule.getSuccessAttempts()).thenReturn(1);
-        when(schedule.getFailureAttempts()).thenReturn(1);
+        int successAttempts = 1;
+        int failureAttempts = 1;
 
         final String name = "test";
         final Counter healthyCounter = metrics.counter("test.healthy");
         final Counter unhealthyCounter = metrics.counter("test.unhealthy");
-        final State state = new State(name, schedule.getFailureAttempts(), schedule.getSuccessAttempts(), false, LISTENER);
+        final State state = new State(name, failureAttempts, successAttempts, false, LISTENER);
         final ScheduledHealthCheck scheduledHealthCheck = new ScheduledHealthCheck(name, HealthCheckType.READY, true,
-            healthCheck, schedule, state, healthyCounter, unhealthyCounter);
+            healthCheck, mock(), state, healthyCounter, unhealthyCounter);
         when(healthCheck.execute()).thenReturn(HealthCheck.Result.unhealthy("something happened"));
 
         assertThat(scheduledHealthCheck.isPreviouslyRecovered()).isFalse();

--- a/dropwizard-health/src/test/java/io/dropwizard/health/check/tcp/TcpHealthCheckTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/check/tcp/TcpHealthCheckTest.java
@@ -8,9 +8,12 @@ import java.io.IOException;
 import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
+import java.net.Socket;
 import java.net.SocketTimeoutException;
+import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -33,9 +36,10 @@ class TcpHealthCheckTest {
     @Test
     void tcpHealthCheckShouldReturnHealthyIfCanConnect() throws IOException {
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
-        executorService.submit(() -> serverSocket.accept());
+        Future<Socket> server = executorService.submit(() -> serverSocket.accept());
         assertThat(tcpHealthCheck.check().isHealthy())
             .isTrue();
+        assertThat(server).succeedsWithin(Duration.ofSeconds(2));
     }
 
     @Test
@@ -52,12 +56,13 @@ class TcpHealthCheckTest {
 
         serverSocket = new ServerSocket();
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
-        executorService.submit(() -> {
+        Future<Boolean> server = executorService.submit(() -> {
             Thread.sleep(tcpHealthCheck.getConnectionTimeout().toMillis() * 3);
             serverSocket.bind(new InetSocketAddress("127.0.0.1", port));
             return true;
         });
 
         assertThatThrownBy(() -> tcpHealthCheck.check()).isInstanceOfAny(ConnectException.class, SocketTimeoutException.class);
+        assertThat(server).isNotDone();
     }
 }

--- a/dropwizard-health/src/test/java/io/dropwizard/health/response/JsonHealthResponseProviderTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/response/JsonHealthResponseProviderTest.java
@@ -124,13 +124,14 @@ class JsonHealthResponseProviderTest {
         // then
         assertThatThrownBy(() -> jsonHealthResponseProvider.healthResponse(queryParams))
             .isInstanceOf(RuntimeException.class)
-            .hasCauseReference(exception);
+            .cause()
+            .isSameAs(exception);
         verifyNoInteractions(healthStatusChecker);
     }
 
     private String fixture(final String filename) throws IOException {
-        try (InputStream is = getClass().getResourceAsStream(filename)) {
-            return new String(requireNonNull(is).readAllBytes(), UTF_8);
+        try (InputStream is = requireNonNull(getClass().getResourceAsStream(filename))) {
+            return new String(is.readAllBytes(), UTF_8);
         }
     }
 }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/TransactionHandlingTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/TransactionHandlingTest.java
@@ -129,16 +129,16 @@ class TransactionHandlingTest {
         private void initDatabase(SessionFactory sessionFactory) {
             try (Session session = sessionFactory.openSession()) {
                 Transaction transaction = session.beginTransaction();
-                session.createNativeQuery(
+                session.createNativeMutationQuery(
                     "CREATE TABLE people (name varchar(100) primary key, email varchar(16), birthday timestamp with time zone)")
                     .executeUpdate();
-                session.createNativeQuery(
+                session.createNativeMutationQuery(
                     "INSERT INTO people VALUES ('Coda', 'coda@example.com', '1979-01-02 00:22:00+0:00')")
                     .executeUpdate();
-                session.createNativeQuery(
+                session.createNativeMutationQuery(
                     "CREATE TABLE dogs (name varchar(100) primary key, owner varchar(100), CONSTRAINT fk_owner FOREIGN KEY (owner) REFERENCES people(name))")
                     .executeUpdate();
-                session.createNativeQuery(
+                session.createNativeMutationQuery(
                     "INSERT INTO dogs VALUES ('Raf', 'Coda')")
                     .executeUpdate();
                 transaction.commit();

--- a/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/jersey/LoggingJdbiExceptionMapperTest.java
+++ b/dropwizard-jdbi3/src/test/java/io/dropwizard/jdbi3/jersey/LoggingJdbiExceptionMapperTest.java
@@ -4,7 +4,6 @@ import org.jdbi.v3.core.JdbiException;
 import org.jdbi.v3.core.result.NoResultsException;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.core.transaction.TransactionException;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 
@@ -15,18 +14,12 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 class LoggingJdbiExceptionMapperTest {
-    private LoggingJdbiExceptionMapper jdbiExceptionMapper;
-    private Logger logger;
-
-    @BeforeEach
-    void setUp() throws Exception {
-        logger = mock(Logger.class);
-        jdbiExceptionMapper = new LoggingJdbiExceptionMapper(logger);
-    }
+    private final Logger logger = mock();
+    private final LoggingJdbiExceptionMapper jdbiExceptionMapper = new LoggingJdbiExceptionMapper(logger);
 
     @Test
-    void testSqlExceptionIsCause() throws Exception {
-        StatementContext statementContext = mock(StatementContext.class);
+    void testSqlExceptionIsCause() {
+        StatementContext statementContext = mock();
         RuntimeException runtimeException = new RuntimeException("DB is down");
         SQLException sqlException = new SQLException("DB error", runtimeException);
         JdbiException jdbiException = new NoResultsException("Unable get a result set", sqlException, statementContext);

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/validation/ConstraintViolationExceptionMapperTest.java
@@ -31,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ConstraintViolationExceptionMapperTest extends AbstractJerseyTest {
     private static class LoggingExceptionMapperBinder extends AbstractBinder {
+        @Override
         protected void configure() {
             this.bind(new LoggingExceptionMapper<Throwable>() {
             }).to(ExceptionMapper.class);

--- a/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/ServerLifecycleListenerTest.java
+++ b/dropwizard-lifecycle/src/test/java/io/dropwizard/lifecycle/ServerLifecycleListenerTest.java
@@ -64,7 +64,7 @@ class ServerLifecycleListenerTest {
         Assertions.assertThat(portDescriptorList).usingElementComparator((o1, o2) -> {
             if (Objects.equals(o1.getConnectorType(), o2.getConnectorType()) &&
                 Objects.equals(o1.getProtocol(), o2.getProtocol()) &&
-                Objects.equals(o1.getPort(), o2.getPort()) &&
+                o1.getPort() == o2.getPort() &&
                 Objects.equals(o1.getHost(), o2.getHost())) {
                 return 0;
             } else {

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/old/DropwizardSlf4jRequestLogWriterTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/old/DropwizardSlf4jRequestLogWriterTest.java
@@ -5,7 +5,6 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.spi.AppenderAttachableImpl;
 import io.dropwizard.logging.common.BootstrapLogging;
-import org.eclipse.jetty.server.HttpChannelState;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -15,7 +14,6 @@ import static org.mockito.Mockito.assertArg;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 class DropwizardSlf4jRequestLogWriterTest {
     static {
@@ -28,9 +26,6 @@ class DropwizardSlf4jRequestLogWriterTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        final HttpChannelState channelState = mock();
-        when(channelState.isInitial()).thenReturn(true);
-
         appenders.addAppender(appender);
 
         slf4jRequestLog.start();

--- a/dropwizard-servlets/src/test/java/io/dropwizard/servlets/SlowRequestFilterTest.java
+++ b/dropwizard-servlets/src/test/java/io/dropwizard/servlets/SlowRequestFilterTest.java
@@ -18,14 +18,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class SlowRequestFilterTest {
-
-    private HttpServletRequest request = mock(HttpServletRequest.class);
-    private HttpServletResponse response = mock(HttpServletResponse.class);
-    private FilterChain chain = mock(FilterChain.class);
-    private FilterConfig filterConfig = mock(FilterConfig.class);
-    private Logger logger = mock(Logger.class);
-
-    private SlowRequestFilter slowRequestFilter = new SlowRequestFilter(Duration.milliseconds(500));
+    private final HttpServletRequest request = mock();
+    private final HttpServletResponse response = mock();
+    private final FilterChain chain = mock();
+    private final FilterConfig filterConfig = mock();
+    private final Logger logger = mock();
+    private final SlowRequestFilter slowRequestFilter = new SlowRequestFilter(Duration.milliseconds(500));
 
     @BeforeEach
     void setUp() throws Exception {
@@ -65,5 +63,4 @@ class SlowRequestFilterTest {
 
         verify(logger, never()).warn("Slow request: {} {} ({}ms)", "GET", "/some/path", 499L);
     }
-
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResource.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/PersonResource.java
@@ -1,7 +1,6 @@
 package io.dropwizard.testing.app;
 
 import com.codahale.metrics.annotation.Timed;
-import io.dropwizard.jersey.params.IntParam;
 import io.dropwizard.validation.Validated;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.jetty.io.EofException;
@@ -20,6 +19,7 @@ import javax.ws.rs.core.MediaType;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 
 import static java.util.Objects.requireNonNull;
 
@@ -48,9 +48,9 @@ public class PersonResource {
     @GET
     @Timed
     @Path("/index")
-    public Person getPersonWithIndex(@QueryParam("ind") @Min(0) IntParam index,
+    public Person getPersonWithIndex(@QueryParam("ind") @Min(0) OptionalInt index,
                                      @PathParam("name") String name) {
-        return getPersonList(name).get(index.get());
+        return getPersonList(name).get(index.orElseThrow());
     }
 
     @POST

--- a/dropwizard-util/src/test/java/io/dropwizard/util/ThrowablesTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/ThrowablesTest.java
@@ -73,7 +73,7 @@ class ThrowablesTest {
 
         @Override
         @Nullable
-        public Throwable getCause() {
+        public synchronized Throwable getCause() {
             return cause;
         }
     }


### PR DESCRIPTION
* Update to use non-deprecated mockito strictness configuration method
* Throwable#getCause is synchronized and should remain so when overridden
* Replace deprecated UsernamePasswordCredentials#getPassword with getUserPassword
* Remove usage of deprecated IntParam from dropwizard-testing tests
* Suppress some errorprone warnings in dropwizard-core tests
* Simplify dropwizard-db TimeBoundHealthCheckTest
* Replace deprecated Session#createNativeQuery in TransactionHandlingTest
* Simplify LoggingJdbiExceptionMapperTest
* Avoid unnecessary autoboxing in ServerLifecycleListenerTest
* Remove unused mock from DropwizardSlf4jRequestLogWriterTest
* Make fields final in SlowRequestFilterTest
* Suppress warning about confusing nullness annotations in ConfigurationValidationExceptionTest
* Add @Override annotation in HealthCheckConfigValidatorTest
* Use logback ListAppender instead of mocking in HealthCheckConfigValidatorTest
* Avoid calling mocked methods in ScheduledHealthCheckTest
* Avoid deprecated assert-j method in JsonHealthResponseProviderTest
* Assert the state of Futures in TcpHealthCheckTest

Refs #10509