### PR TITLE
Structured logging support

### DIFF
--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -925,46 +925,51 @@ JSON layout
       timestampFormat: "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
       prettyPrint: false
       appendLineSeparator: true
-      includes: [timestamp, threadName, level, loggerName, message, mdc, exception]
+      includes: [timestamp, threadName, level, loggerName, message, mdc, exception, keyValuePairs]
       customFieldNames:
         timestamp: "@timestamp"
       additionalFields:
         service-name: "user-service"
       includesMdcKeys: [userId]
       flattenMdc: true
+      includesKeyValuePairsKeys: [traceId]
+      flattenKeyValuePairs: true
       exception:
         rootFirst: true
         depth: full
         evaluators: [org.apache]
 
 
-=======================  =====================  ================
-Name                     Default                Description
-=======================  =====================  ================
-timestampFormat          (none)                 By default, the timestamp is not formatted. To customize how timestamps are formatted,
+========================  =====================  ================
+Name                      Default                Description
+========================  =====================  ================
+timestampFormat           (none)                 By default, the timestamp is not formatted. To customize how timestamps are formatted,
                                                 set the property to the corresponding DateTimeFormatter_ string or one of the
                                                 predefined formats (e.g. ``ISO_LOCAL_TIME``, ``ISO_ZONED_DATE_TIME``, ``RFC_1123_DATE_TIME``).
-prettyPrint              false                  Whether the JSON output should be formatted for human readability.
-appendLineSeparator      true                   Whether to append a line separator at the end of the message formatted as JSON.
-includes                 (timestamp, level,
-                         threadName,  mdc,
-                         loggerName, message,
-                         exception)             Set of logging event attributes to include in the JSON map:
+prettyPrint               false                  Whether the JSON output should be formatted for human readability.
+appendLineSeparator       true                   Whether to append a line separator at the end of the message formatted as JSON.
+includes                  (timestamp, level,
+                          threadName,  mdc,
+                          loggerName, message,
+                          exception, keyValuePairs)             Set of logging event attributes to include in the JSON map:
 
-                                                - ``timestamp``   *true*   Whether to include the timestamp as the ``timestamp`` field.
-                                                - ``level``       *true*   Whether to include the logging level as the ``level`` field.
-                                                - ``threadName``  *true*   Whether to include the thread name as the ``thread`` field.
-                                                - ``mdc``         *true*   Whether to include the MDC properties as the ``mdc`` field.
-                                                - ``loggerName``  *true*   Whether to include the logger name as the ``logger`` field.
-                                                - ``message``     *true*   Whether to include the formatted message as the ``message`` field.
-                                                - ``exception``   *true*   Whether to log exceptions. If the property enabled and there is an exception, it will be formatted to a string as the ``exception`` field.
-                                                - ``contextName`` *false*  Whether to include the logging context name as the ``context`` field .
-customFieldNames         (empty)                Map of field name replacements . For example ``(requestTime:request_time, userAgent:user_agent)``.
-additionalFields         (empty)                Map of fields to add in the JSON map.
-includesMdcKeys          (empty)                Set of MDC keys which should be included in the JSON map. By default includes everything.
-flattenMdc               false                  Flatten the MDC to the root of the JSON object instead of nested in the ``mdc`` field.
-exception                (empty)                The :ref:`exception <man-configuration-json-layout-exception>` configuration for the ``exception`` field.
-=======================  =====================  ================
+                                                 - ``timestamp``      *true*   Whether to include the timestamp as the ``timestamp`` field.
+                                                 - ``level``          *true*   Whether to include the logging level as the ``level`` field.
+                                                 - ``threadName``     *true*   Whether to include the thread name as the ``thread`` field.
+                                                 - ``mdc``            *true*   Whether to include the MDC properties as the ``mdc`` field.
+                                                 - ``loggerName``     *true*   Whether to include the logger name as the ``logger`` field.
+                                                 - ``message``        *true*   Whether to include the formatted message as the ``message`` field.
+                                                 - ``exception``      *true*   Whether to log exceptions. If the property enabled and there is an exception, it will be formatted to a string as the ``exception`` field.
+                                                 - ``contextName``    *false*  Whether to include the logging context name as the ``context`` field.
+                                                 - ``keyValuePairs``  *true*  Whether to include structured logging key-value pairs as the ``keyValuePairs`` field (when not flattened).
+customFieldNames          (empty)                Map of field name replacements . For example ``(requestTime:request_time, userAgent:user_agent)``.
+additionalFields          (empty)                Map of fields to add in the JSON map.
+includesMdcKeys           (empty)                Set of MDC keys which should be included in the JSON map. By default includes everything.
+flattenMdc                false                  Flatten the MDC to the root of the JSON object instead of nested in the ``mdc`` field.
+includesKeyValuePairsKeys (empty)                Set of structured logging key-value pair keys which should be included in the JSON map. By default includes everything.
+flattenKeyValuePairs      false                  Flatten structured logging key-value pairs to the root of the JSON object instead of nested in the ``keyValuePairs`` field.
+exception                 (empty)                The :ref:`exception <man-configuration-json-layout-exception>` configuration for the ``exception`` field.
+========================  =====================  ================
 
 .. _DateTimeFormatter:  https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html
 

--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -1064,6 +1064,53 @@ The ``access-json`` layout will produces the following log message:
 
     {"timestamp":1515002688000, "method":"GET","uri":"/hello-world", "status":200, "protocol":"HTTP/1.1","contentLength":37,"remoteAddress":"127.0.0.1","requestTime":5, "userAgent":"Mozilla/5.0"}
 
+Structured Logging with JSON
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Structured logging is supported using SLF4J 2.0's key-value pair API. This allows you to add structured data to individual log entries that will be automatically included in the JSON output:
+
+.. code-block:: java
+
+    logger.atInfo()
+          .addKeyValue("userId", userId)
+          .addKeyValue("action", "login")
+          .addKeyValue("duration", duration)
+          .log("User login completed");
+
+By default, all key-value pairs are included in the JSON output under the ``keyValuePairs`` field. You can control this behavior using the ``includesKeyValuePairsKeys`` and ``flattenKeyValuePairs`` configuration options.
+
+**Nested format** (default):
+
+.. code-block:: json
+
+    {
+      "timestamp": "2024-01-02T15:19:21.000+0000",
+      "level": "INFO",
+      "message": "User login completed",
+      "keyValuePairs": {
+        "userId": "12345",
+        "action": "login",
+        "duration": 150
+      }
+    }
+
+**Flattened format** (``flattenKeyValuePairs: true``):
+
+.. code-block:: json
+
+    {
+      "timestamp": "2024-01-02T15:19:21.000+0000",
+      "level": "INFO",
+      "message": "User login completed",
+      "userId": "12345",
+      "action": "login",
+      "duration": 150
+    }
+
+.. note::
+
+    String, numeric, and boolean values are automatically detected and serialized with the appropriate JSON type. Other object types are serialized using their ``toString()`` representation.
+
 Logging Configuration via HTTP
 ------------------------------
 

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/EventAttribute.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/EventAttribute.java
@@ -15,5 +15,6 @@ public enum EventAttribute {
     @JsonProperty("exception") EXCEPTION,
     @JsonProperty("contextName") CONTEXT_NAME,
     @JsonProperty("timestamp") TIMESTAMP,
-    @JsonProperty("callerData") CALLER_DATA
+    @JsonProperty("callerData") CALLER_DATA,
+    @JsonProperty("keyValuePairs") KEY_VALUE_PAIRS
 }

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/EventJsonLayoutBaseFactory.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/EventJsonLayoutBaseFactory.java
@@ -41,6 +41,16 @@ import java.util.TimeZone;
  * <td>{@code false}</td>
  * <td>Whether the MDC should be included under the key "mdc" or flattened into the map.</td>
  * </tr>
+ * <tr>
+ * <td>{@code includesKeyValuePairsKeys}</td>
+ * <td>(empty)</td>
+ * <td>Set of structured logging key-value pair keys which should be included in the JSON map. By default includes everything.</td>
+ * </tr>
+ * <tr>
+ * <td>{@code flattenKeyValuePairs}</td>
+ * <td>{@code false}</td>
+ * <td>Whether the structured logging key-value pairs should be included under the key "keyValuePairs" or flattened into the map.</td>
+ * </tr>
  * </table>
  */
 @JsonTypeName("json")
@@ -48,10 +58,12 @@ public class EventJsonLayoutBaseFactory extends AbstractJsonLayoutBaseFactory<IL
 
     private EnumSet<EventAttribute> includes = EnumSet.of(EventAttribute.LEVEL,
         EventAttribute.THREAD_NAME, EventAttribute.MDC, EventAttribute.MARKER, EventAttribute.LOGGER_NAME,
-        EventAttribute.MESSAGE, EventAttribute.EXCEPTION, EventAttribute.TIMESTAMP);
+        EventAttribute.MESSAGE, EventAttribute.EXCEPTION, EventAttribute.TIMESTAMP, EventAttribute.KEY_VALUE_PAIRS);
 
     private Set<String> includesMdcKeys = Collections.emptySet();
     private boolean flattenMdc = false;
+    private boolean flattenKeyValuePairs = false;
+    private Set<String> includesKeyValuePairsKeys = Collections.emptySet();
 
     @Nullable
     private ExceptionFormat exceptionFormat;
@@ -86,6 +98,26 @@ public class EventJsonLayoutBaseFactory extends AbstractJsonLayoutBaseFactory<IL
         this.flattenMdc = flattenMdc;
     }
 
+    @JsonProperty
+    public boolean isFlattenKeyValuePairs() {
+        return flattenKeyValuePairs;
+    }
+
+    @JsonProperty
+    public void setFlattenKeyValuePairs(boolean flattenKeyValuePairs) {
+        this.flattenKeyValuePairs = flattenKeyValuePairs;
+    }
+
+    @JsonProperty
+    public Set<String> getIncludesKeyValuePairsKeys() {
+        return includesKeyValuePairsKeys;
+    }
+
+    @JsonProperty
+    public void setIncludesKeyValuePairsKeys(Set<String> includesKeyValuePairsKeys) {
+        this.includesKeyValuePairsKeys = includesKeyValuePairsKeys;
+    }
+
     /**
      * @since 2.0
      */
@@ -107,7 +139,7 @@ public class EventJsonLayoutBaseFactory extends AbstractJsonLayoutBaseFactory<IL
     public LayoutBase<ILoggingEvent> build(LoggerContext context, TimeZone timeZone) {
         final EventJsonLayout jsonLayout = new EventJsonLayout(createDropwizardJsonFormatter(),
             createTimestampFormatter(timeZone), createThrowableProxyConverter(context), includes, getCustomFieldNames(),
-            getAdditionalFields(), includesMdcKeys, flattenMdc);
+            getAdditionalFields(), includesMdcKeys, flattenMdc, includesKeyValuePairsKeys, flattenKeyValuePairs);
         jsonLayout.setContext(context);
         return jsonLayout;
     }

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/EventJsonLayout.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/EventJsonLayout.java
@@ -4,10 +4,12 @@ import ch.qos.logback.classic.pattern.ThrowableHandlingConverter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import io.dropwizard.logging.json.EventAttribute;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.event.KeyValuePair;
 
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -29,11 +31,13 @@ public class EventJsonLayout extends AbstractJsonLayout<ILoggingEvent> {
 
     private Set<String> includesMdcKeys;
     private final boolean flattenMdc;
+    private final boolean flattenKeyValuePairs;
+    private Set<String> includesKeyValuePairsKeys;
 
     public EventJsonLayout(JsonFormatter jsonFormatter, TimestampFormatter timestampFormatter,
                            ThrowableHandlingConverter throwableProxyConverter, Set<EventAttribute> includes,
                            Map<String, String> customFieldNames, Map<String, Object> additionalFields,
-                           Set<String> includesMdcKeys, boolean flattenMdc) {
+                           Set<String> includesMdcKeys, boolean flattenMdc, Set<String> includesKeyValuePairsKeys, boolean flattenKeyValuePairs) {
         super(jsonFormatter);
         this.timestampFormatter = timestampFormatter;
         this.additionalFields = new HashMap<>(additionalFields);
@@ -42,6 +46,8 @@ public class EventJsonLayout extends AbstractJsonLayout<ILoggingEvent> {
         this.includes = new HashSet<>(includes);
         this.includesMdcKeys = new HashSet<>(includesMdcKeys);
         this.flattenMdc = flattenMdc;
+        this.flattenKeyValuePairs = flattenKeyValuePairs;
+        this.includesKeyValuePairsKeys = new HashSet<>(includesKeyValuePairsKeys);
     }
 
     @Override
@@ -75,6 +81,16 @@ public class EventJsonLayout extends AbstractJsonLayout<ILoggingEvent> {
             filterMdc(event.getMDCPropertyMap()).forEach((k,v) -> mapBuilder.add(k, includeMdc, v));
         } else {
             mapBuilder.addMap("mdc", includeMdc, () -> filterMdc(event.getMDCPropertyMap()));
+        }
+
+        final boolean includeKeyValuePairs = isIncluded(EventAttribute.KEY_VALUE_PAIRS);
+        if(includeKeyValuePairs && event.getKeyValuePairs() != null) {
+            if (flattenKeyValuePairs) {
+                filterKeyValuePairs(event.getKeyValuePairs()).forEach(kvp ->
+                    mapBuilder.add(kvp.key, true, mayConvertKeyValuePairValue(kvp.value)));
+            } else {
+                mapBuilder.add("keyValuePairs", true, convertKeyValuePairsToMap(filterKeyValuePairs(event.getKeyValuePairs())));
+            }
         }
 
         final boolean includeCallerData = isIncluded(EventAttribute.CALLER_DATA);
@@ -127,5 +143,36 @@ public class EventJsonLayout extends AbstractJsonLayout<ILoggingEvent> {
 
     public void setIncludesMdcKeys(Set<String> includesMdcKeys) {
         this.includesMdcKeys = new HashSet<>(includesMdcKeys);
+    }
+
+    public Set<String> getIncludesKeyValuePairsKeys() {
+        return includesKeyValuePairsKeys;
+    }
+
+    public void setIncludesKeyValuePairsKeys(Set<String> includesKeyValuePairsKeys) {
+        this.includesKeyValuePairsKeys = new HashSet<>(includesKeyValuePairsKeys);
+    }
+
+    private List<KeyValuePair> filterKeyValuePairs(List<KeyValuePair> keyValuePairs) {
+        if (includesKeyValuePairsKeys.isEmpty()) {
+            return keyValuePairs;
+        }
+        return keyValuePairs.stream()
+            .filter(kvp -> includesKeyValuePairsKeys.contains(kvp.key))
+            .collect(Collectors.toList());
+    }
+
+    private Map<String, ?> convertKeyValuePairsToMap(List<KeyValuePair> keyValuePairs) {
+        return keyValuePairs.stream()
+            .filter(kvp -> kvp.value != null)
+            .collect(Collectors.toMap(kvp -> kvp.key, kvp -> mayConvertKeyValuePairValue(kvp.value), (v1, v2) -> v2));
+    }
+
+    private @Nullable Object mayConvertKeyValuePairValue(Object value) {
+        if (value instanceof String || value instanceof Number || value instanceof Boolean) {
+            return value;
+        } else {
+            return value != null ? value.toString() : null;
+        }
     }
 }

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/EventJsonLayout.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/EventJsonLayout.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Builds JSON messages from logging events of the type {@link ILoggingEvent}.
@@ -153,22 +154,21 @@ public class EventJsonLayout extends AbstractJsonLayout<ILoggingEvent> {
         this.includesKeyValuePairsKeys = new HashSet<>(includesKeyValuePairsKeys);
     }
 
-    private List<KeyValuePair> filterKeyValuePairs(List<KeyValuePair> keyValuePairs) {
+    private Stream<KeyValuePair> filterKeyValuePairs(List<KeyValuePair> keyValuePairs) {
         if (includesKeyValuePairsKeys.isEmpty()) {
-            return keyValuePairs;
+            return keyValuePairs.stream();
         }
         return keyValuePairs.stream()
-            .filter(kvp -> includesKeyValuePairsKeys.contains(kvp.key))
-            .collect(Collectors.toList());
+            .filter(kvp -> includesKeyValuePairsKeys.contains(kvp.key));
     }
 
-    private Map<String, ?> convertKeyValuePairsToMap(List<KeyValuePair> keyValuePairs) {
-        return keyValuePairs.stream()
+    private Map<String, ?> convertKeyValuePairsToMap(Stream<KeyValuePair> keyValuePairs) {
+        return keyValuePairs
             .filter(kvp -> kvp.value != null)
             .collect(Collectors.toMap(kvp -> kvp.key, kvp -> mayConvertKeyValuePairValue(kvp.value), (v1, v2) -> v2));
     }
 
-    private @Nullable Object mayConvertKeyValuePairValue(Object value) {
+    private @Nullable Object mayConvertKeyValuePairValue(@Nullable Object value) {
         if (value instanceof String || value instanceof Number || value instanceof Boolean) {
             return value;
         } else {

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/EventJsonLayout.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/EventJsonLayout.java
@@ -85,7 +85,7 @@ public class EventJsonLayout extends AbstractJsonLayout<ILoggingEvent> {
         }
 
         final boolean includeKeyValuePairs = isIncluded(EventAttribute.KEY_VALUE_PAIRS);
-        if(includeKeyValuePairs && event.getKeyValuePairs() != null) {
+        if (includeKeyValuePairs && event.getKeyValuePairs() != null) {
             if (flattenKeyValuePairs) {
                 filterKeyValuePairs(event.getKeyValuePairs()).forEach(kvp ->
                     mapBuilder.add(kvp.key, true, mayConvertKeyValuePairValue(kvp.value)));

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/EventJsonLayout.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/EventJsonLayout.java
@@ -79,7 +79,7 @@ public class EventJsonLayout extends AbstractJsonLayout<ILoggingEvent> {
 
         final boolean includeMdc = isIncluded(EventAttribute.MDC);
         if (flattenMdc) {
-            filterMdc(event.getMDCPropertyMap()).forEach((k,v) -> mapBuilder.add(k, includeMdc, v));
+            filterMdc(event.getMDCPropertyMap()).forEach((k, v) -> mapBuilder.add(k, includeMdc, v));
         } else {
             mapBuilder.addMap("mdc", includeMdc, () -> filterMdc(event.getMDCPropertyMap()));
         }
@@ -88,7 +88,7 @@ public class EventJsonLayout extends AbstractJsonLayout<ILoggingEvent> {
         if (includeKeyValuePairs && event.getKeyValuePairs() != null) {
             if (flattenKeyValuePairs) {
                 filterKeyValuePairs(event.getKeyValuePairs()).forEach(kvp ->
-                    mapBuilder.add(kvp.key, true, mayConvertKeyValuePairValue(kvp.value)));
+                    mapBuilder.addObject(kvp.key, true, mayConvertKeyValuePairValue(kvp.value)));
             } else {
                 mapBuilder.add("keyValuePairs", true, convertKeyValuePairsToMap(filterKeyValuePairs(event.getKeyValuePairs())));
             }

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/MapBuilder.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/MapBuilder.java
@@ -127,6 +127,32 @@ public class MapBuilder {
         return this;
     }
 
+    /**
+     * Adds the boolean to the provided map under the provided field name if it should be included.
+     */
+    public MapBuilder addBoolean(String fieldName, boolean include, Boolean value) {
+        if (include && value != null) {
+            map.put(getFieldName(fieldName), value);
+        }
+        return this;
+    }
+
+    /**
+     * Adds the value to the provided map under the provided field name if it should be included.
+     * If the value is a String, Number, or Boolean it's added as it is, otherwise it's converted to string using `toString()`.
+     */
+    public MapBuilder add(String fieldName, boolean include, @Nullable Object value) {
+        if (value instanceof String) {
+            return add(fieldName, include, (String) value);
+        } else if (value instanceof Number) {
+            return addNumber(fieldName, include, (Number) value);
+        } else if (value instanceof Boolean) {
+            return addBoolean(fieldName, include, (Boolean) value);
+        } else {
+            return add(fieldName, include, value != null ? value.toString() : null);
+        }
+    }
+
     private String getFieldName(String fieldName) {
         return customFieldNames.getOrDefault(fieldName, fieldName);
     }

--- a/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/MapBuilder.java
+++ b/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/MapBuilder.java
@@ -141,7 +141,7 @@ public class MapBuilder {
      * Adds the value to the provided map under the provided field name if it should be included.
      * If the value is a String, Number, or Boolean it's added as it is, otherwise it's converted to string using `toString()`.
      */
-    public MapBuilder add(String fieldName, boolean include, @Nullable Object value) {
+    public MapBuilder addObject(String fieldName, boolean include, @Nullable Object value) {
         if (value instanceof String) {
             return add(fieldName, include, (String) value);
         } else if (value instanceof Number) {

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
@@ -18,6 +18,7 @@ import io.dropwizard.logging.common.ConsoleAppenderFactory;
 import io.dropwizard.logging.common.DefaultLoggingFactory;
 import io.dropwizard.request.logging.LogbackAccessRequestLogFactory;
 import io.dropwizard.validation.BaseValidator;
+import jdk.jfr.Event;
 import org.eclipse.jetty.ee10.servlet.ServletChannel;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee10.servlet.ServletContextRequest;
@@ -91,13 +92,16 @@ class LayoutIntegrationTests {
                     EventAttribute.LOGGER_NAME,
                     EventAttribute.EXCEPTION,
                     EventAttribute.TIMESTAMP,
-                    EventAttribute.CALLER_DATA))
+                    EventAttribute.CALLER_DATA,
+                    EventAttribute.KEY_VALUE_PAIRS))
                 .satisfies(factory -> assertThat(factory.isFlattenMdc()).isTrue())
+                .satisfies(factory -> assertThat(factory.isFlattenKeyValuePairs()).isTrue())
                 .satisfies(factory -> assertThat(factory.getCustomFieldNames()).containsOnly(entry("timestamp", "@timestamp")))
                 .satisfies(factory -> assertThat(factory.getAdditionalFields()).containsOnly(
                     entry("service-name", "user-service"),
                     entry("service-build", 218)))
                 .satisfies(factory -> assertThat(factory.getIncludesMdcKeys()).containsOnly("userId"))
+                .satisfies(factory -> assertThat(factory.getIncludesKeyValuePairsKeys()).containsOnly("operation"))
                 .extracting(EventJsonLayoutBaseFactory::getExceptionFormat)
                 .satisfies(exceptionFormat -> assertThat(exceptionFormat.getDepth()).isEqualTo("10"))
                 .satisfies(exceptionFormat -> assertThat(exceptionFormat.isRootFirst()).isFalse())
@@ -151,9 +155,12 @@ class LayoutIntegrationTests {
                     EventAttribute.LOGGER_NAME,
                     EventAttribute.MESSAGE,
                     EventAttribute.EXCEPTION,
-                    EventAttribute.TIMESTAMP))
+                    EventAttribute.TIMESTAMP,
+                    EventAttribute.KEY_VALUE_PAIRS))
                 .satisfies(factory -> assertThat(factory.isFlattenMdc()).isFalse())
+                .satisfies(factory -> assertThat(factory.isFlattenKeyValuePairs()).isFalse())
                 .satisfies(factory -> assertThat(factory.getIncludesMdcKeys()).isEmpty())
+                .satisfies(factory -> assertThat(factory.getIncludesKeyValuePairsKeys()).isEmpty())
                 .satisfies(factory -> assertThat(factory.getExceptionFormat()).isNull()));
 
         PrintStream old = System.out;
@@ -162,7 +169,10 @@ class LayoutIntegrationTests {
             System.setOut(new PrintStream(redirectedStream));
             defaultLoggingFactory.configure(new MetricRegistry(), "json-log-test");
             Marker marker = MarkerFactory.getMarker("marker");
-            LoggerFactory.getLogger("com.example.app").info(marker, "Application log");
+            LoggerFactory.getLogger("com.example.app").atInfo().addMarker(marker)
+                .addKeyValue("operation", "hello world")
+                .addKeyValue("number",5)
+                .log("Application log");
             // Need to wait, because the logger is async
             await().atMost(1, TimeUnit.SECONDS).until(() -> !redirectedStream.toString().isEmpty());
 
@@ -173,6 +183,10 @@ class LayoutIntegrationTests {
             assertThat(jsonNode.get("logger").asText()).isEqualTo("com.example.app");
             assertThat(jsonNode.get("marker").asText()).isEqualTo("marker");
             assertThat(jsonNode.get("message").asText()).isEqualTo("Application log");
+            assertThat(jsonNode.get("keyValuePairs").get("operation").asText()).isEqualTo("hello world");
+            assertThat(jsonNode.get("keyValuePairs").get("number").isNumber()).isTrue();
+            assertThat(jsonNode.get("keyValuePairs").get("number").asInt()).isEqualTo(5);
+
         } finally {
             System.setOut(old);
         }

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/LayoutIntegrationTests.java
@@ -18,7 +18,7 @@ import io.dropwizard.logging.common.ConsoleAppenderFactory;
 import io.dropwizard.logging.common.DefaultLoggingFactory;
 import io.dropwizard.request.logging.LogbackAccessRequestLogFactory;
 import io.dropwizard.validation.BaseValidator;
-import jdk.jfr.Event;
+
 import org.eclipse.jetty.ee10.servlet.ServletChannel;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee10.servlet.ServletContextRequest;
@@ -171,7 +171,7 @@ class LayoutIntegrationTests {
             Marker marker = MarkerFactory.getMarker("marker");
             LoggerFactory.getLogger("com.example.app").atInfo().addMarker(marker)
                 .addKeyValue("operation", "hello world")
-                .addKeyValue("number",5)
+                .addKeyValue("number", 5)
                 .log("Application log");
             // Need to wait, because the logger is async
             await().atMost(1, TimeUnit.SECONDS).until(() -> !redirectedStream.toString().isEmpty());

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/EventJsonLayoutTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/EventJsonLayoutTest.java
@@ -10,12 +10,15 @@ import io.dropwizard.logging.json.EventAttribute;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.slf4j.event.KeyValuePair;
 import org.slf4j.Marker;
 
+import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -41,7 +44,8 @@ class EventJsonLayoutTest {
             EventAttribute.MESSAGE,
             EventAttribute.EXCEPTION,
             EventAttribute.TIMESTAMP,
-            EventAttribute.CALLER_DATA));
+            EventAttribute.CALLER_DATA,
+            EventAttribute.KEY_VALUE_PAIRS));
 
     private final TimestampFormatter timestampFormatter = new TimestampFormatter("yyyy-MM-dd'T'HH:mm:ss.SSSZ", ZoneId.of("UTC"));
     private final JsonFormatter jsonFormatter = new JsonFormatter(Jackson.newObjectMapper(), false, true);
@@ -65,11 +69,12 @@ class EventJsonLayoutTest {
         when(event.getCallerData()).thenReturn(new StackTraceElement[]{
                 new StackTraceElement("declaringClass", "methodName", "fileName", 42)
         });
+        when(event.getKeyValuePairs()).thenReturn(Collections.emptyList());
 
         when(marker.getName()).thenReturn("marker");
 
         eventJsonLayout = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter,
-                DEFAULT_EVENT_ATTRIBUTES, Collections.emptyMap(), Collections.emptyMap(), Collections.emptySet(), false);
+                DEFAULT_EVENT_ATTRIBUTES, Collections.emptyMap(), Collections.emptyMap(), Collections.emptySet(), false, Collections.emptySet(), false);
 
         defaultExpectedFields = new HashMap<>();
         defaultExpectedFields.put("timestamp", timestamp);
@@ -128,7 +133,7 @@ class EventJsonLayoutTest {
                 "timestamp", "@timestamp",
                 "message", "@message");
         Map<String, Object> map = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter, DEFAULT_EVENT_ATTRIBUTES,
-                customFieldNames, Collections.emptyMap(), Collections.emptySet(), false)
+                customFieldNames, Collections.emptyMap(), Collections.emptySet(), false, Collections.emptySet(), false)
             .toJsonMap(event);
 
         final HashMap<String, Object> expectedFields = new HashMap<>(defaultExpectedFields);
@@ -146,7 +151,7 @@ class EventJsonLayoutTest {
                 "serviceBuild", 207);
         Map<String, Object> map = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter, DEFAULT_EVENT_ATTRIBUTES,
             Collections.emptyMap(), additionalFields,
-            Collections.emptySet(), false)
+            Collections.emptySet(), false, Collections.emptySet(), false)
             .toJsonMap(event);
 
         final HashMap<String, Object> expectedFields = new HashMap<>(defaultExpectedFields);
@@ -159,7 +164,7 @@ class EventJsonLayoutTest {
     void testFilterMdc() {
         final Set<String> includesMdcKeys = Set.of("userId", "orderId");
         Map<String, Object> map = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter, DEFAULT_EVENT_ATTRIBUTES,
-            Collections.emptyMap(), Collections.emptyMap(), includesMdcKeys, false)
+            Collections.emptyMap(), Collections.emptyMap(), includesMdcKeys, false, Collections.emptySet(), false)
                 .toJsonMap(event);
 
         final Map<String, String> expectedMdc = Map.of(
@@ -173,7 +178,7 @@ class EventJsonLayoutTest {
     @Test
     void testFlattensMdcMap() {
         Map<String, Object> map = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter,
-                DEFAULT_EVENT_ATTRIBUTES, Collections.emptyMap(), Collections.emptyMap(), Collections.emptySet(), true)
+                DEFAULT_EVENT_ATTRIBUTES, Collections.emptyMap(), Collections.emptyMap(), Collections.emptySet(), true, Collections.emptySet(), false)
                 .toJsonMap(event);
 
         final HashMap<String, Object> expectedFields = new HashMap<>(defaultExpectedFields);
@@ -198,5 +203,104 @@ class EventJsonLayoutTest {
         assertThat(eventJsonLayout.isStarted()).isFalse();
 
         verify(throwableProxyConverter).stop();
+    }
+
+    @Test
+    void testLogsKeyValuePairs() {
+        when(event.getKeyValuePairs()).thenReturn(List.of(
+            new KeyValuePair("test", "value"),
+            new KeyValuePair("testBoolean", true),
+            new KeyValuePair("testInt", 5),
+            new KeyValuePair("testNonPrimitive", LocalDate.of(2025, 11, 2))));
+        eventJsonLayout = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter,
+            DEFAULT_EVENT_ATTRIBUTES, Collections.emptyMap(), Collections.emptyMap(), Collections.emptySet(), false, Collections.emptySet(), false);
+
+        final HashMap<String, Object> expectedFields = new HashMap<>(defaultExpectedFields);
+        expectedFields.put("keyValuePairs", Map.of(
+            "test", "value",
+            "testBoolean", true,
+            "testInt", 5,
+            "testNonPrimitive", LocalDate.of(2025, 11, 2).toString()
+            )
+        );
+        assertThat(eventJsonLayout.toJsonMap(event)).isEqualTo(expectedFields);
+    }
+
+    @Test
+    void testLogsFlattenedKeyValuePairs() {
+        when(event.getKeyValuePairs()).thenReturn(List.of(
+            new KeyValuePair("test", "value"),
+            new KeyValuePair("testBoolean", true),
+            new KeyValuePair("testInt", 5),
+            new KeyValuePair("testNonPrimitive", LocalDate.of(2025, 11, 2))));
+        eventJsonLayout = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter,
+            DEFAULT_EVENT_ATTRIBUTES, Collections.emptyMap(), Collections.emptyMap(), Collections.emptySet(), false, Collections.emptySet(), true);
+
+        final HashMap<String, Object> expectedFields = new HashMap<>(defaultExpectedFields);
+        expectedFields.put("test", "value");
+        expectedFields.put("testBoolean", true);
+        expectedFields.put("testInt", 5);
+        expectedFields.put("testNonPrimitive", LocalDate.of(2025, 11, 2).toString());
+        assertThat(eventJsonLayout.toJsonMap(event)).isEqualTo(expectedFields);
+    }
+
+    @Test
+    void testFilterKeyValueKeys() {
+        final Set<String> includesKeyValuePairsKeys = Set.of("test");
+        when(event.getKeyValuePairs()).thenReturn(List.of(new KeyValuePair("test", "value"), new KeyValuePair("test2", "value2")));
+        eventJsonLayout= new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter, DEFAULT_EVENT_ATTRIBUTES,
+            Collections.emptyMap(), Collections.emptyMap(), Collections.emptySet(), false, includesKeyValuePairsKeys, false);
+
+        final Map<String, String> expectedKeyValuePairs = Map.of("test", "value");
+        final HashMap<String, Object> expectedFields = new HashMap<>(defaultExpectedFields);
+        expectedFields.put("keyValuePairs", expectedKeyValuePairs);
+        assertThat(eventJsonLayout.toJsonMap(event)).isEqualTo(expectedFields);
+    }
+
+    @Test
+    void testFilterAndFlattenKeyValueKeys() {
+        final Set<String> includesKeyValuePairsKeys = Set.of("test");
+        when(event.getKeyValuePairs()).thenReturn(java.util.List.of(new KeyValuePair("test", "value"), new KeyValuePair("test2", "value2")));
+        eventJsonLayout = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter, DEFAULT_EVENT_ATTRIBUTES,
+            Collections.emptyMap(), Collections.emptyMap(), Collections.emptySet(), false, includesKeyValuePairsKeys, true);
+
+        final HashMap<String, Object> expectedFields = new HashMap<>(defaultExpectedFields);
+        expectedFields.put("test", "value");
+        assertThat(eventJsonLayout.toJsonMap(event)).isEqualTo(expectedFields);
+    }
+
+    @Test
+    void testLogsKeyValuePairsFilteringNullValues() {
+        when(event.getKeyValuePairs()).thenReturn(List.of(new KeyValuePair("test", "value"),new KeyValuePair("testNull", null)));
+        eventJsonLayout = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter,
+            DEFAULT_EVENT_ATTRIBUTES, Collections.emptyMap(), Collections.emptyMap(), Collections.emptySet(), false, Collections.emptySet(), false);
+
+        final HashMap<String, Object> expectedFields = new HashMap<>(defaultExpectedFields);
+        expectedFields.put("keyValuePairs", Collections.singletonMap("test", "value"));
+        assertThat(eventJsonLayout.toJsonMap(event))
+            .as("Null values in keyValuePairs are filtered out")
+            .isEqualTo(expectedFields);
+    }
+
+    @Test
+    void testLogsKeyValuePairsDiscardedWhenAllValuesNull() {
+        when(event.getKeyValuePairs()).thenReturn(List.of(new KeyValuePair("testNull", null)));
+        eventJsonLayout = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter,
+            DEFAULT_EVENT_ATTRIBUTES, Collections.emptyMap(), Collections.emptyMap(), Collections.emptySet(), false, Collections.emptySet(), false);
+
+        assertThat(eventJsonLayout.toJsonMap(event))
+            .as("keyValuePairs is not logged when all values are null")
+            .isEqualTo(defaultExpectedFields);
+    }
+
+    @Test
+    void testLogsFlattenedKeyValuePairsFilteringNullValues() {
+        when(event.getKeyValuePairs()).thenReturn(List.of(new KeyValuePair("test", "value"),new KeyValuePair("testNull", null)));
+        eventJsonLayout = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter,
+            DEFAULT_EVENT_ATTRIBUTES, Collections.emptyMap(), Collections.emptyMap(), Collections.emptySet(), false, Collections.emptySet(), true);
+
+        final HashMap<String, Object> expectedFields = new HashMap<>(defaultExpectedFields);
+        expectedFields.put("test", "value");
+        assertThat(eventJsonLayout.toJsonMap(event)).isEqualTo(expectedFields);
     }
 }

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/EventJsonLayoutTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/EventJsonLayoutTest.java
@@ -248,7 +248,7 @@ class EventJsonLayoutTest {
     void testFilterKeyValueKeys() {
         final Set<String> includesKeyValuePairsKeys = Set.of("test");
         when(event.getKeyValuePairs()).thenReturn(List.of(new KeyValuePair("test", "value"), new KeyValuePair("test2", "value2")));
-        eventJsonLayout= new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter, DEFAULT_EVENT_ATTRIBUTES,
+        eventJsonLayout = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter, DEFAULT_EVENT_ATTRIBUTES,
             Collections.emptyMap(), Collections.emptyMap(), Collections.emptySet(), false, includesKeyValuePairsKeys, false);
 
         final Map<String, String> expectedKeyValuePairs = Map.of("test", "value");

--- a/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/EventJsonLayoutTest.java
+++ b/dropwizard-json-logging/src/test/java/io/dropwizard/logging/json/layout/EventJsonLayoutTest.java
@@ -260,7 +260,7 @@ class EventJsonLayoutTest {
     @Test
     void testFilterAndFlattenKeyValueKeys() {
         final Set<String> includesKeyValuePairsKeys = Set.of("test");
-        when(event.getKeyValuePairs()).thenReturn(java.util.List.of(new KeyValuePair("test", "value"), new KeyValuePair("test2", "value2")));
+        when(event.getKeyValuePairs()).thenReturn(List.of(new KeyValuePair("test", "value"), new KeyValuePair("test2", "value2")));
         eventJsonLayout = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter, DEFAULT_EVENT_ATTRIBUTES,
             Collections.emptyMap(), Collections.emptyMap(), Collections.emptySet(), false, includesKeyValuePairsKeys, true);
 
@@ -271,7 +271,7 @@ class EventJsonLayoutTest {
 
     @Test
     void testLogsKeyValuePairsFilteringNullValues() {
-        when(event.getKeyValuePairs()).thenReturn(List.of(new KeyValuePair("test", "value"),new KeyValuePair("testNull", null)));
+        when(event.getKeyValuePairs()).thenReturn(List.of(new KeyValuePair("test", "value"), new KeyValuePair("testNull", null)));
         eventJsonLayout = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter,
             DEFAULT_EVENT_ATTRIBUTES, Collections.emptyMap(), Collections.emptyMap(), Collections.emptySet(), false, Collections.emptySet(), false);
 
@@ -295,7 +295,7 @@ class EventJsonLayoutTest {
 
     @Test
     void testLogsFlattenedKeyValuePairsFilteringNullValues() {
-        when(event.getKeyValuePairs()).thenReturn(List.of(new KeyValuePair("test", "value"),new KeyValuePair("testNull", null)));
+        when(event.getKeyValuePairs()).thenReturn(List.of(new KeyValuePair("test", "value"), new KeyValuePair("testNull", null)));
         eventJsonLayout = new EventJsonLayout(jsonFormatter, timestampFormatter, throwableProxyConverter,
             DEFAULT_EVENT_ATTRIBUTES, Collections.emptyMap(), Collections.emptyMap(), Collections.emptySet(), false, Collections.emptySet(), true);
 

--- a/dropwizard-json-logging/src/test/resources/yaml/json-log.yml
+++ b/dropwizard-json-logging/src/test/resources/yaml/json-log.yml
@@ -13,6 +13,7 @@ layout:
     - exception
     - timestamp
     - callerData
+    - keyValuePairs
   exception:
     rootFirst: false
     depth: 10
@@ -26,3 +27,6 @@ layout:
   includesMdcKeys:
     - userId
   flattenMdc: true
+  includesKeyValuePairsKeys:
+    - operation
+  flattenKeyValuePairs: true

--- a/dropwizard-logging/src/test/java/io/dropwizard/logging/common/TlsSocketAppenderFactoryTest.java
+++ b/dropwizard-logging/src/test/java/io/dropwizard/logging/common/TlsSocketAppenderFactoryTest.java
@@ -72,6 +72,10 @@ class TlsSocketAppenderFactoryTest {
             Logger logger = LoggerFactory.getLogger("com.example.app");
             List<String> loggedMessages = generateLogs(logger);
 
+            // Give the OS network buffer and Logback's async appender a moment to physically
+            // flush the 100 messages to the server before we violently tear down the socket.
+            Thread.sleep(500);
+
             loggingFactory.stop();
             loggingFactory.reset();
 


### PR DESCRIPTION
Add support for SLF4J 2.0 structured logging key-value pairs in EventJsonLayout. This allows developers to add structured data to individual log entries using the addKeyValue() API.


###### Problem:
Solves issue #9734 
Support for SLF4J 2.0 structured logging in JSON Layout.

###### Solution:
Implement keyValuePairs handling into `EventJsonLayout` in the same way MDC values are handled.
By default all pairs are logged in nested format but they can be filtered and flattened using configuration parameters.

KEY_VALUE_PAIRS has been added to EventAttribute enum to be able to disable it.

###### Result:
Given
```java
 logger.atInfo()
        .addKeyValue("userId", userId)
        .addKeyValue("action", "login")
        .addKeyValue("duration", duration)
        .log("User login completed");
```

by default is rendered into:
```json
  {
    "timestamp": "2024-01-02T15:19:21.000+0000",
    "level": "INFO",
    "message": "User login completed",
    "keyValuePairs": {
      "userId": "12345",
      "action": "login",
      "duration": 150
    }
  }
```
