### PR TITLE
Fix: stale Content-Encoding/Content-Length after transparent gzip decompression in DropwizardApacheConnector (#11249)

### DIFF
--- a/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardApacheConnector.java
+++ b/dropwizard-client/src/main/java/io/dropwizard/client/DropwizardApacheConnector.java
@@ -92,12 +92,8 @@ public class DropwizardApacheConnector implements Connector {
             final Response.StatusType status = Statuses.from(apacheResponse.getCode(), reasonPhrase == null ? "" : reasonPhrase);
 
             final ClientResponse jerseyResponse = new ClientResponse(status, jerseyRequest);
-            for (Header header : apacheResponse.getHeaders()) {
-                jerseyResponse.getHeaders().computeIfAbsent(header.getName(), k -> new ArrayList<>())
-                    .add(header.getValue());
-            }
-
             final HttpEntity httpEntity = apacheResponse.getEntity();
+            copyResponseHeaders(apacheResponse, httpEntity, jerseyResponse);
             jerseyResponse.setEntityStream(httpEntity != null ? httpEntity.getContent() :
                     new ByteArrayInputStream(new byte[0]));
 
@@ -105,6 +101,58 @@ public class DropwizardApacheConnector implements Connector {
         } catch (Exception e) {
             throw new ProcessingException(e);
         }
+    }
+
+    /**
+     * Copy the Apache response headers onto the Jersey response, reconciling
+     * {@link HttpHeaders#CONTENT_ENCODING} and {@link HttpHeaders#CONTENT_LENGTH} with the entity.
+     * <p>
+     * When content compression is enabled (the default), Apache HttpClient transparently
+     * decompresses the response body, unwrapping the entity to identity encoding while leaving
+     * the original {@code Content-Encoding} and {@code Content-Length} headers on the message.
+     * Passing those stale headers through would misdescribe the decompressed stream and drive
+     * Jersey's {@code GZipDecoder} to attempt a second decompression (see issue #11249).
+     * The entity is therefore treated as the source of truth for these two headers.
+     *
+     * @param apacheResponse the Apache HTTP response whose headers are copied
+     * @param httpEntity     the (possibly {@code null}) response entity, after HttpClient processing
+     * @param jerseyResponse the Jersey response to populate
+     */
+    private static void copyResponseHeaders(CloseableHttpResponse apacheResponse, @Nullable HttpEntity httpEntity,
+                                            ClientResponse jerseyResponse) {
+        for (Header header : apacheResponse.getHeaders()) {
+            final String headerName = header.getName();
+            if (httpEntity != null && isEntityDerivedHeader(headerName)) {
+                continue;
+            }
+            jerseyResponse.getHeaders().computeIfAbsent(headerName, k -> new ArrayList<>())
+                .add(header.getValue());
+        }
+
+        if (httpEntity == null) {
+            return;
+        }
+
+        final String contentEncoding = httpEntity.getContentEncoding();
+        if (contentEncoding != null) {
+            jerseyResponse.getHeaders().computeIfAbsent(HttpHeaders.CONTENT_ENCODING, k -> new ArrayList<>())
+                .add(contentEncoding);
+        }
+        final long contentLength = httpEntity.getContentLength();
+        if (contentLength >= 0) {
+            jerseyResponse.getHeaders().computeIfAbsent(HttpHeaders.CONTENT_LENGTH, k -> new ArrayList<>())
+                .add(Long.toString(contentLength));
+        }
+    }
+
+    /**
+     * Whether the given header is one that {@link #copyResponseHeaders} re-derives from the
+     * response entity ({@link HttpHeaders#CONTENT_ENCODING} or {@link HttpHeaders#CONTENT_LENGTH})
+     * rather than copying from the raw Apache response.
+     */
+    private static boolean isEntityDerivedHeader(String headerName) {
+        return HttpHeaders.CONTENT_ENCODING.equalsIgnoreCase(headerName)
+            || HttpHeaders.CONTENT_LENGTH.equalsIgnoreCase(headerName);
     }
 
     /**

--- a/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
+++ b/dropwizard-client/src/test/java/io/dropwizard/client/DropwizardApacheConnectorTest.java
@@ -13,6 +13,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.Response;
 import org.apache.hc.client5.http.ConnectTimeoutException;
@@ -47,6 +48,12 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 class DropwizardApacheConnectorTest {
+
+    /**
+     * Large enough to exceed the server's default minimum gzip entity size (256 bytes),
+     * so the response is actually compressed on the wire.
+     */
+    private static final String GZIP_CONTENT = "Dropwizard ".repeat(200);
 
     private static final int SLEEP_TIME_IN_MILLIS = 1000;
     private static final int DEFAULT_CONNECT_TIMEOUT_IN_MILLIS = 500;
@@ -169,6 +176,24 @@ class DropwizardApacheConnectorTest {
         }
     }
 
+    /**
+     * Reproduces issue #11249. With {@code gzipEnabled=true} (the default), Apache HttpClient
+     * transparently decompresses the gzip response entity, but the connector copies the raw
+     * response headers verbatim — leaving a stale {@code Content-Encoding: gzip} and a
+     * {@code Content-Length} describing the compressed body onto the already-decompressed
+     * stream handed to Jersey. Those headers are inconsistent with the entity and drive
+     * Jersey's {@code GZipDecoder} to attempt a second decompression. The connector must drop
+     * them so the response describes the entity Jersey actually receives.
+     */
+    @Test
+    void when_server_gzips_response_then_stale_content_headers_are_dropped() {
+        try (Response response = client.target(testUri + "/gzipped_content").request().get()) {
+            assertThat(response.getHeaderString(HttpHeaders.CONTENT_ENCODING)).isNull();
+            assertThat(response.getHeaderString(HttpHeaders.CONTENT_LENGTH)).isNull();
+            assertThat(response.readEntity(String.class)).isEqualTo(GZIP_CONTENT);
+        }
+    }
+
     @Test
     void multiple_headers_with_the_same_name_are_processed_successfully() throws Exception {
 
@@ -204,6 +229,12 @@ class DropwizardApacheConnectorTest {
         public String getWithSleep() throws InterruptedException {
             TimeUnit.MILLISECONDS.sleep(SLEEP_TIME_IN_MILLIS);
             return "success";
+        }
+
+        @GET
+        @Path("/gzipped_content")
+        public String getGzippedContent() {
+            return GZIP_CONTENT;
         }
 
         @GET


### PR DESCRIPTION
Fixes #11249.

## Problem

With `JerseyClientConfiguration.gzipEnabled = true` (the default), Apache HttpClient's `ContentCompressionExec` advertises `Accept-Encoding` and **transparently decompresses** the response entity, unwrapping it to identity encoding (`DecompressingEntity` reports `getContentEncoding() == null` and `getContentLength() == -1`). Jersey's `GZipDecoder` reader interceptor is also registered.

`DropwizardApacheConnector.apply()` copies **all** raw Apache response headers verbatim — including the original `Content-Encoding: gzip` and the compressed `Content-Length` — onto the entity stream HttpClient has **already** decompressed. The Jersey `ClientResponse` therefore misdescribes its own entity: it claims `Content-Encoding: gzip` and a compressed length over a plain, identity-encoded body.

Historically this drove `GZipDecoder` into a second decompression, producing the `ZipException: Not in GZIP format` reported in the issue. That **crash is now masked on `release/5.0.x`**: `GZipDecoder` gained a gzip magic-byte (`1f 8b`) sniff guard in the httpclient5 5.6.1 bump ([`ab9473780`](https://github.com/dropwizard/dropwizard/commit/ab9473780)), so `readEntity` no longer throws and the body reads back correctly. (The crash still reproduces on httpclient5 < 5.6.1, where the guard isn't present.)

What remains — and what this PR targets — is the underlying connector defect: it hands Jersey a response whose `Content-Encoding`/`Content-Length` headers contradict its entity. This bites any caller that inspects those headers (branching on `Content-Encoding`, using `getLength()`), even though plain entity reads now succeed. The guard papers over the symptom in `GZipDecoder`; the connector is the right place to make the response describe the entity Jersey actually receives — which is the behavior the issue's *Expected* section asks for.

## Fix

Treat the entity as the source of truth for `Content-Encoding` and `Content-Length` instead of copying the raw response headers for those two:

- If HttpClient decompressed the body, the entity reports `null` / `-1`, so neither header is set — the response now correctly describes an identity-encoded body and `GZipDecoder` no-ops.
- If content compression is disabled, the entity still reports the on-the-wire encoding, so the headers pass through and Jersey decodes as before.

All other headers are copied unchanged. When there is no entity (e.g. 204/304), behaviour is unchanged.

## Test

Added `DropwizardApacheConnectorTest#when_server_gzips_response_then_stale_content_headers_are_dropped`, which requests a body large enough to exceed the server's default gzip threshold and asserts the response no longer carries a stale `Content-Encoding`/`Content-Length`, and that the body decodes intact. Against the unfixed connector the test fails on the header assertion (`Content-Encoding` is `"gzip"`) with no exception thrown — confirming the crash is masked but the metadata defect remains; with the fix it passes.

Full `dropwizard-client` module test suite is green.

---

_This pull request was prepared with the assistance of AI (Claude)._
