### PR TITLE
test: cover dropwizard resource config defaults

### DIFF
--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/DropwizardResourceConfigTest.java
@@ -1,6 +1,12 @@
 package io.dropwizard.jersey;
 
+import com.codahale.metrics.jersey3.InstrumentedResourceMethodApplicationListener;
+import io.dropwizard.jersey.caching.CacheControlledResponseFeature;
 import io.dropwizard.jersey.dummy.DummyResource;
+import io.dropwizard.jersey.guava.OptionalParamBinder;
+import io.dropwizard.jersey.params.AbstractParamConverterProvider;
+import io.dropwizard.jersey.sessions.SessionFactoryProvider;
+import io.dropwizard.jersey.validation.FuzzyEnumParamConverterProvider;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
@@ -11,6 +17,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.MediaType;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
+import org.glassfish.jersey.server.ServerProperties;
 import org.glassfish.jersey.server.model.Resource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -84,6 +91,48 @@ class DropwizardResourceConfigTest {
         assertThat(rc.getEndpointsInfo())
                 .contains("GET     /bar (io.dropwizard.jersey.DropwizardResourceConfigTest.ResourcePathOnMethodLevel)")
                 .contains("GET     /dummy (io.dropwizard.jersey.DropwizardResourceConfigTest.TestResource)");
+    }
+
+    @Test
+    void constructorWithoutMetricRegistryUsesDefaults() {
+        DropwizardResourceConfig config = new DropwizardResourceConfig();
+
+        assertThat(config.getContextPath()).isEqualTo("/");
+        assertThat(config.getUrlPattern()).isEqualTo("/*");
+        assertThat(config.getProperty(ServerProperties.WADL_FEATURE_DISABLE)).isEqualTo(true);
+        assertThat(config.getClasses()).contains(
+                CacheControlledResponseFeature.class,
+                io.dropwizard.jersey.guava.OptionalMessageBodyWriter.class,
+                io.dropwizard.jersey.optional.OptionalMessageBodyWriter.class,
+                io.dropwizard.jersey.optional.OptionalDoubleMessageBodyWriter.class,
+                io.dropwizard.jersey.optional.OptionalIntMessageBodyWriter.class,
+                io.dropwizard.jersey.optional.OptionalLongMessageBodyWriter.class,
+                AbstractParamConverterProvider.class
+        );
+        assertThat(config.getSingletons())
+                .map(singleton -> singleton.getClass().getName())
+                .contains(
+                        DropwizardResourceConfig.MetricRegistryBinder.class.getName(),
+                        InstrumentedResourceMethodApplicationListener.class.getName(),
+                        OptionalParamBinder.class.getName(),
+                        FuzzyEnumParamConverterProvider.class.getName(),
+                        SessionFactoryProvider.Binder.class.getName()
+                );
+    }
+
+    @Test
+    void logsEndpointsWithRelativeContextPathAndUrlPattern() {
+        rc.setContextPath("context");
+        rc.setUrlPattern("pattern/*");
+        rc.register(TestResource.class);
+        rc.register(ImplementingResource.class);
+
+        runJersey();
+        assertThat(rc.getEndpointsInfo()).isEqualTo(String.format(
+                "The following paths were found for the configured resources:%n"
+                + "%n"
+                + "    GET     /context/pattern/another (io.dropwizard.jersey.DropwizardResourceConfigTest.ImplementingResource)%n"
+                + "    GET     /context/pattern/dummy (io.dropwizard.jersey.DropwizardResourceConfigTest.TestResource)%n"));
     }
 
     @Test
@@ -443,6 +492,7 @@ class DropwizardResourceConfigTest {
             this.dependency = dependency;
         }
 
+        @Override
         public String bar() {
             return dependency.get();
         }


### PR DESCRIPTION
###### Problem:
`DropwizardResourceConfig` sets up a lot of the default Jersey behavior when it is created, including falling back to a new metric registry when none is passed in. I wanted to add a small regression check for that setup, along with the endpoint logging behavior for relative context paths and wildcard URL patterns.

###### Solution:

I added focused tests for the no-arg config setup and for endpoint logging with relative context and URL pattern values.

###### Result:

This covers the [default setup path](https://github.com/dropwizard/dropwizard/blob/release/5.0.x/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java#L56-L65) and the [path normalization and endpoint output path](https://github.com/dropwizard/dropwizard/blob/release/5.0.x/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java#L320-L349). Line coverage for `DropwizardResourceConfig` increases by 1.23%.

I hope you find these tests useful. 😄 Please let me know if you have any questions or concerns.

Thanks,
