### PR TITLE
fix: Remove Logback dependency when external logging is requested

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/core/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/core/server/AbstractServerFactory.java
@@ -699,7 +699,8 @@ public abstract class AbstractServerFactory implements ServerFactory {
     protected void addRequestLog(Server server, String name, MutableServletContextHandler servletContextHandler) {
         if (getRequestLogFactory().isEnabled()) {
             RequestLog log = getRequestLogFactory().build(name);
-            if (log instanceof LogbackAccessRequestLog) {
+            // Do not hard-code a dependency to logback when external logging such as Log4j is used
+            if ("io.dropwizard.request.logging.LogbackAccessRequestLog".equals(log.getClass().getName())) {
                 servletContextHandler.insertHandler(new LogbackAccessRequestLogAwareHandler());
             }
             server.setRequestLog(log);

--- a/dropwizard-core/src/test/java/io/dropwizard/core/server/AbstractServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/core/server/AbstractServerFactoryTest.java
@@ -8,6 +8,12 @@ import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.setup.JerseyContainerHolder;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
 import io.dropwizard.jetty.MutableServletContextHandler;
+import io.dropwizard.logging.common.ConsoleAppenderFactory;
+import io.dropwizard.request.logging.ExternalRequestLogFactory;
+import io.dropwizard.request.logging.LogbackAccessRequestLog;
+import io.dropwizard.request.logging.LogbackAccessRequestLogAwareHandler;
+import io.dropwizard.request.logging.LogbackAccessRequestLogFactory;
+import java.util.List;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.thread.ThreadPool;
 import org.junit.jupiter.api.BeforeEach;
@@ -80,6 +86,38 @@ class AbstractServerFactoryTest {
         assertThat(serverFactory.getMetricPrefix()).isNull();
     }
 
+    @Test
+    void addRequestLogWithLogbackAddsSpecialHandler() {
+        LogbackAccessRequestLogFactory requestLogFactory = new LogbackAccessRequestLogFactory();
+        requestLogFactory.setAppenders(List.of(new ConsoleAppenderFactory<>()));
+        serverFactory.setRequestLogFactory(requestLogFactory);
+
+        Server server = serverFactory.build(environment);
+
+        assertThat(server.getRequestLog()).isNotNull();
+        assertThat(server.getRequestLog()).isInstanceOf(LogbackAccessRequestLog.class);
+
+        // Check that LogbackAccessRequestLogAwareHandler was added to the application context
+        MutableServletContextHandler appContext = environment.getApplicationContext();
+        assertThat(appContext.getHandler()).isInstanceOf(LogbackAccessRequestLogAwareHandler.class);
+    }
+
+    @Test
+    void addRequestLogWithoutLogbackDoesNotAddSpecialHandler() {
+        ExternalRequestLogFactory requestLogFactory = new ExternalRequestLogFactory();
+        requestLogFactory.setEnabled(true);
+        serverFactory.setRequestLogFactory(requestLogFactory);
+
+        Server server = serverFactory.build(environment);
+
+        assertThat(server.getRequestLog()).isNotNull();
+        assertThat(server.getRequestLog()).isNotInstanceOf(LogbackAccessRequestLog.class);
+
+        // Check that no LogbackAccessRequestLogAwareHandler was added
+        MutableServletContextHandler appContext = environment.getApplicationContext();
+        assertThat(appContext.getHandler()).isNotInstanceOf(LogbackAccessRequestLogAwareHandler.class);
+    }
+
     /**
      * Test implementation of {@link AbstractServerFactory} used to run {@link #createAppServlet}, which triggers the
      * setting of {@link JerseyEnvironment#setUrlPattern(String)}.
@@ -97,6 +135,7 @@ class AbstractServerFactoryTest {
                                   environment.getApplicationContext(),
                                   environment.getJerseyServletContainer(),
                                   environment.metrics());
+            addRequestLog(server, environment.getName(), environment.getApplicationContext());
             return server;
         }
 


### PR DESCRIPTION
Dropwizard 5 initially hardcoded a Logback class reference that prevented the use of external logging without Logback dependencies on the classpath.  This commit changes the instanceof check to a class name check that does not require the Logback class to be present at runtime.

###### Problem:

https://github.com/dropwizard/dropwizard/issues/10711

###### Solution:

Replace `instanceof` with a dynamic class name comparison.

###### Result:

No runtime dependency on Logback classes and existing code that worked on Dropwizard 4 keeps working on Dropwizard 5 with external logging without extra Logback dependencies.

