### PR TITLE
Feat/introduce health check type query filter

### DIFF
--- a/dropwizard-health/src/main/java/io/dropwizard/health/HealthCheckManager.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/HealthCheckManager.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -299,5 +300,20 @@ class HealthCheckManager implements HealthCheckRegistryListener, HealthStatusChe
     public Optional<HealthStateView> healthStateView(@NonNull final String name) {
         return Optional.ofNullable(checks.get(name))
             .map(ScheduledHealthCheck::view);
+    }
+
+    @NonNull
+    @Override
+    public Set<HealthStateView> healthStateViewByType(@NonNull String type) {
+        if (type.equalsIgnoreCase("alive") || type.equalsIgnoreCase("ready")) {
+            return checks.values()
+                .stream()
+                .filter(check -> check.getType().name().equalsIgnoreCase(type))
+                .map(ScheduledHealthCheck::view)
+                .collect(Collectors.toSet());
+        } else {
+            LOGGER.warn("Unexpected health check type requested: type={}", type);
+            return Set.of();
+        }
     }
 }

--- a/dropwizard-health/src/main/java/io/dropwizard/health/HealthStateAggregator.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/HealthStateAggregator.java
@@ -1,5 +1,6 @@
 package io.dropwizard.health;
 
+import java.util.Set;
 import org.jspecify.annotations.NonNull;
 
 import java.util.Collection;
@@ -11,4 +12,7 @@ public interface HealthStateAggregator {
 
     @NonNull
     Optional<HealthStateView> healthStateView(@NonNull String name);
+
+    @NonNull
+    Set<HealthStateView> healthStateViewByType(@NonNull String type);
 }

--- a/dropwizard-health/src/main/java/io/dropwizard/health/response/JsonHealthResponseProvider.java
+++ b/dropwizard-health/src/main/java/io/dropwizard/health/response/JsonHealthResponseProvider.java
@@ -81,16 +81,34 @@ public class JsonHealthResponseProvider implements HealthResponseProvider {
             .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
+    private Set<String> getTypesFromQueryParams(final Map<String, Collection<String>> queryParams) {
+        return queryParams.getOrDefault(CHECK_TYPE_QUERY_PARAM, Collections.emptyList())
+            .stream()
+            .map(String::toLowerCase)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
     private Collection<HealthStateView> getViews(final Map<String, Collection<String>> queryParams) {
         final Set<String> names = getNamesFromQueryParams(queryParams);
+        final Set<String> types = getTypesFromQueryParams(queryParams);
 
         if (shouldReturnAllViews(names)) {
             return List.copyOf(healthStateAggregator.healthStateViews());
         } else {
-            return names.stream()
+            Set<HealthStateView> viewsByType = types.stream()
+                .map(healthStateAggregator::healthStateViewByType)
+                .flatMap(Set::stream)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+            Set<HealthStateView> viewsByName = names.stream()
                 .map(healthStateAggregator::healthStateView)
                 .flatMap(Optional::stream)
-                .collect(Collectors.toUnmodifiableList());
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+            Set<HealthStateView> combinedViews = new LinkedHashSet<>();
+            combinedViews.addAll(viewsByType);
+            combinedViews.addAll(viewsByName);
+            return combinedViews;
         }
     }
 

--- a/dropwizard-health/src/test/java/io/dropwizard/health/response/JsonHealthResponseProviderTest.java
+++ b/dropwizard-health/src/test/java/io/dropwizard/health/response/JsonHealthResponseProviderTest.java
@@ -1,6 +1,7 @@
 package io.dropwizard.health.response;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.health.HealthCheckType;
 import io.dropwizard.health.HealthStateAggregator;
@@ -19,8 +20,11 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -89,6 +93,55 @@ class JsonHealthResponseProviderTest {
         assertThat(response.isHealthy()).isTrue();
         assertThat(response.getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
         assertThat(mapper.readTree(response.getMessage())).isEqualTo(mapper.readTree(fixture("/json/multiple-healthy-responses.json")));
+    }
+
+    @Test
+    void shouldHandleHealthStateViewsByTypeQueryParameter() throws IOException {
+        // given
+        final HealthStateView fooView = new HealthStateView("foo", true, HealthCheckType.READY, true);
+        final HealthStateView barView = new HealthStateView("bar", true, HealthCheckType.ALIVE, true);
+        final HealthStateView bazView = new HealthStateView("baz", false, HealthCheckType.READY, false);
+        final Map<String, Collection<String>> aliveQueryParams = Collections.singletonMap(
+            JsonHealthResponseProvider.CHECK_TYPE_QUERY_PARAM, Collections.singleton("alive"));
+        final Map<String, Collection<String>> readyQueryParams = Collections.singletonMap(
+            JsonHealthResponseProvider.CHECK_TYPE_QUERY_PARAM, Collections.singleton("ready"));
+
+        // when
+        when(healthStateAggregator.healthStateViewByType("alive"))
+            .thenReturn(Set.of(barView));
+        when(healthStatusChecker.isHealthy("alive")).thenReturn(true);
+        final HealthResponse aliveResponse = jsonHealthResponseProvider.healthResponse(aliveQueryParams);
+
+        when(healthStateAggregator.healthStateViewByType("ready"))
+            .thenReturn(Set.of(fooView, bazView));
+        when(healthStatusChecker.isHealthy("ready")).thenReturn(false);
+        final HealthResponse readyResponse = jsonHealthResponseProvider.healthResponse(readyQueryParams);
+
+        // then
+        assertThat(aliveResponse.isHealthy()).isTrue();
+        assertThat(aliveResponse.getStatus()).isEqualTo(200);
+        assertThat(aliveResponse.getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
+        assertThat(mapper.readTree(aliveResponse.getMessage())).isEqualTo(mapper.readTree(fixture("/json/single-alive-type-response.json")));
+
+        assertThat(readyResponse.isHealthy()).isFalse();
+        assertThat(readyResponse.getStatus()).isEqualTo(503);
+        assertThat(readyResponse.getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
+
+        String expectedMessage = fixture("/json/multiple-ready-type-responses.json");
+        String actualMessage = readyResponse.getMessage();
+
+        JsonNode expectedArray = mapper.readTree(expectedMessage);
+        JsonNode actualArray = mapper.readTree(actualMessage);
+
+        assertThat(actualArray.isArray()).isTrue();
+        assertThat(expectedArray.isArray()).isTrue();
+        assertThat(actualArray.size()).isEqualTo(expectedArray.size());
+
+        HashSet<JsonNode> expectedSet = new HashSet<>();
+        expectedArray.forEach(expectedSet::add);
+        HashSet<JsonNode> actualSet = new HashSet<>();
+        actualArray.forEach(actualSet::add);
+        assertThat(actualSet).isEqualTo(expectedSet);
     }
 
     @Test

--- a/dropwizard-health/src/test/resources/json/multiple-ready-type-responses.json
+++ b/dropwizard-health/src/test/resources/json/multiple-ready-type-responses.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "baz",
+        "healthy": false,
+        "type": "READY",
+        "critical": false
+    },
+    {
+        "name": "foo",
+        "healthy": true,
+        "type": "READY",
+        "critical": true
+    }
+]

--- a/dropwizard-health/src/test/resources/json/single-alive-type-response.json
+++ b/dropwizard-health/src/test/resources/json/single-alive-type-response.json
@@ -1,0 +1,8 @@
+[
+    {
+        "name": "bar",
+        "healthy": true,
+        "type": "ALIVE",
+        "critical": true
+    }
+]


### PR DESCRIPTION
###### Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->

 The type query search parameter feature for health checks does not exist as claimed in documentation. 

Documentation inside the [Health Checks section describing health check querying feature](https://github.com/dropwizard/dropwizard/blob/release/5.0.x/docs/source/manual/core.rst?plain=1#L413-L418) claims that

> An example of how you might query the health check, assuming you're using the default responder/responseProvider
settings in configuration:
>
>      https://<hostname>:<port>/health-check?type=<type>&name=<name>
>  replace ``<type>`` with ``ready`` or ``alive``; defaults to ``ready`` if the ``type`` parameter is not provided




Running `curl "locallhost:8080/health-check?type={ready, alive}"` will return an empty array as the query parameter only contains logic for name filtering in the [`JsonHealthResponseProvider::getViews`](https://github.com/dropwizard/dropwizard/blob/5a4738e8a8e24cf1e6630549e3828af9c8c2410f/dropwizard-health/src/main/java/io/dropwizard/health/response/JsonHealthResponseProvider.java#L90-L94) method. 

See [Dropwizard Healthcheck Bug Demo](https://github.com/dfeng-clear/Dropwizard-Healthcheck-Bug-Demo) repo for a demonstration of the issue described above.
```
> curl "localhost:8080/health-check?name=all"
[{"name":"ReadyHealthCheck","healthy":true,"type":"READY","critical":false},{"name":"AliveHealthCheck","healthy":true,"type":"ALIVE","critical":true}]%

> curl "localhost:8080/health-check?type=alive"
[]

> curl "localhost:8080/health-check?type=ready"
[]
```

###### Solution:
<!-- Describe the modifications you've done. -->
- Introduce query filtering health checks by type (alive/ready) via query parameters as stated.
- Implementation details
    - Changed the collections object health check to be a set collection. This keeps consistency with the implementation of query parameter search of type with the previous implementation of query parameter search of name.
    - unit tests

 
###### Result:
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->

- Implement query parameter searching feature in dropwizard health to correct the documentation discrepancy

```
> curl "localhost:8080/health-check?name=all"
[{"name":"ReadyHealthCheck","healthy":true,"type":"READY","critical":false},{"name":"AliveHealthCheck","healthy":true,"type":"ALIVE","critical":true}]

> curl "localhost:8080/health-check?type=alive"
[{"name":"AliveHealthCheck","healthy":true,"type":"ALIVE","critical":true}]

> curl "localhost:8080/health-check?type=ready"
[{"name":"ReadyHealthCheck","healthy":true,"type":"READY","critical":false}]
```
