### PR TITLE
fix(deps): update dependency org.testcontainers:testcontainers-bom to v2

### DIFF
--- a/dropwizard-example/pom.xml
+++ b/dropwizard-example/pom.xml
@@ -36,7 +36,7 @@
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers-bom</artifactId>
-                <version>1.21.4</version>
+                <version>2.0.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -114,12 +114,12 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>mysql</artifactId>
+            <artifactId>testcontainers-mysql</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/dropwizard-example/src/test/java/com/example/helloworld/DockerIntegrationTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/DockerIntegrationTest.java
@@ -14,15 +14,13 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mysql.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.io.File;
@@ -36,10 +34,9 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @Testcontainers(disabledWithoutDocker = true)
 @ExtendWith(DropwizardExtensionsSupport.class)
-@DisabledForJreRange(min = JRE.JAVA_16)
-public class DockerIntegrationTest {
+class DockerIntegrationTest {
     @Container
-    private static final MySQLContainer<?> MY_SQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0.28"));
+    private static final MySQLContainer MY_SQL_CONTAINER = new MySQLContainer(DockerImageName.parse("mysql:8.0.28"));
 
     private static final String CONFIG = "test-docker-example.yml";
 
@@ -59,7 +56,7 @@ public class DockerIntegrationTest {
     );
 
     @BeforeAll
-    public static void migrateDb() throws Exception {
+    static void migrateDb() throws Exception {
         APP.getApplication().run("db", "migrate", resourceFilePath(CONFIG));
     }
 
@@ -141,7 +138,7 @@ public class DockerIntegrationTest {
                 "0.0.0.0:" + APP.getLocalPort(),
                 "Started admin@",
                 "0.0.0.0:" + APP.getAdminPort())
-            .doesNotContain("ERROR", "FATAL", "Exception");
+            .doesNotContain("ERROR", "FATAL");
     }
 
     @Test

--- a/dropwizard-example/src/test/java/com/example/helloworld/db/PersonDAOIntegrationTest.java
+++ b/dropwizard-example/src/test/java/com/example/helloworld/db/PersonDAOIntegrationTest.java
@@ -9,12 +9,10 @@ import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mysql.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.List;
@@ -25,10 +23,9 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @Testcontainers(disabledWithoutDocker = true)
 @ExtendWith(DropwizardExtensionsSupport.class)
-@DisabledForJreRange(min = JRE.JAVA_16)
 class PersonDAOIntegrationTest {
     @Container
-    private static final MySQLContainer<?> MY_SQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0.24"));
+    private static final MySQLContainer MY_SQL_CONTAINER = new MySQLContainer(DockerImageName.parse("mysql:8.0.28"));
 
     public DAOTestExtension daoTestRule = DAOTestExtension.newBuilder()
             .customizeConfiguration(c -> c.setProperty(AvailableSettings.DIALECT, MySQLDialect.class.getName()))


### PR DESCRIPTION
###### Problem:

Fixes failing [fix(deps): update dependency org.testcontainers:testcontainers-bom to v2](https://github.com/dropwizard/dropwizard/pull/11070) created by renovate bot.

###### Solution:
* in addition to updating `org.testcontainers:testcontainers-bom` version, `org.testcontainers:junit-jupiter` and `org.testcontainers:mysql` artifacts have changed location to `org.testcontainers:testcontainers-junit-jupiter` and `org.testcontainers:testcontainers-mysql`
* removed `@DisabledForJreRange` since DW5 requires java 17
* removed contains `"Exception"` check as Database JDBC URL may contain `ignoreExceptionOnPreLoad=false` which would cause test to fail
*  aligned `mysql` version used by testcontainers to `mysql:8.0.28`

Closes #11070