### PR TITLE
Allow Liquibase 4.33.0 revoked signing key

### DIFF
--- a/pgp-keys-map.list
+++ b/pgp-keys-map.list
@@ -2,6 +2,8 @@
 io.reactivex.rxjava2:rxjava = !0x1D9AA7F9E1E2824728B8CD1794B291AEF984A085
 # io.smallrye:jandex:jar:3.2.0 PGP key 0x94976E17E18DD3201447286954963C3E875A56AE has been revoked and public key is not available
 io.smallrye:jandex:3.2.0 = !0x94976E17E18DD3201447286954963C3E875A56AE
+# org.liquibase:liquibase-core:jar:4.33.0 PGP key 0x4F474D657AAB9B387B812DA2915C4D2EC1FE0D33 has been revoked and public key is not available
+org.liquibase:liquibase-core:4.33.0 = !0x4F474D657AAB9B387B812DA2915C4D2EC1FE0D33
 # Not allowed artifact org.hibernate.orm:hibernate-core:jar:6.6.41.Final and keyID
 org.hibernate.orm:hibernate-core = 0x1452F35849B50750F6A3BBB4B54011358B352F85
 # Not allowed artifact org.jboss.logging:jboss-logging:jar:3.6.3.Final and keyID


### PR DESCRIPTION
## Summary

- allow the existing Liquibase 4.33.0 artifact's revoked signing key in the repository PGP map
- scope the exception to that exact group, artifact, and version
- preserve signature verification and every existing key rule for all other artifacts and versions

This is a narrow companion fix for Renovate PR #11300 and targets its branch so the FreeMarker upgrade remains attributable to Renovate.

## Why

The FreeMarker 2.3.35 upgrade compiles and tests successfully, but every Java CI matrix entry now stops in `dropwizard-migrations` because the previously accepted Liquibase 4.33.0 signer has been revoked and its public key is unavailable:

> org.liquibase:liquibase-core:jar:4.33.0 PGP key 0x4F474D657AAB9B387B812DA2915C4D2EC1FE0D33 has been revoked and public key is not available

The repository already uses exact dependency/version exceptions for this PGP failure class. This applies the same narrow policy shape and does not allow the key for another Liquibase release or artifact.

## Verification

- `mvn -B --no-transfer-progress clean install -DskipTests` on JDK 17: all 42 modules passed, including PGP verification throughout the reactor
- `mvn -B --no-transfer-progress -pl dropwizard-migrations,dropwizard-views-freemarker verify` on JDK 17
- 64 focused tests run, 0 failures, 0 errors, 1 skipped
- Maven Enforcer dependency convergence and banned-dependency rules passed
- PGP verification validated 102 artifacts for migrations and 94 for FreeMarker views
- complete diff reviewed: one exact-version PGP map entry and its diagnostic comment

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):
- Skills: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, and `jaipilot-review-diff`
- Execution profile: `gpt-5.6-sol · xhigh · fast`