### PR TITLE
Move format strings into helper methods in dropwizard-auth

### DIFF
--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/DefaultUnauthorizedHandler.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/DefaultUnauthorizedHandler.java
@@ -5,14 +5,16 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 public class DefaultUnauthorizedHandler implements UnauthorizedHandler {
-    private static final String CHALLENGE_FORMAT = "%s realm=\"%s\"";
-
     @Override
     public Response buildResponse(String prefix, String realm) {
         return Response.status(Response.Status.UNAUTHORIZED)
-                .header(HttpHeaders.WWW_AUTHENTICATE, String.format(CHALLENGE_FORMAT, prefix, realm))
+                .header(HttpHeaders.WWW_AUTHENTICATE, getChallengeHeader(prefix, realm))
                 .type(MediaType.TEXT_PLAIN_TYPE)
                 .entity("Credentials are required to access this resource.")
                 .build();
+    }
+
+    private String getChallengeHeader(String prefix, String realm) {
+        return String.format("%s realm=\"%s\"", prefix, realm);
     }
 }

--- a/dropwizard-auth/src/main/java/io/dropwizard/auth/JSONUnauthorizedHandler.java
+++ b/dropwizard-auth/src/main/java/io/dropwizard/auth/JSONUnauthorizedHandler.java
@@ -6,8 +6,6 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 public class JSONUnauthorizedHandler implements UnauthorizedHandler {
-    private static final String CHALLENGE_FORMAT = "%s realm=\"%s\"";
-
     @Override
     public Response buildResponse(String prefix, String realm) {
         ErrorMessage errorMessage = new ErrorMessage(
@@ -15,9 +13,13 @@ public class JSONUnauthorizedHandler implements UnauthorizedHandler {
             "Credentials are required to access this resource."
         );
         return Response.status(errorMessage.getCode())
-            .header(HttpHeaders.WWW_AUTHENTICATE, String.format(CHALLENGE_FORMAT, prefix, realm))
+            .header(HttpHeaders.WWW_AUTHENTICATE, getChallengeHeader(prefix, realm))
             .type(MediaType.APPLICATION_JSON_TYPE)
             .entity(errorMessage)
             .build();
+    }
+
+    private String getChallengeHeader(String prefix, String realm) {
+        return String.format("%s realm=\"%s\"", prefix, realm);
     }
 }


### PR DESCRIPTION
errorprone isn't a fan of extracting format strings, accusing it of making code harder to read.

Extract the generation of the response header value into a helper methods instead.