### PR TITLE
fix(deps): update jackson-datatype-hibernate5-jakarta to  jackson-datatype-hibernate6 

### DIFF
--- a/dropwizard-hibernate/pom.xml
+++ b/dropwizard-hibernate/pom.xml
@@ -51,7 +51,7 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-hibernate5-jakarta</artifactId>
+            <artifactId>jackson-datatype-hibernate6</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>jakarta.transaction</groupId>

--- a/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/HibernateBundle.java
+++ b/dropwizard-hibernate/src/main/java/io/dropwizard/hibernate/HibernateBundle.java
@@ -1,7 +1,7 @@
 package io.dropwizard.hibernate;
 
-import com.fasterxml.jackson.datatype.hibernate5.jakarta.Hibernate5JakartaModule;
-import com.fasterxml.jackson.datatype.hibernate5.jakarta.Hibernate5JakartaModule.Feature;
+import com.fasterxml.jackson.datatype.hibernate6.Hibernate6Module;
+import com.fasterxml.jackson.datatype.hibernate6.Hibernate6Module.Feature;
 import io.dropwizard.core.ConfiguredBundle;
 import io.dropwizard.core.setup.Bootstrap;
 import io.dropwizard.core.setup.Environment;
@@ -45,14 +45,14 @@ public abstract class HibernateBundle<T> implements ConfiguredBundle<T>, Databas
 
     @Override
     public final void initialize(Bootstrap<?> bootstrap) {
-        bootstrap.getObjectMapper().registerModule(createHibernate5Module());
+        bootstrap.getObjectMapper().registerModule(createHibernate6Module());
     }
 
     /**
-     * Override to configure the {@link Hibernate5JakartaModule}.
+     * Override to configure the {@link Hibernate6Module}.
      */
-    protected Hibernate5JakartaModule createHibernate5Module() {
-        Hibernate5JakartaModule module = new Hibernate5JakartaModule();
+    protected Hibernate6Module createHibernate6Module() {
+        Hibernate6Module module = new Hibernate6Module();
         if (lazyLoadingEnabled) {
             module.enable(Feature.FORCE_LAZY_LOADING);
         }

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/HibernateBundleTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/HibernateBundleTest.java
@@ -3,7 +3,7 @@ package io.dropwizard.hibernate;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.hibernate5.jakarta.Hibernate5JakartaModule;
+import com.fasterxml.jackson.datatype.hibernate6.Hibernate6Module;
 import io.dropwizard.core.Configuration;
 import io.dropwizard.core.setup.Bootstrap;
 import io.dropwizard.core.setup.Environment;
@@ -69,7 +69,7 @@ class HibernateBundleTest {
         final ArgumentCaptor<Module> captor = ArgumentCaptor.forClass(Module.class);
         verify(objectMapperFactory).registerModule(captor.capture());
 
-        assertThat(captor.getValue()).isInstanceOf(Hibernate5JakartaModule.class);
+        assertThat(captor.getValue()).isInstanceOf(Hibernate6Module.class);
     }
 
     @Test

--- a/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/dual/HibernateBundleTest.java
+++ b/dropwizard-hibernate/src/test/java/io/dropwizard/hibernate/dual/HibernateBundleTest.java
@@ -2,7 +2,7 @@ package io.dropwizard.hibernate.dual;
 
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.hibernate5.jakarta.Hibernate5JakartaModule;
+import com.fasterxml.jackson.datatype.hibernate6.Hibernate6Module;
 import io.dropwizard.core.Configuration;
 import io.dropwizard.core.setup.Bootstrap;
 import io.dropwizard.core.setup.Environment;
@@ -86,7 +86,7 @@ public class HibernateBundleTest {
         bundle.initialize(bootstrap);
 
         verify(objectMapperFactory).registerModule(assertArg(module ->
-            assertThat(module).isInstanceOf(Hibernate5JakartaModule.class)));
+            assertThat(module).isInstanceOf(Hibernate6Module.class)));
     }
 
     @Test


### PR DESCRIPTION

Dropwizard 5.x uses Hibernate 6, which requires `jackson-datatype-hibernate6` instead of `jackson-datatype-hibernate5-jakarta`. This updates the dependency to the correct Hibernate 6 compatible version.

Fixes [#10673](https://github.com/dropwizard/dropwizard/issues/10673)
