### PR TITLE
<argLine> cleanups (submodules are inadvertently overriding parent argLine)

### DIFF
--- a/dropwizard-example/pom.xml
+++ b/dropwizard-example/pom.xml
@@ -11,7 +11,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.release>11</maven.compiler.release>
-        <argLine>-Duser.language=en -Duser.region=US -Duser.timezone=UTC</argLine>
 
         <!-- You'll probably want to remove this for your project. We're just using it here
              so that dropwizard-example doesn't get deployed as a library. -->

--- a/dropwizard-http2/pom.xml
+++ b/dropwizard-http2/pom.xml
@@ -13,7 +13,6 @@
     <name>Dropwizard HTTP/2 Support</name>
 
     <properties>
-        <argLine>-Duser.language=en -Duser.region=US</argLine>
         <module.name>io.dropwizard.http2</module.name>
     </properties>
 

--- a/dropwizard-jackson/pom.xml
+++ b/dropwizard-jackson/pom.xml
@@ -13,8 +13,6 @@
     <name>Dropwizard Jackson Support</name>
 
     <properties>
-        <!-- https://github.com/FasterXML/jackson-modules-base/issues/37#issuecomment-389581245 -->
-        <argLine>${surefire.argLine} --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
         <module.name>io.dropwizard.jackson</module.name>
     </properties>
 

--- a/dropwizard-parent/pom.xml
+++ b/dropwizard-parent/pom.xml
@@ -27,7 +27,7 @@
 
         <surefire.argLine>-Duser.language=en -Duser.region=US -Duser.timezone=UTC</surefire.argLine>
         <agents.argLine>-javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy.version}/byte-buddy-agent-${byte-buddy.version}.jar</agents.argLine>
-        <argLine>${surefire.argLine} --illegal-access=deny --add-opens java.base/java.net=ALL-UNNAMED ${agents.argLine}</argLine>
+        <argLine>${surefire.argLine} --add-opens java.base/java.net=ALL-UNNAMED ${agents.argLine}</argLine>
     </properties>
 
     <profiles>


### PR DESCRIPTION
Spotted while I was working on #11303: argLine right now is a bit of a jumbled mess.

This tries to clean it up:
1. Remove `--illegal-access=deny` since Java 17 is required (thus it's a no-op just generating warnings)
2. Remove unnecessary dropwizard-jackson argLine customization
3. Remove dropwizard-example and dropwizard-http2 <argLine> which is overriding the parent argLine which is likely unintentional

Further thoughts:  if we anticipate needing custom argLines per submodule we could later add a `<argLine.parent>` property in the parent POM and then define `<argLine>${argline.parent}</argLine>` in the parent.  This would give submodules a simple way to include the parent value and add to it.

But TBH I was having trouble anticipating when we'd really need this.  IMO the whole project should be tested with the same argLine which should (ideally) be the one documented as required for use of Dropwizard + perhaps a few affects-tests-only changes.  So for now I did not do that.