### PR TITLE
Stop using deprecated aspects of logback

### DIFF
--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/common/AbstractAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/common/AbstractAppenderFactory.java
@@ -108,7 +108,7 @@ public abstract class AbstractAppenderFactory<E extends DeferredProcessingAware>
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractAppenderFactory.class);
 
     @NotNull
-    protected Level threshold = Level.ALL;
+    protected Level threshold = Level.TRACE;
 
     @Nullable
     protected String logFormat;

--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/common/DefaultLoggingFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/common/DefaultLoggingFactory.java
@@ -9,7 +9,7 @@ import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.AsyncAppenderBase;
 import ch.qos.logback.core.ConsoleAppender;
 import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
-import ch.qos.logback.core.util.StatusPrinter;
+import ch.qos.logback.core.util.StatusPrinter2;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.logback.InstrumentedAppender;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -130,11 +130,12 @@ public class DefaultLoggingFactory implements LoggingFactory {
             root.addAppender(output.build(loggerContext, name, layoutFactory, levelFilterFactory, asyncAppenderFactory));
         }
 
-        StatusPrinter.setPrintStream(configurationErrorsStream);
+        StatusPrinter2 statusPrinter = new StatusPrinter2();
+        statusPrinter.setPrintStream(configurationErrorsStream);
         try {
-            StatusPrinter.printIfErrorsOccured(loggerContext);
+            statusPrinter.printIfErrorsOccured(loggerContext);
         } finally {
-            StatusPrinter.setPrintStream(System.out);
+            statusPrinter.setPrintStream(System.out);
         }
 
         configureInstrumentation(root, metricRegistry);
@@ -268,7 +269,7 @@ public class DefaultLoggingFactory implements LoggingFactory {
             return Level.OFF;
         } else if ("true".equalsIgnoreCase(text)) {
             // required because YAML maps "on" to a boolean true
-            return Level.ALL;
+            return Level.TRACE;
         }
         return Level.toLevel(text, Level.INFO);
     }


### PR DESCRIPTION
* Use logback Level.TRACE instead of Level.ALL

Level.ALL is deprecated by logback in favour of Level.TRACE.

* Swap deprecated logback StatusPrinter for StatusPrinter2

Refs #10470