### PR TITLE
Move the Client instance out of DropwizardAppExtension into DropwizardTestSupport

### DIFF
--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java
@@ -11,14 +11,23 @@ import io.dropwizard.core.cli.EnvironmentCommand;
 import io.dropwizard.core.cli.ServerCommand;
 import io.dropwizard.core.setup.Bootstrap;
 import io.dropwizard.core.setup.Environment;
+import io.dropwizard.jersey.jackson.JacksonFeature;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.logging.common.LoggingUtil;
 import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.client.Client;
 import net.sourceforge.argparse4j.inf.Namespace;
-import org.jspecify.annotations.Nullable;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.glassfish.jersey.apache5.connector.Apache5ConnectorProvider;
+import org.glassfish.jersey.apache5.connector.Apache5HttpClientBuilderConfigurator;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.JerseyClientBuilder;
+import org.glassfish.jersey.client.RequestEntityProcessing;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
 import java.lang.reflect.InvocationTargetException;
@@ -43,6 +52,9 @@ import static java.util.Objects.requireNonNull;
  * @param <C> the configuration type
  */
 public class DropwizardTestSupport<C extends Configuration> {
+    private static final int CLIENT_DEFAULT_CONNECT_TIMEOUT_MS = 1000;
+    private static final int CLIENT_DEFAULT_READ_TIMEOUT_MS = 5000;
+
     protected final Class<? extends Application<C>> applicationClass;
 
     @Nullable
@@ -53,6 +65,9 @@ public class DropwizardTestSupport<C extends Configuration> {
     @Nullable
     protected final String customPropertyPrefix;
     protected final Function<Application<C>, Command> commandInstantiator;
+
+    @Nullable
+    private Client client;
 
     /**
      * Flag that indicates whether instance was constructed with an explicit
@@ -218,6 +233,12 @@ public class DropwizardTestSupport<C extends Configuration> {
             stopIfRequired();
         } finally {
             resetConfigOverrides();
+            synchronized (this) {
+                if (client != null) {
+                    client.close();
+                    client = null;
+                }
+            }
         }
     }
 
@@ -361,5 +382,54 @@ public class DropwizardTestSupport<C extends Configuration> {
         public void onStop(DropwizardTestSupport<T> rule) throws Exception {
             // Default NOP
         }
+    }
+
+    /**
+     * Returns a new HTTP Jersey {@link Client} for performing HTTP requests against the tested
+     * Dropwizard server. The client can be reused across different tests and automatically
+     * closed along with the server. The client can be augmented by overriding the
+     * {@link #clientBuilder()} method or calling it directly.
+     *
+     * @return a shared {@link Client} managed by the extension. Do not close it.
+     */
+    public Client client() {
+        synchronized (this) {
+            if (client == null) {
+                client = clientBuilder().build();
+            }
+            return client;
+        }
+    }
+
+    /**
+     * Alias for {@link #client()} that is more friendly to IDE warnings about not closing a resource.
+     *
+     * @return a shared {@link Client} managed by the extension. Do not close it.
+     */
+    public Client getClient() {
+        return client();
+    }
+
+    /**
+     * Returns a Jersey client builder object with the various configurations applied that would be done if the
+     * {@link #client()} or {@link #getClient()} methods were called to build/acquire the shared {@link Client} for
+     * testing.
+     * <p>
+     * Using this method means that the caller now inherits all responsibility of managing any created {@code Client}
+     * instance's lifecycle.
+     *
+     * @return builder for creating a {@link Client} object
+     */
+    public JerseyClientBuilder clientBuilder() {
+        ClientConfig clientConfig = new ClientConfig();
+        Apache5HttpClientBuilderConfigurator contentCompressionConfigurator =
+            HttpClientBuilder::disableContentCompression;
+        clientConfig.connectorProvider(new Apache5ConnectorProvider())
+            .register(new JacksonFeature(getObjectMapper()))
+            .register(contentCompressionConfigurator)
+            .property(ClientProperties.CONNECT_TIMEOUT, CLIENT_DEFAULT_CONNECT_TIMEOUT_MS)
+            .property(ClientProperties.READ_TIMEOUT, CLIENT_DEFAULT_READ_TIMEOUT_MS)
+            .property(ClientProperties.REQUEST_ENTITY_PROCESSING, RequestEntityProcessing.BUFFERED);
+        return new JerseyClientBuilder().withConfig(clientConfig);
     }
 }

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardAppExtension.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/junit5/DropwizardAppExtension.java
@@ -7,19 +7,12 @@ import io.dropwizard.core.Configuration;
 import io.dropwizard.core.cli.Command;
 import io.dropwizard.core.cli.ServerCommand;
 import io.dropwizard.core.setup.Environment;
-import io.dropwizard.jersey.jackson.JacksonFeature;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.DropwizardTestSupport;
 import jakarta.ws.rs.client.Client;
-import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
-import org.jspecify.annotations.Nullable;
-import org.glassfish.jersey.apache5.connector.Apache5ConnectorProvider;
-import org.glassfish.jersey.apache5.connector.Apache5HttpClientBuilderConfigurator;
-import org.glassfish.jersey.client.ClientConfig;
-import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.JerseyClientBuilder;
-import org.glassfish.jersey.client.RequestEntityProcessing;
+import org.jspecify.annotations.Nullable;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -43,15 +36,9 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 public class DropwizardAppExtension<C extends Configuration> implements DropwizardExtension,
     BeforeAllCallback, AfterAllCallback {
 
-    private static final int DEFAULT_CONNECT_TIMEOUT_MS = 1000;
-    private static final int DEFAULT_READ_TIMEOUT_MS = 5000;
-
     private final DropwizardTestSupport<C> testSupport;
 
     private final AtomicInteger recursiveCallCount = new AtomicInteger(0);
-
-    @Nullable
-    private Client client;
 
     public DropwizardAppExtension(Class<? extends Application<C>> applicationClass) {
         this(applicationClass, (String) null);
@@ -181,12 +168,6 @@ public class DropwizardAppExtension<C extends Configuration> implements Dropwiza
     public void after() {
         if (recursiveCallCount.decrementAndGet() == 0) {
             testSupport.after();
-            synchronized (this) {
-                if (client != null) {
-                    client.close();
-                    client = null;
-                }
-            }
         }
     }
 
@@ -242,29 +223,34 @@ public class DropwizardAppExtension<C extends Configuration> implements Dropwiza
      * Returns a new HTTP Jersey {@link Client} for performing HTTP requests against the tested
      * Dropwizard server. The client can be reused across different tests and automatically
      * closed along with the server. The client can be augmented by overriding the
-     * {@link #clientBuilder()} method.
+     * {@link #clientBuilder()} method or calling it directly.
      *
-     * @return a new {@link Client} managed by the extension.
+     * @return a shared {@link Client} managed by the extension. Do not close it.
      */
     public Client client() {
-        synchronized (this) {
-            if (client == null) {
-                client = clientBuilder().build();
-            }
-            return client;
-        }
+        return testSupport.client();
     }
 
-    protected JerseyClientBuilder clientBuilder() {
-        ClientConfig clientConfig = new ClientConfig();
-        Apache5HttpClientBuilderConfigurator contentCompressionConfigurator =
-            HttpClientBuilder::disableContentCompression;
-        clientConfig.connectorProvider(new Apache5ConnectorProvider())
-            .register(new JacksonFeature(getObjectMapper()))
-            .register(contentCompressionConfigurator)
-            .property(ClientProperties.CONNECT_TIMEOUT, DEFAULT_CONNECT_TIMEOUT_MS)
-            .property(ClientProperties.READ_TIMEOUT, DEFAULT_READ_TIMEOUT_MS)
-            .property(ClientProperties.REQUEST_ENTITY_PROCESSING, RequestEntityProcessing.BUFFERED);
-        return new JerseyClientBuilder().withConfig(clientConfig);
+    /**
+     * Alias for {@link #client()} that is more friendly to IDE warnings about not closing a resource.
+     *
+     * @return a shared {@link Client} managed by the extension. Do not close it.
+     */
+    public Client getClient() {
+        return client();
+    }
+
+    /**
+     * Returns a Jersey client builder object with the various configurations applied that would be done if the
+     * {@link #client()} or {@link #getClient()} methods were called to build/acquire the shared {@link Client} for
+     * testing.
+     * <p>
+     * Using this method means that the caller now inherits all responsibility of managing any created {@code Client}
+     * instance's lifecycle.
+     *
+     * @return builder for creating a {@link Client} object
+     */
+    public JerseyClientBuilder clientBuilder() {
+        return testSupport.clientBuilder();
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/DropwizardTestSupportTest.java
@@ -11,20 +11,24 @@ import io.dropwizard.core.setup.Environment;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.servlets.tasks.PostBodyTask;
 import io.dropwizard.servlets.tasks.Task;
+import io.dropwizard.testing.app.DropwizardTestApplication;
 import io.dropwizard.testing.app.TestConfiguration;
 import io.dropwizard.validation.BaseValidator;
 import jakarta.validation.Validator;
+import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import org.glassfish.jersey.client.JerseyClientBuilder;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.io.PrintWriter;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static io.dropwizard.jackson.Jackson.newObjectMapper;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -126,6 +130,62 @@ class DropwizardTestSupportTest {
                 support.after();
             }
         });
+    }
+
+    @Nested
+    class ClientTests {
+        @Test
+        void canGetExpectedResourceOverHttp() {
+            final String content = TEST_SUPPORT.getClient()
+                .target("http://localhost:" + TEST_SUPPORT.getLocalPort() + "/test")
+                .request()
+                .get(String.class);
+
+            assertThat(content).isEqualTo("Yes, it's here");
+        }
+
+        @Test
+        void canPerformAdminTaskWithPostBody() {
+            final String response = TEST_SUPPORT.getClient()
+                .target("http://localhost:" + TEST_SUPPORT.getAdminPort() + "/tasks/echo")
+                .request()
+                .post(Entity.entity("Custom message", MediaType.TEXT_PLAIN), String.class);
+
+            assertThat(response).isEqualTo("Custom message");
+        }
+
+        @Test
+        void clientUsesJacksonMapperFromEnvironment() {
+            final Optional<String> message = TEST_SUPPORT.getClient()
+                .target("http://localhost:" + TEST_SUPPORT.getLocalPort() + "/message")
+                .request()
+                .get(DropwizardTestApplication.MessageView.class)
+                .getMessage();
+            assertThat(message)
+                .hasValue("Yes, it's here");
+        }
+
+        @Test
+        void customBuiltClientUsesJacksonMapperFromEnvironment() {
+            try (Client createdClient = TEST_SUPPORT.clientBuilder().build()) {
+                final Optional<String> message
+                    = createdClient.target("http://localhost:" + TEST_SUPPORT.getLocalPort() + "/message")
+                    .request()
+                    .get(DropwizardTestApplication.MessageView.class)
+                    .getMessage();
+                assertThat(message)
+                    .hasValue("Yes, it's here");
+            }
+        }
+
+        @Test
+        void clientSupportsPatchMethod() {
+            final String method = TEST_SUPPORT.getClient()
+                .target("http://localhost:" + TEST_SUPPORT.getLocalPort() + "/echoPatch")
+                .request()
+                .method("PATCH", Entity.text("Patch is working"), String.class);
+            assertThat(method).isEqualTo("Patch is working");
+        }
     }
 
     public static class FailingApplication extends Application<TestConfiguration> {

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/app/TestResource.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/app/TestResource.java
@@ -1,7 +1,10 @@
 package io.dropwizard.testing.app;
 
+import io.dropwizard.jersey.PATCH;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path("/")
 public class TestResource {
@@ -22,5 +25,18 @@ public class TestResource {
     @GET
     public String test() {
         return message;
+    }
+
+    @Path("message")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public DropwizardTestApplication.MessageView messageView() {
+        return new DropwizardTestApplication.MessageView(message);
+    }
+
+    @Path("echoPatch")
+    @PATCH
+    public String echoPatch(String patchMessage) {
+        return patchMessage;
     }
 }

--- a/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/AbstractDropwizardAppExtensionTest.java
+++ b/dropwizard-testing/src/test/java/io/dropwizard/testing/junit5/AbstractDropwizardAppExtensionTest.java
@@ -3,6 +3,7 @@ package io.dropwizard.testing.junit5;
 import io.dropwizard.core.setup.Environment;
 import io.dropwizard.testing.app.DropwizardTestApplication;
 import io.dropwizard.testing.app.TestConfiguration;
+import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import org.glassfish.jersey.client.JerseyClientBuilder;
@@ -71,6 +72,19 @@ abstract class AbstractDropwizardAppExtensionTest {
                 .getMessage();
         assertThat(message)
                 .hasValue("Yes, it's here");
+    }
+
+    @Test
+    void customBuiltClientUsesJacksonMapperFromEnvironment() {
+        try (Client createdClient = getExtension().clientBuilder().build()) {
+            final Optional<String> message
+                = createdClient.target("http://localhost:" + getExtension().getLocalPort() + "/message")
+                .request()
+                .get(DropwizardTestApplication.MessageView.class)
+                .getMessage();
+            assertThat(message)
+                .hasValue("Yes, it's here");
+        }
     }
 
     @Test


### PR DESCRIPTION
Issue #11304: Move the Client instance out of `DropwizardAppExtension` into `DropwizardTestSupport` so it can be used via either class.

###### Problem:
See #11304.

###### Solution:
1. I've directly moved `Client` to `DropwizardTestSupport`.
2. I've retained 'relay' methods in `DropwizardAppExtension`.
3. Doing a "direct" relay of `clientBuilder()` is difficult unless `DropwizardTestSupport` is converted from protected to public scope.  I therefore have made it public in both cases and added some Javadocs.  It can be used via the old pattern (subclassing and overriding), or via a new pattern of direct invocation.

Tweak along the way:
* Added `getClient()` method which is an alias for `client()`.  My IDE (IntelliJ) by default prints warnings for client logic invoking methods that return `AutoCloseable`/`Closeable`, if the calling logic doesn't close them.  In this case the caller should NOT close the result of client() since it is shared.  Switching to a `getClient()` name causes the IDE warning to be suppressed without a special rule.  So this feels helpful as a linting/IDE hint if callers prefer that.
 