### PR TITLE
Fix bug causing lots of logback initialization log spam when using classic request log

### DIFF
--- a/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/old/LogbackClassicRequestLogFactory.java
+++ b/dropwizard-request-logging/src/main/java/io/dropwizard/request/logging/old/LogbackClassicRequestLogFactory.java
@@ -61,6 +61,7 @@ public class LogbackClassicRequestLogFactory implements RequestLogFactory<Reques
         private RequestLogLayout(Context context) {
             super();
             setContext(context);
+            setPattern(" ");  // required by PatternLayoutBase.start(); doLayout bypasses it
         }
 
         @Override


### PR DESCRIPTION
Caught while I was working on #11303 / #11309: Fix bug causing 

> ERROR in io.dropwizard.request.logging.old.LogbackClassicRequestLogFactory$RequestLogLayout("null") - Empty or null pattern.

log spam when using classic request log.

My personal interest in this is to merge #11309 which adds lots of integration tests for both logback access log and the classic log.  I don't want those tests to generate tons of noise.

###### Problem:
At present, if you enable classic request log (for whatever reason), it triggers a code path that results in a warning being generated in Logback's initial 'logger initialization' log output.  This results in ALL logging-setup internal-related messages (not just warning level, but everything) being written out for the lifetime of the app.

###### Solution:
Worked around the problematic code path with a hack.

###### Result:
Anyone using "classic" request log will no longer get spammed by logging initialization messages just by starting their app.
