### PR TITLE
Replace usage of 'internal'/deprecated Hibernate classes in favor of defaults acquired through factory

### DIFF
--- a/dropwizard-core/src/test/java/io/dropwizard/core/validation/InjectValidatorFeatureTest.java
+++ b/dropwizard-core/src/test/java/io/dropwizard/core/validation/InjectValidatorFeatureTest.java
@@ -5,13 +5,17 @@ import io.dropwizard.core.Configuration;
 import io.dropwizard.core.setup.Bootstrap;
 import io.dropwizard.core.setup.Environment;
 import io.dropwizard.jersey.validation.MutableValidatorFactory;
+import io.dropwizard.util.DataSize;
+import io.dropwizard.util.DataSizeUnit;
+import io.dropwizard.validation.MinDataSize;
+import io.dropwizard.validation.MinDataSizeValidator;
 import jakarta.validation.ConstraintValidatorFactory;
 import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
 import jakarta.validation.constraints.Min;
-import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForInteger;
-import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorFactoryImpl;
+import org.hibernate.validator.HibernateValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -24,7 +28,7 @@ import static org.mockito.Mockito.verify;
 
 class InjectValidatorFeatureTest {
 
-    private final Application<Configuration> application = new Application<Configuration>() {
+    private final Application<Configuration> application = new Application<>() {
         @Override
         public void initialize(Bootstrap<Configuration> bootstrap) { }
 
@@ -69,7 +73,7 @@ class InjectValidatorFeatureTest {
 
         ConstraintValidatorFactory mockedFactory = mock(
             ConstraintValidatorFactory.class,
-            delegatesTo(new ConstraintValidatorFactoryImpl())
+            delegatesTo(Validation.byProvider(HibernateValidator.class).configure().getDefaultConstraintValidatorFactory())
         );
 
         // Swap validator factory at runtime
@@ -77,9 +81,9 @@ class InjectValidatorFeatureTest {
 
         // Run validation manually
         Validator validator = validatorFactory.getValidator();
-        validator.validate(new Bean(1));
+        validator.validate(new DataSizeRecord(DataSize.bytes(100)));
 
-        verify(mockedFactory).getInstance(MinValidatorForInteger.class);
+        verify(mockedFactory).getInstance(MinDataSizeValidator.class);
     }
 
     static class Bean {
@@ -91,4 +95,9 @@ class InjectValidatorFeatureTest {
             this.value = value;
         }
     }
+
+    private record DataSizeRecord(@MinDataSize(value = 30, unit = DataSizeUnit.BYTES) DataSize value) {
+
+    }
+
 }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/JerseyParameterNameProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/JerseyParameterNameProvider.java
@@ -1,5 +1,7 @@
 package io.dropwizard.jersey.validation;
 
+import jakarta.validation.ParameterNameProvider;
+import jakarta.validation.Validation;
 import jakarta.ws.rs.CookieParam;
 import jakarta.ws.rs.FormParam;
 import jakarta.ws.rs.HeaderParam;
@@ -7,9 +9,10 @@ import jakarta.ws.rs.MatrixParam;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
-import org.hibernate.validator.parameternameprovider.ReflectionParameterNameProvider;
+import org.hibernate.validator.HibernateValidator;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.ArrayList;
@@ -19,11 +22,18 @@ import java.util.Optional;
 /**
  * Adds jersey support to parameter name discovery in hibernate validator.
  *
- * <p>This provider will behave like the hibernate-provided {@link ReflectionParameterNameProvider} except when a
+ * <p>This provider will behave like the default hibernate-provided {@link ParameterNameProvider} implementation except when a
  * method parameter is annotated with a jersey parameter annotation, like {@link QueryParam}. If a jersey parameter
  * annotation is present the value of the annotation is used as the parameter name.</p>
  */
-public class JerseyParameterNameProvider extends ReflectionParameterNameProvider {
+public class JerseyParameterNameProvider implements ParameterNameProvider {
+
+    private final ParameterNameProvider delegate = Validation.byProvider(HibernateValidator.class).configure().getDefaultParameterNameProvider();
+
+    @Override
+    public List<String> getParameterNames(Constructor<?> constructor) {
+        return delegate.getParameterNames(constructor);
+    }
 
     @Override
     public List<String> getParameterNames(Method method) {

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/MutableValidatorFactory.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/validation/MutableValidatorFactory.java
@@ -2,14 +2,15 @@ package io.dropwizard.jersey.validation;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorFactory;
-import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorFactoryImpl;
+import jakarta.validation.Validation;
+import org.hibernate.validator.HibernateValidator;
 
 /**
  * @since 2.0
  */
 public class MutableValidatorFactory implements ConstraintValidatorFactory {
 
-    private ConstraintValidatorFactory validatorFactory = new ConstraintValidatorFactoryImpl();
+    private ConstraintValidatorFactory validatorFactory = Validation.byProvider(HibernateValidator.class).configure().getDefaultConstraintValidatorFactory();
 
     @Override
     public final <T extends ConstraintValidator<?, ?>> T getInstance(Class<T> key) {


### PR DESCRIPTION
###### Problem:
* `JerseyParameterNameProvider` uses `ReflectionParameterNameProvider` which was [deprecated in Hibernate Validator 6.0](https://hibernate.atlassian.net/browse/HV-1537) and [removed](https://hibernate.atlassian.net/browse/HV-2038) in `9.0.0.Final`
* `MutableValidatorFactory` uses the internal `org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorFactoryImpl` class, which was [moved and renamed](https://github.com/hibernate/hibernate-validator/commit/b09248adc38ab0769c9ff0e8efa1d33715069ac9) in `9.1.2.Final`

###### Solution:
This change removes Dropwizard’s direct dependencies on internal and deprecated Hibernate Validator classes.
Instead, it uses the default components exposed through `HibernateValidator` provider, enabling the `hibernate-validator` dependency to be upgraded.
1. `JerseyParameterNameProvider` now implements `ParameterNameProvider` and delegates to the default `ParameterNameProvider` obtained from `HibernateValidator` provider.
2. `MutableValidatorFactory` now uses the default `ConstraintValidatorFactory` obtained from `HibernateValidator` provider.
3. `InjectValidatorFeatureTest` is updated to delegate to the default `ConstraintValidatorFactory` obtained from `HibernateValidator` provider.
4. Replaced `InjectValidatorFeatureTest::shouldInvokeUpdatedFactory` test's reliance on Hibernate Validator's internal `MinValidatorForInteger` class with Dropwizard's `MinDataSizeValidator` class