### PR TITLE
Fix dropwizard-request-logging module's incorrect scope of jetty-security and jetty-session

### DIFF
--- a/dropwizard-request-logging/pom.xml
+++ b/dropwizard-request-logging/pom.xml
@@ -73,6 +73,14 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-session</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
         </dependency>
         <dependency>
@@ -116,16 +124,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-security</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-session</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>
@@ -136,4 +134,28 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>analyze</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <configuration>
+                            <ignoredNonTestScopedDependencies>
+                                <!-- plugin reports test-only scope but really due to transitive requirements these are compile scope -->
+                                <ignoredUsedUndeclaredDependency>org.eclipse.jetty:jetty-security</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.eclipse.jetty:jetty-session</ignoredUsedUndeclaredDependency>
+                            </ignoredNonTestScopedDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Caught while I was working on #11303 / #11309: Fix `dropwizard-request-logging` module's incorrect scope of `jetty-security` and `jetty-session` (transitively relied upon by `jetty-ee10-servlet`).

###### Problem:
At present, `dropwizard-request-logging`'s dependency scope for `jetty-security` and `jetty-session` are being manually overridden to `test` when `compile` scope is required (since `jetty-ee10-servlet` is compile scope, and depends on these modules).

###### Solution:
1. Fix the scope.
2. Override the erroneous output of `maven-dependency-plugin` for these modules.

###### Result:
Anyone directly depending on `dropwizard-request-log` module won't be missing the required `jetty-security` and `jetty-session` transitives.