### PR TITLE
fix(jersey): reject empty UUID query params with 400

### DIFF
--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/DropwizardResourceConfig.java
@@ -7,6 +7,7 @@ import com.fasterxml.classmate.ResolvedType;
 import com.fasterxml.classmate.TypeResolver;
 import io.dropwizard.jersey.caching.CacheControlledResponseFeature;
 import io.dropwizard.jersey.params.AbstractParamConverterProvider;
+import io.dropwizard.jersey.params.UUIDParamConverterProvider;
 import io.dropwizard.jersey.sessions.SessionFactoryProvider;
 import io.dropwizard.jersey.validation.FuzzyEnumParamConverterProvider;
 import jakarta.validation.constraints.NotNull;
@@ -77,6 +78,7 @@ public class DropwizardResourceConfig extends ResourceConfig {
         register(io.dropwizard.jersey.optional.OptionalIntMessageBodyWriter.class);
         register(io.dropwizard.jersey.optional.OptionalLongMessageBodyWriter.class);
         register(AbstractParamConverterProvider.class);
+        register(new UUIDParamConverterProvider());
         register(new FuzzyEnumParamConverterProvider());
         register(new SessionFactoryProvider.Binder());
     }

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/UUIDParamConverter.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/UUIDParamConverter.java
@@ -1,0 +1,62 @@
+package io.dropwizard.jersey.params;
+
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ext.ParamConverter;
+import org.jspecify.annotations.Nullable;
+
+import java.util.UUID;
+
+/**
+ * Converts request parameters to {@link UUID} values.
+ *
+ * <p>Jersey's default converters map an empty parameter value (for example {@code ?id=}) to
+ * {@code null} when {@link UUID#fromString(String)} fails. For multi-valued parameters that yields
+ * a collection containing a single {@code null} element. This converter rejects empty and
+ * non-parsable values with {@code 400 Bad Request} instead.</p>
+ *
+ * @see <a href="https://github.com/dropwizard/dropwizard/issues/3435">dropwizard/dropwizard#3435</a>
+ * @since 5.0.3
+ */
+public class UUIDParamConverter implements ParamConverter<UUID> {
+    private final String parameterName;
+
+    public UUIDParamConverter(String parameterName) {
+        this.parameterName = parameterName;
+    }
+
+    @Override
+    @Nullable
+    public UUID fromString(@Nullable String value) {
+        // Missing parameters are represented as null; leave them as null so optional single
+        // values and absent multi-valued parameters keep working as before.
+        if (value == null) {
+            return null;
+        }
+
+        // Empty string is not a valid UUID. Jersey would otherwise swallow the parse failure and
+        // insert null into List/Set/SortedSet parameters (see #3435).
+        if (value.isEmpty()) {
+            throw invalidUuid();
+        }
+
+        // Match UUIDParam: require RFC 4122 length (36) so extra hex is not silently accepted.
+        if (value.length() != 36) {
+            throw invalidUuid();
+        }
+
+        try {
+            return UUID.fromString(value);
+        } catch (IllegalArgumentException e) {
+            throw invalidUuid();
+        }
+    }
+
+    @Override
+    public String toString(UUID value) {
+        return value.toString();
+    }
+
+    private BadRequestException invalidUuid() {
+        return new BadRequestException(parameterName + " is not a UUID.");
+    }
+}

--- a/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/UUIDParamConverterProvider.java
+++ b/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/UUIDParamConverterProvider.java
@@ -1,0 +1,36 @@
+package io.dropwizard.jersey.params;
+
+import io.dropwizard.jersey.validation.JerseyParameterNameProvider;
+import jakarta.ws.rs.ext.ParamConverter;
+import jakarta.ws.rs.ext.ParamConverterProvider;
+import jakarta.ws.rs.ext.Provider;
+import org.jspecify.annotations.Nullable;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.UUID;
+
+/**
+ * Provides a {@link ParamConverter} for {@link UUID} resource parameters with consistent
+ * {@code 400 Bad Request} handling for empty and invalid values.
+ *
+ * @see UUIDParamConverter
+ * @see <a href="https://github.com/dropwizard/dropwizard/issues/3435">dropwizard/dropwizard#3435</a>
+ * @since 5.0.3
+ */
+@Provider
+public class UUIDParamConverterProvider implements ParamConverterProvider {
+    @Override
+    @Nullable
+    public <T> ParamConverter<T> getConverter(Class<T> rawType, @Nullable Type genericType, Annotation[] annotations) {
+        if (!UUID.class.equals(rawType)) {
+            return null;
+        }
+
+        final String parameterName = JerseyParameterNameProvider.getParameterNameFromAnnotations(annotations)
+                .orElse("Parameter");
+        @SuppressWarnings("unchecked") final ParamConverter<T> converter =
+                (ParamConverter<T>) new UUIDParamConverter(parameterName);
+        return converter;
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/UUIDParamConverterTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/UUIDParamConverterTest.java
@@ -1,0 +1,51 @@
+package io.dropwizard.jersey.params;
+
+import jakarta.ws.rs.BadRequestException;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class UUIDParamConverterTest {
+    private final UUIDParamConverter converter = new UUIDParamConverter("id");
+
+    @Test
+    void parsesValidUuid() {
+        final String uuidString = "067e6162-3b6f-4ae2-a171-2470b63dff00";
+        assertThat(converter.fromString(uuidString)).isEqualTo(UUID.fromString(uuidString));
+    }
+
+    @Test
+    void nullReturnsNull() {
+        assertThat(converter.fromString(null)).isNull();
+    }
+
+    @Test
+    void emptyStringIsRejected() {
+        assertThatExceptionOfType(BadRequestException.class)
+                .isThrownBy(() -> converter.fromString(""))
+                .withMessage("id is not a UUID.");
+    }
+
+    @Test
+    void invalidUuidIsRejected() {
+        assertThatExceptionOfType(BadRequestException.class)
+                .isThrownBy(() -> converter.fromString("not-a-uuid"))
+                .withMessage("id is not a UUID.");
+    }
+
+    @Test
+    void wrongLengthIsRejected() {
+        assertThatExceptionOfType(BadRequestException.class)
+                .isThrownBy(() -> converter.fromString("067e61623b6f4ae2a1712470b63dff00"))
+                .withMessage("id is not a UUID.");
+    }
+
+    @Test
+    void toStringReturnsCanonicalForm() {
+        final UUID uuid = UUID.fromString("067e6162-3b6f-4ae2-a171-2470b63dff00");
+        assertThat(converter.toString(uuid)).isEqualTo(uuid.toString());
+    }
+}

--- a/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/UUIDQueryParamResourceTest.java
+++ b/dropwizard-jersey/src/test/java/io/dropwizard/jersey/params/UUIDQueryParamResourceTest.java
@@ -1,0 +1,145 @@
+package io.dropwizard.jersey.params;
+
+import io.dropwizard.jersey.AbstractJerseyTest;
+import io.dropwizard.jersey.DropwizardResourceConfig;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for empty multi-valued UUID query parameters producing a collection of null
+ * ({@code dropwizard/dropwizard#3435}).
+ */
+class UUIDQueryParamResourceTest extends AbstractJerseyTest {
+
+    private static final String VALID_UUID = "ec0cf621-d744-4a1c-b1d8-4b8a44b3dad7";
+
+    @Override
+    protected Application configure() {
+        return DropwizardResourceConfig.forTesting()
+                .register(UUIDQueryParamResource.class);
+    }
+
+    @Test
+    void emptyListQueryParamIsRejected() {
+        final Response response = target("/uuid/list")
+                .queryParam("id", "")
+                .request()
+                .get();
+        assertThat(response.getStatus()).isEqualTo(400);
+    }
+
+    @Test
+    void emptySetQueryParamIsRejected() {
+        final Response response = target("/uuid/set")
+                .queryParam("id", "")
+                .request()
+                .get();
+        assertThat(response.getStatus()).isEqualTo(400);
+    }
+
+    @Test
+    void missingListQueryParamReturnsEmptyCollection() {
+        final Response response = target("/uuid/list").request().get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.readEntity(String.class)).isEqualTo("0: []");
+    }
+
+    @Test
+    void missingSetQueryParamReturnsEmptyCollection() {
+        final Response response = target("/uuid/set").request().get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.readEntity(String.class)).isEqualTo("0: []");
+    }
+
+    @Test
+    void validListQueryParamIsAccepted() {
+        final Response response = target("/uuid/list")
+                .queryParam("id", VALID_UUID)
+                .request()
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.readEntity(String.class)).isEqualTo("1: [" + VALID_UUID + "]");
+    }
+
+    @Test
+    void validSetQueryParamIsAccepted() {
+        final Response response = target("/uuid/set")
+                .queryParam("id", VALID_UUID)
+                .request()
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.readEntity(String.class)).isEqualTo("1: [" + VALID_UUID + "]");
+    }
+
+    @Test
+    void invalidListQueryParamIsRejected() {
+        final Response response = target("/uuid/list")
+                .queryParam("id", "not-a-uuid")
+                .request()
+                .get();
+        assertThat(response.getStatus()).isEqualTo(400);
+    }
+
+    @Test
+    void emptySingleQueryParamIsRejected() {
+        final Response response = target("/uuid/single")
+                .queryParam("id", "")
+                .request()
+                .get();
+        assertThat(response.getStatus()).isEqualTo(400);
+    }
+
+    @Test
+    void missingSingleQueryParamIsNull() {
+        final Response response = target("/uuid/single").request().get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.readEntity(String.class)).isEqualTo("null");
+    }
+
+    @Test
+    void validSingleQueryParamIsAccepted() {
+        final Response response = target("/uuid/single")
+                .queryParam("id", VALID_UUID)
+                .request()
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.readEntity(String.class)).isEqualTo(VALID_UUID);
+    }
+
+    @Path("/uuid")
+    public static class UUIDQueryParamResource {
+        @GET
+        @Path("/list")
+        public String list(@QueryParam("id") List<UUID> ids) {
+            return ids.size() + ": " + ids.toString();
+        }
+
+        @GET
+        @Path("/set")
+        public String set(@QueryParam("id") Set<UUID> ids) {
+            // Sort for stable assertion output (HashSet iteration order is undefined).
+            final String body = ids.stream()
+                    .map(uuid -> uuid == null ? "null" : uuid.toString())
+                    .sorted()
+                    .collect(Collectors.joining(", ", "[", "]"));
+            return ids.size() + ": " + body;
+        }
+
+        @GET
+        @Path("/single")
+        public String single(@QueryParam("id") UUID id) {
+            return String.valueOf(id);
+        }
+    }
+}


### PR DESCRIPTION
###### Problem:
Empty multi-valued UUID query parameters (e.g. `?id=`) are converted by Jersey into a collection containing a single `null` element. Bean Validation annotations such as `@NotEmpty` on the collection or `@NotNull` on the element type do not reject the request.

This is Jersey's default `ParamConverter` behavior: when `UUID.fromString("")` fails, the empty string is mapped to `null` and that null is added to `List`/`Set`/`SortedSet` parameters. See #3435.

###### Solution:
Register a Dropwizard `UUIDParamConverter` / `UUIDParamConverterProvider` (same pattern as `FuzzyEnumParamConverterProvider`) that:
- returns `null` only for a **missing** parameter
- rejects **empty** and **invalid** values with `400 Bad Request` and message `{parameter} is not a UUID.`

This mirrors the historical `UUIDParam` parsing rules (including the RFC 4122 length check) for plain `java.util.UUID` parameters.

###### Result:
- `@QueryParam List<UUID>` / `Set<UUID>` with `?id=` → **400** (no longer a collection of null)
- Missing `id` → empty collection (unchanged)
- Valid UUID values → accepted (unchanged)
- Single optional `@QueryParam UUID` that is omitted → still `null`

Fixes #3435

###### Tested
- `./mvnw -pl dropwizard-jersey -am test -Dtest=UUIDParamConverterTest,UUIDQueryParamResourceTest`
- Temurin JDK 21.0.12 — **16/16** tests passed