### PR TITLE
feat: Add nonce-based Content Security Policy (CSP) support

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/core/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/core/server/AbstractServerFactory.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.core.setup.AdminEnvironment;
 import io.dropwizard.core.setup.ExceptionMapperBinder;
 import io.dropwizard.jersey.filter.AllowedMethodsFilter;
+import io.dropwizard.jersey.filter.CspFilter;
 import io.dropwizard.jersey.jackson.JacksonFeature;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
 import io.dropwizard.jersey.validation.HibernateValidationBinder;
@@ -301,6 +302,10 @@ public abstract class AbstractServerFactory implements ServerFactory {
 
     private Optional<String> jerseyRootPath = Optional.empty();
 
+    @Valid
+    @NotNull
+    private CspConfiguration csp = new CspConfiguration();
+
     private boolean enableThreadNameFilter = true;
 
     private boolean dumpAfterStart = false;
@@ -516,6 +521,16 @@ public abstract class AbstractServerFactory implements ServerFactory {
         this.jerseyRootPath = Optional.ofNullable(jerseyRootPath);
     }
 
+    @JsonProperty("csp")
+    public CspConfiguration getCsp() {
+        return csp;
+    }
+
+    @JsonProperty("csp")
+    public void setCsp(CspConfiguration csp) {
+        this.csp = csp;
+    }
+
     @JsonProperty
     public boolean getEnableThreadNameFilter() {
         return enableThreadNameFilter;
@@ -616,6 +631,9 @@ public abstract class AbstractServerFactory implements ServerFactory {
             jersey.register(new HibernateValidationBinder(validator));
             if (registerDefaultExceptionMappers == null || registerDefaultExceptionMappers) {
                 jersey.register(new ExceptionMapperBinder(detailedJsonProcessingExceptionMapper));
+            }
+            if (csp.getPolicy().isPresent() || csp.getReportOnlyPolicy().isPresent()) {
+                jersey.register(new CspFilter(csp.getPolicy().orElse(null), csp.getReportOnlyPolicy().orElse(null)));
             }
             handler.addServlet(new ServletHolder("jersey", jerseyContainer), jersey.getUrlPattern());
         }

--- a/dropwizard-core/src/main/java/io/dropwizard/core/server/CspConfiguration.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/core/server/CspConfiguration.java
@@ -1,0 +1,38 @@
+package io.dropwizard.core.server;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Optional;
+
+/**
+ * Configuration options for Content Security Policy (CSP).
+ */
+public class CspConfiguration {
+
+    @Nullable
+    private String policy;
+
+    @Nullable
+    private String reportOnlyPolicy;
+
+    @JsonProperty
+    public Optional<String> getPolicy() {
+        return Optional.ofNullable(policy);
+    }
+
+    @JsonProperty
+    public void setPolicy(String policy) {
+        this.policy = policy;
+    }
+
+    @JsonProperty
+    public Optional<String> getReportOnlyPolicy() {
+        return Optional.ofNullable(reportOnlyPolicy);
+    }
+
+    @JsonProperty
+    public void setReportOnlyPolicy(String reportOnlyPolicy) {
+        this.reportOnlyPolicy = reportOnlyPolicy;
+    }
+}

--- a/dropwizard-core/src/test/java/io/dropwizard/core/server/AbstractServerFactoryTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/core/server/AbstractServerFactoryTest.java
@@ -118,6 +118,35 @@ class AbstractServerFactoryTest {
         assertThat(appContext.getHandler()).isNotInstanceOf(LogbackAccessRequestLogAwareHandler.class);
     }
 
+    @Test
+    void registersCspFilterWhenCspConfigured() {
+        serverFactory.getCsp().setPolicy("default-src 'self'; script-src 'nonce-$NONCE';");
+        serverFactory.build(environment);
+
+        final boolean hasCspFilter = config.getSingletons().stream()
+                .anyMatch(s -> s instanceof io.dropwizard.jersey.filter.CspFilter);
+        assertThat(hasCspFilter).isTrue();
+    }
+
+    @Test
+    void registersCspFilterWhenCspReportOnlyConfigured() {
+        serverFactory.getCsp().setReportOnlyPolicy("default-src 'self';");
+        serverFactory.build(environment);
+
+        final boolean hasCspFilter = config.getSingletons().stream()
+                .anyMatch(s -> s instanceof io.dropwizard.jersey.filter.CspFilter);
+        assertThat(hasCspFilter).isTrue();
+    }
+
+    @Test
+    void doesNotRegisterCspFilterWhenNotConfigured() {
+        serverFactory.build(environment);
+
+        final boolean hasCspFilter = config.getSingletons().stream()
+                .anyMatch(s -> s instanceof io.dropwizard.jersey.filter.CspFilter);
+        assertThat(hasCspFilter).isFalse();
+    }
+
     /**
      * Test implementation of {@link AbstractServerFactory} used to run {@link #createAppServlet}, which triggers the
      * setting of {@link JerseyEnvironment#setUrlPattern(String)}.

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/CspFilter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/filter/CspFilter.java
@@ -1,0 +1,64 @@
+package io.dropwizard.jersey.filter;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.ext.Provider;
+import org.jspecify.annotations.Nullable;
+
+import java.io.IOException;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+/**
+ * A JAX-RS filter that generates a Content Security Policy (CSP) nonce per request,
+ * stores it in the request context properties, and injects it into configured
+ * {@code Content-Security-Policy} and/or {@code Content-Security-Policy-Report-Only} headers.
+ * <p>
+ * The placeholder {@code $NONCE} in the configured policy templates is replaced
+ * with the generated nonce value.
+ * </p>
+ */
+@Provider
+@Priority(Priorities.HEADER_DECORATOR)
+public class CspFilter implements ContainerRequestFilter, ContainerResponseFilter {
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    @Nullable
+    private final String policyTemplate;
+
+    @Nullable
+    private final String reportOnlyPolicyTemplate;
+
+    public CspFilter(@Nullable String policyTemplate, @Nullable String reportOnlyPolicyTemplate) {
+        this.policyTemplate = policyTemplate;
+        this.reportOnlyPolicyTemplate = reportOnlyPolicyTemplate;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        final byte[] nonceBytes = new byte[16];
+        SECURE_RANDOM.nextBytes(nonceBytes);
+        final String nonce = Base64.getEncoder().encodeToString(nonceBytes);
+        requestContext.setProperty("csp-nonce", nonce);
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+        final String nonce = (String) requestContext.getProperty("csp-nonce");
+        if (nonce != null) {
+            if (policyTemplate != null) {
+                final String policy = policyTemplate.replace("$NONCE", nonce);
+                responseContext.getHeaders().putSingle("Content-Security-Policy", policy);
+            }
+            if (reportOnlyPolicyTemplate != null) {
+                final String reportOnlyPolicy = reportOnlyPolicyTemplate.replace("$NONCE", nonce);
+                responseContext.getHeaders().putSingle("Content-Security-Policy-Report-Only", reportOnlyPolicy);
+            }
+        }
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/CspFilterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/filter/CspFilterTest.java
@@ -1,0 +1,81 @@
+package io.dropwizard.jersey.filter;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CspFilterTest {
+
+    private final ContainerRequestContext request = mock(ContainerRequestContext.class);
+    private final ContainerResponseContext response = mock(ContainerResponseContext.class);
+    private final MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+    private final Map<String, Object> requestProperties = new HashMap<>();
+
+    @BeforeEach
+    void setUp() {
+        headers.clear();
+        requestProperties.clear();
+        when(response.getHeaders()).thenReturn(headers);
+
+        Mockito.doAnswer(invocation -> {
+            final String key = invocation.getArgument(0);
+            final Object val = invocation.getArgument(1);
+            requestProperties.put(key, val);
+            return null;
+        }).when(request).setProperty(Mockito.anyString(), Mockito.any());
+
+        when(request.getProperty(Mockito.anyString())).thenAnswer(invocation -> {
+            final String key = invocation.getArgument(0);
+            return requestProperties.get(key);
+        });
+    }
+
+    @Test
+    void injectsCspHeadersWithGeneratedNonce() throws Exception {
+        final CspFilter filter = new CspFilter(
+                "default-src 'self'; script-src 'nonce-$NONCE';",
+                "default-src 'self'; report-uri /report;"
+        );
+
+        // Run request filter to generate nonce
+        filter.filter(request);
+
+        final String nonce = (String) request.getProperty("csp-nonce");
+        assertThat(nonce).isNotEmpty();
+
+        // Run response filter to inject headers
+        filter.filter(request, response);
+
+        // Verify headers are present and $NONCE was replaced
+        assertThat(headers.getFirst("Content-Security-Policy"))
+                .isEqualTo("default-src 'self'; script-src 'nonce-" + nonce + "';");
+        assertThat(headers.getFirst("Content-Security-Policy-Report-Only"))
+                .isEqualTo("default-src 'self'; report-uri /report;");
+    }
+
+    @Test
+    void generatesUniqueNonces() throws Exception {
+        final CspFilter filter = new CspFilter(null, null);
+
+        filter.filter(request);
+        final String nonce1 = (String) request.getProperty("csp-nonce");
+
+        filter.filter(request);
+        final String nonce2 = (String) request.getProperty("csp-nonce");
+
+        assertThat(nonce1).isNotEmpty();
+        assertThat(nonce2).isNotEmpty();
+        assertThat(nonce1).isNotEqualTo(nonce2);
+    }
+}

--- a/dropwizard-views-freemarker/src/main/java/io/dropwizard/views/freemarker/FreemarkerViewRenderer.java
+++ b/dropwizard-views-freemarker/src/main/java/io/dropwizard/views/freemarker/FreemarkerViewRenderer.java
@@ -94,7 +94,13 @@ public class FreemarkerViewRenderer implements ViewRenderer {
         try {
             final Charset charset = view.getCharset().orElseGet(() -> Charset.forName(configuration.getEncoding(locale)));
             final Template template = configuration.getTemplate(view.getTemplateName(), locale, charset.name());
-            template.process(view, new OutputStreamWriter(output, template.getEncoding()));
+            final OutputStreamWriter writer = new OutputStreamWriter(output, template.getEncoding());
+            final freemarker.core.Environment env = template.createProcessingEnvironment(view, writer);
+            final String nonce = io.dropwizard.views.common.CspNonceLookup.get().orElse(null);
+            if (nonce != null) {
+                env.setVariable("cspNonce", env.getObjectWrapper().wrap(nonce));
+            }
+            env.process();
         } catch (Exception e) {
             throw new ViewRenderException(e);
         }

--- a/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/CspView.java
+++ b/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/CspView.java
@@ -1,0 +1,9 @@
+package io.dropwizard.views.freemarker;
+
+import io.dropwizard.views.common.View;
+
+public class CspView extends View {
+    protected CspView() {
+        super("/csp-nonce.ftl");
+    }
+}

--- a/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/FreemarkerViewRendererTest.java
+++ b/dropwizard-views-freemarker/src/test/java/io/dropwizard/views/freemarker/FreemarkerViewRendererTest.java
@@ -67,6 +67,12 @@ class FreemarkerViewRendererTest extends JerseyTest {
         public AutoEscapingView showUserInputSafely(@FormParam("input") String userInput) {
             return new AutoEscapingView(userInput);
         }
+
+        @GET
+        @Path("/csp")
+        public CspView showCsp() {
+            return new CspView();
+        }
     }
 
     @Override
@@ -86,6 +92,7 @@ class FreemarkerViewRendererTest extends JerseyTest {
         ResourceConfig config = new ResourceConfig();
         final ViewRenderer renderer = new FreemarkerViewRenderer(Configuration.VERSION_2_3_30);
         config.register(new ViewMessageBodyWriter(new MetricRegistry(), Collections.singletonList(renderer)));
+        config.register(new io.dropwizard.jersey.filter.CspFilter("default-src 'self'; script-src 'nonce-$NONCE';", null));
         config.register(new ExampleResource());
         config.register(new ViewRenderExceptionMapper());
         return config;
@@ -137,6 +144,22 @@ class FreemarkerViewRendererTest extends JerseyTest {
                 .satisfies(r -> assertThat(r.getStatus()).isEqualTo(Response.Status.OK.getStatusCode()))
                 .satisfies(r -> assertThat(r.getHeaderString("content-type")).isEqualToIgnoringCase(MediaType.TEXT_HTML))
                 .satisfies(r -> assertThat(r.readEntity(String.class)).doesNotContain(unsafe));
+        }
+    }
+
+    @Test
+    void rendersViewsWithCspNonce() {
+        try (final Response response = target("/test/csp").request().get()) {
+            assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+            final String body = response.readEntity(String.class);
+            final String cspHeader = response.getHeaderString("Content-Security-Policy");
+            assertThat(cspHeader).startsWith("default-src 'self'; script-src 'nonce-");
+
+            final String prefix = "default-src 'self'; script-src 'nonce-";
+            final String suffix = "';";
+            final String nonce = cspHeader.substring(prefix.length(), cspHeader.length() - suffix.length());
+
+            assertThat(body).isEqualTo("<script nonce=\"" + nonce + "\">console.log(\"hello\");</script>\n");
         }
     }
 }

--- a/dropwizard-views-freemarker/src/test/resources/csp-nonce.ftl
+++ b/dropwizard-views-freemarker/src/test/resources/csp-nonce.ftl
@@ -1,0 +1,1 @@
+<script nonce="${cspNonce}">console.log("hello");</script>

--- a/dropwizard-views-mustache/src/main/java/io/dropwizard/views/mustache/MustacheViewRenderer.java
+++ b/dropwizard-views-mustache/src/main/java/io/dropwizard/views/mustache/MustacheViewRenderer.java
@@ -53,7 +53,12 @@ public class MustacheViewRenderer implements ViewRenderer {
             final Mustache template = mustacheFactory.compile(view.getTemplateName());
             final Charset charset = view.getCharset().orElse(StandardCharsets.UTF_8);
             try (OutputStreamWriter writer = new OutputStreamWriter(output, charset)) {
-                template.execute(writer, view);
+                final String nonce = io.dropwizard.views.common.CspNonceLookup.get().orElse(null);
+                if (nonce != null) {
+                    template.execute(writer, new Object[]{ view, java.util.Map.of("cspNonce", nonce) });
+                } else {
+                    template.execute(writer, view);
+                }
             }
         } catch (Throwable e) {
             throw new ViewRenderException("Mustache template error: " + view.getTemplateName(), e);

--- a/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/CspView.java
+++ b/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/CspView.java
@@ -1,0 +1,9 @@
+package io.dropwizard.views.mustache;
+
+import io.dropwizard.views.common.View;
+
+public class CspView extends View {
+    protected CspView() {
+        super("/csp-nonce.mustache");
+    }
+}

--- a/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererTest.java
+++ b/dropwizard-views-mustache/src/test/java/io/dropwizard/views/mustache/MustacheViewRendererTest.java
@@ -53,6 +53,12 @@ class MustacheViewRendererTest extends JerseyTest {
         public ErrorView showError() {
             return new ErrorView();
         }
+
+        @GET
+        @Path("/csp")
+        public CspView showCsp() {
+            return new CspView();
+        }
     }
 
     @Override
@@ -72,6 +78,7 @@ class MustacheViewRendererTest extends JerseyTest {
         ResourceConfig config = DropwizardResourceConfig.forTesting();
         final ViewRenderer renderer = new MustacheViewRenderer();
         config.register(new ViewMessageBodyWriter(new MetricRegistry(), Collections.singletonList(renderer)));
+        config.register(new io.dropwizard.jersey.filter.CspFilter("default-src 'self'; script-src 'nonce-$NONCE';", null));
         config.register(new ViewRenderExceptionMapper());
         config.register(new ExampleResource());
         return config;
@@ -123,5 +130,21 @@ class MustacheViewRendererTest extends JerseyTest {
         MustacheViewRenderer mustacheViewRenderer = new MustacheViewRenderer();
         mustacheViewRenderer.configure(Collections.singletonMap("cache", "false"));
         assertThat(mustacheViewRenderer.isUseCache()).isFalse();
+    }
+
+    @Test
+    void rendersViewsWithCspNonce() {
+        try (final jakarta.ws.rs.core.Response response = target("/test/csp").request().get()) {
+            assertThat(response.getStatus()).isEqualTo(jakarta.ws.rs.core.Response.Status.OK.getStatusCode());
+            final String body = response.readEntity(String.class);
+            final String cspHeader = response.getHeaderString("Content-Security-Policy");
+            assertThat(cspHeader).startsWith("default-src 'self'; script-src 'nonce-");
+
+            final String prefix = "default-src 'self'; script-src 'nonce-";
+            final String suffix = "';";
+            final String nonce = cspHeader.substring(prefix.length(), cspHeader.length() - suffix.length());
+
+            assertThat(body).isEqualTo("<script nonce=\"" + nonce + "\">console.log(\"hello\");</script>\n");
+        }
     }
 }

--- a/dropwizard-views-mustache/src/test/resources/csp-nonce.mustache
+++ b/dropwizard-views-mustache/src/test/resources/csp-nonce.mustache
@@ -1,0 +1,1 @@
+<script nonce="{{{cspNonce}}}">console.log("hello");</script>

--- a/dropwizard-views/pom.xml
+++ b/dropwizard-views/pom.xml
@@ -42,6 +42,10 @@
             <artifactId>jspecify</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>

--- a/dropwizard-views/src/main/java/io/dropwizard/views/common/CspNonceLookup.java
+++ b/dropwizard-views/src/main/java/io/dropwizard/views/common/CspNonceLookup.java
@@ -1,0 +1,39 @@
+package io.dropwizard.views.common;
+
+import java.util.Optional;
+
+/**
+ * A utility class providing thread-local lookup for the CSP nonce
+ * during the synchronous view rendering lifecycle.
+ */
+public final class CspNonceLookup {
+    private static final ThreadLocal<String> CURRENT_NONCE = new ThreadLocal<>();
+
+    private CspNonceLookup() {
+    }
+
+    /**
+     * Returns the CSP nonce for the current rendering thread.
+     *
+     * @return an {@link Optional} containing the nonce, or empty if not set.
+     */
+    public static Optional<String> get() {
+        return Optional.ofNullable(CURRENT_NONCE.get());
+    }
+
+    /**
+     * Sets the CSP nonce for the current rendering thread.
+     *
+     * @param nonce the nonce value
+     */
+    public static void set(String nonce) {
+        CURRENT_NONCE.set(nonce);
+    }
+
+    /**
+     * Clears the CSP nonce for the current rendering thread.
+     */
+    public static void remove() {
+        CURRENT_NONCE.remove();
+    }
+}

--- a/dropwizard-views/src/main/java/io/dropwizard/views/common/ViewMessageBodyWriter.java
+++ b/dropwizard-views/src/main/java/io/dropwizard/views/common/ViewMessageBodyWriter.java
@@ -3,6 +3,7 @@ package io.dropwizard.views.common;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
@@ -31,6 +32,10 @@ public class ViewMessageBodyWriter implements MessageBodyWriter<View> {
     @Context
     @Nullable
     private HttpHeaders headers;
+
+    @Context
+    @SuppressWarnings("NullAway")
+    private jakarta.inject.Provider<ContainerRequestContext> requestContextProvider;
 
     void setHeaders(HttpHeaders headers) {
         this.headers = headers;
@@ -67,7 +72,12 @@ public class ViewMessageBodyWriter implements MessageBodyWriter<View> {
                         MultivaluedMap<String, Object> httpHeaders,
                         OutputStream entityStream) throws IOException {
         final Timer.Context context = metricRegistry.timer(name(t.getClass(), "rendering")).time();
+        final ContainerRequestContext requestContext = requestContextProvider != null ? requestContextProvider.get() : null;
+        final String nonce = requestContext != null ? (String) requestContext.getProperty("csp-nonce") : null;
         try {
+            if (nonce != null) {
+                CspNonceLookup.set(nonce);
+            }
             for (ViewRenderer renderer : renderers) {
                 if (renderer.isRenderable(t)) {
                     renderer.render(t, detectLocale(requireNonNull(headers)), entityStream);
@@ -78,6 +88,7 @@ public class ViewMessageBodyWriter implements MessageBodyWriter<View> {
         } catch (ViewRenderException e) {
             throw new WebApplicationException(e);
         } finally {
+            CspNonceLookup.remove();
             context.stop();
         }
     }


### PR DESCRIPTION
 Problem:

Dropwizard applications rendering HTML views lack native support for nonce-based Content Security Policy (CSP), making it difficult to securely authorize inline scripts and styles and increasing the risk of XSS attacks.

Solution:

Implemented nonce-based CSP support by adding a request-scoped filter that generates secure nonces, configurable CSP policies, and a thread-safe mechanism to expose the nonce during view rendering. The nonce is available as `${cspNonce}` in FreeMarker templates and `{{{cspNonce}}}` in Mustache templates, with accompanying unit and integration tests.

Result:

Dropwizard applications can now enable nonce-based CSP protection through configuration, allowing templates to safely use dynamic inline scripts and styles while maintaining thread safety.
