### PR TITLE
Fix SafeRequestParameterConverter registration

### DIFF
--- a/dropwizard-request-logging/pom.xml
+++ b/dropwizard-request-logging/pom.xml
@@ -91,6 +91,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/layout/LogbackAccessRequestLayout.java
+++ b/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/layout/LogbackAccessRequestLayout.java
@@ -17,8 +17,8 @@ public class LogbackAccessRequestLayout extends PatternLayout {
 
     static  {
         // Replace the buggy default converter which don't work async appenders
-        ch.qos.logback.classic.PatternLayout.DEFAULT_CONVERTER_MAP.put("requestParameter", SafeRequestParameterConverter.class.getName());
-        ch.qos.logback.classic.PatternLayout.DEFAULT_CONVERTER_MAP.put("reqParameter", SafeRequestParameterConverter.class.getName());
+        PatternLayout.ACCESS_DEFAULT_CONVERTER_SUPPLIER_MAP.put("requestParameter", SafeRequestParameterConverter::new);
+        PatternLayout.ACCESS_DEFAULT_CONVERTER_SUPPLIER_MAP.put("reqParameter", SafeRequestParameterConverter::new);
     }
 
     public LogbackAccessRequestLayout(Context context, TimeZone timeZone) {

--- a/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/layout/SafeRequestParameterConverter.java
+++ b/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/layout/SafeRequestParameterConverter.java
@@ -20,7 +20,7 @@ public class SafeRequestParameterConverter extends AccessConverter {
     @Override
     public void start() {
         key = getFirstOption();
-        if (OptionHelper.isEmpty(key)) {
+        if (OptionHelper.isNullOrEmptyOrAllSpaces(key)) {
             addWarn("Missing key for the request parameter");
         } else {
             super.start();

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/layout/LogbackAccessRequestLayoutTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/layout/LogbackAccessRequestLayoutTest.java
@@ -1,18 +1,26 @@
 package io.dropwizard.request.logging.layout;
 
+import ch.qos.logback.access.common.spi.AccessEvent;
+import ch.qos.logback.access.common.spi.ServerAdapter;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.core.Context;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import java.util.TimeZone;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 class LogbackAccessRequestLayoutTest {
-    final Context context = mock(LoggerContext.class);
+    private final Context context = mock(LoggerContext.class);
     private final TimeZone timeZone = TimeZone.getTimeZone("UTC");
-    final LogbackAccessRequestLayout layout = new LogbackAccessRequestLayout(context, timeZone);
+    private final LogbackAccessRequestLayout layout = new LogbackAccessRequestLayout(context, timeZone);
 
     @Test
     void outputPatternAsHeaderIsFalse() {
@@ -30,4 +38,22 @@ class LogbackAccessRequestLayoutTest {
         assertThat(layout.getPattern())
             .isEqualTo("%h %l %u [%t{dd/MMM/yyyy:HH:mm:ss Z,UTC}] \"%r\" %s %b \"%i{Referer}\" \"%i{User-Agent}\" %D");
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "requestParameter", "reqParameter" })
+    void requestParametersAreConvertedUsingSafeRequestParameterConverter(String patternKey) {
+        HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+        HttpServletResponse httpServletResponse = mock(HttpServletResponse.class);
+        ServerAdapter serverAdapter = mock(ServerAdapter.class);
+        AccessEvent accessEvent = mock(
+                AccessEvent.class,
+                delegatesTo(new AccessEvent(context, httpServletRequest, httpServletResponse, serverAdapter)));
+
+        layout.setPattern("%" + patternKey + "{parameterName}");
+        layout.start();
+        layout.doLayout(accessEvent);
+
+        verify(accessEvent).getRequestParameterMap();
+    }
+
 }

--- a/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/layout/LogbackAccessRequestLayoutTest.java
+++ b/dropwizard-request-logging/src/test/java/io/dropwizard/request/logging/layout/LogbackAccessRequestLayoutTest.java
@@ -53,6 +53,9 @@ class LogbackAccessRequestLayoutTest {
         layout.start();
         layout.doLayout(accessEvent);
 
+        assertThat(layout.getEffectiveConverterMap())
+                .hasEntrySatisfying(patternKey, supplier -> assertThat(supplier.get()).isInstanceOf(SafeRequestParameterConverter.class));
+
         verify(accessEvent).getRequestParameterMap();
     }
 


### PR DESCRIPTION
###### Problem:
`LogbackAccessRequestLayout` is an Access-log layout, but it registers `SafeRequestParameterConverter` in Logback Classic's converter map, therefore leading to usage of (default) `RequestParameterConverter` instead of `SafeRequestParameterConverter`.

###### Solution:
* Register `SafeRequestParameterConverter` with Logback Access's PatternLayout rather than Logback Classic's unrelated PatternLayout
* Replace deprecated `OptionHelper.isEmpty` with `OptionHelper.isNullOrEmptyOrAllSpaces`